### PR TITLE
app-catalog: Override prismjs to 1.30.0

### DIFF
--- a/app-catalog/package-lock.json
+++ b/app-catalog/package-lock.json
@@ -14401,15 +14401,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/refractor/node_modules/prismjs": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz",
-      "integrity": "sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",

--- a/app-catalog/package-lock.json
+++ b/app-catalog/package-lock.json
@@ -8,7 +8,7 @@
       "name": "app-catalog",
       "version": "0.6.0",
       "dependencies": {
-        "react-syntax-highlighter": "^15.5.0",
+        "react-syntax-highlighter": "^15.6.1",
         "remark-gfm": "^4.0.1",
         "semver": "^6.3.1"
       },

--- a/app-catalog/package.json
+++ b/app-catalog/package.json
@@ -38,6 +38,7 @@
     "semver": "^6.3.1"
   },
   "overrides": {
+    "prismjs": "^1.30.0",
     "typescript": "5.6.2"
   }
 }

--- a/app-catalog/package.json
+++ b/app-catalog/package.json
@@ -33,7 +33,7 @@
     "@kinvolk/headlamp-plugin": "^0.12.0"
   },
   "dependencies": {
-    "react-syntax-highlighter": "^15.5.0",
+    "react-syntax-highlighter": "^15.6.1",
     "remark-gfm": "^4.0.1",
     "semver": "^6.3.1"
   },


### PR DESCRIPTION
These changes update the react-syntax-highlighter to reflect the installed version and override prismjs to the desired 1.30.0 version.