### PR TITLE
karpenter: Dashboard for pending pods

### DIFF
--- a/karpenter/src/PendingPods/Events.tsx
+++ b/karpenter/src/PendingPods/Events.tsx
@@ -3,17 +3,65 @@ import Event from '@kinvolk/headlamp-plugin/lib/K8s/event';
 import { timeAgo } from '@kinvolk/headlamp-plugin/lib/Utils';
 import { PendingPodsRenderer } from './List';
 
+/**
+ * Represents a pending Kubernetes pod with associated event information.
+ * This interface combines pod metadata with relevant event details that
+ * explain why the pod is in a pending state.
+ */
 export interface PendingPod {
+  /**
+   * The unique identifier of the pod (UID)
+   */
   id: string;
+
+  /**
+   * The name of the pod
+   */
   name: string;
+
+  /**
+   * The type of event associated with the pod
+   */
   type: string;
+
+  /**
+   * The component that generated the event
+   */
   source: string;
+
+  /**
+   * The namespace where the pod is located
+   */
   namespace: string;
+
+  /**
+   * The reason for the event
+   */
   reason: string;
+
+  /**
+   * Detailed message describing the event
+   */
   message: string;
+
+  /**
+   * How long the pod has been pending
+   */
   age: string;
+
+  /**
+   * Number of times this event has occurred
+   */
   count: number;
+
+  /**
+   * Timestamp of when the event last occurred
+   */
   lastOccurrence: any;
+
+  /**
+   * Timestamp of when the event first occurred
+   */
   firstOccurrence: any;
 }
 

--- a/karpenter/src/PendingPods/Events.tsx
+++ b/karpenter/src/PendingPods/Events.tsx
@@ -1,7 +1,7 @@
 import { K8s } from '@kinvolk/headlamp-plugin/lib';
 import Event from '@kinvolk/headlamp-plugin/lib/K8s/event';
 import { timeAgo } from '@kinvolk/headlamp-plugin/lib/Utils';
-import {PendingPodsRenderer} from './List';
+import { PendingPodsRenderer } from './List';
 
 export interface PendingPod {
   id: string;
@@ -73,5 +73,5 @@ export const PodEvents = (props: { reason: string; kind: string; phase: string }
 
   const data = Array.from(podsWithEvents.values());
 
-  return <PendingPodsRenderer pods={data} />
+  return <PendingPodsRenderer pods={data} />;
 };

--- a/karpenter/src/PendingPods/Events.tsx
+++ b/karpenter/src/PendingPods/Events.tsx
@@ -1,0 +1,77 @@
+import { K8s } from '@kinvolk/headlamp-plugin/lib';
+import Event from '@kinvolk/headlamp-plugin/lib/K8s/event';
+import { timeAgo } from '@kinvolk/headlamp-plugin/lib/Utils';
+import {PendingPodsRenderer} from './List';
+
+export interface PendingPod {
+  id: string;
+  name: string;
+  type: string;
+  source: string;
+  namespace: string;
+  reason: string;
+  message: string;
+  age: string;
+  count: number;
+  lastOccurrence: any;
+  firstOccurrence: any;
+}
+
+export const PodEvents = (props: { reason: string; kind: string; phase: string }) => {
+  const [events] = Event.useList({
+    fieldSelector:
+      `reason=${props.reason},involvedObject.kind=${props.kind},` +
+      'involvedObject.fieldPath!=spec.initContainers{*}',
+  });
+  const [pods] = K8s.ResourceClasses.Pod.useList({
+    fieldSelector: `status.phase=${props.phase}`,
+  });
+
+  if (!events || !pods) {
+    return null;
+  }
+
+  const podMap = new Map<string, PendingPod>();
+
+  pods.forEach(pod => {
+    podMap.set(pod.jsonData.metadata.name, {
+      id: pod.jsonData.metadata.uid,
+      name: pod.jsonData.metadata.name,
+      type: '',
+      source: '',
+      namespace: pod.jsonData.metadata.namespace,
+      reason: '',
+      message: '',
+      age: timeAgo(pod.metadata.creationTimestamp),
+      count: 0,
+      lastOccurrence: '',
+      firstOccurrence: '',
+    });
+  });
+
+  const podsWithEvents = new Map<string, PendingPod>();
+
+  events.forEach(event => {
+    const podName = event.involvedObject.name;
+    if (podMap.has(podName)) {
+      const pod = podMap.get(podName)!;
+
+      if (event.reason && event.message && event.type) {
+        podsWithEvents.set(podName, {
+          ...pod,
+          reason: event.reason,
+          message: event.message,
+          type: event.type,
+          source: event.source?.component || '',
+          count: event.count || 0,
+          lastOccurrence: event.lastOccurrence || '',
+          firstOccurrence: event.firstOccurrence || '',
+        });
+      }
+    }
+  });
+
+  const data = Array.from(podsWithEvents.values());
+
+  return <PendingPodsRenderer pods={data} />
+};

--- a/karpenter/src/PendingPods/List.tsx
+++ b/karpenter/src/PendingPods/List.tsx
@@ -1,0 +1,124 @@
+import {
+  HoverInfoLabel,
+  Link,
+  SectionBox,
+  SectionFilterHeader,
+  ShowHideLabel,
+  Table,
+} from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { localeDate, timeAgo } from '@kinvolk/headlamp-plugin/lib/Utils';
+import { PendingPod } from './Events';
+
+export const PendingPodsRenderer = (props: { pods?: PendingPod[] }) => {
+  const { pods } = props;
+  if (!pods) {
+    return <></>;
+  }
+
+  return (
+    <>
+      <SectionBox title={<SectionFilterHeader title={'Pending Pods'} noNamespaceFilter />}>
+        <Table
+          columns={[
+            {
+              id: 'name',
+              header: 'Name',
+              accessorFn: item => (
+                <Link
+                  routeName="Pod"
+                  params={{
+                    name: item.name,
+                    namespace: item.namespace,
+                  }}
+                >
+                  {item.name}
+                </Link>
+              ),
+            },
+            {
+              header: 'Namespace',
+              accessorFn: item => (
+                <Link
+                  routeName="namespace"
+                  params={{
+                    name: item.namespace,
+                  }}
+                >
+                  {item.namespace}
+                </Link>
+              ),
+            },
+            {
+              header: 'Type',
+              accessorFn: item => {
+                return item.type;
+              },
+            },
+            {
+              header: 'Reason',
+              accessorFn: item => {
+                return item.reason;
+              },
+            },
+            {
+              header: 'From',
+              accessorFn: item => {
+                return item.source;
+              },
+            },
+            {
+              header: 'Message',
+              accessorFn: item => {
+                return (
+                  item && (
+                    <ShowHideLabel labelId={`${item?.id}-message`}>
+                      {item.message ?? ''}
+                    </ShowHideLabel>
+                  )
+                );
+              },
+            },
+            {
+              id: 'age',
+              header: 'Age',
+              accessorFn: item => {
+                if (item.count > 1) {
+                  return `${timeAgo(item.lastOccurrence)} (${item.count} times over ${timeAgo(
+                    item.firstOccurrence
+                  )})`;
+                }
+                const eventDate = timeAgo(item.lastOccurrence, { format: 'mini' });
+                let label: string;
+                if (item.count > 1) {
+                  label = `${eventDate} ${item.count} times since ${timeAgo(item.firstOccurrence)}`;
+                } else {
+                  label = eventDate;
+                }
+                return (
+                  <HoverInfoLabel
+                    label={label}
+                    hoverInfo={localeDate(item.lastOccurrence)}
+                    icon="mdi:calendar"
+                  />
+                );
+              },
+              gridTemplate: 'min-content',
+              muiTableBodyCellProps: {
+                align: 'right',
+              },
+            },
+          ]}
+          data={pods}
+          initialState={{
+            sorting: [
+              {
+                id: 'name',
+                desc: false,
+              },
+            ],
+          }}
+        />
+      </SectionBox>
+    </>
+  );
+};

--- a/karpenter/src/PendingPods/index.tsx
+++ b/karpenter/src/PendingPods/index.tsx
@@ -1,0 +1,9 @@
+import { PodEvents } from './Events';
+
+export const PendingPods = () => {
+  return (
+    <>
+      <PodEvents reason="FailedScheduling" kind="Pod" phase="Pending" />
+    </>
+  );
+};

--- a/karpenter/src/index.tsx
+++ b/karpenter/src/index.tsx
@@ -18,6 +18,7 @@ import { NodeClassDetailView } from './NodeClass/Details';
 import { NodeClasses } from './NodeClass/List';
 import { NodePoolDetailView } from './NodePool/Details';
 import { NodePools } from './NodePool/List';
+import { PendingPods } from './PendingPods';
 
 registerSidebarEntry({
   parent: null,
@@ -67,3 +68,17 @@ registerRoute({
   component: NodePoolDetailView,
   name: 'nodepools-detail',
 });
+
+registerSidebarEntry({
+  parent: 'karpenter.k8s',
+  name: 'pending-pods',
+  label: 'Pending Pods',
+  url: '/karpenter/pending-pods',
+});
+
+registerRoute({
+  path: '/karpenter/pending-pods',
+  sidebar: 'pending-pods',
+  component: PendingPods,
+  name: 'pending-pods-view'
+})

--- a/karpenter/src/index.tsx
+++ b/karpenter/src/index.tsx
@@ -80,5 +80,5 @@ registerRoute({
   path: '/karpenter/pending-pods',
   sidebar: 'pending-pods',
   component: PendingPods,
-  name: 'pending-pods-view'
-})
+  name: 'pending-pods-view',
+});


### PR DESCRIPTION
## Dashboard for Pending Pods highlighting why they couldn't be scheduled

### Overview

This PR introduces a dashboard view to observe Pending Pods and observe the reason behind the pending status.

## Related Issue
Part of https://github.com/kubernetes-sigs/headlamp/issues/3231

### Demo/Screenshots


[Screencast from 2025-07-18 01-34-51.webm](https://github.com/user-attachments/assets/4aec7272-f42b-4a54-821f-bde5d436e63b)
