### PR TITLE
flux: fix namespaced crds fetching for users with limited perissions

### DIFF
--- a/flux/src/helm-releases/HelmReleaseList.tsx
+++ b/flux/src/helm-releases/HelmReleaseList.tsx
@@ -4,11 +4,11 @@ import React from 'react';
 import { NotSupported } from '../checkflux';
 import { HelmRelease } from '../common/Resources';
 import Table from '../common/Table';
-import { NameLink } from '../helpers';
+import { NameLink, useNamespaces } from '../helpers';
 
 export function HelmReleases() {
   const filterFunction = useFilterFunc();
-  const [resources, error] = HelmRelease.useList();
+  const [resources, error] = HelmRelease.useList({ namespace: useNamespaces() });
 
   if (error?.status === 404) {
     return <NotSupported typeName="Helm Releases" />;

--- a/flux/src/helpers/index.tsx
+++ b/flux/src/helpers/index.tsx
@@ -8,7 +8,8 @@ import K8s from '@kinvolk/headlamp-plugin/lib/k8s';
 import Event from '@kinvolk/headlamp-plugin/lib/K8s/event';
 import { KubeObject, KubeObjectClass } from '@kinvolk/headlamp-plugin/lib/lib/k8s/cluster';
 import { localeDate, timeAgo } from '@kinvolk/headlamp-plugin/lib/Utils';
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
+import { useSelector } from 'react-redux';
 import Table from '../common/Table';
 import { PluralName } from './pluralName';
 
@@ -243,3 +244,12 @@ export function useFluxCheck() {
     allCrdsSuccessful,
   };
 }
+
+export const useNamespaces = () => {
+  interface FilterState {
+    namespaces: Set<string>;
+  }
+
+  const namespacesSet = useSelector(({ filter }: { filter: FilterState }) => filter.namespaces);
+  return useMemo(() => [...namespacesSet], [namespacesSet]);
+};

--- a/flux/src/image-automation/ImageAutomationList.tsx
+++ b/flux/src/image-automation/ImageAutomationList.tsx
@@ -11,7 +11,7 @@ import { NotSupported } from '../checkflux';
 import SourceLink from '../common/Link';
 import { ImagePolicy, ImageRepository, ImageUpdateAutomation } from '../common/Resources';
 import Table from '../common/Table';
-import { NameLink } from '../helpers';
+import { NameLink, useNamespaces } from '../helpers';
 
 export function ImageAutomation() {
   return (
@@ -25,7 +25,7 @@ export function ImageAutomation() {
 
 function ImageUpdateAutomationList() {
   const filterFunction = useFilterFunc();
-  const [resources, error] = ImageUpdateAutomation.useList();
+  const [resources, error] = ImageUpdateAutomation.useList({ namespace: useNamespaces() });
 
   if (error?.status === 404) {
     return <NotSupported typeName="Image Update Automations" />;
@@ -74,7 +74,7 @@ function ImageUpdateAutomationList() {
 
 function ImagePolicyList() {
   const filterFunction = useFilterFunc();
-  const [resources, error] = ImagePolicy.useList();
+  const [resources, error] = ImagePolicy.useList({ namespace: useNamespaces() });
 
   if (error?.status === 404) {
     return <NotSupported typeName="Image Update Policies" />;
@@ -107,7 +107,7 @@ function ImagePolicyList() {
 
 function ImageRepositoryList() {
   const filterFunction = useFilterFunc();
-  const [resources, error] = ImageRepository.useList();
+  const [resources, error] = ImageRepository.useList({ namespace: useNamespaces() });
 
   if (error?.status === 404) {
     return <NotSupported typeName="Image Repositories" />;

--- a/flux/src/kustomizations/KustomizationList.tsx
+++ b/flux/src/kustomizations/KustomizationList.tsx
@@ -4,11 +4,11 @@ import React from 'react';
 import { NotSupported } from '../checkflux';
 import { Kustomization } from '../common/Resources';
 import Table from '../common/Table';
-import { NameLink } from '../helpers';
+import { NameLink, useNamespaces } from '../helpers';
 
 export function Kustomizations() {
   const filterFunction = useFilterFunc();
-  const [resources, error] = Kustomization.useList();
+  const [resources, error] = Kustomization.useList({ namespace: useNamespaces() });
 
   if (error?.status === 404) {
     return <NotSupported typeName="Kustomizations" />;

--- a/flux/src/notifications/NotificationList.tsx
+++ b/flux/src/notifications/NotificationList.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import { NotSupported } from '../checkflux';
 import { AlertNotification, ProviderNotification, ReceiverNotification } from '../common/Resources';
 import Table from '../common/Table';
+import { useNamespaces } from '../helpers';
 
 export function Notifications() {
   return (
@@ -22,7 +23,7 @@ export function Notifications() {
 
 function Alerts() {
   const filterFunction = useFilterFunc();
-  const [resources, error] = AlertNotification.useList();
+  const [resources, error] = AlertNotification.useList({ namespace: useNamespaces() });
 
   if (error?.status === 404) {
     return <NotSupported typeName="Alerts" />;
@@ -90,7 +91,7 @@ function Alerts() {
 
 function Providers() {
   const filterFunction = useFilterFunc();
-  const [resources, error] = ProviderNotification.useList();
+  const [resources, error] = ProviderNotification.useList({ namespace: useNamespaces() });
 
   if (error?.status === 404) {
     return <NotSupported typeName="Providers" />;
@@ -174,7 +175,7 @@ function Providers() {
 
 function Receivers() {
   const filterFunction = useFilterFunc();
-  const [resources, error] = ReceiverNotification.useList();
+  const [resources, error] = ReceiverNotification.useList({ namespace: useNamespaces() });
 
   if (error?.status === 404) {
     return <NotSupported typeName="Receivers" />;

--- a/flux/src/sources/SourceList.tsx
+++ b/flux/src/sources/SourceList.tsx
@@ -13,6 +13,7 @@ import {
   OCIRepository,
 } from '../common/Resources';
 import Table, { TableProps } from '../common/Table';
+import { useNamespaces } from '../helpers';
 
 export function FluxSources() {
   return (
@@ -52,7 +53,7 @@ interface FluxSourceCustomResourceRendererProps {
 function FluxSource(props: FluxSourceCustomResourceRendererProps) {
   const filterFunction = useFilterFunc();
   const { resourceClass, title, pluralName } = props;
-  const [resources, error] = resourceClass.useList();
+  const [resources, error] = resourceClass.useList({ namespace: useNamespaces() });
 
   function prepareColumns() {
     const columns: TableProps['columns'] = [


### PR DESCRIPTION
Hi!

This pull request fixes Flux resource fetching for users with limited cluster permissions.

When a user has access to only a few namespaces (but not all), Kubernetes resources - including Flux resources - are not displayed by default. Throughout Headlamp, such users must filter by the namespaces they are allowed to access in order to see data. However, for the Flux plugin, users previously had to manually configure `Settings > Cluster > Allowed namespaces` before being able to view them.

With this PR, that extra step is no longer necessary. The Flux plugin will now behave consistently with the rest of the app, providing a more seamless and homogeneous user experience.