### PR TITLE
app-catalog: Fix broken chart search caused by API response change

### DIFF
--- a/app-catalog/src/components/charts/List.tsx
+++ b/app-catalog/src/components/charts/List.tsx
@@ -22,11 +22,7 @@ import { Autocomplete, Pagination } from '@mui/material';
 import { useEffect, useRef, useState } from 'react';
 import { getCatalogConfig } from '../../api/catalogConfig';
 import { fetchChartIcon, fetchChartsFromArtifact } from '../../api/charts';
-import {
-  COMMUNITY_REPO,
-  PAGE_OFFSET_COUNT_FOR_CHARTS,
-  VANILLA_HELM_REPO,
-} from '../../constants/catalog';
+import { PAGE_OFFSET_COUNT_FOR_CHARTS, VANILLA_HELM_REPO } from '../../constants/catalog';
 import { AvailableComponentVersions } from '../../helpers/catalog';
 import { EditorDialog } from './EditorDialog';
 import { SettingsLink } from './SettingsLink';
@@ -181,16 +177,13 @@ export function ChartsList({ fetchCharts = fetchChartsFromArtifact }) {
             setChartsTotalCount(parseInt(total));
             // Capture available versions from the response and set AVAILABLE_VERSIONS
             globalThis.AVAILABLE_VERSIONS = AvailableComponentVersions(data.entries);
-          } else if (chartCfg.chartProfile === COMMUNITY_REPO) {
-            setCharts(Object.fromEntries(data.packages.map((chart: any) => [chart.name, chart])));
-            setChartsTotalCount(parseInt(total));
           } else {
-            setCharts(data.packages);
+            setCharts(Object.fromEntries(data.packages.map((chart: any) => [chart.name, chart])));
             setChartsTotalCount(parseInt(total));
           }
         } catch (err) {
           console.error('Error fetching charts', err);
-          setCharts([]);
+          setCharts({});
         }
       }
       fetchData();


### PR DESCRIPTION
**Description:**

It seems the Artifact Hub API now returns an array instead of an object. This broke the search functionality, causing it to match array indices instead of chart names.

This PR fixes the issue by filtering the chart list based on the `name` property.

**Verification:**
*   Before: Searching for words (e.g., "redis") returned no results; searching numbers only matched the array index.
*   After: Searching for any keyword returns charts whose names contain that keyword.