### PR TITLE
opencost plugin: fix correct endpoint for OpenCost API

### DIFF
--- a/opencost/src/request.tsx
+++ b/opencost/src/request.tsx
@@ -29,7 +29,7 @@ export function fetchOpencostData(
   resource: string,
   accumulate: boolean
 ) {
-  const url = `/api/v1/namespaces/${namespace}/services/${serviceName}/proxy/model/allocation/compute?window=${window}&aggregate=${resource}&step=1d&accumulate=${accumulate.toString()}`;
+  const url = `/api/v1/namespaces/${namespace}/services/${serviceName}/proxy/allocation?window=${window}&aggregate=${resource}&step=1d&accumulate=${accumulate.toString()}`;
 
   return request(url).then(data => {
     return data;


### PR DESCRIPTION
After kubecost became opencost there have been changes to its API, where model and compute were removed from the allocation endpoint. Ref. https://github.com/opencost/opencost/issues/2845#issuecomment-2249815631
Currently opencost plugin doesn't populate any data with the original endpoint.
This PR fixes the endpoint according to the opencost API and testing confirms that the plugin works as expected after this change and data is populated correctly.