### PR TITLE
Flux: Add flux crds hierarchy in Map feature

### DIFF
--- a/flux/src/index.tsx
+++ b/flux/src/index.tsx
@@ -2,6 +2,7 @@ import { addIcon, Icon } from '@iconify/react';
 import {
   registerKindIcon,
   registerMapSource,
+  registerPluginSettings,
   registerRoute,
   registerSidebarEntry,
 } from '@kinvolk/headlamp-plugin/lib';
@@ -18,6 +19,7 @@ import { Notifications } from './notifications/NotificationList';
 import { Notification } from './notifications/NotificationSingle';
 import { FluxOverview } from './overview';
 import { FluxRunTime } from './runtime/RuntimeList';
+import { FluxSettings } from './settings';
 import { FluxSources } from './sources/SourceList';
 import { FluxSourceDetailView } from './sources/SourceSingle';
 
@@ -28,6 +30,8 @@ addIcon('simple-icons:flux', {
   width: 24,
   height: 24,
 });
+
+registerPluginSettings('@headlamp-k8s/flux', FluxSettings, false);
 
 registerSidebarEntry({
   parent: null,
@@ -201,6 +205,11 @@ registerRoute({
 });
 
 registerMapSource(fluxSource);
+
+registerKindIcon('GitRepository', {
+  icon: <Icon icon="simple-icons:flux" width="70%" height="70%" />,
+  color: 'rgb(50, 108, 229)',
+});
 
 registerKindIcon('HelmRelease', {
   icon: <Icon icon="simple-icons:flux" width="70%" height="70%" />,

--- a/flux/src/settings/index.tsx
+++ b/flux/src/settings/index.tsx
@@ -1,0 +1,94 @@
+import { ConfigStore } from '@kinvolk/headlamp-plugin/lib';
+import { NameValueTable } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { Typography } from '@mui/material';
+import Box from '@mui/material/Box';
+import FormHelperText from '@mui/material/FormHelperText';
+import Switch from '@mui/material/Switch';
+import { type ChangeEvent, type ReactNode, useEffect, useState } from 'react';
+
+interface AutoSaveSwitchProps {
+  settingKey: keyof PluginConfig;
+  onSave: (key: keyof PluginConfig, value: boolean) => void;
+  defaultValue?: boolean;
+  helperText?: ReactNode;
+}
+
+function AutoSaveSwitch({
+  settingKey,
+  onSave,
+  defaultValue,
+  helperText = null,
+}: AutoSaveSwitchProps) {
+  const [value, setValue] = useState(defaultValue);
+  const [timer, setTimer] = useState<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const newValue = event.target.checked;
+    setValue(newValue);
+
+    if (timer) {
+      clearTimeout(timer);
+    }
+
+    const newTimer = setTimeout(() => onSave(settingKey, newValue), 100);
+    setTimer(newTimer);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (timer) {
+        clearTimeout(timer);
+      }
+    };
+  }, [timer]);
+
+  return (
+    <>
+      <Switch checked={value} onChange={handleChange} />
+      {helperText && <FormHelperText sx={{ ml: 1.75, mt: 0.5 }}>{helperText}</FormHelperText>}
+    </>
+  );
+}
+
+interface PluginConfig {
+  linkHRelToKs: boolean;
+}
+
+const DEFAULT_CONFIG: PluginConfig = {
+  linkHRelToKs: false,
+};
+
+export const store = new ConfigStore<PluginConfig>('@headlamp-k8s/flux');
+
+export function FluxSettings() {
+  const [currentConfig, setCurrentConfig] = useState<PluginConfig>(() => ({
+    ...DEFAULT_CONFIG,
+    ...store.get(),
+  }));
+
+  function handleSave(key: keyof PluginConfig, value: boolean) {
+    const updatedConfig = { ...currentConfig, [key]: value };
+    store.set(updatedConfig);
+    setCurrentConfig(updatedConfig);
+  }
+
+  const settingsRows = [
+    {
+      name: 'Link HelmReleases to Kustomizations instead of HelmRepositories',
+      value: (
+        <AutoSaveSwitch
+          settingKey="linkHRelToKs"
+          defaultValue={currentConfig?.linkHRelToKs}
+          onSave={handleSave}
+        />
+      ),
+    },
+  ];
+
+  return (
+    <Box style={{ paddingTop: '8vh' }}>
+      <Typography variant="h6">Map settings</Typography>
+      <NameValueTable rows={settingsRows} />
+    </Box>
+  );
+}


### PR DESCRIPTION
Hi!

This pull request introduces several improvements to Headlamp’s Map feature.
Since Kustomizations can deploy other Flux CRDs (including Kustomizations that themselves deploy other Flux CRDs, and so on), a hierarchy naturally exists between these objects. The `flux tree` command is a good illustration of how Kubernetes objects can be nested.

Currently, the Map feature displays all Flux resources at the same level. This PR adds support for representing the hierarchy between them by creating edges between parent and child Flux resources.

## Changes

* [x] Added GitRepository as a Flux resource
* [x] Added edges between Flux resource nodes
* [x] Added plugin settings

## About the settings

In my opinion, there are two valid ways to represent HelmRelease relations:

* They can be linked to a Kustomization, since they are deployed by it
* Or they can be linked to a HelmRepository, since it is the source of the chart used by the HelmRelease

Because both interpretations make sense, the user can select their preferred relationship model.
This is why I introduced a plugin settings page with a switch to control HelmRelease relation behavior.