### PR TITLE
fix: use error color for failed reconciliations

### DIFF
--- a/flux/src/overview/index.tsx
+++ b/flux/src/overview/index.tsx
@@ -539,7 +539,7 @@ function FluxOverviewChart({ resourceClass }) {
         {
           name: 'failed',
           value: adjustedFailedPercent,
-          fill: '#DC7501',
+          fill: theme.palette.error.main,
         },
         {
           name: 'suspended',


### PR DESCRIPTION
Fixes #401 

This PR fixes the color used for failed reconciliations in the chart UI. Previously, a fully failed state (e.g., 1/1 failed resources) was displayed using the warning (orange) color, which downplayed the severity of the issue.

The chart now correctly uses the error (red) color for failed reconciliations, making critical states more visually distinct and easier to identify.

