### PR TITLE
Fixes for app catalog

### DIFF
--- a/app-catalog/package-lock.json
+++ b/app-catalog/package-lock.json
@@ -13,7 +13,8 @@
         "js-yaml": "^4.1.0",
         "react-markdown": "^8.0.7",
         "react-syntax-highlighter": "^15.5.0",
-        "remark-gfm": "^3.0.1"
+        "remark-gfm": "^3.0.1",
+        "semver": "^7.6.3"
       },
       "devDependencies": {
         "@kinvolk/headlamp-plugin": "0.9.2"
@@ -36650,13 +36651,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -36668,24 +36665,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
       "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
-      "dev": true
-    },
-    "node_modules/semver/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semver/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
     "node_modules/send": {
@@ -67853,30 +67832,9 @@
       }
     },
     "semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "requires": {
-        "lru-cache": "^6.0.0"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true
-        }
-      }
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A=="
     },
     "semver-compare": {
       "version": "1.0.0",

--- a/app-catalog/package.json
+++ b/app-catalog/package.json
@@ -38,6 +38,7 @@
     "js-yaml": "^4.1.0",
     "react-markdown": "^8.0.7",
     "react-syntax-highlighter": "^15.5.0",
-    "remark-gfm": "^3.0.1"
+    "remark-gfm": "^3.0.1",
+    "semver": "^7.6.3"
   }
 }

--- a/app-catalog/src/components/charts/EditorDialog.tsx
+++ b/app-catalog/src/components/charts/EditorDialog.tsx
@@ -76,10 +76,9 @@ export function EditorDialog(props: {
     setChartInstallDescription(`${chart.name} deployment`);
     fetchChartDetailFromArtifact(chart.name, chart.repository.name).then(response => {
       if (response.available_versions) {
-        setVersions(
-          response.available_versions.map(({ version }) => ({ title: version, value: version }))
-        );
-        setSelectedVersion(response.available_versions[0].version);
+        const availableVersions = response.available_versions.map(({ version }) => ({ title: version, value: version }));
+        setVersions(availableVersions);
+        setSelectedVersion(availableVersions[0]);
       }
     });
     handleChartValueFetch(chart);
@@ -259,7 +258,7 @@ export function EditorDialog(props: {
                 }}
                 options={versions}
                 getOptionLabel={(option: any) => option.title ?? option}
-                value={selectedVersion}
+                value={selectedVersion ?? versions[0]}
                 // @ts-ignore
                 onChange={(event, newValue: FieldType) => {
                   setSelectedVersion(newValue);

--- a/app-catalog/src/components/charts/EditorDialog.tsx
+++ b/app-catalog/src/components/charts/EditorDialog.tsx
@@ -305,7 +305,6 @@ export function EditorDialog(props: {
               onMount={editor => {
                 setInstallLoading(false);
                 editor.focus();
-                setReleaseName('');
               }}
               language="yaml"
               height="500px"

--- a/app-catalog/src/components/charts/List.tsx
+++ b/app-catalog/src/components/charts/List.tsx
@@ -118,12 +118,17 @@ export function ChartsList({ fetchCharts = fetchChartsFromArtifact }) {
           width: '20vw',
         }}
         options={helmChartCategoryList}
-        getOptionLabel={option => option.title}
+        getOptionLabel={option => option?.title ?? helmChartCategoryList[0].title}
         defaultValue={helmChartCategoryList[0]}
         value={chartCategory}
         onChange={(event, newValue) => {
           // @ts-ignore
-          setChartCategory(newValue);
+          setChartCategory((oldValue) => {
+            if ((newValue?.value ?? helmChartCategoryList[0].value) === oldValue.value) {
+              return oldValue;
+            }
+            return newValue ?? helmChartCategoryList[0];
+          });
         }}
         renderInput={params => {
           if (process.env.NODE_ENV === 'test') {


### PR DESCRIPTION
fixes https://github.com/headlamp-k8s/headlamp/issues/2618

## Steps to reproduce:
1. Try to install any chart -> now it works

## Test other fixes in this PR

### Do not crash when clearing the categories
1. Open the app-catalog and click the X next to the All category -> no crash, the All word goes away but the apps are still there

### Editor dialog setting the release name on version change
1. Click Install on a chart, then type a release name
2. Change the version
3. Realize that the values editor was reloaded but the release name is the same

### Update editor UX: spinner
1. Go to an installed version and click Update
2. Verify that a spinner is shown until the versions are fetched

### Update editor UX: insensitive update button
1. Go to an installed version and click Update
2. When the versions are loading -> the Update button is disabled

### Update editor UX: versions' sorting
1. Go to an installed version and click Update
2. After the versions are loaded -> check that the versions are shown with the most recent at the top
