### PR TITLE
app-catalog: Support serviceproxy and support helm repos in the catalog

### DIFF
--- a/app-catalog/src/api/catalogs.tsx
+++ b/app-catalog/src/api/catalogs.tsx
@@ -1,0 +1,53 @@
+import { QueryParameters, request } from '@kinvolk/headlamp-plugin/lib/ApiProxy';
+import { ChartsList, COMMUNITY_REPO, VANILLA_HELM_REPO } from '../components/charts/List';
+
+const SERVICE_ENDPOINT = '/api/v1/services';
+const LABEL_CATALOG = 'catalog.ocne.io/is-catalog';
+
+declare global {
+  var CHART_URL_PREFIX: string;
+  var CHART_PROFILE: string;
+  var CHART_VALUES_PREFIX: string;
+  var CATALOG_NAMESPACE: string;
+  var CATALOG_NAME: string;
+}
+
+// Reset the CHART_URL_PREFIX and CHART_PROFILE, to switch between different catalogs
+export function ResetGlobalVars(
+  metadataName: string,
+  namespace: string,
+  prefix: string,
+  profile: string
+) {
+  globalThis.CATALOG_NAME = metadataName;
+  globalThis.CATALOG_NAMESPACE = namespace;
+  globalThis.CHART_URL_PREFIX = prefix;
+  globalThis.CHART_PROFILE = profile;
+}
+
+// Constants for the supported protocols
+export const HELM_PROTOCOL = 'helm';
+export const ARTIFACTHUB_PROTOCOL = 'artifacthub';
+
+// Reset the variables and call ChartsList, when the protocol is helm
+export function HelmChartList(metadataName: string, namespace: string, chartUrl: string) {
+  ResetGlobalVars(metadataName, namespace, chartUrl, VANILLA_HELM_REPO);
+  // Let the default value for CHART_VALUES_PREFIX be "values"
+  globalThis.CHART_VALUES_PREFIX = `values`;
+  return <ChartsList />;
+}
+
+// Reset the variables and call ChartsList, when the protocol is artifacthub
+export function CommunityChartList(metadataName: string, namespace: string, chartUrl: string) {
+  ResetGlobalVars(metadataName, namespace, chartUrl, COMMUNITY_REPO);
+  return <ChartsList />;
+}
+
+// Fetch the list of services in the cluster
+export function fetchCatalogs() {
+  // Use query parameter to fetch the services with label catalog.ocne.io/is-catalog
+  const queryParam: QueryParameters = {
+    labelSelector: LABEL_CATALOG + '=',
+  };
+  return request(SERVICE_ENDPOINT, {}, true, true, queryParam).then(response => response);
+}

--- a/app-catalog/src/api/charts.tsx
+++ b/app-catalog/src/api/charts.tsx
@@ -1,4 +1,18 @@
-import { PAGE_OFFSET_COUNT_FOR_CHARTS } from '../components/charts/List';
+import { request } from '@kinvolk/headlamp-plugin/lib/ApiProxy';
+import {
+  COMMUNITY_REPO,
+  CUSTOM_CHART_VALUES_PREFIX,
+  PAGE_OFFSET_COUNT_FOR_CHARTS,
+  VANILLA_HELM_REPO,
+} from '../components/charts/List';
+import { yamlToJSON } from '../helpers';
+import { isElectron } from '../index';
+
+const SERVICE_PROXY = '/serviceproxy';
+
+const getURLSearchParams = url => {
+  return new URLSearchParams({ request: url }).toString();
+};
 
 export async function fetchChartsFromArtifact(
   search: string = '',
@@ -7,6 +21,46 @@ export async function fetchChartsFromArtifact(
   page: number,
   limit: number = PAGE_OFFSET_COUNT_FOR_CHARTS
 ) {
+  if (!isElectron()) {
+    if (CHART_PROFILE === VANILLA_HELM_REPO) {
+      // When CHART_PROFILE is VANILLA_HELM_REPOSITORY, the code expects /charts/index.yaml
+      // to contain the metadata of the available charts
+      const url =
+        `${SERVICE_PROXY}/${CATALOG_NAMESPACE}/${CATALOG_NAME}?` +
+        getURLSearchParams(`charts/index.yaml`);
+
+      // Ensure that the UI renders index.yaml in yaml and json format. Please note that, helm repo index generates index.yaml
+      // in yaml as the default format, although latest versions support generating the file in json format.
+      // The API yamlToJSON works for the response in yaml as well as json format.
+      //const dataResponse = request(url, { isJSON: false }, true, true, {})
+      //  .then(response => response.text())
+      //  .then(yamlResponse => yamlToJSON(yamlResponse));
+      const dataResponse = await request(url, { isJSON: false }, true, true, {});
+      const total=0;
+      return { dataResponse, total };
+    } else if (CHART_PROFILE === COMMUNITY_REPO) {
+      let requestParam = '';
+      if (!category || category.value === 0) {
+        requestParam = `api/v1/packages/search?kind=0&ts_query_web=${search}&sort=relevance&facets=true&limit=${limit}&offset=${
+          (page - 1) * limit
+        }`;
+      } else {
+        requestParam = `api/v1/packages/search?kind=0&ts_query_web=${search}&category=${
+          category.value
+        }&sort=relevance&facets=true&limit=${limit}&offset=${(page - 1) * limit}`;
+      }
+
+      const url =
+        `${SERVICE_PROXY}/${CATALOG_NAMESPACE}/${CATALOG_NAME}?` + getURLSearchParams(requestParam);
+      const response = request(url, {}, true, true, {}).then(response => response);
+      const dataResponse = response
+      const total = response.headers.get('pagination-total-count');
+      return { dataResponse, total };
+      //return request(url, {}, true, true, {}).then(response => response);
+    }
+  }
+
+  // App-catalog desktop version
   // note: we are currently defaulting to search by verified and official as default
   const url = new URL('https://artifacthub.io/api/v1/packages/search');
   url.searchParams.set('offset', ((page - 1) * limit).toString());
@@ -30,6 +84,16 @@ export async function fetchChartsFromArtifact(
 }
 
 export function fetchChartDetailFromArtifact(chartName: string, repoName: string) {
+  // Use /serviceproxy to fetch the resource, by specifying the access token
+  if (!isElectron() && CHART_PROFILE === COMMUNITY_REPO) {
+    const url =
+      `${SERVICE_PROXY}/${CATALOG_NAMESPACE}/${CATALOG_NAME}?` +
+      getURLSearchParams(`api/v1/packages/helm/${repoName}/${chartName}`);
+    return request(url, {}, true, true, {}).then(response => response);
+  }
+
+  // Use /externalproxy for App-catalog desktop version
+
   return fetch(`http://localhost:4466/externalproxy`, {
     headers: {
       'Forward-To': `https://artifacthub.io/api/v1/packages/helm/${repoName}/${chartName}`,
@@ -38,9 +102,39 @@ export function fetchChartDetailFromArtifact(chartName: string, repoName: string
 }
 
 export function fetchChartValues(packageID: string, packageVersion: string) {
+  if (!isElectron()) {
+    let requestParam = '';
+    if (CHART_PROFILE === VANILLA_HELM_REPO) {
+      // When the token CUSTOM_CHART_VALUES_PREFIX is replaced during the deployment, expect the values.yaml for the specified
+      // package and version accessible on ${CUSTOM_CHART_VALUES_PREFIX}/${packageID}/${packageVersion}/values.yaml
+      if (CUSTOM_CHART_VALUES_PREFIX !== 'CUSTOM_CHART_VALUES_PREFIX') {
+        globalThis.CHART_VALUES_PREFIX = `${CUSTOM_CHART_VALUES_PREFIX}`;
+      }
+      // The code expects /${packageID}/${packageVersion}/values.yaml to return values.yaml for the component
+      // denoted by packageID and a given packageVersion. Please note that, chart.name is used for packageID in this case.
+      requestParam = `${CHART_VALUES_PREFIX}/${packageID}/${packageVersion}/values.yaml`;
+    } else if (CHART_PROFILE === COMMUNITY_REPO) {
+      requestParam = `api/v1/packages/${packageID}/${packageVersion}/values`;
+    }
+    const url =
+      `${SERVICE_PROXY}/${CATALOG_NAMESPACE}/${CATALOG_NAME}?` + getURLSearchParams(requestParam);
+
+    // Use /serviceproxy to fetch the resource, by specifying the access token
+    return request(url, { isJSON: false }, true, true, {}).then(response => response.text());
+  }
+
+  // Use /externalproxy for App-catalog desktop version
   return fetch(`http://localhost:4466/externalproxy`, {
     headers: {
       'Forward-To': `https://artifacthub.io/api/v1/packages/${packageID}/${packageVersion}/values`,
     },
   }).then(response => response.text());
 }
+
+export async function  fetchChartIcon(iconName: string) {
+  const url =
+      `${SERVICE_PROXY}/${CATALOG_NAMESPACE}/${CATALOG_NAME}?` +
+      getURLSearchParams(`${iconName}`);
+  return request(url, {isJSON: false}, true, true, {}).then(response => response);
+}
+

--- a/app-catalog/src/components/charts/Details.tsx
+++ b/app-catalog/src/components/charts/Details.tsx
@@ -13,6 +13,7 @@ import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import remarkGfm from 'remark-gfm';
 import { fetchChartDetailFromArtifact } from '../../api/charts';
 import { EditorDialog } from './EditorDialog';
+import { VANILLA_HELM_REPO } from './List';
 
 const { createRouteURL } = Router;
 export default function ChartDetails() {
@@ -31,6 +32,12 @@ export default function ChartDetails() {
   const [openEditor, setOpenEditor] = useState(false);
 
   useEffect(() => {
+    // Note: This path is not enabled for vanilla helm repo. Please check the following comment in charts/List.tsx
+    // TODO: The app-catalog using artifacthub.io loads the details about the chart with an option to install the chart
+    //
+    // An API to get details about a particular chart is required to achieve this. For example, take a look at the response
+    // from https://artifacthub.io/api/v1/packages/helm/grafana/grafana
+    // Easiest thing is to fetch index.yaml, get the details for chartName and fill the details
     fetchChartDetailFromArtifact(chartName, repoName).then(response => {
       setChart(response);
     });
@@ -81,12 +88,16 @@ export default function ChartDetails() {
                   <Box display="flex" alignItems="center">
                     {chart.logo_image_id && (
                       <Box mr={1}>
-                        <img
-                          src={`https://artifacthub.io/image/${chart.logo_image_id}`}
-                          width="25"
-                          height="25"
-                          alt={chart.name}
-                        />
+                          {CHART_PROFILE === VANILLA_HELM_REPO ? (
+                              <img src={`${chart?.icon || ''}`} width="25" height="25" alt={chart.name} />
+                              ) : (
+                              <img
+                                  src={`https://artifacthub.io/image/${chart.logo_image_id}`}
+                                  width="25"
+                                  height="25"
+                                  alt={chart.name}
+                              />
+                          )}
                       </Box>
                     )}
                     <Box>{chart.name}</Box>

--- a/app-catalog/src/components/charts/List.tsx
+++ b/app-catalog/src/components/charts/List.tsx
@@ -20,11 +20,13 @@ import {
 } from '@mui/material';
 import { Autocomplete, Pagination } from '@mui/material';
 import { useEffect, useRef, useState } from 'react';
-//import { jsonToYAML, yamlToJSON } from '../../helpers';
-import { fetchChartsFromArtifact } from '../../api/charts';
+import { yamlToJSON } from '../../helpers';
+import { fetchChartIcon, fetchChartsFromArtifact } from '../../api/charts';
+import { AvailableComponentVersions } from '../../helpers/catalog';
 //import { createRelease } from '../../api/releases';
 import { EditorDialog } from './EditorDialog';
 import { SettingsLink } from './SettingsLink';
+//import * as global from "global";
 
 interface AppCatalogConfig {
   /**
@@ -37,6 +39,25 @@ export const store = new ConfigStore<AppCatalogConfig>('app-catalog');
 const useStoreConfig = store.useConfig();
 
 export const PAGE_OFFSET_COUNT_FOR_CHARTS = 9;
+
+export const VANILLA_HELM_REPO = 'VANILLA_HELM_REPOSITORY';
+
+export const COMMUNITY_REPO = 'COMMUNITY_REPOSITORY';
+
+// Replace the token with the URL prefix to values.yaml for a component on ${CUSTOM_CHART_VALUES_PREFIX}/${packageID}/${packageVersion}/values.yaml
+// This is used only for the catalog provided by a vanilla Helm repository.
+// For the default behavior when this token is not replaced during deployment, please take a look at the global variable CHART_VALUES_PREFIX and its
+// usage in src/api/catalogs.tsx
+export const CUSTOM_CHART_VALUES_PREFIX = 'CUSTOM_CHART_VALUES_PREFIX';
+
+// The name of the helm repository added before installing an application, while using vanilla helm repository
+export const APP_CATALOG_HELM_REPOSITORY = 'app-catalog';
+
+// Define a global variable to hold the available versions of the components in the catalog
+declare global {
+  var AVAILABLE_VERSIONS: Map<any, any[]>;
+}
+
 
 interface SearchProps {
   search: string;
@@ -147,6 +168,7 @@ export function ChartsList({ fetchCharts = fetchChartsFromArtifact }) {
   const [chartCategory, setChartCategory] = useState(helmChartCategoryList[0]);
   const [search, setSearch] = useState('');
   const [selectedChartForInstall, setSelectedChartForInstall] = useState<any | null>(null);
+  const [iconUrls, setIconUrls] = useState<{ [url: string]: string }>({}); // New state for multiple icon URLs
 
   // note: since we default to true for showOnlyVerified and the settings page is not accessible from anywhere else but the list comp
   // we must have the default value here and have it imported for use in the settings tab
@@ -165,9 +187,18 @@ export function ChartsList({ fetchCharts = fetchChartsFromArtifact }) {
 
       async function fetchData() {
         try {
-          const response: any = await fetchCharts(search, showOnlyVerified, chartCategory, page);
-          setCharts(response.dataResponse.packages);
-          setChartsTotalCount(parseInt(response.total));
+          const response = await fetchCharts(search, showOnlyVerified, chartCategory, page);
+          const data = await response.dataResponse.text();
+          const d=yamlToJSON(data);
+          if (globalThis.CHART_PROFILE === VANILLA_HELM_REPO) {
+            setCharts(d.entries);
+            setChartsTotalCount(parseInt(response.total));
+            // Capture available versions from the response and set AVAILABLE_VERSIONS
+            globalThis.AVAILABLE_VERSIONS = AvailableComponentVersions(d.entries);
+          } else {
+            setCharts(d.packages);
+            setChartsTotalCount(parseInt(response.total));
+          }
         } catch (err) {
           console.error('Error fetching charts', err);
           setCharts([]);
@@ -178,6 +209,69 @@ export function ChartsList({ fetchCharts = fetchChartsFromArtifact }) {
     },
     [page, chartCategory, search, showOnlyVerified]
   );
+
+  useEffect(() => {
+        if (charts && Object.keys(charts).length > 0) {
+            const fetchIcons = async () => {
+                try {
+                    const iconUrls = {};
+                    const iconPromises = Object.values(charts).flatMap(chartArray =>
+                        chartArray.map(async chart => {
+                            const iconURL = chart.icon ?? '';
+                                if (iconURL === '') {
+                                    return;
+                                }
+                                const isURL = (urlString) => {
+                                    try {
+                                        new URL(urlString);
+                                        return true;
+                                    } catch (e) {
+                                        return false;
+                                    }
+                                };
+                                if (isURL(iconURL)) {
+                                    // may be an external icon URL, so, just use as is
+                                    iconUrls[iconURL] = iconURL
+                                } else {
+                                    const p = await fetchChartIcon(iconURL)
+                                        .then((response: any) =>  {
+                                            const contentType = response.headers.get('Content-Type');
+                                            if (contentType.includes('image/svg+xml') || contentType.includes('text/xml') || contentType.includes('text/plain')) {
+                                                response.text()
+                                                    .then((txt) =>
+                                                        new Promise((resolve, reject) => {
+                                                            const reader = new FileReader();
+                                                            reader.onloadend = () => reader.result
+                                                            reader.onerror = reject;
+                                                            iconUrls[iconURL] = `data:image/svg+xml;utf8,${encodeURIComponent(txt)}`;
+                                                        })
+                                                    );
+                                            } else if (contentType.includes('image/')) {
+                                                response.blob()
+                                                    .then((blob) =>
+                                                        new Promise((resolve, reject) => {
+                                                            const reader = new FileReader();
+                                                            reader.onloadend = () => reader.result
+                                                            reader.onerror = reject;
+                                                            reader.readAsDataURL(blob);
+                                                            iconUrls[iconURL] = URL.createObjectURL(blob);
+                                                        })
+                                                    );
+                                            }
+                                        })
+                                        .catch(error => console.error("failed to fetch icon:", error))
+                                }
+                        })
+                    );
+                     await Promise.all(iconPromises);
+                    setIconUrls(iconUrls);
+                } catch (error) {
+                    console.error("Error fetching icons:", error);
+                }
+            };
+            fetchIcons();
+        }
+  }, [charts]);
 
   return (
     <>
@@ -224,162 +318,221 @@ export function ChartsList({ fetchCharts = fetchChartsFromArtifact }) {
               flexDirection: { sm: 'column', md: 'row' },
             }}
           >
-            {charts.map(chart => {
-              return (
-                <Card
-                  sx={{
-                    margin: '1rem',
-                    display: 'flex',
-                    flexDirection: 'column',
-                    height: '100%',
-                    boxShadow: '0px 0px 5px 0px rgba(0,0,0,0.5)',
-                    width: {
-                      md: '40%',
-                      lg: '30%',
-                    },
-                  }}
-                >
-                  <Box
-                    height="60px"
-                    display="flex"
-                    alignItems="center"
-                    justifyContent="space-between"
-                    marginTop="15px"
-                  >
-                    {chart.logo_image_id && (
-                      <CardMedia
-                        image={`https://artifacthub.io/image/${chart.logo_image_id}`}
-                        alt={`${chart.name} logo`}
-                        sx={{
-                          width: '60px',
-                          height: '60px',
-                          margin: '1rem',
-                          alignSelf: 'flex-start',
-                          objectFit: 'contain',
-                        }}
-                        component="img"
-                      />
-                    )}
-                    <Box display="flex" alignItems="center" marginLeft="auto" marginRight="10px">
-                      {(chart.cncf || chart.repository.cncf) && (
-                        <Tooltip title="CNCF Project">
-                          <Icon
-                            icon="simple-icons:cncf"
-                            style={{
-                              marginLeft: '0.5em',
-                              fontSize: '20px',
-                            }}
-                          />
-                        </Tooltip>
-                      )}
-                      {(chart.official || chart.repository.official) && (
-                        <Tooltip title="Official Chart">
-                          <Icon
-                            icon="mdi:star-circle"
-                            style={{
-                              marginLeft: '0.5em',
-                              fontSize: '22px',
-                            }}
-                          />
-                        </Tooltip>
-                      )}
-                      {chart.repository.verified_publisher && (
-                        <Tooltip title="Verified Publisher">
-                          <Icon
-                            icon="mdi:check-decagram"
-                            style={{
-                              marginLeft: '0.5em',
-                              fontSize: '22px',
-                            }}
-                          />
-                        </Tooltip>
-                      )}
-                    </Box>
-                  </Box>
-                  <CardContent
-                    sx={{
-                      margin: '1rem 0rem',
-                      height: '25vh',
-                      overflow: 'hidden',
-                      paddingTop: 0,
-                    }}
-                  >
-                    <Box
-                      sx={{
-                        overflow: 'hidden',
-                        textOverflow: 'ellipsis',
-                        whiteSpace: 'nowrap',
-                      }}
+            {
+                // Filter out the charts meeting the value entered for search field and display only the matching charts
+                Object.keys(
+                  Object.keys(charts)
+                    .filter(key => key.match(search))
+                    .reduce((obj, key) => {
+                      return Object.assign(obj, {
+                        [key]: charts[key],
+                      });
+                    }, {})
+                ).map(chartName => {
+                  // When a chart contains multiple versions, only display the first version
+                  return charts[chartName].slice(0, 1).map(chart => {
+                return (
+                    <Card key={chart.icon}
+                          sx={{
+                            margin: '1rem',
+                            display: 'flex',
+                            flexDirection: 'column',
+                            height: '100%',
+                            boxShadow: '0px 0px 5px 0px rgba(0,0,0,0.5)',
+                            width: {
+                              md: '40%',
+                              lg: '30%',
+                            },
+                          }}
                     >
-                      <Tooltip title={chart.name}>
-                        <Typography component="h2" variant="h5">
-                          <RouterLink
-                            routeName="/helm/:repoName/charts/:chartName"
-                            params={{
-                              chartName: chart.name,
-                              repoName: chart.repository.name,
-                            }}
-                          >
-                            {chart.name}
-                          </RouterLink>
-                        </Typography>
-                      </Tooltip>
-                    </Box>
-                    <Box display="flex" justifyContent="space-between" my={1}>
-                      <Typography>v{chart.version}</Typography>
                       <Box
-                        marginLeft={1}
-                        sx={{
-                          overflow: 'hidden',
-                          textOverflow: 'ellipsis',
-                          whiteSpace: 'nowrap',
-                        }}
+                          height="60px"
+                          display="flex"
+                          alignItems="center"
+                          justifyContent="space-between"
+                          marginTop="15px"
                       >
-                        <Tooltip title={chart?.repository?.name || ''}>
-                          <Typography>{chart?.repository?.name || ''}</Typography>
-                        </Tooltip>
-                      </Box>
-                    </Box>
-                    <Divider />
-                    <Box mt={1}>
-                      <Typography>
-                        {chart?.description?.slice(0, 100)}
-                        {chart?.description?.length > 100 && (
-                          <Tooltip title={chart?.description}>
-                            <span>…</span>
-                          </Tooltip>
+                        {globalThis.CHART_PROFILE === VANILLA_HELM_REPO ? (
+                            iconUrls[chart.icon] && (
+                                <CardMedia
+                                    image={iconUrls[chart.icon]}
+                                    alt={`${chart.name} logo`}
+                                    sx={{
+                                      width: '60px',
+                                      height: '60px',
+                                      margin: '1rem',
+                                      alignSelf: 'flex-start',
+                                      objectFit: 'contain',
+                                    }}
+                                    component="img"
+                                />
+                            )
+                        ) : (
+                            chart.logo_image_id && (
+                                <CardMedia
+                                    image={`https://artifacthub.io/image/${chart.logo_image_id}`}
+                                    alt={`${chart.name} logo`}
+                                    sx={{
+                                      width: '60px',
+                                      height: '60px',
+                                      margin: '1rem',
+                                      alignSelf: 'flex-start',
+                                      objectFit: 'contain',
+                                    }}
+                                    component="img"
+                                />
+                            )
                         )}
-                      </Typography>
-                    </Box>
-                  </CardContent>
-                  <CardActions
-                    sx={{
-                      justifyContent: 'space-between',
-                      padding: '14px',
-                    }}
-                  >
-                    <Button
-                      sx={{
-                        backgroundColor: '#000',
-                        color: 'white',
-                        textTransform: 'none',
-                        '&:hover': {
-                          background: '#605e5c',
-                        },
-                      }}
-                      onClick={() => {
-                        setSelectedChartForInstall(chart);
-                        setEditorOpen(true);
-                      }}
-                    >
-                      Install
-                    </Button>
-                    <Link href={chart?.repository?.url} target="_blank">
-                      Learn More
-                    </Link>
-                  </CardActions>
-                </Card>
-              );
+                        <Box display="flex" alignItems="center" marginLeft="auto" marginRight="10px">
+                          {(chart?.cncf || chart?.repository?.cncf) && (
+                              <Tooltip title="CNCF Project">
+                                <Icon
+                                    icon="simple-icons:cncf"
+                                    style={{
+                                      marginLeft: '0.5em',
+                                      fontSize: '20px',
+                                    }}
+                                />
+                              </Tooltip>
+                          )}
+                          {(chart?.official || chart?.repository?.official) && (
+                              <Tooltip title="Official Chart">
+                                <Icon
+                                    icon="mdi:star-circle"
+                                    style={{
+                                      marginLeft: '0.5em',
+                                      fontSize: '22px',
+                                    }}
+                                />
+                              </Tooltip>
+                          )}
+                          {chart?.repository?.verified_publisher && (
+                              <Tooltip title="Verified Publisher">
+                                <Icon
+                                    icon="mdi:check-decagram"
+                                    style={{
+                                      marginLeft: '0.5em',
+                                      fontSize: '22px',
+                                    }}
+                                />
+                              </Tooltip>
+                          )}
+                        </Box>
+                      </Box>
+                      <CardContent
+                          sx={{
+                            margin: '1rem 0rem',
+                            height: '10vh',
+                            overflow: 'hidden',
+                            paddingTop: 0,
+                          }}
+                      >
+                        <Box
+                            sx={{
+                              overflow: 'hidden',
+                              textOverflow: 'ellipsis',
+                              whiteSpace: 'nowrap',
+                            }}
+                        >
+                          <Tooltip title={chart.name}>
+                            <Typography component="h2" variant="h5">
+                                {/* TODO: The app-catalog using artifacthub.io loads the details about the chart with an option to install the chart
+                                    Fix this for vanilla helm repo */}
+                                {globalThis.CHART_PROFILE === VANILLA_HELM_REPO ? chart.name :
+                                (
+                                    <RouterLink
+                                        routeName="/helm/:repoName/charts/:chartName"
+                                        params={{
+                                            chartName: chart.name,
+                                            repoName: chart?.repository?.name,
+                                        }}
+                                    >
+                                     {chart.name}
+                                    </RouterLink>
+                                )}
+
+                            </Typography>
+                          </Tooltip>
+                        </Box>
+                        <Box display="flex" justifyContent="space-between" my={1}>
+                          {/* If the chart.version contains v prefix, remove it */}
+                          {chart.version.startsWith('v') ? (
+                              <Typography>{chart.version}</Typography>
+                          ) : (
+                              <Typography>v{chart.version}</Typography>
+                          )}
+                          <Box
+                              marginLeft={1}
+                              sx={{
+                                overflow: 'hidden',
+                                textOverflow: 'ellipsis',
+                                whiteSpace: 'nowrap',
+                              }}
+                          >
+                            <Tooltip title={chart?.repository?.name || ''}>
+                              <Typography>{chart?.repository?.name || ''}</Typography>
+                            </Tooltip>
+                          </Box>
+                        </Box>
+                        <Divider />
+                        <Box mt={1}>
+                          <Typography>
+                            {chart?.description?.slice(0, 100)}
+                            {chart?.description?.length > 100 && (
+                                <Tooltip title={chart?.description}>
+                                  <span>…</span>
+                                </Tooltip>
+                            )}
+                          </Typography>
+                        </Box>
+                      </CardContent>
+                      <CardActions
+                          sx={{
+                            justifyContent: 'space-between',
+                            padding: '14px',
+                          }}
+                      >
+                        <Button
+                            sx={{
+                              backgroundColor: '#000',
+                              color: 'white',
+                              textTransform: 'none',
+                              '&:hover': {
+                                background: '#605e5c',
+                              },
+                            }}
+                            onClick={() => {
+                              setSelectedChartForInstall(chart);
+                              setEditorOpen(true);
+                            }}
+                        >
+                          Install
+                        </Button>
+                        {/*
+                            Provide Learn More link only when the chart has source
+                            When there are multiple sources for a chart, use the first source for the link, rather than using comma separated values
+                    */}
+                          {globalThis.CHART_PROFILE === VANILLA_HELM_REPO ? (
+                              !chart?.sources ? (
+                                  ''
+                              ) : chart?.sources?.length === 1 ? (
+                                  <Link href={chart?.sources} target="_blank">
+                                      Learn More
+                                  </Link>
+                              ) : (
+                                  <Link href={chart?.sources[0]} target="_blank">
+                                      Learn More
+                                  </Link>
+                              )
+                          ):(
+                              <Link href={chart?.repository?.url} target="_blank">
+                                  Learn More
+                              </Link>
+                          )}
+                      </CardActions>
+                    </Card>
+                );
+              });
             })}
           </Box>
         )}
@@ -398,11 +551,13 @@ export function ChartsList({ fetchCharts = fetchChartsFromArtifact }) {
           />
         </Box>
       )}
-      <Box textAlign="right">
-        <Link href="https://artifacthub.io/" target="_blank">
-          Powered by ArtifactHub
-        </Link>
-      </Box>
+      {globalThis.CHART_PROFILE !== VANILLA_HELM_REPO && (
+          <Box textAlign="right">
+              <Link href="https://artifacthub.io/" target="_blank">
+                  Powered by ArtifactHub
+              </Link>
+          </Box>
+      )}
     </>
   );
 }

--- a/app-catalog/src/components/releases/EditorDialog.tsx
+++ b/app-catalog/src/components/releases/EditorDialog.tsx
@@ -16,6 +16,7 @@ import { useEffect, useRef, useState } from 'react';
 import semver from 'semver';
 import { fetchChart, getActionStatus, upgradeRelease } from '../../api/releases';
 import { jsonToYAML, yamlToJSON } from '../../helpers';
+import {APP_CATALOG_HELM_REPOSITORY} from "../charts/List";
 
 export function EditorDialog(props: {
   openEditor: boolean;
@@ -64,7 +65,8 @@ export function EditorDialog(props: {
         let response;
         let error: Error | null = null;
         try {
-          response = await fetchChart(release.chart.metadata.name);
+          const metadataName = release.chart.metadata.name === APP_CATALOG_HELM_REPOSITORY ? '/' + release.chart.metadata.name : release.chart.metadata.name;
+          response = await fetchChart(metadataName);
         } catch (err) {
           error = err;
         }
@@ -74,11 +76,10 @@ export function EditorDialog(props: {
         }
 
         if (!!error) {
-          enqueueSnackbar(`Error fetching chart versions: ${error}`, {
+          enqueueSnackbar(`Error fetching chart versions: ${error.message}`, {
             variant: 'error',
             autoHideDuration: 5000,
           });
-          return;
         }
 
         setIsLoading(false);

--- a/app-catalog/src/helpers/catalog.ts
+++ b/app-catalog/src/helpers/catalog.ts
@@ -1,0 +1,89 @@
+import { fetchCatalogs } from '../api/catalogs';
+
+const ANNOTATION_URI = 'catalog.ocne.io/uri';
+const ANNOTATION_NAME = 'catalog.ocne.io/name';
+const ANNOTATION_PROTOCOL = 'catalog.ocne.io/protocol';
+const ANNOTATION_DISPLAY_NAME = 'catalog.ocne.io/displayName';
+
+const DEFAULT_CATALOG_NAME = 'app-catalog';
+const DEFAULT_CATALOG_NAMESPACE = 'ocne-system';
+
+// Catalog interface, containing information relevant to register a catalog in the sidebar
+interface Catalog {
+  name: string;
+  displayName: string;
+  metadataName: string;
+  namespace: string;
+  protocol: string;
+  uri: string;
+}
+
+// An interface to define component versions
+interface ComponentVersions {
+  version: string;
+}
+
+// Fetch the list of catalogs installed
+export function CatalogLists() {
+  return fetchCatalogs().then(function (response) {
+    const catalogList: Array<Catalog> = new Array<Catalog>();
+    for (let i = 0; i < response.items.length; i++) {
+      let serviceUri = '';
+      const metadata = response.items[i].metadata;
+      if (ANNOTATION_URI in metadata.annotations) {
+        serviceUri = metadata.annotations[ANNOTATION_URI];
+      }
+
+      // Using the first port
+      if (serviceUri === '') {
+        const port = response.items[i].spec.ports[0];
+        serviceUri = port.name + '://' + metadata.name + '.' + metadata.namespace + ':' + port.port;
+      }
+
+      let catalogDisplayName = '';
+      if (ANNOTATION_DISPLAY_NAME in metadata.annotations && metadata.annotations[ANNOTATION_DISPLAY_NAME] != '') {
+        catalogDisplayName = metadata.annotations[ANNOTATION_DISPLAY_NAME]
+      } else {
+        catalogDisplayName = metadata.annotations[ANNOTATION_NAME]
+      }
+
+      const catalog: Catalog = {
+        name: metadata.name + '-' + metadata.namespace,
+        // If there are 2 catalogs deployed with same name, the sidebar will be same. If we use the namespace,
+        // the sidebar will be too long
+        displayName: catalogDisplayName,
+        metadataName: metadata.name,
+        namespace: metadata.namespace,
+        protocol: metadata.annotations[ANNOTATION_PROTOCOL],
+        uri: serviceUri,
+      };
+
+      // Insert the default catalog as the first element of the array
+      if (
+        metadata.name === DEFAULT_CATALOG_NAME &&
+        metadata.namespace === DEFAULT_CATALOG_NAMESPACE
+      ) {
+        catalogList.unshift(catalog);
+      } else {
+        catalogList.push(catalog);
+      }
+    }
+    return catalogList;
+  });
+}
+
+// Return a map with component as the key and an array of versions as the value
+export function AvailableComponentVersions(chartEntries: any[]) {
+  const compVersions = new Map<any, any[]>();
+  for (const [key, value] of Object.entries(chartEntries)) {
+    const versions: Array<ComponentVersions> = new Array<ComponentVersions>();
+    for (let i = 0; i < value.length; i++) {
+      const v: ComponentVersions = {
+        version: value[i].version,
+      };
+      versions.push(v);
+    }
+    compVersions.set(key, versions);
+  }
+  return compVersions;
+}


### PR DESCRIPTION
This PR adds support for securely fetching charts from both Vanilla Helm and Artifact Hub repositories using the /serviceproxy route.

Changes: 
- Added serviceproxy support for secure in-cluster chart access.
- Enabled support for Helm repositories via index.yaml parsing.
- Dynamically generated sidebars and routes based on catalog metadata.
- Updated UI components (List, EditorDialog, Details) to support both Helm and ArtifactHub protocols.
- Fallback support for Electron via externalproxy

