### PR TITLE
Dockerfile: Added logic to skip development dependencies in…

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+.git
+*.md
+tests/
+coverage/
+.env
+*.log


### PR DESCRIPTION
A new PR to resolve PR conflicts from here https://github.com/headlamp-k8s/plugins/pull/292

## Description

-  Optimized Dockerfile: Added logic to skip development dependencies in production builds when ENVIRONMENT is set to production.
- Added `.dockerignore`: Excluded node_modules, .git, and test files to reduce Docker image size and improve build efficiency.
- Configurable Image Versions: Introduced BASE_IMAGE_VERSION and FINAL_IMAGE_VERSION arguments in the Dockerfile and fixed unsupported Node base image versions.

---
Split [this](https://github.com/headlamp-k8s/plugins/pull/290) PR.
https://github.com/headlamp-k8s/plugins/pull/290#issuecomment-2994200788