### PR TITLE
flux: Fix pluralName helper and update how we show overview

### DIFF
--- a/flux/src/helpers/pluralName.tsx
+++ b/flux/src/helpers/pluralName.tsx
@@ -10,9 +10,9 @@ const consonants = 'bcdfghjklmnpqrstvwxyz';
 
 // Name returns the plural form of the type's name.
 export function PluralName(kind: string): string {
-  const singular = kind.toLowerCase();
-  const lastChar = singular.substring(singular.length - 1, singular.length);
-  const beforeLastChar = singular.substring(singular.length - 2, singular.length - 1);
+  const singular = kind?.toLowerCase();
+  const lastChar = singular?.substring(singular.length - 1, singular.length);
+  const beforeLastChar = singular?.substring(singular.length - 2, singular.length - 1);
 
   switch (lastChar) {
     case 's':

--- a/flux/src/index.tsx
+++ b/flux/src/index.tsx
@@ -228,6 +228,7 @@ registerKindIcon('Kustomization', {
   icon: <Icon icon="simple-icons:flux" width="70%" height="70%" />,
   color: 'rgb(50, 108, 229)',
 });
+
 registerKindIcon('OCIRepository', {
   icon: <Icon icon="simple-icons:flux" width="70%" height="70%" />,
   color: 'rgb(50, 108, 229)',


### PR DESCRIPTION
We want the failed status to be shown first thing in the overview. This PR takes the failed ones and shows them first and then the rest. We also fix the pluralName to call for functions when the kind could be undefined.