### PR TITLE
minikube: Add default cluster name, and validation for existing cluster names

### DIFF
--- a/minikube/src/CommandCluster/CommandDialog.tsx
+++ b/minikube/src/CommandCluster/CommandDialog.tsx
@@ -67,6 +67,25 @@ export default function CommandDialog({
   const clusters = useClustersConf() || {};
   const clusterNames = Object.keys(clusters);
 
+  React.useEffect(() => {
+    if (!initialClusterName) {
+      setClusterName(generateClusterName(clusterNames));
+    }
+  }, [initialClusterName, clusterNames]);
+
+  function generateClusterName(existingNames: string[]): string {
+    const baseName = 'minikube';
+    let newName = baseName;
+    let counter = 1;
+
+    while (existingNames.includes(newName)) {
+      newName = `${baseName}-${counter}`;
+      counter++;
+    }
+
+    return newName;
+  }
+
   if (acting && open && !running) {
     if (askClusterName) {
       return <Loader title={`Loading data for ${title}`} />;

--- a/minikube/src/CommandCluster/CommandDialog.tsx
+++ b/minikube/src/CommandCluster/CommandDialog.tsx
@@ -1,4 +1,5 @@
 import { Loader } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { useClustersConf } from '@kinvolk/headlamp-plugin/lib/k8s';
 import { Card } from '@mui/material';
 import { Typography } from '@mui/material';
 import Box from '@mui/material/Box';
@@ -60,8 +61,11 @@ export default function CommandDialog({
 }: CommandDialogProps) {
   const [clusterName, setClusterName] = React.useState(initialClusterName);
   const [driver, setDriver] = React.useState('');
+  const [nameTaken, setNameTaken] = React.useState(false);
 
   const history = useHistory();
+  const clusters = useClustersConf() || {};
+  const clusterNames = Object.keys(clusters);
 
   if (acting && open && !running) {
     if (askClusterName) {
@@ -88,9 +92,13 @@ export default function CommandDialog({
                 label="Cluster Name"
                 value={clusterName}
                 onChange={function handleNameChange(event: React.ChangeEvent<HTMLInputElement>) {
-                  setClusterName(event.target.value);
+                  const name = event.target.value;
+                  setClusterName(name);
+                  setNameTaken(clusterNames.includes(name));
                 }}
                 variant="outlined"
+                error={nameTaken}
+                helperText={nameTaken ? 'Cluster name is already taken' : ''}
               />
             </Box>
           </FormControl>
@@ -123,6 +131,7 @@ export default function CommandDialog({
             }}
             variant="contained"
             color="primary"
+            disabled={nameTaken && askClusterName}
           >
             {`${command}`}
           </Button>


### PR DESCRIPTION
- Add generation of cluster name by default (minikube, minikube-1, minikube-2, etc)
- Add validation for existing cluster names


### How to test

- npm start
- Load Cluster
- Add minikube cluster
- See that the name is minikube-1 or so.
- Enter an existing cluster name, and see an error, 
  - prevented from using form to create with existing name

![image](https://github.com/user-attachments/assets/a537839d-0f4d-4879-94c2-b955113a2146)


---

![image](https://github.com/user-attachments/assets/068d64d5-483e-4418-b0be-40ec9df48155)

