### PR TITLE
Add security policy with SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please read our documentation on how to [report security issues](https://headlamp.dev/docs/latest/contributing/#security-issues).
+
+We kindly ask that you responsibly disclose any vulnerabilities and give us appropriate time to develop a fix.


### PR DESCRIPTION
This change adds a security policy to the plugins repo with the SECURITY.md file, aligned with the framework of OpenSSF.

Fixes: #266 