### PR TITLE
github/workflows/headlamp-plugin-github-workflow: Limit token perms

### DIFF
--- a/.github/workflows/headlamp-plugin-github-workflow.yaml
+++ b/.github/workflows/headlamp-plugin-github-workflow.yaml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  
+permissions:
+  contents: read
 
 env:
   HEADLAMP_PLUGIN_VERSION: latest


### PR DESCRIPTION
This change limits the permissions of the GITHUB_TOKEN as desired.