### PR TITLE
karpenter: fix memory limit view

### DIFF
--- a/karpenter/src/NodePool/List.tsx
+++ b/karpenter/src/NodePool/List.tsx
@@ -101,18 +101,18 @@ function NodePoolsList() {
           render: nodePool => {
             const used = parseRam(nodePool.jsonData.status?.resources?.memory || '0');
             const limit = parseRam(nodePool.jsonData.spec?.limits?.memory || '0');
+
             const data: ChartDataPoint[] = [
               {
                 name: 'Memory',
-                value: used,
+                value: limit > 0 ? used : 0,
               },
             ];
-            const effectiveLimit = limit > 0 ? limit : used || 1;
 
             return (
               <PercentageBar
                 data={data}
-                total={effectiveLimit}
+                total={limit > 0 ? limit : 1}
                 tooltipFunc={() => Memorytooltip(used, limit)}
               />
             );


### PR DESCRIPTION
## Description
The memory bar now does not fill up when limit is not specified . 

## Video

[Screencast from 2025-08-22 22-49-29.webm](https://github.com/user-attachments/assets/896f6211-a79f-4f56-93e6-3e9e4fd0e2b1)

Fixes #370 
Part of https://github.com/kubernetes-sigs/headlamp/issues/3231