### PR TITLE
github: Add workflow to build and publish container image

### DIFF
--- a/.github/workflows/build-and-publish-image.yml
+++ b/.github/workflows/build-and-publish-image.yml
@@ -1,0 +1,90 @@
+name: Build and publish plugin container image
+
+on:
+  workflow_dispatch:
+    inputs:
+      plugin:
+        description: 'The plugin name (e.g., flux)'
+        required: true
+        type: string
+      version:
+        description: 'The plugin version (without a v prefix e.g., 0.1.0) - if not provided, will use version from package.json'
+        required: false
+        type: string
+
+env:
+  REGISTRY: ghcr.io
+  ORG: headlamp-k8s
+  PLUGIN: ${{ github.event.inputs.plugin }}
+  IMAGE_NAME: headlamp-plugin-${{ github.event.inputs.plugin }}
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write # needed for publishing the container image
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Verify plugin exists
+        run: |
+          if [ ! -d "${{ env.PLUGIN }}" ]; then
+            echo "::error::Plugin directory '${{ env.PLUGIN }}' does not exist"
+            exit 1
+          fi
+          echo "Plugin directory '${{ env.PLUGIN }}' verified"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+
+      - name: Determine version
+        id: determine_version
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          if [ -z "$VERSION" ]; then
+            echo "Version not provided, extracting from package.json"
+            VERSION=$(node -p "require('./${{ env.PLUGIN }}/package.json').version")
+            echo "Extracted version: $VERSION"
+          fi
+          # Remove leading 'v' if present
+          VERSION="${VERSION#v}"
+          # Create v-prefixed version for image tags
+          IMAGE_TAG_VERSION="v${VERSION}"
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "IMAGE_TAG_VERSION=$IMAGE_TAG_VERSION" >> $GITHUB_ENV
+          echo "FULL_IMAGE_NAME=${{ env.REGISTRY }}/${{ env.ORG }}/${{ env.IMAGE_NAME }}" >> $GITHUB_ENV
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
+        with:
+          context: .
+          push: true
+          pull: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ env.FULL_IMAGE_NAME }}:${{ env.IMAGE_TAG_VERSION }},${{ env.FULL_IMAGE_NAME }}:latest
+          labels: |
+            org.opencontainers.image.source=${{ github.event.repository.html_url }}
+            org.opencontainers.image.licenses=Apache-2.0
+          provenance: true
+          build-args: PLUGIN=${{ env.PLUGIN }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Summary
+        run: |
+          echo "## Container Image Published" >> $GITHUB_STEP_SUMMARY
+          echo "Plugin: ${{ env.PLUGIN }}" >> $GITHUB_STEP_SUMMARY
+          echo "Version: ${{ env.VERSION }}" >> $GITHUB_STEP_SUMMARY
+          echo "Image: ${{ env.FULL_IMAGE_NAME }}:${{ env.IMAGE_TAG_VERSION }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
This is based on #172 but is limited to building and publishing the image.
I believe we need to have what's in #172 but we need to do it in separate actions because, e.g. if the image fails, we shouldn't resort to doing things locally.
In the future we may trigger this workflow from a tag push.