### PR TITLE
app-catalog: Remove unused props

### DIFF
--- a/app-catalog/src/components/charts/List.tsx
+++ b/app-catalog/src/components/charts/List.tsx
@@ -75,10 +75,6 @@ export function ChartsList({ fetchCharts = fetchChartsFromArtifact }) {
 
       store.set({ showOnlyVerified: showOnlyVerified });
 
-      if (props.showOnlyVerified!!) {
-        store.set({ showOnlyVerified: props.showOnlyVerified });
-      }
-
       async function fetchData() {
         try {
           const response: any = await fetchCharts(search, showOnlyVerified, chartCategory, page);


### PR DESCRIPTION
This change removes a reference to undefined props which is causing the app-catalog to crash.

Fixes: #92 

### Testing
- [X] Open the app catalog within Headlamp on the main branch and note the crash:

![image](https://github.com/user-attachments/assets/f8454d72-a3b3-404d-937e-1888aaa31881)

- [X] Open the app catalog within Headlamp on the fix-broken-charts branch and ensure it doesn't crash:

![image](https://github.com/user-attachments/assets/0d242744-2ea4-40e1-9173-43819b4d477c)