### PR TITLE
.github: README: Add OpenSSF scorecard badge

### DIFF
--- a/.github/workflows/scorecard-analysis.yml
+++ b/.github/workflows/scorecard-analysis.yml
@@ -1,0 +1,60 @@
+name: Scorecard analysis workflow
+on:
+  push:
+    # Only the default branch is supported.
+    branches:
+    - main
+  schedule:
+    # Daily
+    - cron: '30 1 * * *'
+
+
+# based on https://github.com/ossf/scorecard/blob/main/.github/workflows/scorecard-analysis.yml
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed for Code scanning upload
+      security-events: write
+      # Needed for GitHub OIDC token if publish_results is true
+      id-token: write
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@f49aabe0b5af0936a0987cfb85d86b75731b0186 # v2.4.1
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Scorecard team runs a weekly scan of public GitHub repos,
+          # see https://github.com/ossf/scorecard#public-data.
+          # Setting `publish_results: true` helps us scale by leveraging your workflow to
+          # extract the results instead of relying on our own infrastructure to run scans.
+          # And it's free for you!
+          publish_results: true
+
+      # Upload the results as artifacts (optional). Commenting out will disable
+      # uploads of run results in SARIF format to the repository Actions tab.
+      # https://docs.github.com/en/actions/advanced-guides/storing-workflow-data-as-artifacts
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Upload the results to GitHub's code scanning dashboard (optional).
+      # Commenting out will disable upload of results to your repo's Code Scanning dashboard
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@60168efe1c415ce0f5521ea06d5c2062adbeed1b # v3.28.17
+        with:
+          sarif_file: results.sarif
+

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This is a repository of official plugins that Headlamp uses or recommends.
 
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/7551/badge)](https://www.bestpractices.dev/projects/7551)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/headlamp-k8s/plugins/badge)](https://scorecard.dev/viewer/?uri=github.com/headlamp-k8s/plugins)
+
+
 ## Current Plugins
 
 | Plugin | Description | Notes | Maintainers |


### PR DESCRIPTION
# Add OpenSSF scorecard badge

- .github: scorecard-analysis: Add config for OpenSSF scorecard
- README: Add OpenSSF scorecard badge

This is required for CNCF projects at the incubated stage.

Additionally, once merged it gives more code scanning results in the Security tab -> Code Scanning section on github.
https://github.com/headlamp-k8s/plugins/security/code-scanning

## How to use

Once merged click on the badge in the README.

Note, `headlamp-k8s/plugins` isn't already scanned by OpenSSF, so it does not have data for it yet.
To get the data, the action will have to be run manually the first time, OR wait for the badge results to be updated once daily.
The action is run daily via github action cron.


## Testing done

We use it in the headlamp repos, and it uses the OpenSSF template for the workflow.

