### PR TITLE
github/workflows/build-and-publish-image: Set top level permissions

### DIFF
--- a/.github/workflows/build-and-publish-image.yml
+++ b/.github/workflows/build-and-publish-image.yml
@@ -12,6 +12,9 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: read
+
 env:
   REGISTRY: ghcr.io
   ORG: headlamp-k8s


### PR DESCRIPTION
This change sets top level permissions in the build-and-publish-image workflow as desired.