### PR TITLE
plugin-catalog: Add update available label to card

### DIFF
--- a/plugin-catalog/src/components/plugins/PluginCard.tsx
+++ b/plugin-catalog/src/components/plugins/PluginCard.tsx
@@ -151,7 +151,9 @@ export function PluginCard(props: PluginCardProps) {
           }}
         >
           <span></span>
-          {plugin.isInstalled && <Typography>Installed</Typography>}
+          {plugin.isInstalled && (
+            <Typography>{plugin.isUpdateAvailable ? 'Update available' : 'Installed'}</Typography>
+          )}
         </CardActions>
       </Card>
     </Box>


### PR DESCRIPTION
This change adds a label in the card for plugins with available updates. The "Installed" label now gets replaced with "Update available" in this case.

Fixes: #138 

### Testing
- [X] Open Headlamp and navigate to the plugin catalog
- [X] For any plugins with updates, ensure that the card displays the "Update available" label

![image](https://github.com/user-attachments/assets/5d80ddfb-26b6-47f6-9d19-0e521ccee026)