### PR TITLE
flux: Add types and fix unknown string function in Inventory

### DIFF
--- a/flux/src/helm-releases/Inventory.tsx
+++ b/flux/src/helm-releases/Inventory.tsx
@@ -1,6 +1,7 @@
 import { K8s } from '@kinvolk/headlamp-plugin/lib';
 import { request } from '@kinvolk/headlamp-plugin/lib/ApiProxy';
 import { DateLabel, Link } from '@kinvolk/headlamp-plugin/lib/components/common';
+import type { KubeObjectInterface } from '@kinvolk/headlamp-plugin/lib/lib/k8s/cluster';
 import { Base64 } from 'js-base64';
 import React from 'react';
 import Table from '../common/Table';
@@ -214,14 +215,18 @@ function parseHelmTemplate(template): {
  * @param {Array<{ kind: string, apiVersion: string, hasNamespace: boolean }>} resourceKinds - Array of resource kind objects containing kind, apiVersion, and hasNamespace properties.
  * @param {string} chartName - The name of the Helm chart.
  * @param {string} namespace - The namespace in which the Helm chart is deployed.
- * @returns {Promise<Array<Object>>} - A promise that resolves to an array of fetched resources with additional metadata.
+ * @returns {Promise<Array<HelmResourceKind>>} - A promise that resolves to an array of fetched resources with additional metadata.
  */
+
+interface HelmResourceKind extends KubeObjectInterface {
+  groupName: string;
+}
 
 async function fetchResources(
   resourceKinds,
   chartName: string,
   namespace: string
-): Promise<Array<Object>> {
+): Promise<Array<HelmResourceKind>> {
   const resources = [];
 
   const queryParams = new URLSearchParams();
@@ -263,16 +268,16 @@ async function fetchResources(
  * parameters depending on the resource's kind and group name.
  *
  * @param {Object} item - A Kubernetes resource object.
- * @returns {JSX.Element} - A link to the resource.
+ * @returns {React.ReactNode} - A link to the resource.
  */
-function inventoryNameLink(item): JSX.Element {
+function inventoryNameLink(item: HelmResourceKind): React.ReactNode {
   const kind = item.kind;
   const groupName = item.groupName;
   const pluralName = PluralName(kind);
 
   // Flux types
   const allowedDomain = 'toolkit.fluxcd.io';
-  if (groupName === allowedDomain || groupName.endswith(`.${allowedDomain}`)) {
+  if (groupName === allowedDomain || groupName.endsWith(`.${allowedDomain}`)) {
     const routeName =
       groupName === allowedDomain ? 'toolkit' : groupName.substring(0, groupName.indexOf('.'));
 

--- a/flux/src/kustomizations/Inventory.tsx
+++ b/flux/src/kustomizations/Inventory.tsx
@@ -1,6 +1,6 @@
 import { K8s } from '@kinvolk/headlamp-plugin/lib';
 import { DateLabel, Link } from '@kinvolk/headlamp-plugin/lib/components/common';
-import { KubeObject } from '@kinvolk/headlamp-plugin/lib/lib/k8s/cluster';
+import type { KubeObject, KubeObjectInterface } from '@kinvolk/headlamp-plugin/lib/lib/k8s/cluster';
 import { makeCustomResourceClass } from '@kinvolk/headlamp-plugin/lib/lib/k8s/crd';
 import React from 'react';
 import Table from '../common/Table';
@@ -124,15 +124,16 @@ function inventoryNameLink(item: KubeObject) {
   }
 
   const kind = item.kind;
+  const itemJsonData: KubeObjectInterface = item.jsonData;
   // remove version from apiVersion to get the groupName
-  const apiVersion = item.jsonData.apiVersion;
+  const apiVersion = itemJsonData.apiVersion;
   const slashIndex = apiVersion.lastIndexOf('/');
   const groupName = slashIndex > 0 ? apiVersion.substring(0, slashIndex) : apiVersion;
   const pluralName = PluralName(kind);
 
   // Flux types
   const allowedDomain = 'toolkit.fluxcd.io';
-  if (groupName === allowedDomain || groupName.endswith(`.${allowedDomain}`)) {
+  if (groupName === allowedDomain || groupName.endsWith(`.${allowedDomain}`)) {
     const routeName =
       groupName === allowedDomain ? 'toolkit' : groupName.substring(0, groupName.indexOf('.'));
 


### PR DESCRIPTION
Due to the types not being defined, a typo ("endswith" instead of "endsWith") was being covered and led to issues when running.