### PR TITLE
github: Add filter to only run jobs for changed plugins

### DIFF
--- a/.github/workflows/headlamp-plugin-github-workflow.yaml
+++ b/.github/workflows/headlamp-plugin-github-workflow.yaml
@@ -5,7 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  
+
 permissions:
   contents: read
 
@@ -13,19 +13,56 @@ env:
   HEADLAMP_PLUGIN_VERSION: latest
 
 jobs:
-  # Get list of folders containing headlamp plugins
+  # Get list of folders containing changed headlamp plugins
   # We need a separate step to be able to pass the list to the matrix of the build job
-  find_plugin_dirs:
+  find_changed_plugin_dirs:
     runs-on: ubuntu-latest
     outputs:
       dirs: ${{ steps.dirs.outputs.dirs }}
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # 4.1.7
-      - id: dirs
-        run: echo "dirs=$(grep -m1 -lR @kinvolk/headlamp-plugin ./*/package.json | xargs -n1 dirname | jq --raw-input --slurp --compact-output 'split("\n")[:-1]')" >> ${GITHUB_OUTPUT}
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          fetch-depth: 0 # Fetch all history
 
+      - name: Fetch base branch
+        run: git fetch origin main
+
+      - name: Find changed Headlamp plugin directories
+        id: dirs
+        run: |
+          # Get all top-level directories that had changes
+          changed_dirs=$(git diff --name-only origin/main...HEAD | awk -F/ '{print $1}' | sort -u)
+          echo "Changed directories: $changed_dirs"
+
+          # If .github/ changed, run all plugins
+          if echo "$changed_dirs" | tr ' ' '\n' | grep -q '^\.github$'; then
+            echo "Changes detected in .github/ directory, running all plugins."
+            changed_dirs=$(grep -lR 'headlamp-plugin' ./*/package.json | xargs -n1 dirname | sort -u)
+            echo "Changed directories: $changed_dirs"
+          fi
+
+          plugin_dirs=()
+          for dir in $changed_dirs; do
+            pkg="$dir/package.json"
+            if [ -f "$pkg" ] && grep -q 'headlamp-plugin' "$pkg"; then
+              plugin_dirs+=("$dir")
+            fi
+          done
+
+          # Output as JSON array for matrix
+          if [ ${#plugin_dirs[@]} -eq 0 ]; then
+            echo "No changed Headlamp plugins found."
+            final_json="[]"
+          else
+            echo "Changed Headlamp plugin directories: ${plugin_dirs[*]}"
+            final_json=$(printf '%s\n' "${plugin_dirs[@]}" | jq --raw-input --slurp --compact-output 'split("\n")[:-1]')
+          fi
+          echo "Final plugin_dirs JSON: $final_json"
+          echo "dirs=$final_json" >> "$GITHUB_OUTPUT"
+          
   build:
-    needs: find_plugin_dirs
+    needs: find_changed_plugin_dirs
+    if: needs.find_changed_plugin_dirs.outputs.dirs != '[]'
     runs-on: ubuntu-latest
 
     defaults:
@@ -36,7 +73,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [18.x]
-        dir: ${{ fromJson(needs.find_plugin_dirs.outputs.dirs) }}
+        dir: ${{ fromJson(needs.find_changed_plugin_dirs.outputs.dirs) }}
 
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # 4.1.7


### PR DESCRIPTION
## When one package changes
- there was a change in the flux/ folder only
- only the flux job ran

![image](https://github.com/user-attachments/assets/5f8ca8f5-effd-4f3b-8ead-bb1c72fc4498)


### No change to any plugin dir
Now it skips the build job entirely.
![image](https://github.com/user-attachments/assets/6a21c18f-ce77-4a09-af16-cd55e987344a)


### If .github folder changes we run all plugin folders

This is useful if for example we change the node version from 18 to 22, and we want to check all plugins are ok.
