### PR TITLE
plugin-catalog: Rework installed list to include all plugins

### DIFF
--- a/plugin-catalog/src/components/plugins/InstalledList.stories.tsx
+++ b/plugin-catalog/src/components/plugins/InstalledList.stories.tsx
@@ -31,6 +31,7 @@ const Template: StoryFn<PurePluginInstalledListProps> = args => (
 
 const samplePlugins = [
   {
+    artifacthub: 'abcde1',
     pluginName: 'plugin1',
     pluginTitle: 'Plugin 1',
     pluginVersion: '1.0.0',
@@ -39,6 +40,7 @@ const samplePlugins = [
     author: 'Author 1',
   },
   {
+    artifacthub: 'abcde2',
     pluginName: 'plugin2',
     pluginTitle: 'Plugin 2',
     pluginVersion: '1.2.0',
@@ -57,6 +59,13 @@ Default.args = {
 export const WithError = Template.bind({});
 WithError.args = {
   installedPlugins: null,
+  error: 'Failed to load plugins.',
+};
+
+export const WithRepeatedPlugins = Template.bind({});
+WithRepeatedPlugins.args = {
+  installedPlugins: samplePlugins,
+  otherInstalledPlugins: [samplePlugins[1]],
   error: 'Failed to load plugins.',
 };
 


### PR DESCRIPTION
## Description

Solves Issue: [#2586](https://github.com/headlamp-k8s/headlamp/issues/2586)

This PR addresses the issue observed during our ContribuFest at KubeCon, where users expressed confusion about the `Installed` view in the Plugin Catalog. Specifically, users were expecting to find their development plugins in the `Installed` view, but only plugins installed via the Plugin Catalog were listed. 

To resolve this, this PR proposes the following updates:

- **Unified Installed View**: The `Installed` view in the Plugin Catalog will now display all installed plugins, regardless of their installation source.
- **Categorization**:
  - Plugins installed via the Plugin Catalog will appear under a section titled `Installed from the Plugin Catalog`.
  - Plugins installed from other sources will appear under a section titled `Other Installed Plugins`.
- **Link to Plugin Details**: Each plugin entry will include a link to its respective details/settings page to provide more information and configuration options.

These changes aim to improve user experience by consolidating plugin information in one view while maintaining clarity about their source and functionality.

---
## Image
![image](https://github.com/user-attachments/assets/4442ab09-e276-46ba-964f-d3d0819c1081)

---

## Changes Made

1. Updated the Plugin Catalog `Installed` view to:
   - Display all plugins (both catalog-installed and non catalog-installed).
   - Categorize plugins into `Installed from the Plugin Catalog` and `Other Installed Plugins`.
2. Added links to plugin details/settings for each listed plugin.

---

## Steps to Test

1. Open the Plugin Catalog in the Headlamp application.
2. Install a plugin via the Plugin Catalog.
3. Add a plugin manually to simulate a non-catalog installation.
4. Navigate to the `Installed` view and confirm:
   - Plugins are categorized under `Installed from the Plugin Catalog` or `Other Plugins`.
   - Each plugin has a working link to its details/settings page.

---

## Notes

- Plugins listed under `Other Plugins` will not include uninstall functionality if they were not installed via the Plugin Catalog.
