### PR TITLE
flux: sort events on timestamp

### DIFF
--- a/flux/src/helpers/index.tsx
+++ b/flux/src/helpers/index.tsx
@@ -110,18 +110,13 @@ export function ObjectEvents(props: { events: any }) {
             muiTableBodyCellProps: {
               align: 'right',
             },
-            sortingFn: (rowA, rowB) => {
-              return (
-                new Date(rowB.lastTimestamp).getTime() - new Date(rowA.lastTimestamp).getTime()
-              );
-            },
           },
         ]}
         data={events}
         initialState={{
           sorting: [
             {
-              id: 'Age',
+              id: 'age',
               desc: false,
             },
           ],


### PR DESCRIPTION
Users are normally interested in the most recent events. Events should therefore be sorted on timestamp with the newest event on top. 