### PR TITLE
app-catalog: Fix missing icons for installed apps

### DIFF
--- a/app-catalog/src/components/releases/List.tsx
+++ b/app-catalog/src/components/releases/List.tsx
@@ -31,13 +31,15 @@ export default function ReleaseList({ fetchReleases = listReleases }) {
             label: 'Name',
             getter: release => (
               <Box display="flex" alignItems="center">
-                <Box>
-                  <img
-                    width={50}
-                    src={release.chart.metadata.icon}
-                    alt={release.chart.metadata.name}
-                  />
-                </Box>
+                {release.chart.metadata.icon && (
+                  <Box>
+                    <img
+                      width={50}
+                      src={release.chart.metadata.icon}
+                      alt={release.chart.metadata.name}
+                    />
+                  </Box>
+                )}
                 <Box ml={1}>
                   <Link
                     routeName="/helm/:namespace/releases/:releaseName"


### PR DESCRIPTION
This change fixes missing icons in the Installed tab of the app catalog by not rendering them.

Fixes: #316 

----

![image](https://github.com/user-attachments/assets/41227ff5-3b73-4657-8fe0-05cf33cd3c31)
