### PR TITLE
app-catalog: Use the getHeadlampAPIHeaders from headlamp-plugin/lib

### DIFF
--- a/app-catalog/src/api/releases.tsx
+++ b/app-catalog/src/api/releases.tsx
@@ -1,9 +1,6 @@
-import { ApiProxy } from '@kinvolk/headlamp-plugin/lib';
+import { ApiProxy, getHeadlampAPIHeaders } from '@kinvolk/headlamp-plugin/lib';
 
 const request = ApiProxy.request;
-export const getHeadlampAPIHeaders = () => ({
-  'X-HEADLAMP_BACKEND-TOKEN': new URLSearchParams(window.location.search).get('backendToken'),
-});
 
 export function listReleases() {
   return request('/helm/releases/list', {

--- a/app-catalog/src/api/repository.tsx
+++ b/app-catalog/src/api/repository.tsx
@@ -1,5 +1,4 @@
-import { ApiProxy } from '@kinvolk/headlamp-plugin/lib';
-import { getHeadlampAPIHeaders } from './releases';
+import { ApiProxy, getHeadlampAPIHeaders } from '@kinvolk/headlamp-plugin/lib';
 
 const request = ApiProxy.request;
 


### PR DESCRIPTION
Instead of relying on the URL search params.