### PR TITLE
Flux: fix oci repo status in overview page

### DIFF
--- a/flux/src/overview/index.tsx
+++ b/flux/src/overview/index.tsx
@@ -524,12 +524,8 @@ function FluxOverviewChart({ resourceClass }) {
       const total = crds.length;
       if (total === 0) return '0%';
 
-      const success = crds.filter(
-        crd =>
-          crd.jsonData.status?.conditions?.some(
-            condition => condition.type === 'Ready' && condition.status === 'True'
-          ) && !crd.jsonData.spec?.suspend
-      ).length;
+      const [success] = getStatus(crds);
+
       const percentage = Math.round((success / total) * 100);
 
       return `${percentage}%`;


### PR DESCRIPTION
In PR https://github.com/headlamp-k8s/plugins/pull/199 the status of oci repos on the overview page was fixed. However the status in TileChart was missed. 

This PR fixes also the status in the TileChart. 