### PR TITLE
prometheus: Add resolution input for metrics

### DIFF
--- a/prometheus/src/components/Chart/CPUChart/CPUChart.tsx
+++ b/prometheus/src/components/Chart/CPUChart/CPUChart.tsx
@@ -17,6 +17,7 @@ interface CPUChartProps {
   query: string;
   prometheusPrefix: string;
   interval: string;
+  resolution: string;
   autoRefresh: boolean;
   subPath: string;
 }

--- a/prometheus/src/components/Chart/Chart/chart.stories.tsx
+++ b/prometheus/src/components/Chart/Chart/chart.stories.tsx
@@ -336,6 +336,7 @@ const Template: StoryFn<ChartProps> = () => {
         },
       ]}
       interval="10m"
+      resolution="medium"
       autoRefresh={false}
       xAxisProps={XTickProps}
       yAxisProps={YTickProps}

--- a/prometheus/src/components/Chart/DiskChart/DiskChart.tsx
+++ b/prometheus/src/components/Chart/DiskChart/DiskChart.tsx
@@ -18,6 +18,7 @@ interface DiskChartProps {
   usageQuery: string;
   capacityQuery: string;
   interval: string;
+  resolution: string;
   prometheusPrefix: string;
   autoRefresh: boolean;
   subPath: string;

--- a/prometheus/src/components/Chart/DiskMetricsChart/DiskMetricsChart.tsx
+++ b/prometheus/src/components/Chart/DiskMetricsChart/DiskMetricsChart.tsx
@@ -1,13 +1,16 @@
 import { SectionBox } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 import { Loader } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 import { useCluster } from '@kinvolk/headlamp-plugin/lib/lib/k8s';
-import { Box, Icon, IconButton } from '@mui/material';
 import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Icon from '@mui/material/Icon';
+import IconButton from '@mui/material/IconButton';
 import { useEffect, useState } from 'react';
 import {
   getConfigStore,
   getPrometheusInterval,
   getPrometheusPrefix,
+  getPrometheusResolution,
   getPrometheusSubPath,
 } from '../../../util';
 import { PrometheusNotFoundBanner } from '../common';
@@ -76,6 +79,7 @@ export function DiskMetricsChart(props: DiskMetricsChartProps) {
   }
 
   const interval = getPrometheusInterval(cluster);
+  const resolution = getPrometheusResolution(cluster);
   const subPath = getPrometheusSubPath(cluster);
   return (
     <SectionBox>
@@ -116,6 +120,7 @@ export function DiskMetricsChart(props: DiskMetricsChartProps) {
             usageQuery={props.usageQuery}
             capacityQuery={props.capacityQuery}
             interval={interval}
+            resolution={resolution}
             autoRefresh={refresh}
             prometheusPrefix={prometheusPrefix}
             subPath={subPath}

--- a/prometheus/src/components/Chart/FilesystemChart/FilesystemChart.tsx
+++ b/prometheus/src/components/Chart/FilesystemChart/FilesystemChart.tsx
@@ -19,6 +19,7 @@ interface FilesystemChartProps {
   readQuery: string;
   writeQuery: string;
   interval: string;
+  resolution: string;
   prometheusPrefix: string;
   autoRefresh: boolean;
   subPath: string;

--- a/prometheus/src/components/Chart/GenericMetricsChart/GenericMetricsChart.tsx
+++ b/prometheus/src/components/Chart/GenericMetricsChart/GenericMetricsChart.tsx
@@ -2,21 +2,21 @@ import { Icon } from '@iconify/react';
 import { Loader } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 import { SectionBox } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 import { useCluster } from '@kinvolk/headlamp-plugin/lib/k8s';
-import {
-  Box,
-  Button,
-  MenuItem,
-  Paper,
-  Select,
-  ToggleButton,
-  ToggleButtonGroup,
-} from '@mui/material';
 import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import ListSubheader from '@mui/material/ListSubheader';
+import MenuItem from '@mui/material/MenuItem';
+import Paper from '@mui/material/Paper';
+import Select from '@mui/material/Select';
+import ToggleButton from '@mui/material/ToggleButton';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import { useEffect, useState } from 'react';
 import {
   getConfigStore,
   getPrometheusInterval,
   getPrometheusPrefix,
+  getPrometheusResolution,
   getPrometheusSubPath,
 } from '../../../util';
 import { PrometheusNotFoundBanner } from '../common';
@@ -96,9 +96,11 @@ export function GenericMetricsChart(props: GenericMetricsChartProps) {
   };
 
   const interval = getPrometheusInterval(cluster);
+  const graphResolution = getPrometheusResolution(cluster);
   const subPath = getPrometheusSubPath(cluster);
 
   const [timespan, setTimespan] = useState(interval ?? '1h');
+  const [resolution, setResolution] = useState(graphResolution ?? 'medium');
 
   if (!isVisible) {
     return null;
@@ -160,6 +162,28 @@ export function GenericMetricsChart(props: GenericMetricsChartProps) {
                 <MenuItem value={'14d'}>14 days</MenuItem>
               </Select>
             </Box>
+            <Box>
+              <Select
+                variant="outlined"
+                size="small"
+                name="Time"
+                value={resolution}
+                onChange={e => setResolution(e.target.value)}
+              >
+                <ListSubheader>Automatic resolution</ListSubheader>
+                <MenuItem value="low">Low res.</MenuItem>
+                <MenuItem value="medium">Medium res.</MenuItem>
+                <MenuItem value="high">High res.</MenuItem>
+
+                <ListSubheader>Fixed resolution</ListSubheader>
+                <MenuItem value="10s">10s</MenuItem>
+                <MenuItem value="30s">30s</MenuItem>
+                <MenuItem value="1m">1m</MenuItem>
+                <MenuItem value="5m">5m</MenuItem>
+                <MenuItem value="15m">15m</MenuItem>
+                <MenuItem value="1h">1h</MenuItem>
+              </Select>
+            </Box>
           </Box>
         )}
         {state === prometheusState.INSTALLED ? (
@@ -174,6 +198,7 @@ export function GenericMetricsChart(props: GenericMetricsChartProps) {
                 autoRefresh={refresh}
                 prometheusPrefix={prometheusPrefix}
                 interval={timespan}
+                resolution={resolution}
                 subPath={subPath}
               />
             )}
@@ -183,6 +208,7 @@ export function GenericMetricsChart(props: GenericMetricsChartProps) {
                 autoRefresh={refresh}
                 prometheusPrefix={prometheusPrefix}
                 interval={timespan}
+                resolution={resolution}
                 subPath={subPath}
               />
             )}
@@ -192,6 +218,7 @@ export function GenericMetricsChart(props: GenericMetricsChartProps) {
                 txQuery={props.networkTxQuery}
                 autoRefresh={refresh}
                 interval={timespan}
+                resolution={resolution}
                 prometheusPrefix={prometheusPrefix}
                 subPath={subPath}
               />
@@ -202,6 +229,7 @@ export function GenericMetricsChart(props: GenericMetricsChartProps) {
                 writeQuery={props.filesystemWriteQuery}
                 autoRefresh={refresh}
                 interval={timespan}
+                resolution={resolution}
                 prometheusPrefix={prometheusPrefix}
                 subPath={subPath}
               />

--- a/prometheus/src/components/Chart/MemoryChart/MemoryChart.tsx
+++ b/prometheus/src/components/Chart/MemoryChart/MemoryChart.tsx
@@ -18,6 +18,7 @@ interface MemoryChartProps {
   query: string;
   prometheusPrefix: string;
   interval: string;
+  resolution: string;
   autoRefresh: boolean;
   subPath: string;
 }

--- a/prometheus/src/components/Chart/NetworkChart/NetworkChart.tsx
+++ b/prometheus/src/components/Chart/NetworkChart/NetworkChart.tsx
@@ -19,6 +19,7 @@ interface NetworkChartProps {
   rxQuery: string;
   txQuery: string;
   interval: string;
+  resolution: string;
   prometheusPrefix: string;
   autoRefresh: boolean;
   subPath: string;

--- a/prometheus/src/components/Settings/Settings.tsx
+++ b/prometheus/src/components/Settings/Settings.tsx
@@ -1,6 +1,7 @@
 import { NameValueTable } from '@kinvolk/headlamp-plugin/lib/components/common';
 import { useClustersConf } from '@kinvolk/headlamp-plugin/lib/k8s';
 import Box from '@mui/material/Box';
+import ListSubheader from '@mui/material/ListSubheader';
 import MenuItem from '@mui/material/MenuItem';
 import Select from '@mui/material/Select';
 import Switch from '@mui/material/Switch';
@@ -23,7 +24,7 @@ function isValidAddress(address: string): boolean {
 /**
  * Props for the Settings component.
  * @interface SettingsProps
- * @property {Object.<string, {isMetricsEnabled?: boolean, autoDetect?: boolean, address?: string, defaultTimespan?: string}>} data - Configuration data for each cluster
+ * @property {Object.<string, {isMetricsEnabled?: boolean, autoDetect?: boolean, address?: string, defaultTimespan?: string, defaultResolution?: string}>} data - Configuration data for each cluster
  * @property {Function} onDataChange - Callback function when data changes
  */
 interface SettingsProps {
@@ -35,6 +36,7 @@ interface SettingsProps {
       address?: string;
       subPath?: string;
       defaultTimespan?: string;
+      defaultResolution?: string;
     }
   >;
   onDataChange: (newData: SettingsProps['data']) => void;
@@ -64,6 +66,7 @@ export function Settings(props: SettingsProps) {
           isMetricsEnabled: true,
           autoDetect: true,
           defaultTimespan: '24h',
+          defaultResolution: 'medium',
         },
       });
     }
@@ -164,7 +167,7 @@ export function Settings(props: SettingsProps) {
       ),
     },
     {
-      name: 'Default timespan',
+      name: 'Default Timespan',
       value: (
         <Select
           disabled={!isMetricsEnabled}
@@ -193,6 +196,37 @@ export function Settings(props: SettingsProps) {
           <MenuItem value={'lastweek'}>Last week</MenuItem>
           <MenuItem value={'7d'}>7 days</MenuItem>
           <MenuItem value={'14d'}>14 days</MenuItem>
+        </Select>
+      ),
+    },
+    {
+      name: 'Default Resolution',
+      value: (
+        <Select
+          disabled={!isMetricsEnabled}
+          value={data?.[selectedCluster]?.defaultResolution || 'medium'}
+          onChange={e =>
+            onDataChange({
+              ...(data || {}),
+              [selectedCluster]: {
+                ...((data || {})[selectedCluster] || {}),
+                defaultResolution: e.target.value,
+              },
+            })
+          }
+        >
+          <ListSubheader>Automatic resolution</ListSubheader>
+          <MenuItem value="low">Low res.</MenuItem>
+          <MenuItem value="medium">Medium res.</MenuItem>
+          <MenuItem value="high">High res.</MenuItem>
+
+          <ListSubheader>Fixed resolution</ListSubheader>
+          <MenuItem value="10s">10s</MenuItem>
+          <MenuItem value="30s">30s</MenuItem>
+          <MenuItem value="1m">1m</MenuItem>
+          <MenuItem value="5m">5m</MenuItem>
+          <MenuItem value="15m">15m</MenuItem>
+          <MenuItem value="1h">1h</MenuItem>
         </Select>
       ),
     },


### PR DESCRIPTION
The official Prometheus Query UI accepts resolution as an input from the user:

![image](https://github.com/user-attachments/assets/9b5a6005-bb3a-4884-bf22-e4147cceca08)

It will be better if we also allow Headlamp to accept such an input. This will help us in calculating the step size at runtime based on `timeRange` and `resolution` rather than hard coding it like we are currently doing it at [this](https://github.com/headlamp-k8s/plugins/blob/main/prometheus/src/util.ts#L250-#L279) place. 

The inspiration for dynamic step size calculation has been taken from the [official Prometheus' UI code](https://github.com/prometheus/prometheus/blob/main/web/ui/mantine-ui/src/state/queryPageSlice.ts#L28-#L50)

![image](https://github.com/user-attachments/assets/47ea7a21-006c-4e66-b616-ab278c06cff3)

![image](https://github.com/user-attachments/assets/b1425faf-c608-4c5a-93f0-d85a094b8a8f)

cc @yolossn 