### PR TITLE
KEDA: Add Map View for KEDA Resources

### DIFF
--- a/keda/src/components/clustertriggerauthentication/Detail.tsx
+++ b/keda/src/components/clustertriggerauthentication/Detail.tsx
@@ -1,6 +1,15 @@
+import { useParams } from 'react-router-dom';
 import { ClusterTriggerAuthentication } from '../../resources/clusterTriggerAuthentication';
 import { BaseKedaAuthenticationDetail } from '../common/CommonComponents';
 
-export function ClusterTriggerAuthenticationDetail() {
-  return <BaseKedaAuthenticationDetail resourceType={ClusterTriggerAuthentication} />;
+export function ClusterTriggerAuthenticationDetail(props: { name?: string }) {
+  const params = useParams<{ namespace: string; name: string }>();
+  const { name = params.name } = props;
+
+  return (
+    <BaseKedaAuthenticationDetail
+      resourceType={ClusterTriggerAuthentication} 
+      name={name}
+    />
+  );
 }

--- a/keda/src/components/common/CommonComponents.tsx
+++ b/keda/src/components/common/CommonComponents.tsx
@@ -72,10 +72,11 @@ export function NotInstalledBanner({ isLoading = false }: NotInstalledBannerProp
 interface BaseKedaAuthenticationProps {
   title?: string;
   resourceType: typeof TriggerAuthentication | typeof ClusterTriggerAuthentication;
+  namespace?: string;
+  name: string;
 }
 
-export function BaseKedaAuthenticationDetail({ resourceType }: BaseKedaAuthenticationProps) {
-  const { name, namespace } = useParams<{ name: string; namespace?: string }>();
+export function BaseKedaAuthenticationDetail({ resourceType, namespace, name }: BaseKedaAuthenticationProps) {
   const { isKedaInstalled, isKedaCheckLoading } = useKedaInstalled();
 
   function isAuthTargetRef(value: any): value is AuthTargetRef {

--- a/keda/src/components/scaledjobs/Detail.tsx
+++ b/keda/src/components/scaledjobs/Detail.tsx
@@ -47,9 +47,10 @@ export function OwnedJobsSection(props: OwnedJobsSectionProps) {
   );
 }
 
-export function ScaledJobDetail() {
-  const { name, namespace } = useParams<{ name: string; namespace: string }>();
+export function ScaledJobDetail(props: { namespace?: string; name?: string }) {
   const { isKedaInstalled, isKedaCheckLoading } = useKedaInstalled();
+  const params = useParams<{ namespace: string; name: string }>();
+  const { namespace = params.namespace, name = params.name } = props;
 
   return (
     <>

--- a/keda/src/components/scaledobjects/Detail.tsx
+++ b/keda/src/components/scaledobjects/Detail.tsx
@@ -13,9 +13,10 @@ import { useKedaInstalled } from '../../hooks/useKedaInstalled';
 import { ScaledObject, ScalingModifierMetricType } from '../../resources/scaledobject';
 import { NotInstalledBanner, TriggersSection } from '../common/CommonComponents';
 
-export function ScaledObjectDetail() {
-  const { name, namespace } = useParams<{ name: string; namespace: string }>();
+export function ScaledObjectDetail(props: { namespace?: string; name?: string }) {
   const { isKedaInstalled, isKedaCheckLoading } = useKedaInstalled();
+  const params = useParams<{ namespace: string; name: string }>();
+  const { namespace = params.namespace, name = params.name } = props;
 
   const [scaledObject] = ScaledObject.useGet(name, namespace);
   const scaleTargetKind = scaledObject?.scaleTargetKind;

--- a/keda/src/components/triggerauthentication/Detail.tsx
+++ b/keda/src/components/triggerauthentication/Detail.tsx
@@ -1,6 +1,16 @@
+import { useParams } from 'react-router-dom';
 import { TriggerAuthentication } from '../../resources/triggerAuthentication';
 import { BaseKedaAuthenticationDetail } from '../common/CommonComponents';
 
-export function TriggerAuthenticationDetail() {
-  return <BaseKedaAuthenticationDetail resourceType={TriggerAuthentication} />;
+export function TriggerAuthenticationDetail(props: { namespace?: string; name?: string }) {
+  const params = useParams<{ namespace: string; name: string }>();
+  const { namespace = params.namespace, name = params.name } = props;
+  
+  return (
+    <BaseKedaAuthenticationDetail 
+      resourceType={TriggerAuthentication} 
+      namespace={namespace} 
+      name={name} 
+    />
+  );
 }

--- a/keda/src/index.tsx
+++ b/keda/src/index.tsx
@@ -1,4 +1,10 @@
-import { registerRoute, registerSidebarEntry } from '@kinvolk/headlamp-plugin/lib';
+import { Icon } from '@iconify/react';
+import { 
+  registerKindIcon,
+  registerRoute,
+  registerSidebarEntry,
+  registerMapSource
+} from '@kinvolk/headlamp-plugin/lib';
 import { ClusterTriggerAuthenticationDetail } from './components/clustertriggerauthentication/Detail';
 import { ClusterTriggerAuthenticationsList } from './components/clustertriggerauthentication/List';
 import { ScaledJobDetail } from './components/scaledjobs/Detail';
@@ -7,6 +13,7 @@ import { ScaledObjectDetail } from './components/scaledobjects/Detail';
 import { ScaledObjectsList } from './components/scaledobjects/List';
 import { TriggerAuthenticationDetail } from './components/triggerauthentication/Detail';
 import { TriggerAuthenticationsList } from './components/triggerauthentication/List';
+import { kedaSource } from './mapView';
 
 interface ResourceRegistrationConfig {
   name: string;
@@ -82,3 +89,25 @@ registerKedaResource({
   ListComponent: ClusterTriggerAuthenticationsList,
   hasNamespace: false,
 });
+
+registerMapSource(kedaSource);
+
+registerKindIcon('ScaledObject', {
+  icon: <Icon icon="mdi:lightning-bolt" width="70%" height="70%" />,
+  color: 'rgb(50, 108, 229)',
+})
+
+registerKindIcon('ScaledJob', {
+  icon: <Icon icon="mdi:lightning-bolt" width="70%" height="70%" />,
+  color: 'rgb(50, 108, 229)',
+})
+
+registerKindIcon('TriggerAuthentication', {
+  icon: <Icon icon="mdi:shield-key" width="70%" height="70%" />,
+  color: 'rgb(50, 108, 229)',
+})
+
+registerKindIcon('ClusterTriggerAuthentication', {
+  icon: <Icon icon="mdi:shield-key" width="70%" height="70%" />,
+  color: 'rgb(50, 108, 229)',
+})

--- a/keda/src/mapView.tsx
+++ b/keda/src/mapView.tsx
@@ -1,0 +1,254 @@
+import { useMemo } from 'react';
+import { Icon } from '@iconify/react';
+import { ScaledObject } from "./resources/scaledobject";
+import { ScaledObjectDetail } from './components/scaledobjects/Detail';
+import { K8s } from '@kinvolk/headlamp-plugin/lib';
+import { ScaledJob } from "./resources/scaledjob";
+import { ScaledJobDetail } from './components/scaledjobs/Detail';
+import Job from '@kinvolk/headlamp-plugin/lib/K8s/job';
+import { TriggerAuthentication } from "./resources/triggerAuthentication";
+import { TriggerAuthenticationDetail } from './components/triggerauthentication/Detail';
+import { ClusterTriggerAuthentication } from './resources/clusterTriggerAuthentication';
+import { ClusterTriggerAuthenticationDetail } from './components/clustertriggerauthentication/Detail';
+
+export const makeKubeToKubeEdge = (from: any, to: any): any => ({
+    id: `${from.metadata.uid}-${to.metadata.uid}`,
+    source: from.metadata.uid,
+    target: to.metadata.uid,
+});
+
+const findAuthenticationEdges = (
+  sourceObject: ScaledObject | ScaledJob,
+  triggerAuthentications: TriggerAuthentication[],
+  clusterTriggerAuthentications: ClusterTriggerAuthentication[]
+) => {
+  const edges = [];
+  const { triggers } = sourceObject.spec;
+
+  if (!triggers || !triggerAuthentications || !clusterTriggerAuthentications) {
+    return edges;
+  };
+
+  triggers.forEach(trigger => {
+    if (trigger.authenticationRef) {
+      const authRefKind = trigger.authenticationRef.kind || TriggerAuthentication.kind;
+      const authRefName = trigger.authenticationRef.name;
+
+      let auth = null;
+      if (authRefKind === TriggerAuthentication.kind) {
+        auth = triggerAuthentications.find(
+          auth =>
+            auth.metadata.namespace === sourceObject.metadata.namespace &&
+            auth.metadata.name === authRefName
+        );  
+      } else if (authRefKind === ClusterTriggerAuthentication.kind) {
+        auth = clusterTriggerAuthentications.find(
+          auth => auth.metadata.name === authRefName
+        )
+      }
+
+      if (auth) {
+        edges.push(makeKubeToKubeEdge(sourceObject, auth));
+      }
+    }
+  });
+
+  return edges;
+}
+
+const triggerAuthenticationSource = {
+  id: 'keda-trigger-authentications',
+  label: 'triggerauthentications',
+  icon: <Icon icon="mdi:shield-key" width="100%" height="100%" color="rgb(50, 108, 229)" />,
+  useData() {
+    const [triggerAuthentications] = TriggerAuthentication.useList();
+
+    return useMemo(() => {
+      if (!triggerAuthentications) return null;
+
+      const nodes = triggerAuthentications?.map(it => ({
+        id: it.metadata.uid,
+        kubeObject: it,
+        weight: 1050,
+        detailsComponent: ({ node }) => (
+          <TriggerAuthenticationDetail
+            namespace={node.kubeObject.jsonData.metadata.namespace}
+            name={node.kubeObject.jsonData.metadata.name}
+          />
+        ),
+      }))
+
+      return {
+        nodes,
+      }
+    }, [triggerAuthentications])
+  }
+}
+
+const clusterTriggerAuthenticationSource = {
+  id: 'keda-cluster-trigger-authentications',
+  label: 'clustertriggerauthentications',
+  icon: <Icon icon="mdi:shield-key" width="100%" height="100%" color="rgb(50, 108, 229)" />,
+  useData() {
+    const [clusterTriggerAuthentications] = ClusterTriggerAuthentication.useList();
+
+    return useMemo(() => {
+      if (!clusterTriggerAuthentications) return null;
+
+      const nodes = clusterTriggerAuthentications?.map(it => ({
+        id: it.metadata.uid,
+        kubeObject: it,
+        weight: 1050,
+        detailsComponent: ({ node }) => (
+          <ClusterTriggerAuthenticationDetail
+            name={node.kubeObject.jsonData.metadata.name}
+          />
+        ),
+      }));
+
+      return {
+        nodes,
+      };
+    }, [clusterTriggerAuthentications]);
+  },
+};
+
+
+const scaledObjectSource = {
+  id: 'keda-scaled-objects',
+  label: 'scaledobjects',
+  icon: <Icon icon="mdi:lightning-bolt" width="100%" height="100%" color="rgb(50, 108, 229)" />,
+  useData() {
+      const [scaledObjects] = ScaledObject.useList();
+      const [triggerAuthentications] = TriggerAuthentication.useList();
+      const [clusterTriggerAuthentications] = ClusterTriggerAuthentication.useList();
+      const [hpas] = K8s.ResourceClasses.HorizontalPodAutoscaler.useList();
+      
+      return useMemo(() => {
+        if (!scaledObjects) return null;
+        
+        const nodes = scaledObjects?.map(it => ({
+          id: it.metadata.uid,
+          kubeObject: it,
+          weight: 1100,
+          detailsComponent: ({ node }) => (
+            <ScaledObjectDetail
+                namespace={node.kubeObject.jsonData.metadata.namespace}
+                name={node.kubeObject.jsonData.metadata.name}
+            />
+          ),
+        }));
+        
+        const edges = [];
+        
+        scaledObjects?.forEach(scaledObject => {
+          const scaledObjectNamespace = scaledObject.metadata.namespace;
+          const scaledObjectName = scaledObject.metadata.name;
+          const { scaleTargetRef: scaledObjectTargetRef } = scaledObject.spec;
+
+          const authEdges = findAuthenticationEdges(
+            scaledObject,
+            triggerAuthentications,
+            clusterTriggerAuthentications
+          );
+          edges.push(...authEdges);
+
+          if (scaledObjectTargetRef && scaledObjectTargetRef.name) {
+            const relatedHPA = hpas?.find(hpa => {
+              const hpaNamespace = hpa.jsonData?.metadata?.namespace || hpa.metadata?.namespace;
+              const hpaOwnerRefs = hpa.jsonData?.metadata?.ownerReferences || hpa.metadata?.ownerReferences;
+              
+              return hpaNamespace === scaledObjectNamespace &&
+                     hpaOwnerRefs?.find(ownerRef =>
+                         ownerRef.apiVersion === ScaledObject.apiVersion &&
+                         ownerRef.kind === ScaledObject.kind &&
+                         ownerRef.name === scaledObjectName
+                     );
+            });
+
+            if (relatedHPA) {
+                edges.push(makeKubeToKubeEdge(scaledObject, relatedHPA));
+            }
+          }
+        });
+        
+        return {
+          nodes,
+          edges,
+        };
+      }, [scaledObjects, triggerAuthentications, clusterTriggerAuthentications, hpas]);
+  },
+};
+
+const scaledJobSource = {
+  id: 'keda-scaled-jobs',
+  label: 'scaledjobs',
+  icon: <Icon icon="mdi:lightning-bolt" width="100%" height="100%" color="rgb(50, 108, 229)" />,
+  useData() {
+      const [scaledJobs] = ScaledJob.useList();
+      const [triggerAuthentications] = TriggerAuthentication.useList();
+      const [clusterTriggerAuthentications] = ClusterTriggerAuthentication.useList();
+      const [jobs] = Job.useList();
+
+      return useMemo(() => {
+        if (!scaledJobs) return null;
+        
+        const nodes = scaledJobs?.map(it => ({
+          id: it.metadata.uid,
+          kubeObject: it,
+          weight: 1100,
+          detailsComponent: ({ node }) => (
+            <ScaledJobDetail
+                namespace={node.kubeObject.jsonData.metadata.namespace}
+                name={node.kubeObject.jsonData.metadata.name}
+            />
+          ),
+        }));
+        
+        const edges = [];
+        
+        scaledJobs?.forEach(scaledJob => {
+          const scaledJobNamespace = scaledJob.metadata.namespace;
+          const { jobTargetRef } = scaledJob.spec;
+
+          const authEdges = findAuthenticationEdges(
+            scaledJob,
+            triggerAuthentications,
+            clusterTriggerAuthentications
+          )
+          edges.push(...authEdges)
+
+          if (jobTargetRef &&
+              jobTargetRef.template &&
+              jobTargetRef.template.spec
+          ) {
+            const relatedJobs = jobs?.filter(
+              job =>
+                job.metadata.namespace === scaledJobNamespace &&
+                job.metadata.ownerReferences?.some(
+                  ownerRef => 
+                    ownerRef.kind === ScaledJob.kind &&
+                    ownerRef.name === scaledJob.metadata.name                    
+                )
+            )
+  
+            relatedJobs?.forEach(job => {
+              edges.push(makeKubeToKubeEdge(scaledJob, job));
+            });
+          };
+        });
+        
+        return {
+          nodes,
+          edges,
+        };
+      }, [scaledJobs, triggerAuthentications, clusterTriggerAuthentications, jobs]);
+  },
+};
+
+export const kedaSource = {
+    id: 'keda',
+    label: 'KEDA',
+    icon: <Icon icon="mdi:lightning-bolt" width="100%" height="100%" color="rgb(50, 108, 229)" />,
+    sources: [scaledObjectSource, scaledJobSource, triggerAuthenticationSource, clusterTriggerAuthenticationSource],
+};


### PR DESCRIPTION
`ScaledObject` View:

![Screenshot from 2025-05-24 12-51-20](https://github.com/user-attachments/assets/81573da5-bf8d-4d6b-b05f-4779b91c27f4)

`ScaledJob` View:

![Screenshot from 2025-05-24 13-34-51](https://github.com/user-attachments/assets/d7687fdb-acfb-4e97-acce-ea201f721993)

Hi @yolossn, Hi @sniok.

I have the below queries that need to be addressed. I would appreciate your help so that I can fix them at the earliest.

1) On the Map View landing page grouped by `default` namespace, we don't see `ScaledObject` and/or `ScaledJob` resources even after selecting KEDA checkbox in the dropdown, they are hidden behind their respective `Deployment` and/or `Job` nodes. Is there a way of changing this behavior?

![image](https://github.com/user-attachments/assets/a23f29c1-52d9-45a5-9d1e-0977c015b4c3)

2) In the `ScaledObject` Map View page, I was trying to load the `HPA` resources using `HPA.useList()` functionality at the below line:

https://github.com/headlamp-k8s/plugins/blob/0c71913206d49536723ec2b541384833b16e6988/keda/src/mapView.tsx#L125

This is not working and the map view simply crashes on doing this. However, this does work for loading of other resources like `Deployment`, `StatefulSet`, etc.

3) Is there a way of configuring the on hover display text for the nodes?

for `ScaledObject` I currrently see the below which looks very cluttered and congested since we are displaying all the events:

![Screenshot from 2025-05-24 15-41-24](https://github.com/user-attachments/assets/1839c945-fdba-4da0-aff5-fc71da217cfa)

but it would be much more UX friendly if we are able to show something similar to this:

![image](https://github.com/user-attachments/assets/43f4885d-9678-4688-9a88-8f5c764b68e4)
