### PR TITLE
prometheus: Handle Non JSON errors in response

### DIFF
--- a/prometheus/src/chart.tsx
+++ b/prometheus/src/chart.tsx
@@ -65,7 +65,8 @@ export function Chart(props: ChartProps) {
           step: 2,
         });
       } catch (e) {
-        setError(e);
+        fetchedMetrics[plot.name] = { data: [], state: ChartState.ERROR };
+        setError(e.message);
         setState(ChartState.ERROR);
         break;
       }

--- a/prometheus/src/request.tsx
+++ b/prometheus/src/request.tsx
@@ -16,13 +16,24 @@ export async function isPrometheusInstalled() {
   return [false, null, null];
 }
 
-export function fetchMetrics(data: {
+/**
+ * Fetches metrics data from Prometheus using the provided parameters.
+ * @param {object} data - The parameters for fetching metrics.
+ * @param {string} data.prefix - The namespace prefix.
+ * @param {string} data.query - The Prometheus query string.
+ * @param {number} data.from - The start time for the query (Unix timestamp).
+ * @param {number} data.to - The end time for the query (Unix timestamp).
+ * @param {number} data.step - The step size for the query (in seconds).
+ * @returns {Promise<object>} - A promise that resolves to the fetched metrics data.
+ * @throws {Error} - Throws an error if the request fails.
+ */
+export async function fetchMetrics(data: {
   prefix: string;
   query: string;
   from: number;
   to: number;
   step: number;
-}) {
+}): Promise<object> {
   const params = new URLSearchParams();
   if (data.from) {
     params.append('start', data.from.toString());
@@ -37,10 +48,17 @@ export function fetchMetrics(data: {
     params.append('query', data.query);
   }
 
-  return request(
+  const response = await request(
     `/api/v1/namespaces/${data.prefix}/proxy/api/v1/query_range?${params.toString()}`,
     {
       method: 'GET',
+      isJSON: false,
     }
   );
+  if (response.status === 200) {
+    return response.json();
+  } else {
+    const error = new Error(response.statusText);
+    return Promise.reject(error);
+  }
 }


### PR DESCRIPTION
this patch handles the Non JSON errors that
are thrown by the k8s proxy when the pod isn't
in Ready state.