### PR TITLE
app-catalog: Update name and author in package.json to standard

### DIFF
--- a/app-catalog/package-lock.json
+++ b/app-catalog/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "app-catalog",
+  "name": "@headlamp-k8s/app-catalog",
   "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "app-catalog",
+      "name": "@headlamp-k8s/app-catalog",
       "version": "0.7.0",
       "dependencies": {
         "react-syntax-highlighter": "^15.6.6",
@@ -18553,21 +18553,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/app-catalog/package.json
+++ b/app-catalog/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "app-catalog",
+  "name": "@headlamp-k8s/app-catalog",
   "version": "0.7.0",
   "description": "An app catalog for Headlamp",
   "scripts": {


### PR DESCRIPTION
This PR fixes the issue that causes the app-catalog origin field to render as "unknown" when viewed in the plugin tab in the settings. 

Currently, almost all other plugins in our plugin repo have the name standard as `@headlamp-k8s/plugin-name` within its package.json file. In the main project, for the settings view, we parse the name field to extract an author for the origin field.
Currently the name field for the app-catalog just reads `app-catalog` thus rendering `unknown` in the settings.

If there is not a specific reason why we must keep it as `app-catalog` then these changes should fix this.


Fixes https://github.com/kubernetes-sigs/headlamp/issues/4101

### Changes
- Update the app-catalog package.json name field from `app-catalog` to `@headlamp-k8s/app-catalog`

### How to test
- On main install the latest app-catalog plugin
- Navigate to settings then navigate to the plugins tab
- Notice that app-catalog origin field renders `unknown`
- Close the app and check out these changes
- Install and run these changes via run `npm i` and `npm run start`
- Navigate back to settings then navigate to the plugins tab
- Notice that the origin field should now render `headlamp-k8s` and not `unknown`

### Images

### Before
<img width="1827" height="392" alt="image" src="https://github.com/user-attachments/assets/98658675-f6c7-45d4-bfd7-ce8a2adcdbab" />


### After
<img width="1806" height="350" alt="image" src="https://github.com/user-attachments/assets/7e271cf2-678c-4b54-9eff-c42a9916a718" />
