### PR TITLE
KEDA: Pin golang dependency by hash

### DIFF
--- a/keda/test-files/Dockerfile
+++ b/keda/test-files/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21 AS builder
+FROM golang:1.21@sha256:4746d26432a9117a5f58e95cb9f954ddf0de128e9d5816886514199316e4a2fb AS builder
 ENV CGO_ENABLED=0
 
 WORKDIR /publish-src


### PR DESCRIPTION
This change pins the golang dependency in the test-files Dockerfile by hash as desired.