### PR TITLE
Dockerfile: restored npm install to fix Docker build on main branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN echo "Cleaning arch-dependent files for plugin $PLUGIN..."; \
 # Install dependencies for the specified plugin
 RUN echo "Installing deps for plugin $PLUGIN..."; \
     cd /headlamp-plugins/$PLUGIN; \
-    npm ci
+    npm install
 
 # Build the specified plugin
 RUN echo "Building plugin $PLUGIN..."; \


### PR DESCRIPTION
Fixes the Dockerfile by reverting the npm ci change from @skoeva. npm ci relies on the package-lock.json that is explicitly deleted in the previous step. I agree npm ci is better but before restoring npm ci, the previous step that deletes package-lock.json needs to be fixed.