### PR TITLE
github: Add workflow to draft plugin releases

### DIFF
--- a/.github/workflows/plugin-draft-release.yml
+++ b/.github/workflows/plugin-draft-release.yml
@@ -1,0 +1,68 @@
+name: Create plugin release draft
+
+on:
+  workflow_dispatch:
+    inputs:
+      plugin:
+        description: 'The plugin name (e.g., flux)'
+        required: true
+        type: string
+      version:
+        description: 'The plugin version (e.g., 0.1.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # 4.1.7
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
+        with:
+          node-version: '20'
+      
+      - name: Build plugin tarball
+        id: build_tarball
+        run: |
+          PLUGIN="${{ github.event.inputs.plugin }}"
+          cd $PLUGIN
+          npm install
+          npm run build
+          OUTPUT=$(npx @kinvolk/headlamp-plugin package | tail -n2)
+          TARBALL=$(echo "$OUTPUT" | head -n1 | sed -E 's/Created tarball: "([^"]+)".*/\1/')
+          CHECKSUM=$(echo "$OUTPUT" | tail -n1 | sed -E 's/Tarball checksum \(sha256\): (.*)/\1/')
+          echo "tarball_path=$TARBALL" >> $GITHUB_ENV
+          echo "checksum=$CHECKSUM" >> $GITHUB_ENV
+
+      - name: Create release draft and push tarball
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
+        with:
+          draft: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: "${{ github.event.inputs.plugin }} ${{ github.event.inputs.version }}"
+          body: Draft release for ${{ github.event.inputs.plugin }} version ${{ github.event.inputs.version }}
+          files: ${{ steps.build_tarball.outputs.tarball_path }}
+        env:
+          GITHUB_TOKEN: ${{ github.repository }}
+
+      - name: Update ArtifactHub pkg file
+        env:
+          PLUGIN: ${{ github.event.inputs.plugin }}
+          VERSION: ${{ github.event.inputs.version }}
+          TAR_PATH: ${{ steps.build_tarball.outputs.tarball_path }}
+          CHECKSUM: ${{ steps.build_tarball.outputs.checksum }}
+        run: |
+          PKG_FILE="${PLUGIN}/artifacthub-pkg.yml"
+          TAR_URL="https://github.com/headlamp-k8s/plugins/releases/download/${PLUGIN}-${VERSION}/$(basename $TAR_PATH)"
+          sed -i "s|^\(headlamp/plugin/archive-url:\).*|\1 \"$TAR_URL\"|g" "$PKG_FILE"
+          sed -i "s|^\(headlamp/plugin/archive-checksum:\).*|\1 \"SHA256:$CHECKSUM\"|g" "$PKG_FILE"
+
+          echo "ArtifactHub pkg file updated. Please review the changes below and commit manually:"
+          git diff "$PKG_FILE"
+


### PR DESCRIPTION
This change adds a workflow for plugins which accomplishes the following:
- [X] Builds the plugin tarball
- [X] Creates a draft release and pushes the tarball to it
- [X] Updates the ArtifactHub pkg file for the plugin

The workflow requires two inputs:
- The plugin name (e.g., flux)
- The plugin version (e.g., 0.1.0)