### PR TITLE
ai-assistant: Bump prismjs to 1.30.0

### DIFF
--- a/ai-assistant/package-lock.json
+++ b/ai-assistant/package-lock.json
@@ -16318,15 +16318,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/refractor/node_modules/prismjs": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz",
-      "integrity": "sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",

--- a/ai-assistant/package.json
+++ b/ai-assistant/package.json
@@ -57,6 +57,7 @@
     "zod": "^3.24.2"
   },
   "overrides": {
+    "prismjs": "^1.30.0",
     "typescript": "5.6.2"
   }
 }


### PR DESCRIPTION
This change updates the prismjs dependency in the ai-assistant plugin to 1.30.0 as desired.