### PR TITLE
app-catalog: Allow dialog to display chart version

### DIFF
--- a/app-catalog/src/components/charts/EditorDialog.tsx
+++ b/app-catalog/src/components/charts/EditorDialog.tsx
@@ -55,7 +55,7 @@ export function EditorDialog(props: {
 
   function handleChartValueFetch(chart: any) {
     const packageID = chart.package_id;
-    const packageVersion = selectedVersion.value;
+    const packageVersion = selectedVersion?.value ?? chart.version;
     setChartValuesLoading(true);
     fetchChartValues(packageID, packageVersion)
       .then((response: any) => {


### PR DESCRIPTION
This change fixes a regression caused by #94 where the app-catalog would crash on the install dialog. We now allow the dialog to display the chart version in the case where the selectedVersion is not initialized.

### Testing
- [X] Build and start the app-catalog plugin in one terminal
- [X] Start the Headlamp dev app in another terminal
- [X] Try to install an app in the catalog
- [X] Ensure the install dialog does not crash and displays default values in the fields