### PR TITLE
app-catalog: Change name back to app-catalog

### DIFF
--- a/app-catalog/package-lock.json
+++ b/app-catalog/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@headlamp-k8s/app-catalog",
+  "name": "app-catalog",
   "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@headlamp-k8s/app-catalog",
+      "name": "app-catalog",
       "version": "0.7.0",
       "dependencies": {
         "react-syntax-highlighter": "^15.6.6",

--- a/app-catalog/package.json
+++ b/app-catalog/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@headlamp-k8s/app-catalog",
+  "name": "app-catalog",
   "version": "0.7.0",
   "description": "An app catalog for Headlamp",
   "scripts": {


### PR DESCRIPTION
Reverting for now, because it complicates testing and we need to cover a few issues first.
