### PR TITLE
karpenter: NodePools: Visualize NodePool resource of Karpenter

### DIFF
--- a/karpenter/src/NodePool/Details.tsx
+++ b/karpenter/src/NodePool/Details.tsx
@@ -1,0 +1,120 @@
+import {
+  DetailsGrid,
+  Link,
+  NameValueTable,
+  SectionBox,
+} from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { getResourceStr } from '@kinvolk/headlamp-plugin/lib/Utils';
+import { useParams } from 'react-router-dom';
+import { renderInstanceRequirements } from '../helpers/instanceRequirements';
+import { parseRam } from '../helpers/parseRam';
+import { renderDisruptionBudgets } from '../helpers/renderBudgets';
+import { nodePoolClass } from './List';
+
+export function NodePoolDetailView(props: { name?: string }) {
+  const params = useParams<{ name: string }>();
+  const { name = params.name } = props;
+  const NodePoolClass = nodePoolClass();
+
+  return (
+    <DetailsGrid
+      resourceType={NodePoolClass}
+      name={name}
+      withEvents
+      extraInfo={item => {
+        const usedCPU = parseInt(item.jsonData.status?.resources?.cpu || '0');
+        const CPUlimit = parseInt(item.jsonData.spec?.limits?.cpu || '0');
+
+        const usedMemory = parseRam(item.jsonData.status?.resources?.memory || '0');
+        const memoryLimit = parseRam(item.jsonData.spec?.limits?.memory || '0');
+
+        return (
+          item && [
+            {
+              name: 'CPU',
+              value: `${usedCPU} ${CPUlimit > 0 ? `of ${CPUlimit}` : '(No limit set)'}`,
+            },
+            {
+              name: 'Memory',
+              value: `${getResourceStr(usedMemory, 'memory')} ${
+                memoryLimit > 0 ? `of ${getResourceStr(memoryLimit, 'memory')}` : '(No limit set)'
+              }`,
+            },
+            {
+              name: 'Nodes',
+              value: item.jsonData.status?.resources?.nodes,
+            },
+            {
+              name: 'Pods',
+              value: item.jsonData.status?.resources?.pods,
+            },
+          ]
+        );
+      }}
+      extraSections={item =>
+        item && [
+          {
+            id: 'nodepool-disruption',
+            section: (
+              <SectionBox title="Disruption Settings">
+                <NameValueTable
+                  rows={[
+                    {
+                      name: 'Consolidation Policy',
+                      value: item.jsonData.spec?.disruption?.consolidationPolicy || '-',
+                    },
+                    {
+                      name: 'Consolidate After',
+                      value: item.jsonData.spec?.disruption?.consolidateAfter || '-',
+                    },
+                    {
+                      name: 'Disruption Budgets',
+                      value:
+                        renderDisruptionBudgets(item.jsonData.spec?.disruption?.budgets) || '-',
+                    },
+                    {
+                      name: 'Expire After',
+                      value: item.jsonData.spec?.template?.spec?.expireAfter || '-',
+                    },
+                  ]}
+                />
+              </SectionBox>
+            ),
+          },
+          {
+            id: 'nodepool-template',
+            section: (
+              <SectionBox title="Node Template Configuration">
+                <NameValueTable
+                  rows={[
+                    {
+                      name: 'Node Class',
+                      value: (
+                        <Link
+                          routeName={'nodeclasses-detail'}
+                          params={{ name: item.jsonData.spec?.template?.spec?.nodeClassRef?.name }}
+                        >
+                          {item.jsonData.spec?.template?.spec?.nodeClassRef?.name || '-'}
+                        </Link>
+                      ),
+                    },
+                    {
+                      name: 'Instance Requirements',
+                      value: renderInstanceRequirements(
+                        item.jsonData.spec?.template?.spec?.requirements
+                      ),
+                    },
+                    {
+                      name: 'Expire After',
+                      value: item.jsonData.spec?.template?.spec?.expireAfter || '-',
+                    },
+                  ]}
+                />
+              </SectionBox>
+            ),
+          },
+        ]
+      }
+    />
+  );
+}

--- a/karpenter/src/NodePool/List.tsx
+++ b/karpenter/src/NodePool/List.tsx
@@ -26,7 +26,11 @@ export function nodePoolClass() {
     pluralName: 'nodepools',
   });
 
-  return NodePool;
+  return class extendedNodePoolClass extends NodePool {
+    static get detailsRoute() {
+      return 'nodepools-detail';
+    }
+  };
 }
 
 function NodePoolsList() {

--- a/karpenter/src/NodePool/List.tsx
+++ b/karpenter/src/NodePool/List.tsx
@@ -1,0 +1,135 @@
+import { Link, ResourceListView } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { PercentageBar } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { makeCustomResourceClass } from '@kinvolk/headlamp-plugin/lib/lib/k8s/crd';
+import { getResourceStr } from '@kinvolk/headlamp-plugin/lib/Utils';
+import { parseRam } from '../helpers/parseRam';
+import { CPUtooltip, Memorytooltip } from '../helpers/tooltip';
+
+interface ChartDataPoint {
+  name: string;
+  value: number;
+  fill?: string;
+}
+
+export function NodePools() {
+  return <NodePoolsList />;
+}
+
+export function nodePoolClass() {
+  const nodePoolGroup = 'karpenter.sh';
+  const nodePoolVersion = 'v1';
+
+  const NodePool = makeCustomResourceClass({
+    apiInfo: [{ group: nodePoolGroup, version: nodePoolVersion }],
+    isNamespaced: false,
+    singularName: 'NodePool',
+    pluralName: 'nodepools',
+  });
+
+  return NodePool;
+}
+
+function NodePoolsList() {
+  return (
+    <ResourceListView
+      title={'NodePools'}
+      resourceClass={nodePoolClass()}
+      columns={[
+        'name',
+        {
+          id: 'nodeclass-ref',
+          label: 'NodeClass',
+          getValue: nodePool => nodePool.jsonData.spec?.template?.spec?.nodeClassRef?.name || '-',
+          render: nodePool => {
+            const nodePoolName = nodePool.jsonData.spec?.template?.spec?.nodeClassRef?.name;
+            return (
+              <Link
+                routeName={'nodeclasses-detail'}
+                params={{
+                  name: nodePoolName || '',
+                }}
+              >
+                {nodePoolName}
+              </Link>
+            );
+          },
+        },
+        {
+          id: 'nodepool-cpu',
+          label: 'CPU',
+          getValue: nodePool => {
+            const used = parseInt(nodePool.jsonData.status?.resources?.cpu || '0');
+            const limit = parseInt(nodePool.jsonData.spec?.limits?.cpu || '0');
+
+            return limit > 0 ? `${used}/${limit}` : `${used} (No limit)`;
+          },
+          render: nodePool => {
+            const used = parseInt(nodePool.jsonData.status?.resources?.cpu || 0);
+            const limit = parseInt(nodePool.jsonData.spec?.limits?.cpu || 0);
+            const data: ChartDataPoint[] = [
+              {
+                name: 'CPU',
+                value: used,
+              },
+            ];
+
+            const effectiveLimit = limit > 0 ? limit : used || 1;
+
+            return (
+              <PercentageBar
+                data={data}
+                total={effectiveLimit}
+                tooltipFunc={() => CPUtooltip(used, limit)}
+              />
+            );
+          },
+        },
+        {
+          id: 'nodepool-memory',
+          label: 'Memory',
+          getValue: nodePool => {
+            const used = parseRam(nodePool.jsonData.status?.resources?.memory || '0');
+            const limit = parseRam(nodePool.jsonData.spec?.limits?.memory || '0');
+            return limit > 0
+              ? `${getResourceStr(used, 'memory')}/${getResourceStr(limit, 'memory')}`
+              : `${getResourceStr(used, 'memory')} (No limit)`;
+          },
+          render: nodePool => {
+            const used = parseRam(nodePool.jsonData.status?.resources?.memory || '0');
+            const limit = parseRam(nodePool.jsonData.spec?.limits?.memory || '0');
+            const data: ChartDataPoint[] = [
+              {
+                name: 'Memory',
+                value: used,
+              },
+            ];
+            const effectiveLimit = limit > 0 ? limit : used || 1;
+
+            return (
+              <PercentageBar
+                data={data}
+                total={effectiveLimit}
+                tooltipFunc={() => Memorytooltip(used, limit)}
+              />
+            );
+          },
+        },
+        {
+          id: 'nodepool-nodes',
+          label: 'Nodes',
+          getValue: nodePool => nodePool.jsonData.status?.resources?.nodes || 0,
+        },
+        {
+          id: 'nodepool-status',
+          label: 'Status',
+          getValue: nodePool => {
+            const conditions = nodePool.jsonData?.status?.conditions || [];
+            const readyCondition = conditions.find(c => c.type === 'Ready');
+            return readyCondition?.status === 'True' ? 'Ready' : 'Not Ready';
+          },
+        },
+        'age',
+      ]}
+    />
+  );
+}

--- a/karpenter/src/helpers/instanceRequirements.tsx
+++ b/karpenter/src/helpers/instanceRequirements.tsx
@@ -1,0 +1,17 @@
+import { MetadataDictGrid } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { Box } from '@mui/material';
+
+export function renderInstanceRequirements(requirements: any[] = []) {
+  if (!requirements || requirements.length === 0) return 'No requirements';
+
+  const requirementsDict = requirements.reduce((acc, req) => {
+    acc[req.key] = `${req.operator} ${req.values?.join(', ') || ''}`.trim();
+    return acc;
+  }, {} as Record<string, string>);
+
+  return (
+    <Box sx={{ mt: 1 }}>
+      <MetadataDictGrid dict={requirementsDict} showKeys />
+    </Box>
+  );
+}

--- a/karpenter/src/helpers/parseRam.tsx
+++ b/karpenter/src/helpers/parseRam.tsx
@@ -1,0 +1,21 @@
+export function parseRam(ramStr: string): number {
+  if (!ramStr) return 0;
+  const match = ramStr.match(/^(\d+)([KMGT]i?)?$/i);
+  if (!match) return 0;
+
+  const num = parseInt(match[1]);
+  const unit = match[2]?.toUpperCase();
+
+  const units: Record<string, number> = {
+    K: 1024,
+    KI: 1024,
+    M: 1024 * 1024,
+    MI: 1024 * 1024,
+    G: 1024 * 1024 * 1024,
+    GI: 1024 * 1024 * 1024,
+    T: 1024 * 1024 * 1024 * 1024,
+    TI: 1024 * 1024 * 1024 * 1024,
+  };
+
+  return num * (units[unit] || 1);
+}

--- a/karpenter/src/helpers/renderBudgets.tsx
+++ b/karpenter/src/helpers/renderBudgets.tsx
@@ -1,0 +1,14 @@
+import { Box, Chip } from '@mui/material';
+
+export function renderDisruptionBudgets(budgets: any[] = []) {
+  if (!budgets || budgets.length === 0) return 'No budgets set';
+  return (
+    <Box sx={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+      {budgets.map((budget, index) =>
+        Object.entries(budget).map(([k, v]) => (
+          <Chip key={index} label={`${k}: ${v}`} variant="outlined" size="small" />
+        ))
+      )}
+    </Box>
+  );
+}

--- a/karpenter/src/helpers/tooltip.tsx
+++ b/karpenter/src/helpers/tooltip.tsx
@@ -1,0 +1,23 @@
+import { getPercentStr, getResourceStr } from '@kinvolk/headlamp-plugin/lib/Utils';
+import { Typography } from '@mui/material';
+
+export const CPUtooltip = (used: number, limit: number) => {
+  const percent = limit > 0 ? getPercentStr(used, limit) : 'No limit set';
+
+  return (
+    <Typography>
+      {used} {limit > 0 ? `of ${limit} (${percent})` : 'No limit set'}
+    </Typography>
+  );
+};
+
+export const Memorytooltip = (used: number, limit: number) => {
+  const percentage = limit > 0 ? getPercentStr(used, limit) : 'No limit set';
+
+  return (
+    <Typography>
+      {getResourceStr(used, 'memory')}{' '}
+      {limit > 0 ? `of ${getResourceStr(limit, 'memory')} (${percentage})` : '(No memory limit)'}
+    </Typography>
+  );
+};

--- a/karpenter/src/index.tsx
+++ b/karpenter/src/index.tsx
@@ -16,6 +16,7 @@
 import { registerRoute, registerSidebarEntry } from '@kinvolk/headlamp-plugin/lib';
 import { NodeClassDetailView } from './NodeClass/Details';
 import { NodeClasses } from './NodeClass/List';
+import { NodePools } from './NodePool/List';
 
 registerSidebarEntry({
   parent: null,
@@ -43,4 +44,18 @@ registerRoute({
   sidebar: 'nodeclass',
   component: NodeClassDetailView,
   name: 'nodeclasses-detail',
+});
+
+registerSidebarEntry({
+  parent: 'karpenter.k8s',
+  name: 'nodepool',
+  label: 'Node Pool',
+  url: '/karpenter/nodepools',
+});
+
+registerRoute({
+  path: '/karpenter/nodepools',
+  sidebar: 'nodepool',
+  component: NodePools,
+  name: 'nodepools-list',
 });

--- a/karpenter/src/index.tsx
+++ b/karpenter/src/index.tsx
@@ -16,6 +16,7 @@
 import { registerRoute, registerSidebarEntry } from '@kinvolk/headlamp-plugin/lib';
 import { NodeClassDetailView } from './NodeClass/Details';
 import { NodeClasses } from './NodeClass/List';
+import { NodePoolDetailView } from './NodePool/Details';
 import { NodePools } from './NodePool/List';
 
 registerSidebarEntry({
@@ -58,4 +59,11 @@ registerRoute({
   sidebar: 'nodepool',
   component: NodePools,
   name: 'nodepools-list',
+});
+
+registerRoute({
+  path: '/karpenter/details/nodepools/:name',
+  sidebar: 'nodepool',
+  component: NodePoolDetailView,
+  name: 'nodepools-detail',
 });


### PR DESCRIPTION
## Headlamp Plugin to visualize Karpenter NodePool resource

### Overview

This PR introduces comprehensive support for visualizing Karpenter NodePool resource within the Headlamp UI.

## Related Issue
Part of https://github.com/kubernetes-sigs/headlamp/issues/3231

### Demo

[Screencast from 2025-06-20 22-53-54.webm](https://github.com/user-attachments/assets/442cac13-d495-4abd-8114-a7aa196c96ac)
