### PR TITLE
app-catalog: Fix Updated column values

### DIFF
--- a/app-catalog/src/components/releases/Detail.tsx
+++ b/app-catalog/src/components/releases/Detail.tsx
@@ -250,7 +250,11 @@ export default function ReleaseDetail() {
       {releaseHistory && (
         <SectionBox title="History">
           <SimpleTable
-            data={releaseHistory === null ? null : releaseHistory.releases}
+            data={
+              releaseHistory === null
+                ? null
+                : [...releaseHistory.releases].sort((a, b) => b.version - a.version)
+            }
             defaultSortingColumn={1}
             columns={[
               {


### PR DESCRIPTION
This change fixes the values in the Updated column of the app catalog, which were previously displaying the values in reverse (i.e. most recent revision would look oldest and vice versa).

Fixes: #311 

### Testing
- [X] Go to the Installed apps tab of the app catalog
- [X] Select an app with multiple revisions
- [X] Observe the values in the Updated column vs. the order of the revisions

![image](https://github.com/user-attachments/assets/4f931300-36c0-443a-81d0-2a9bcbd013c4)