### PR TITLE
plugin-catalog: Replace "Activate Now" by "Reload Now"

### DIFF
--- a/plugin-catalog/src/components/plugins/Detail.tsx
+++ b/plugin-catalog/src/components/plugins/Detail.tsx
@@ -126,7 +126,7 @@ const pluginSnackbarAction = (closeCallback: () => void) => {
           window.location.reload();
         }}
       >
-        Activate Now
+        Reload Now
       </Button>
       <Button onClick={closeCallback}>Close</Button>
     </>


### PR DESCRIPTION
This is also shown when the plugin is removed.