### PR TITLE
ai-assistant: Added API Key for Local Provider

### DIFF
--- a/ai-assistant/src/config/modelConfig.ts
+++ b/ai-assistant/src/config/modelConfig.ts
@@ -189,6 +189,13 @@ export const modelProviders: ModelProvider[] = [
     description: 'Integration with locally hosted models (Ollama or similar)',
     fields: [
       {
+        name: 'apiKey',
+        label: 'API Key',
+        type: 'text',
+        required: false,
+        placeholder: 'Your Local Model API key',
+      },
+      {
         name: 'baseUrl',
         label: 'Base URL',
         type: 'text',

--- a/ai-assistant/src/langchain/LangChainManager.ts
+++ b/ai-assistant/src/langchain/LangChainManager.ts
@@ -170,15 +170,21 @@ export default class LangChainManager extends AIManager {
             verbose: true,
           });
         }
-        case 'local':
+        case 'local': {
           if (!sanitizedConfig.baseUrl) {
             throw new Error('Base URL is required for local models');
+          }
+          const headers: Record<string, string> = {};
+          if (sanitizedConfig.apiKey) {
+            headers['Authorization'] = `Bearer ${sanitizedConfig.apiKey}`;
           }
           return new ChatOllama({
             baseUrl: sanitizedConfig.baseUrl,
             model: sanitizedConfig.model,
             verbose: true,
+            headers: Object.keys(headers).length ? headers : undefined,
           });
+        }
         default:
           throw new Error(`Unsupported provider: ${providerId}`);
       }


### PR DESCRIPTION
fixes: #438 

This PR adds an optional API key field for the Local AI Provider. Some local AI endpoints are protected by API Keys, and the absence of this field prevents users from authenticating. 
This change makes the Local provider consistent with other providers while keeping the API key optional

<img width="1137" height="601" alt="image" src="https://github.com/user-attachments/assets/0bea927e-1ac1-4332-9afa-a368516be7a2" />

