### PR TITLE
minikube: CommandCluster: Add warning if leaving and command is still running

### DIFF
--- a/minikube/src/CommandCluster/CommandCluster.tsx
+++ b/minikube/src/CommandCluster/CommandCluster.tsx
@@ -1,5 +1,6 @@
 import { clusterAction, runCommand } from '@kinvolk/headlamp-plugin/lib';
 import React from 'react';
+import { Prompt } from 'react-router-dom';
 import CommandDialog from './CommandDialog';
 
 const DEBUG = false;
@@ -140,33 +141,40 @@ export default function CommandCluster(props: CommandClusterProps) {
   }
 
   return (
-    <CommandDialog
-      open={openDialog}
-      onClose={() => {
-        setOpenDialog(false);
-        handleClose();
-        allDataRef.current = [];
-        setActing(false);
-        setCommandDone(false);
-      }}
-      onConfirm={({ clusterName, driver }) => handleRunCommand({ clusterName, driver })}
-      command={command}
-      title={
-        askClusterName
-          ? acting
-            ? `Creating Minikube Cluster ${theCluster}...`
-            : 'Create a New Minikube Cluster'
-          : acting
-          ? `Running "${command}" on Minikube Cluster`
-          : `Running "${command}" on Minikube Cluster`
-      }
-      acting={acting}
-      running={running}
-      actingLines={runningLines}
-      commandDone={commandDone}
-      useGrid={props.useGrid}
-      initialClusterName={initialClusterName}
-      askClusterName={askClusterName}
-    />
+    <>
+      <Prompt
+        when={!commandDone && running}
+        message="The command is still running. If you leave, the command 
+may keep running in the background. Leave?"
+      />
+      <CommandDialog
+        open={openDialog}
+        onClose={() => {
+          setOpenDialog(false);
+          handleClose();
+          allDataRef.current = [];
+          setActing(false);
+          setCommandDone(false);
+        }}
+        onConfirm={({ clusterName, driver }) => handleRunCommand({ clusterName, driver })}
+        command={command}
+        title={
+          askClusterName
+            ? acting
+              ? `Creating Minikube Cluster ${theCluster}...`
+              : 'Create a New Minikube Cluster'
+            : acting
+            ? `Running "${command}" on Minikube Cluster`
+            : `Running "${command}" on Minikube Cluster`
+        }
+        acting={acting}
+        running={running}
+        actingLines={runningLines}
+        commandDone={commandDone}
+        useGrid={props.useGrid}
+        initialClusterName={initialClusterName}
+        askClusterName={askClusterName}
+      />
+    </>
   );
 }


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/20281977-ccbb-40b3-a1c3-81a020d36fe4)


### How to test

- in this branch minikube/ folder `npm start`
- Then in the app, go to load cluster.
- Start adding a cluster. 
- Then when it starts running... Try to navigate away from the page. You should see a warning message, click ok to leave (cancel to not leave).


( Uses [React Router Prompt component](https://v5.reactrouter.com/core/api/Prompt) )