### PR TITLE
app-catalog: Fix vite crash by using named import for monaco editor

### DIFF
--- a/app-catalog/src/components/charts/EditorDialog.tsx
+++ b/app-catalog/src/components/charts/EditorDialog.tsx
@@ -1,6 +1,6 @@
 import { K8s } from '@kinvolk/headlamp-plugin/lib';
 import { Dialog, Loader } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
-import MonacoEditor from '@monaco-editor/react';
+import { Editor } from '@monaco-editor/react';
 import { Box, Button, DialogActions, DialogContent, DialogTitle, TextField } from '@mui/material';
 import { Autocomplete } from '@mui/material';
 import _ from 'lodash';
@@ -283,7 +283,7 @@ export function EditorDialog(props: {
           {chartValuesLoading ? (
             <Loader title="" />
           ) : (
-            <MonacoEditor
+            <Editor
               value={chartValues}
               onChange={value => {
                 if (!value) {

--- a/app-catalog/src/components/releases/EditorDialog.tsx
+++ b/app-catalog/src/components/releases/EditorDialog.tsx
@@ -1,5 +1,5 @@
 import { Dialog } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
-import MonacoEditor from '@monaco-editor/react';
+import { Editor } from '@monaco-editor/react';
 import {
   Box,
   Button,
@@ -262,7 +262,7 @@ export function EditorDialog(props: {
       <DialogContent>
         <Box pt={2} height="100%" my={1} p={1}>
           {openEditor && (
-            <MonacoEditor
+            <Editor
               value={jsonToYAML(valuesToShow)}
               language="yaml"
               height="400px"


### PR DESCRIPTION
**TLDR**: This is a quick fix for the app-catalog plugin crash with vite frontend
This will work with both webpack and vite

**Explanation:**

On the app side we expose `window.pluginLib` variable that contains modules that plugins can use without having to bundle it in the plugins. 
When plugins try to import (for example monaco editor) `import Editor from '@monaco-editor/react'` gets replaced by `const Editor = window.pluginLib.ReactMonacoEditor` in plugins built by vite  or `const Editor = webpack_require(window.pluginLib.ReactMonacoEditor)"` in plugins built by webpack (very simplified)

When frontend and plugins are built with webpack the monaco editor module will have a special "__esModule" field that will then be recognized by `webpack_require` function on the plugin side. But vite doesn't have this non-standard behavior and by default the `Editor` will contain full module instead of a default export. 

A simple solution on the plugin side is not to use default imports of modules that are bundled in `window.pluginLib`, thankfully we don't have a lot of them with default exports. I'm not sure how to properly do default import in plugins though, I will investigate further