### PR TITLE
ai-assistant: Override axios to 1.12.2

### DIFF
--- a/ai-assistant/package-lock.json
+++ b/ai-assistant/package-lock.json
@@ -6587,10 +6587,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
-      "license": "MIT",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",

--- a/ai-assistant/package.json
+++ b/ai-assistant/package.json
@@ -57,6 +57,7 @@
     "zod": "^3.24.2"
   },
   "overrides": {
+    "axios": "^1.12.0",
     "prismjs": "^1.30.0",
     "typescript": "5.6.2"
   }


### PR DESCRIPTION
This change overrides the axios dependency in ai-assistant to the desired 1.12.0+ version.