### PR TITLE
Fix(karpenter): Restore missing menu items & set engine compatibility

### DIFF
--- a/karpenter/package.json
+++ b/karpenter/package.json
@@ -2,6 +2,7 @@
   "name": "@headlamp-k8s/karpenter",
   "version": "0.1.0",
   "description": "A Headlamp plugin that provides a UI for visualizing and managing Karpenter's autoscaling decisions, custom resources, and provisioning behavior in real-time. (Alpha Release)",
+  "main": "dist/main.js",
   "scripts": {
     "start": "headlamp-plugin start",
     "build": "headlamp-plugin build",
@@ -36,6 +37,9 @@
   },
   "devDependencies": {
     "@kinvolk/headlamp-plugin": "^0.13.0"
+  },
+  "engines": {
+    "headlamp": ">=0.20.0"
   },
   "dependencies": {
     "ajv-formats": "^3.0.1"

--- a/karpenter/src/NodePool/List.tsx
+++ b/karpenter/src/NodePool/List.tsx
@@ -25,12 +25,18 @@ export function nodePoolClass() {
     singularName: 'NodePool',
     pluralName: 'nodepools',
     kind: 'NodePool',
-    customResourceDefinition: undefined as any,
+    customResourceDefinition: {
+      getMainAPIGroup: () => [nodePoolGroup, nodePoolVersion],
+    } as any,
   });
 
   return class extendedNodePoolClass extends NodePool {
     static get detailsRoute() {
       return 'nodepools-detail';
+    }
+
+    static getMainAPIGroup() {
+      return [nodePoolGroup, nodePoolVersion];
     }
   };
 }

--- a/karpenter/src/Scaling/List.tsx
+++ b/karpenter/src/Scaling/List.tsx
@@ -11,12 +11,18 @@ export function nodeClaimClass() {
     singularName: 'NodeClaim',
     pluralName: 'nodeclaims',
     kind: 'NodeClaim',
-    customResourceDefinition: undefined as any,
+    customResourceDefinition: {
+      getMainAPIGroup: () => [nodeClaimGroup, nodeClaimVersion],
+    } as any,
   });
 
   return class extendedNodeClaim extends NodeClaim {
     static get detailsRoute() {
       return 'nodeclaims-detail';
+    }
+
+    static getMainAPIGroup() {
+      return [nodeClaimGroup, nodeClaimVersion];
     }
   };
 }

--- a/karpenter/src/helpers/createNodeClassClass.ts
+++ b/karpenter/src/helpers/createNodeClassClass.ts
@@ -1,7 +1,7 @@
 import { makeCustomResourceClass } from '@kinvolk/headlamp-plugin/lib/lib/k8s/crd';
 
+// Create the NodeClass resource class with the specified configuration
 export function createNodeClassClass(config) {
-  // Create the NodeClass resource class with the specified configuration
   const NodeClass = makeCustomResourceClass({
     apiInfo: [
       {
@@ -13,7 +13,9 @@ export function createNodeClassClass(config) {
     singularName: config.singularName,
     pluralName: config.pluralName,
     kind: config.kind,
-    customResourceDefinition: undefined as any,
+    customResourceDefinition: {
+      getMainAPIGroup: () => [config.group, config.version],
+    } as any,
   });
 
   return class extends NodeClass {
@@ -32,6 +34,10 @@ export function createNodeClassClass(config) {
 
     static get kind() {
       return config.kind;
+    }
+
+    static getMainAPIGroup() {
+      return [config.group, config.version];
     }
   };
 }


### PR DESCRIPTION
## Description
This PR addresses a runtime error causing the Karpenter menu to only display the NodeClass section. It resolves the `undefined` error on `getMainAPIGroup` to ensure NodePool, Pending Pods, and Scaling views render correctly.

Additionally, this PR updates the plugin manifest to explicitly support newer Headlamp versions.

## Changes
- **Runtime Fix:** Patched `createNodeClassClass.ts` and List views to mock the `customResourceDefinition` property. This satisfies the Headlamp runtime requirement and prevents `getMainAPIGroup` failures.
- **Compatibility:** Added the `engines` field to `package.json` to declare support for Headlamp `>=0.20.0`. This resolves "Incompatible" errors on updated clusters.
![pr1](https://github.com/user-attachments/assets/6c50dcc2-78fc-4a06-8293-8fc12c763045)
![pr2](https://github.com/user-attachments/assets/89295f3a-91d6-4018-9efc-299af56b0c12)
<img width="1162" height="717" alt="Screenshot 2026-01-22 at 12 28 39 PM" src="https://github.com/user-attachments/assets/92692c0a-f498-49a6-974d-228f4d6adcef" />
<img width="1162" height="737" alt="Screenshot 2026-01-22 at 12 29 03 PM" src="https://github.com/user-attachments/assets/f01ffb98-7b2a-4985-960e-d8e04965ec52" />


## Testing
- Verified on local Kind cluster.
- Verified on EKS (Headlamp v0.39.0).
- All list views (Node Class, Node Pool, Scaling) now render correctly without crashing.

## Fixes
Fixes #477