### PR TITLE
cert-manager: Add artifacthub package

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is a repository of official plugins that Headlamp uses or recommends.
 | [opencost](./opencost)             | See the costs of your workloads in Headlamp.                                 |
 | [plugin-catalog](./plugin-catalog) | Install Headlamp plugins with one click.                                     | Shipped with Headlmp desktop builds by default.                                                                             |
 | [prometheus](./prometheus)         | Provides a Prometheus powered chart in the details views of workloads.       | Needs Prometheus installed in the cluster for the chart to be shown. Shipped with Headlmp desktop and CI builds by default. |
-
+| [cert-manager](./cert-manager)     | A UI for viewing and managing cert-manager.                                  | 
 ## Development
 
 For examples of plugins created for learning and documentation purposes, please refer to the [examples folder](https://github.com/headlamp-k8s/headlamp/tree/main/plugins#plugins) in Headlamp's repository.

--- a/cert-manager/artifacthub-pkg.yml
+++ b/cert-manager/artifacthub-pkg.yml
@@ -1,0 +1,11 @@
+version: 0.1.0
+name: headlamp_cert-manager
+displayName: cert-manager
+createdAt: "2025-02-21T05:35:50Z"
+logoURL: "https://raw.githubusercontent.com/cert-manager/cert-manager/refs/heads/master/logo/logo.png"
+description: A UI for viewing and managing cert-manager.
+annotations:
+  headlamp/plugin/archive-url: "https://github.com/headlamp-k8s/plugins/releases/download/cert-manager-0.1.0/headlamp-k8s-cert-manager-0.1.0.tar.gz"
+  headlamp/plugin/archive-checksum: "SHA256:87acdab62a7e36c9826fdfc6169048245af0d026d4af3e2b759b15a7baa42580"
+  headlamp/plugin/version-compat: ">=0.22"
+  headlamp/plugin/distro-compat: "in-cluster,web,docker-desktop,desktop"


### PR DESCRIPTION
this patch adds the artifacthub package for the cert-manager plugin