### PR TITLE
Improve Prometheus detection

### DIFF
--- a/prometheus/src/request.tsx
+++ b/prometheus/src/request.tsx
@@ -2,19 +2,247 @@ import { ApiProxy } from '@kinvolk/headlamp-plugin/lib';
 
 const request = ApiProxy.request;
 
-export async function isPrometheusInstalled() {
-  const queryParams = new URLSearchParams();
-  queryParams.append('labelSelector', 'app.kubernetes.io/name=prometheus');
+const CUSTOM_HEADLAMP_LABEL = 'headlamp-prometheus=true';
+const COMMON_PROMETHEUS_POD_LABEL = 'app.kubernetes.io/name=prometheus';
+const COMMON_PROMETHEUS_SERVICE_LABEL = 'app.kubernetes.io/name=prometheus,app.kubernetes.io/component=server';
+const DEFAULT_PROMETHEUS_PORT = '9090';
 
-  const response = await request(`/api/v1/pods?${queryParams.toString()}`, {
+export type KubernetesPodListResponseItem = {
+  metadata: {
+    name: string;
+    namespace: string;
+  };
+  spec: {
+    containers: [
+      {
+        name: string;
+        image: string;
+        ports: [
+          {
+            name: string;
+            containerPort: number;
+            protocol: string;
+          }
+        ];
+      }
+    ];
+  };
+};
+
+export type KubernetesPodListResponse = {
+  kind: 'PodList';
+  items: KubernetesPodListResponseItem[];
+};
+
+export type KubernetesServiceListResponseItem = {
+  metadata: {
+    name: string;
+    namespace: string;
+  };
+  spec: {
+    ports: [
+      {
+        name: string;
+        port: number;
+        protocol: string;
+      }
+    ];
+  };
+};
+
+export type KubernetesServiceListResponse = {
+  kind: 'ServiceList';
+  items: KubernetesServiceListResponseItem[];
+};
+
+export type KubernetesSearchResponse = KubernetesPodListResponse | KubernetesServiceListResponse;
+
+export enum KubernetesType {
+  none = 'none',
+  pods   = 'pods',
+  services = 'services',
+};
+
+export type PrometheusEndpoint = {
+  type: KubernetesType;
+  name: string | undefined;
+  namespace: string | undefined;
+  port: string | undefined;
+};
+
+/**
+ * Factory to create a new instance of PrometheusEndpoint.
+ * @param {KubernetesType} type - The type of Kubernetes resource.
+ * @param {string} name - The name of the Kubernetes resource.
+ * @param {string} namespace - The namespace of the Kubernetes resource.
+ * @param {string} port - The port of the Kubernetes resource.
+ * @returns {PrometheusEndpoint} - A new instance of PrometheusEndpoint.
+ */
+export function createPrometheusEndpoint(
+  type: KubernetesType = KubernetesType.none,
+  name: string | undefined = undefined,
+  namespace: string | undefined = undefined,
+  port: string | undefined = undefined
+): PrometheusEndpoint {
+  return {
+    type,
+    name,
+    namespace,
+    port
+  };
+}
+
+/**
+ * Returns the first Prometheus pod or service that fits our search and is reachable.
+ * @returns {Promise<PrometheusEndpoint>} - A promise that resolves to the first reachable Prometheus pod/service or none if none are reachable.
+ */
+export async function isPrometheusInstalled(): Promise<PrometheusEndpoint> {
+  // Search by a specific label for a pod
+  const podSearchSpecificResponse = await searchKubernetesByLabel(KubernetesType.pods, CUSTOM_HEADLAMP_LABEL);
+  if (podSearchSpecificResponse.type !== KubernetesType.none) {
+    return podSearchSpecificResponse;
+  }
+
+  // Search by a specific label for a service
+  const serviceSearchSpecificResponse = await searchKubernetesByLabel(KubernetesType.services, CUSTOM_HEADLAMP_LABEL);
+  if (serviceSearchSpecificResponse.type !== KubernetesType.none) {
+    return serviceSearchSpecificResponse;
+  }
+
+  // Search by common label for a pod
+  const podSearchResponse = await searchKubernetesByLabel(KubernetesType.pods, COMMON_PROMETHEUS_POD_LABEL);
+  if (podSearchResponse.type !== KubernetesType.none) {
+    return podSearchResponse;
+  }
+
+  // Search by common label for a service
+  const serviceSearchResponse = await searchKubernetesByLabel(KubernetesType.services, COMMON_PROMETHEUS_SERVICE_LABEL);
+  if (serviceSearchResponse.type !== KubernetesType.none) {
+    return serviceSearchResponse;
+  }
+
+  // No Prometheus pod or service found
+  return createPrometheusEndpoint();
+}
+
+async function searchKubernetesByLabel(
+  kubernetesType: KubernetesType,
+  labelSelector: string
+): Promise<PrometheusEndpoint> {
+  if (kubernetesType === KubernetesType.none) {
+    return createPrometheusEndpoint();
+  }
+
+  const queryParams = new URLSearchParams();
+  queryParams.append('labelSelector', labelSelector);
+
+  const searchResponse = await request(`/api/v1/${kubernetesType}?${queryParams}`, {
     method: 'GET',
   });
 
-  if (response.items && response.items.length > 0) {
-    return [true, response.items[0].metadata.name, response.items[0].metadata.namespace];
+  if (!searchResponse?.kind || ['PodList', 'ServiceList'].indexOf(searchResponse.kind) === -1) {
+    return createPrometheusEndpoint();
   }
-  return [false, null, null];
+
+  const searchResponseTyped = searchResponse as KubernetesSearchResponse;
+
+  if (searchResponseTyped.items?.length > 0) {
+    const metadata = searchResponseTyped.items[0].metadata;
+    if (!metadata) {
+      return createPrometheusEndpoint();
+    }
+
+    const prometheusName = metadata.name;
+    const prometheusNamespace = metadata.namespace;
+    const prometheusPorts = getPrometheusPortsFromResponse(searchResponseTyped);
+    
+    const testResults = await Promise.all(
+      prometheusPorts.map(async (prometheusPort) => {
+        const testSuccess = await testPrometheusQuery(kubernetesType, prometheusName, prometheusNamespace, prometheusPort);
+        return {
+          prometheusPort,
+          testSuccess
+        };
+      })
+    );
+
+    for (const result of testResults) {
+      if (result.testSuccess) {
+        return createPrometheusEndpoint(kubernetesType, prometheusName, prometheusNamespace, result.prometheusPort);
+      }
+    }
+  }
+
+  return createPrometheusEndpoint();
 }
+
+/**
+ * Gets the Prometheus service port from the response.
+ * @param response - A PodList or ServiceList response.
+ * @returns {string[]} - The Prometheus service ports.
+ */
+function getPrometheusPortsFromResponse(response: KubernetesSearchResponse): string[] {
+  const ports: string[] = [];
+  if (response.kind === 'PodList') {
+    // Pod response
+    for (const item of response.items) {
+      for (const container of item.spec.containers) {
+        for (const port of container.ports) {
+          if (port.protocol === 'TCP') {
+            ports.push(String(port.containerPort));
+          }
+        }
+      }
+    }
+  } else if (response.kind === 'ServiceList') {
+    // Service response
+    for (const item of response.items) {
+      for (const port of item.spec.ports) {
+        if (port.protocol === 'TCP') {
+          ports.push(String(port.port));
+        }
+      }
+    }
+  }
+
+  if (ports.length === 0) {
+    // Add the default Prometheus port if no ports are found
+    ports.push(DEFAULT_PROMETHEUS_PORT);
+  }
+
+  return ports;
+}
+
+/**
+ * Tests if prometheus will respond to a query.
+ * @param {string} prometheusPodName - The name of the Prometheus pod.
+ * @param {string} prometheusPodNamespace - The namespace of the Prometheus pod.
+ * @param {string} prometheusPodPort - The port of the Prometheus pod.
+ */
+async function testPrometheusQuery(
+  kubernetesType: KubernetesType,
+  prometheusPodName: string,
+  prometheusPodNamespace: string,
+  prometheusPodPort: string
+): Promise<boolean> {
+  const queryParams = new URLSearchParams();
+  queryParams.append('query', 'up');
+  const start = Math.floor(Date.now() / 1000);
+  const testSuccess = await fetchMetrics({
+    prefix: `${prometheusPodNamespace}/${kubernetesType}/${prometheusPodName}${prometheusPodPort ? `:${prometheusPodPort}` : ''}`,
+    query: 'up',
+    from: start - 86400,
+    to: start,
+    step: 300,
+  }).then(() => {
+    return true;
+  }).catch(() => {
+    return false;
+  });
+
+  return testSuccess;
+}
+
 
 /**
  * Fetches metrics data from Prometheus using the provided parameters.

--- a/prometheus/src/util.ts
+++ b/prometheus/src/util.ts
@@ -1,5 +1,5 @@
 import { ConfigStore } from '@kinvolk/headlamp-plugin/lib';
-import { isPrometheusInstalled } from './request';
+import { isPrometheusInstalled, KubernetesType } from './request';
 
 export const PLUGIN_NAME = 'prometheus';
 
@@ -101,13 +101,14 @@ export async function getPrometheusPrefix(cluster: string): Promise<string | nul
   // if so return the prometheus pod address
   const clusterData = getClusterConfig(cluster);
   if (clusterData?.autoDetect) {
-    const [isInstalled, prometheusPodName, prometheusPodNamespace] = await isPrometheusInstalled();
-    if (isInstalled) {
-      return `${prometheusPodNamespace}/pods/${prometheusPodName}`;
-    } else {
+    const prometheusEndpoint = await isPrometheusInstalled();
+    if (prometheusEndpoint.type === KubernetesType.none) {
       return null;
     }
+    const prometheusPortStr = prometheusEndpoint.port ? (':' + prometheusEndpoint.port) : '';
+    return `${prometheusEndpoint.namespace}/${prometheusEndpoint.type}/${prometheusEndpoint.name}${prometheusPortStr}`;
   }
+
   if (clusterData?.address) {
     const [namespace, service] = clusterData?.address.split('/');
     return `${namespace}/services/${service}`;

--- a/prometheus/src/util.ts
+++ b/prometheus/src/util.ts
@@ -105,7 +105,7 @@ export async function getPrometheusPrefix(cluster: string): Promise<string | nul
     if (prometheusEndpoint.type === KubernetesType.none) {
       return null;
     }
-    const prometheusPortStr = prometheusEndpoint.port ? (':' + prometheusEndpoint.port) : '';
+    const prometheusPortStr = prometheusEndpoint.port ? `:${prometheusEndpoint.port}` : '';
     return `${prometheusEndpoint.namespace}/${prometheusEndpoint.type}/${prometheusEndpoint.name}${prometheusPortStr}`;
   }
 


### PR DESCRIPTION
The Prometheus plugin's auto-detection wasn't working for me because the port wasn't being included in the queries. Manually specifying the service did work but I don't want to re-enter that in all my various browsers. Having it 'just work' is better.

This improves Prometheus detection by searching through pods and services, testing the open ports with an 'up' query, and selecting the first working instance (similar to how it currently works in main). It also adds a custom label (`headlamp-prometheus=true`) which allows marking a pod or service as the one that this plugin should be using for the case where multiple Prometheus instances are available; this case is outside of my usage, but I'm confident that it will work.

I'm currently running this in my personal cluster without issue.

Let me know if anything in this PR needs modification and I'd be happy to accommodate.