### PR TITLE
README: Add links to some external plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,23 @@ This is a repository of official plugins that Headlamp uses or recommends.
 | [cert-manager](./cert-manager) | A UI for viewing and managing cert-manager. | |[@yolossn](https://github.com/yolossn)|
 | [minikube](./minikube) | A UI for minikube, for running Kubernetes locally. | |[@illume](https://github.com/illume)|
 
+
+## External plugins
+
+These are some of the plugins maintained outside of the plugins repo by others.
+
+Please see [headlamp plugins on Artifact Hub](https://artifacthub.io/packages/search?kind=21&sort=relevance&page=1) for a list of plugins published there.
+
+| Plugin | Description | Notes | Maintainers |
+| ---------------------------------- | ---------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| [inspektor-gadget](https://github.com/inspektor-gadget/headlamp-plugin/) | This is a Headlamp plugin exposing and show-casing IG gadgets. |  | [@ashu8912](https://github.com/ashu8912) |
+| [Trivy](https://github.com/kubebeam/trivy-headlamp-plugin) | Trivy compliance and vulnerabilities in Headlamp. |   | [@mgalesloot](https://github.com/mgalesloot) |
+| [Kyverno](https://github.com/kubebeam/kyverno-headlamp-plugin) | The Kyverno Headlamp plugin provides views in Headlamp for Policies and Reports. | Archived.  | [@mgalesloot](https://github.com/mgalesloot) |
+| [Kubescape](https://github.com/kubescape/headlamp-plugin) | The Kubescape Headlamp plugin provides views in Headlamp for configuration and vulnerabilities scanning, based on information delivered by the Kubescape operator. |  | [@mgalesloot](https://github.com/mgalesloot) |
+| [KubeVirt](https://github.com/buttahtoast/headlamp-plugins/tree/main/kubevirt) | A plugin for managing KubeVirt virtual machines within a Kubernetes cluster. |   | [@buttahtoast](https://github.com/buttahtoast) |
+
+
+
 ## Development
 
 For examples of plugins created for learning and documentation purposes, please refer to the [examples folder](https://github.com/headlamp-k8s/headlamp/tree/main/plugins#plugins) in Headlamp's repository.


### PR DESCRIPTION
So people might discover external plugins more easily.


Adds below to the README.

---

## External plugins

These are some of the plugins maintained outside of the plugins repo by others.

Please see [headlamp plugins on Artifact Hub](https://artifacthub.io/packages/search?kind=21&sort=relevance&page=1) for a list of plugins published there.

| Plugin | Description | Notes | Maintainers |
| ---------------------------------- | ---------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ----------- |
| [inspektor-gadget](https://github.com/inspektor-gadget/headlamp-plugin/) | This is a Headlamp plugin exposing and show-casing IG gadgets. |  | [@ashu8912](https://github.com/ashu8912) |
| [Trivy](https://github.com/kubebeam/trivy-headlamp-plugin) | Trivy compliance and vulnerabilities in Headlamp. |   | [@mgalesloot](https://github.com/mgalesloot) |
| [Kyverno](https://github.com/kubebeam/kyverno-headlamp-plugin) | The Kyverno Headlamp plugin provides views in Headlamp for Policies and Reports. | Archived.  |  |
| [Kubescape](https://github.com/kubescape/headlamp-plugin) | The Kubescape Headlamp plugin provides views in Headlamp for configuration and vulnerabilities scanning, based on information delivered by the Kubescape operator. |  | [@mgalesloot](https://github.com/mgalesloot) |
| [KubeVirt](https://github.com/buttahtoast/headlamp-plugins/tree/main/kubevirt) | A plugin for managing KubeVirt virtual machines within a Kubernetes cluster. |   | [@buttahtoast](https://github.com/buttahtoast) |
