### PR TITLE
app-catalog: Rollback #47. Use default export of the monaco-editor

### DIFF
--- a/app-catalog/src/components/charts/EditorDialog.tsx
+++ b/app-catalog/src/components/charts/EditorDialog.tsx
@@ -1,6 +1,6 @@
 import { K8s } from '@kinvolk/headlamp-plugin/lib';
 import { Dialog, Loader } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
-import { Editor } from '@monaco-editor/react';
+import Editor from '@monaco-editor/react';
 import { Box, Button, DialogActions, DialogContent, DialogTitle, TextField } from '@mui/material';
 import { Autocomplete } from '@mui/material';
 import _ from 'lodash';

--- a/app-catalog/src/components/releases/EditorDialog.tsx
+++ b/app-catalog/src/components/releases/EditorDialog.tsx
@@ -1,5 +1,5 @@
 import { Dialog } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
-import { Editor } from '@monaco-editor/react';
+import Editor from '@monaco-editor/react';
 import {
   Box,
   Button,


### PR DESCRIPTION
This rollbacks #47 

Apparently when building frontend with webpack, the named export 'Editor' is missing for whatever reason.
This rollbacks to just using default export since it now works on main (with vite)

- [x] Tested that it works on 0.24.1
- [x] Tested that it works on main