### PR TITLE
app-catalog: Add the backend token to the helm-related requests

### DIFF
--- a/app-catalog/src/api/releases.tsx
+++ b/app-catalog/src/api/releases.tsx
@@ -1,34 +1,42 @@
 import { ApiProxy } from '@kinvolk/headlamp-plugin/lib';
 
 const request = ApiProxy.request;
+const getHeadlampAPIHeaders = () => ({
+  'X-HEADLAMP_BACKEND-TOKEN': new URLSearchParams(window.location.search).get('backendToken'),
+});
 
 export function listReleases() {
   return request('/helm/releases/list', {
     method: 'GET',
+    headers: { ...getHeadlampAPIHeaders() },
   });
 }
 
 export function getRelease(namespace: string, releaseName: string) {
   return request(`/helm/releases?name=${releaseName}&namespace=${namespace}`, {
     method: 'GET',
+    headers: { ...getHeadlampAPIHeaders() },
   });
 }
 
 export function getReleaseHistory(namespace: string, releaseName: string) {
   return request(`/helm/release/history?name=${releaseName}&namespace=${namespace}`, {
     method: 'GET',
+    headers: { ...getHeadlampAPIHeaders() },
   });
 }
 
 export function deleteRelease(namespace: string, releaseName: string) {
   return request(`/helm/releases/uninstall?name=${releaseName}&namespace=${namespace}`, {
     method: 'DELETE',
+    headers: { ...getHeadlampAPIHeaders() },
   });
 }
 
 export function rollbackRelease(namespace: string, releaseName: string, version: string) {
   return request(`/helm/releases/rollback?name=${releaseName}&namespace=${namespace}`, {
     method: 'PUT',
+    headers: { ...getHeadlampAPIHeaders() },
     body: JSON.stringify({
       name: releaseName,
       namespace: namespace,
@@ -46,6 +54,7 @@ export function createRelease(
 ) {
   return request(`/helm/release/install?namespace=${namespace}`, {
     method: 'POST',
+    headers: { ...getHeadlampAPIHeaders() },
     body: JSON.stringify({
       name,
       namespace,
@@ -59,6 +68,7 @@ export function createRelease(
 export function getActionStatus(name: string, action: string) {
   return request(`/helm/action/status?name=${name}&action=${action}`, {
     method: 'GET',
+    headers: { ...getHeadlampAPIHeaders() },
   });
 }
 
@@ -72,6 +82,7 @@ export function upgradeRelease(
 ) {
   return request(`/helm/releases/upgrade?name=${name}&namespace=${namespace}`, {
     method: 'PUT',
+    headers: { ...getHeadlampAPIHeaders() },
     body: JSON.stringify({
       name,
       namespace,
@@ -86,5 +97,6 @@ export function upgradeRelease(
 export function fetchChart(name: string) {
   return request(`/helm/charts?filter=${name}`, {
     method: 'GET',
+    headers: { ...getHeadlampAPIHeaders() },
   });
 }


### PR DESCRIPTION
We have recently restricted some backend endpoints to the use of a
token generated by the app, so this plugin was failing since it needed
to use it.
