### PR TITLE
Dockerfile: Use npm install instead of npm ci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,9 +32,9 @@ RUN echo "Installing deps for plugin $PLUGIN..."; \
     cd /headlamp-plugins/$PLUGIN; \
     echo "Installing $ENVIRONMENT dependencies..."; \
     if [ "$ENVIRONMENT" = "production" ]; then \
-     npm ci --omit=dev; \
+     npm install --omit=dev; \
     else \
-      npm ci; \
+      npm install; \
     fi
 
 # Build the specified plugin


### PR DESCRIPTION
This PR reverts the change done in #315 since we delete the `package-lock.json` in the previous step.

Follow-up from #325 