### PR TITLE
ai-assistant: Prevent submit during IME composition

### DIFF
--- a/ai-assistant/src/components/assistant/AIInputSection.tsx
+++ b/ai-assistant/src/components/assistant/AIInputSection.tsx
@@ -46,7 +46,7 @@ export const AIInputSection: React.FC<AIInputSectionProps> = ({
   onTestModeResponse,
 }) => {
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
+    if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
       e.preventDefault();
       const prompt = promptVal;
       setPromptVal('');


### PR DESCRIPTION
Update Enter handling in the AI Assistant input to prevent accidental submits during IME composition.

Verified with Traditional Chinese and Japanese IMEs on macOS.