### PR TITLE
prometheus: Add support for configuring subpath

### DIFF
--- a/prometheus/src/components/Chart/CPUChart/CPUChart.tsx
+++ b/prometheus/src/components/Chart/CPUChart/CPUChart.tsx
@@ -18,6 +18,7 @@ interface CPUChartProps {
   prometheusPrefix: string;
   interval: string;
   autoRefresh: boolean;
+  subPath: string;
 }
 
 export function CPUChart(props: CPUChartProps) {

--- a/prometheus/src/components/Chart/Chart/Chart.tsx
+++ b/prometheus/src/components/Chart/Chart/Chart.tsx
@@ -49,6 +49,7 @@ export interface ChartProps {
     [key: string]: any;
   };
   CustomTooltip?: ({ active, payload, label }) => JSX.Element | null;
+  subPath?: string;
 }
 
 export default function Chart(props: ChartProps) {
@@ -90,6 +91,7 @@ export default function Chart(props: ChartProps) {
           from: from,
           to: to,
           step: step,
+          subPath: props.subPath,
         });
       } catch (e) {
         fetchedMetrics[plot.name] = { data: [], state: ChartState.ERROR };

--- a/prometheus/src/components/Chart/DiskChart/DiskChart.tsx
+++ b/prometheus/src/components/Chart/DiskChart/DiskChart.tsx
@@ -20,6 +20,7 @@ interface DiskChartProps {
   interval: string;
   prometheusPrefix: string;
   autoRefresh: boolean;
+  subPath: string;
 }
 
 export function DiskChart(props: DiskChartProps) {

--- a/prometheus/src/components/Chart/DiskMetricsChart/DiskMetricsChart.tsx
+++ b/prometheus/src/components/Chart/DiskMetricsChart/DiskMetricsChart.tsx
@@ -4,7 +4,12 @@ import { useCluster } from '@kinvolk/headlamp-plugin/lib/lib/k8s';
 import { Box, Icon, IconButton } from '@mui/material';
 import Alert from '@mui/material/Alert';
 import { useEffect, useState } from 'react';
-import { getConfigStore, getPrometheusInterval, getPrometheusPrefix } from '../../../util';
+import {
+  getConfigStore,
+  getPrometheusInterval,
+  getPrometheusPrefix,
+  getPrometheusSubPath,
+} from '../../../util';
 import { PrometheusNotFoundBanner } from '../common';
 import { DiskChart } from '../DiskChart/DiskChart';
 
@@ -71,6 +76,7 @@ export function DiskMetricsChart(props: DiskMetricsChartProps) {
   }
 
   const interval = getPrometheusInterval(cluster);
+  const subPath = getPrometheusSubPath(cluster);
   return (
     <SectionBox>
       <Box
@@ -112,6 +118,7 @@ export function DiskMetricsChart(props: DiskMetricsChartProps) {
             interval={interval}
             autoRefresh={refresh}
             prometheusPrefix={prometheusPrefix}
+            subPath={subPath}
           />
         </Box>
       ) : state === prometheusState.LOADING ? (

--- a/prometheus/src/components/Chart/FilesystemChart/FilesystemChart.tsx
+++ b/prometheus/src/components/Chart/FilesystemChart/FilesystemChart.tsx
@@ -21,6 +21,7 @@ interface FilesystemChartProps {
   interval: string;
   prometheusPrefix: string;
   autoRefresh: boolean;
+  subPath: string;
 }
 
 export function FilesystemChart(props: FilesystemChartProps) {

--- a/prometheus/src/components/Chart/GenericMetricsChart/GenericMetricsChart.tsx
+++ b/prometheus/src/components/Chart/GenericMetricsChart/GenericMetricsChart.tsx
@@ -13,7 +13,12 @@ import {
 } from '@mui/material';
 import Alert from '@mui/material/Alert';
 import { useEffect, useState } from 'react';
-import { getConfigStore, getPrometheusInterval, getPrometheusPrefix } from '../../../util';
+import {
+  getConfigStore,
+  getPrometheusInterval,
+  getPrometheusPrefix,
+  getPrometheusSubPath,
+} from '../../../util';
 import { PrometheusNotFoundBanner } from '../common';
 import { CPUChart } from '../CPUChart/CPUChart';
 import { FilesystemChart } from '../FilesystemChart/FilesystemChart';
@@ -91,6 +96,7 @@ export function GenericMetricsChart(props: GenericMetricsChartProps) {
   };
 
   const interval = getPrometheusInterval(cluster);
+  const subPath = getPrometheusSubPath(cluster);
 
   const [timespan, setTimespan] = useState(interval ?? '1h');
 
@@ -168,6 +174,7 @@ export function GenericMetricsChart(props: GenericMetricsChartProps) {
                 autoRefresh={refresh}
                 prometheusPrefix={prometheusPrefix}
                 interval={timespan}
+                subPath={subPath}
               />
             )}
             {chartVariant === 'memory' && (
@@ -176,6 +183,7 @@ export function GenericMetricsChart(props: GenericMetricsChartProps) {
                 autoRefresh={refresh}
                 prometheusPrefix={prometheusPrefix}
                 interval={timespan}
+                subPath={subPath}
               />
             )}
             {chartVariant === 'network' && (
@@ -185,6 +193,7 @@ export function GenericMetricsChart(props: GenericMetricsChartProps) {
                 autoRefresh={refresh}
                 interval={timespan}
                 prometheusPrefix={prometheusPrefix}
+                subPath={subPath}
               />
             )}
             {chartVariant === 'filesystem' && (
@@ -194,6 +203,7 @@ export function GenericMetricsChart(props: GenericMetricsChartProps) {
                 autoRefresh={refresh}
                 interval={timespan}
                 prometheusPrefix={prometheusPrefix}
+                subPath={subPath}
               />
             )}
           </Box>

--- a/prometheus/src/components/Chart/MemoryChart/MemoryChart.tsx
+++ b/prometheus/src/components/Chart/MemoryChart/MemoryChart.tsx
@@ -19,6 +19,7 @@ interface MemoryChartProps {
   prometheusPrefix: string;
   interval: string;
   autoRefresh: boolean;
+  subPath: string;
 }
 
 export function MemoryChart(props: MemoryChartProps) {

--- a/prometheus/src/components/Chart/NetworkChart/NetworkChart.tsx
+++ b/prometheus/src/components/Chart/NetworkChart/NetworkChart.tsx
@@ -21,6 +21,7 @@ interface NetworkChartProps {
   interval: string;
   prometheusPrefix: string;
   autoRefresh: boolean;
+  subPath: string;
 }
 
 export function NetworkChart(props: NetworkChartProps) {

--- a/prometheus/src/components/Settings/Settings.tsx
+++ b/prometheus/src/components/Settings/Settings.tsx
@@ -33,6 +33,7 @@ interface SettingsProps {
       isMetricsEnabled?: boolean;
       autoDetect?: boolean;
       address?: string;
+      subPath?: string;
       defaultTimespan?: string;
     }
   >;
@@ -141,6 +142,23 @@ export function Settings(props: SettingsProps) {
               },
             });
             setAddressError(!isValidAddress(newAddress));
+          }}
+        />
+      ),
+    },
+    {
+      name: 'Prometheus Service Subpath',
+      value: (
+        <TextField
+          value={selectedClusterData.subPath || ''}
+          disabled={!isAddressFieldEnabled}
+          helperText="Optional subpath to the Prometheus Service endpoint. Only used when auto-detection is disabled. Examples: 'prometheus'."
+          onChange={e => {
+            const newSubPath = e.target.value;
+            onDataChange({
+              ...(data || {}),
+              [selectedCluster]: { ...((data || {})[selectedCluster] || {}), subPath: newSubPath },
+            });
           }}
         />
       ),

--- a/prometheus/src/request.tsx
+++ b/prometheus/src/request.tsx
@@ -294,6 +294,7 @@ export async function fetchMetrics(data: {
   from: number;
   to: number;
   step: number;
+  subPath?: string;
 }): Promise<object> {
   const params = new URLSearchParams();
   if (data.from) {
@@ -308,14 +309,23 @@ export async function fetchMetrics(data: {
   if (data.query) {
     params.append('query', data.query);
   }
-
-  const response = await request(
-    `/api/v1/namespaces/${data.prefix}/proxy/api/v1/query_range?${params.toString()}`,
-    {
-      method: 'GET',
-      isJSON: false,
+  var url = `/api/v1/namespaces/${data.prefix}/proxy/api/v1/query_range?${params.toString()}`;
+  if (data.subPath && data.subPath !== '') {
+    if (data.subPath.startsWith('/')) {
+      data.subPath = data.subPath.slice(1);
     }
-  );
+    if (data.subPath.endsWith('/')) {
+      data.subPath = data.subPath.slice(0, -1);
+    }
+    url = `/api/v1/namespaces/${data.prefix}/proxy/${
+      data.subPath
+    }/api/v1/query_range?${params.toString()}`;
+  }
+
+  const response = await request(url, {
+    method: 'GET',
+    isJSON: false,
+  });
   if (response.status === 200) {
     return response.json();
   } else {

--- a/prometheus/src/util.ts
+++ b/prometheus/src/util.ts
@@ -14,6 +14,7 @@ type ClusterData = {
   autoDetect?: boolean;
   isMetricsEnabled?: boolean;
   address?: string;
+  subPath?: string;
   defaultTimespan?: string;
 };
 
@@ -114,6 +115,16 @@ export async function getPrometheusPrefix(cluster: string): Promise<string | nul
     return `${namespace}/services/${service}`;
   }
   return null;
+}
+
+/**
+ * getPrometheusSubPath returns the subpath for the Prometheus metrics.
+ * @param {string} cluster - The name of the cluster.
+ * @returns {string | null} The subpath for the Prometheus metrics, or null if not found.
+ */
+export function getPrometheusSubPath(cluster: string): string | null {
+  const clusterData = getClusterConfig(cluster);
+  return !clusterData?.subPath || clusterData.subPath === '' ? null : clusterData.subPath;
 }
 
 /**


### PR DESCRIPTION
this patch adds support for configuring subpath, this is helpful for users who use mimir/victoria metrics. these tools make the prometheus compatible api avaialble in /prometheus path and the plugin can be configured to fetch metrics from these sources.