### PR TITLE
minikube: Fix stop to leave context in .kube/config

### DIFF
--- a/minikube/src/CommandCluster/CommandCluster.tsx
+++ b/minikube/src/CommandCluster/CommandCluster.tsx
@@ -79,7 +79,14 @@ export default function CommandCluster(props: CommandClusterProps) {
       if (DEBUG) {
         console.log('runFunc', clusterName);
       }
-      const args = [command, '-p', clusterName];
+      const args = [command];
+      if (command === 'stop') {
+        // minikube removes the context from kubectl config when stopping by default
+        // so we ask it to not remove it
+        // "keep the kube-context active after cluster is stopped. Defaults to false."
+        args.push('--keep-context-active', 'true');
+      }
+      args.push('-p', clusterName);
       if (driver) {
         args.push('--driver', driver);
       }


### PR DESCRIPTION
By default minikube stop removes the context from the .kube/config
file, which means that it is not displayed on the home screen. The user can not start it up again.
Note: This plugin now stops minikube with `minikube stop --keep-context-active true`.

---

Before:


After:

![image](https://github.com/user-attachments/assets/39f36e09-d10a-4639-ba16-dbe7c246c91b)
_This screen shot shows that after stopping minikube with headlamp that it is still listed on the home screen._



---

Related to:
- https://github.com/headlamp-k8s/plugins/issues/269

### How to test

- `cd minikube && npm i && npm start`
- start app version of headlamp (`cd app && npm i && npm start`)
- Stop a minikube cluster with headlamp (not on command line).
- See that it's still listed on the home screen.
- Start the minikube cluster again.
