### PR TITLE
Fix: Cannot read properties of undefined (reading 'conditions')

### DIFF
--- a/cert-manager/src/components/certificateRequests/Detail.tsx
+++ b/cert-manager/src/components/certificateRequests/Detail.tsx
@@ -72,7 +72,7 @@ export function CertificateRequestDetail() {
               },
               {
                 name: 'CA',
-                value: item.status.ca && <CopyToClipboard text={item.status.ca} />,
+                value: item.status?.ca && <CopyToClipboard text={item.status.ca} />,
               },
               {
                 name: 'Failure Time',
@@ -84,7 +84,7 @@ export function CertificateRequestDetail() {
             item && [
               {
                 id: 'Status',
-                section: item.status.conditions && (
+                section: item.status?.conditions && (
                   <ConditionsTable conditions={item.status.conditions} />
                 ),
               },

--- a/cert-manager/src/resources/certificate.ts
+++ b/cert-manager/src/resources/certificate.ts
@@ -123,7 +123,9 @@ export class Certificate extends KubeObject<CertManagerCertificate> {
   static isNamespaced = true;
 
   get ready() {
-    return this.status.conditions.find(condition => condition.type === 'Ready')?.status === 'True';
+    return (
+      this.status?.conditions?.find(condition => condition.type === 'Ready')?.status === 'True'
+    );
   }
 
   // Note: This workaround is needed to make the plugin compatible with older versions of Headlamp

--- a/cert-manager/src/resources/certificateRequest.ts
+++ b/cert-manager/src/resources/certificateRequest.ts
@@ -43,14 +43,14 @@ export class CertificateRequest extends KubeObject<CertManagerCertificateRequest
   }
 
   get approved() {
-    return this.status.conditions.find(condition => condition.type === 'Approved')?.status;
+    return this.status?.conditions?.find(condition => condition.type === 'Approved')?.status;
   }
 
   get denied() {
-    return this.status.conditions.find(condition => condition.type === 'Denied')?.status;
+    return this.status?.conditions?.find(condition => condition.type === 'Denied')?.status;
   }
 
   get ready() {
-    return this.status.conditions.find(condition => condition.type === 'Ready')?.status;
+    return this.status?.conditions?.find(condition => condition.type === 'Ready')?.status;
   }
 }


### PR DESCRIPTION
## Summary:
Fixes undefined error by adding optional chaining operator

## Issue:
Fixes Issue: #482 (Originally present in the Parent Repo: https://github.com/kubernetes-sigs/headlamp/issues/4358)

## Changes:
Added optional chaining operator while accessing `CertifcateRequest.status` and `CertifcateRequest.status.conditions`  to not cause an error if undefined.