### PR TITLE
prometheus: fix doubled memory usage

### DIFF
--- a/prometheus/src/index.tsx
+++ b/prometheus/src/index.tsx
@@ -16,7 +16,7 @@ function PrometheusMetrics(resource: DetailsViewSectionProps) {
     return (
       <GenericMetricsChart
         cpuQuery={`sum(rate(container_cpu_usage_seconds_total{container!='',namespace='${resource.jsonData.metadata.namespace}',pod='${resource.jsonData.metadata.name}'}[1m])) by (pod,namespace)`}
-        memoryQuery={`sum(container_memory_working_set_bytes{namespace='${resource.jsonData.metadata.namespace}',pod=~'${resource.jsonData.metadata.name}'}) by (pod,namespace)`}
+        memoryQuery={`sum(container_memory_working_set_bytes{container!='',namespace='${resource.jsonData.metadata.namespace}',pod=~'${resource.jsonData.metadata.name}'}) by (pod,namespace)`}
         networkRxQuery={`sum(rate(container_network_receive_bytes_total{namespace='${resource.jsonData.metadata.namespace}',pod='${resource.jsonData.metadata.name}'}[1m])) by (pod,namespace)`}
         networkTxQuery={`sum(rate(container_network_transmit_bytes_total{namespace='${resource.jsonData.metadata.namespace}',pod='${resource.jsonData.metadata.name}'}[1m])) by (pod,namespace)`}
         filesystemReadQuery={`sum(rate(container_fs_reads_bytes_total{namespace='${resource.jsonData.metadata.namespace}',pod='${resource.jsonData.metadata.name}'}[1m])) by (pod,namespace)`}


### PR DESCRIPTION
Currently memory usage is doubled because cadvisor is taking the values from cgroups which contains the parent group.
The parrent group accumulates the memory, so we need  to ignore the parent.

https://stackoverflow.com/a/69282328/10109857

- closes headlamp-k8s/headlamp#2920