### PR TITLE
ai-assistant: Bump langchain and langchain/core

### DIFF
--- a/ai-assistant/package-lock.json
+++ b/ai-assistant/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0-alpha",
       "dependencies": {
         "@langchain/anthropic": "^1.1.1",
-        "@langchain/core": "^1.0.6",
-        "@langchain/google-genai": "^1.0.3",
+        "@langchain/core": "^1.1.8",
+        "@langchain/google-genai": "^2.1.4",
         "@langchain/mistralai": "^1.0.0",
         "@langchain/ollama": "^1.0.1",
         "@langchain/openai": "^1.1.2",
@@ -1987,9 +1987,9 @@
       }
     },
     "node_modules/@langchain/core": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.0.6.tgz",
-      "integrity": "sha512-rDSjXATujCdJlL+OJFfyZhEca8kLmqGr4W2ebJvSHiUgXEDqu/IOWC+ZWgoKKHkGOGFdVTqQ7Qi0j2RnYS9Qlg==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.9.tgz",
+      "integrity": "sha512-LDz7MjrZRAK4pxsh5bc0ZiBRdDUawKfw+dYdMRdQmJSKoeXFWPgzZqx5JQCyJ0AqIsZS6q1amZuiSLU9MoPqaQ==",
       "license": "MIT",
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
@@ -1997,10 +1997,9 @@
         "camelcase": "6",
         "decamelize": "1.2.0",
         "js-tiktoken": "^1.0.12",
-        "langsmith": "^0.3.64",
+        "langsmith": ">=0.4.0 <1.0.0",
         "mustache": "^4.2.0",
         "p-queue": "^6.6.2",
-        "p-retry": "4",
         "uuid": "^10.0.0",
         "zod": "^3.25.76 || ^4"
       },
@@ -2009,9 +2008,9 @@
       }
     },
     "node_modules/@langchain/google-genai": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@langchain/google-genai/-/google-genai-1.0.3.tgz",
-      "integrity": "sha512-ZN3f6SPFZI3FMjJ1C0y5A/lWlZ/x+A9RoIKg1PNYdX6bEu7/BR7oz0dYYI2+YGl3TRp1u75e3SzzL0MxmfWfDA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@langchain/google-genai/-/google-genai-2.1.4.tgz",
+      "integrity": "sha512-kiizkpAibOj5SQDuxvGsIglTIO8xoWpQtv7XAapSrdPjigpDYMlHHQBj5aPVcFuV0/uCt5QKTgyCmaPmqQ8Olg==",
       "license": "MIT",
       "dependencies": {
         "@google/generative-ai": "^0.24.0",
@@ -2021,7 +2020,7 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@langchain/core": "1.0.6"
+        "@langchain/core": "1.1.9"
       }
     },
     "node_modules/@langchain/google-genai/node_modules/uuid": {

--- a/ai-assistant/package.json
+++ b/ai-assistant/package.json
@@ -37,8 +37,8 @@
   },
   "dependencies": {
     "@langchain/anthropic": "^1.1.1",
-    "@langchain/core": "^1.0.6",
-    "@langchain/google-genai": "^1.0.3",
+    "@langchain/core": "^1.1.8",
+    "@langchain/google-genai": "^2.1.4",
     "@langchain/mistralai": "^1.0.0",
     "@langchain/ollama": "^1.0.1",
     "@langchain/openai": "^1.1.2",


### PR DESCRIPTION
These changes bump langchain to 1.2.3 and langchain/core to 1.1.9 in the ai-assistant plugin.

### Testing
Testing required