### PR TITLE
github: Update CI checks to use node to LTS version 22.x from 18.x

### DIFF
--- a/.github/workflows/headlamp-plugin-github-workflow.yaml
+++ b/.github/workflows/headlamp-plugin-github-workflow.yaml
@@ -72,7 +72,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x]
+        node-version: [22.x]
         dir: ${{ fromJson(needs.find_changed_plugin_dirs.outputs.dirs) }}
 
     steps:


### PR DESCRIPTION
This is the version we are using in the headlamp repo.


