### PR TITLE
cert-manager: Add Storybook stories for all components

### DIFF
--- a/cert-manager/src/components/certificateRequests/Detail.stories.tsx
+++ b/cert-manager/src/components/certificateRequests/Detail.stories.tsx
@@ -1,0 +1,448 @@
+import {
+  NameValueTable,
+  SectionBox,
+  SectionHeader,
+} from '@kinvolk/headlamp-plugin/lib/components/common';
+import { Box } from '@mui/material';
+import { Meta, StoryFn } from '@storybook/react';
+import { BrowserRouter } from 'react-router-dom';
+import { Condition, IssuerReference } from '../../resources/common';
+import {
+  ConditionsTable,
+  CopyToClipboard,
+  IssuerRef,
+  NotInstalledBanner,
+} from '../common/CommonComponents';
+
+// Mock certificate request data structure for stories
+interface MockCertificateRequestDetail {
+  metadata: {
+    name: string;
+    namespace: string;
+    creationTimestamp: string;
+    uid: string;
+    labels?: Record<string, string>;
+    annotations?: Record<string, string>;
+  };
+  spec: {
+    issuerRef: IssuerReference;
+    request: string;
+    username?: string;
+    duration?: string;
+    isCA?: boolean;
+    usages?: string[];
+  };
+  status: {
+    conditions: Condition[];
+    certificate?: string;
+    ca?: string;
+    failureTime?: string;
+  };
+  ready: boolean;
+  approved: string;
+  denied: string;
+}
+
+interface PureCertificateRequestDetailProps {
+  certificateRequest: MockCertificateRequestDetail | null;
+  isLoading?: boolean;
+  isCertManagerInstalled?: boolean;
+}
+
+// Pure component for Storybook testing
+export function PureCertificateRequestDetail({
+  certificateRequest,
+  isLoading = false,
+  isCertManagerInstalled = true,
+}: PureCertificateRequestDetailProps) {
+  if (!isCertManagerInstalled) {
+    return <NotInstalledBanner isLoading={isLoading} />;
+  }
+
+  if (!certificateRequest) {
+    return (
+      <Box p={2}>
+        <SectionHeader title="Certificate Request Details" />
+        <Box>Certificate request not found</Box>
+      </Box>
+    );
+  }
+
+  return (
+    <Box>
+      <SectionHeader title={`Certificate Request: ${certificateRequest.metadata.name}`} />
+
+      {/* Main Info */}
+      <SectionBox title="Info">
+        <NameValueTable
+          rows={[
+            {
+              name: 'Name',
+              value: certificateRequest.metadata.name,
+            },
+            {
+              name: 'Namespace',
+              value: certificateRequest.metadata.namespace,
+            },
+            {
+              name: 'Ready',
+              value: certificateRequest.ready ? 'Ready' : 'Not Ready',
+            },
+            {
+              name: 'Approved',
+              value: certificateRequest.approved === 'True' ? 'Yes' : 'No',
+            },
+            {
+              name: 'Denied',
+              value: certificateRequest.denied === 'True' ? 'Yes' : 'No',
+            },
+            {
+              name: 'Duration',
+              value: certificateRequest.spec?.duration || '-',
+            },
+            {
+              name: 'Is CA',
+              value: certificateRequest.spec?.isCA ? 'Yes' : 'No',
+            },
+            {
+              name: 'Usages',
+              value:
+                certificateRequest.spec?.usages?.length > 0 ? (
+                  <NameValueTable
+                    rows={certificateRequest.spec.usages.map((usage, index) => ({
+                      name: `Usage ${index + 1}`,
+                      value: usage,
+                    }))}
+                  />
+                ) : (
+                  '-'
+                ),
+            },
+            {
+              name: 'Issuer Ref',
+              value: certificateRequest.spec.issuerRef && (
+                <IssuerRef
+                  issuerRef={certificateRequest.spec.issuerRef}
+                  namespace={certificateRequest.metadata.namespace}
+                />
+              ),
+            },
+            {
+              name: 'Request',
+              value: <CopyToClipboard text={certificateRequest.spec.request} />,
+            },
+            {
+              name: 'Certificate',
+              value: certificateRequest.status?.certificate ? (
+                <CopyToClipboard text={certificateRequest.status.certificate} />
+              ) : (
+                '-'
+              ),
+            },
+            {
+              name: 'CA',
+              value: certificateRequest.status?.ca ? (
+                <CopyToClipboard text={certificateRequest.status.ca} />
+              ) : (
+                '-'
+              ),
+            },
+            {
+              name: 'Failure Time',
+              value: certificateRequest.status?.failureTime || '-',
+            },
+          ]}
+        />
+      </SectionBox>
+
+      {/* Conditions */}
+      {certificateRequest.status?.conditions && certificateRequest.status.conditions.length > 0 && (
+        <ConditionsTable conditions={certificateRequest.status.conditions} />
+      )}
+    </Box>
+  );
+}
+
+export default {
+  title: 'cert-manager/CertificateRequests/Detail',
+  component: PureCertificateRequestDetail,
+  decorators: [
+    (Story: StoryFn) => (
+      <BrowserRouter>
+        <Story />
+      </BrowserRouter>
+    ),
+  ],
+} as Meta;
+
+const Template: StoryFn<PureCertificateRequestDetailProps> = args => (
+  <PureCertificateRequestDetail {...args} />
+);
+
+// Sample mock data
+const approvedAndReadyRequest: MockCertificateRequestDetail = {
+  metadata: {
+    name: 'example-com-tls-1',
+    namespace: 'default',
+    creationTimestamp: '2024-01-15T10:30:00Z',
+    uid: 'cr-1',
+    labels: {
+      'cert-manager.io/certificate-name': 'example-com-tls',
+    },
+  },
+  spec: {
+    issuerRef: {
+      name: 'letsencrypt-prod',
+      kind: 'ClusterIssuer',
+      group: 'cert-manager.io',
+    },
+    request:
+      'LS0tLS1CRUdJTiBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0KTUlJQ3dqQ0NBYWtDQVFBd0FEQUJCZ05WQkFNVENHVjRZVzF3YkdVd2...',
+    username: 'system:serviceaccount:cert-manager:cert-manager',
+    duration: '2160h',
+    isCA: false,
+    usages: ['digital signature', 'key encipherment', 'server auth'],
+  },
+  status: {
+    conditions: [
+      {
+        type: 'Approved',
+        status: 'True',
+        reason: 'cert-manager.io',
+        message: 'Certificate request has been approved by cert-manager.io',
+        lastTransitionTime: '2024-01-15T10:31:00Z',
+      },
+      {
+        type: 'Ready',
+        status: 'True',
+        reason: 'Issued',
+        message: 'Certificate fetched from issuer successfully',
+        lastTransitionTime: '2024-01-15T10:35:00Z',
+      },
+    ],
+    certificate: 'LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURJVENDQWdtZ0F3SUJBZ0lSQU9GQktrNjJya...',
+    ca: 'LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUV4VENDQXF5Z0F3SUJBZ0lSQU9GQktr...',
+  },
+  ready: true,
+  approved: 'True',
+  denied: 'False',
+};
+
+const pendingRequest: MockCertificateRequestDetail = {
+  metadata: {
+    name: 'pending-tls-request',
+    namespace: 'staging',
+    creationTimestamp: '2024-01-20T14:00:00Z',
+    uid: 'cr-2',
+  },
+  spec: {
+    issuerRef: {
+      name: 'letsencrypt-staging',
+      kind: 'Issuer',
+    },
+    request: 'LS0tLS1CRUdJTiBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0KTUlJQ3dqQ0NBYWtDQVFBd0FEQ...',
+    username: 'system:serviceaccount:staging:web-app',
+    duration: '2160h',
+    isCA: false,
+    usages: ['digital signature', 'key encipherment', 'server auth'],
+  },
+  status: {
+    conditions: [
+      {
+        type: 'Approved',
+        status: 'True',
+        reason: 'cert-manager.io',
+        message: 'Certificate request has been approved',
+        lastTransitionTime: '2024-01-20T14:00:30Z',
+      },
+      {
+        type: 'Ready',
+        status: 'False',
+        reason: 'Pending',
+        message: 'Waiting for certificate to be issued',
+        lastTransitionTime: '2024-01-20T14:00:00Z',
+      },
+    ],
+  },
+  ready: false,
+  approved: 'True',
+  denied: 'False',
+};
+
+const deniedRequest: MockCertificateRequestDetail = {
+  metadata: {
+    name: 'denied-request',
+    namespace: 'default',
+    creationTimestamp: '2024-01-19T11:00:00Z',
+    uid: 'cr-3',
+  },
+  spec: {
+    issuerRef: {
+      name: 'restricted-issuer',
+      kind: 'Issuer',
+    },
+    request: 'LS0tLS1CRUdJTiBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0KTUlJQ3dqQ0NBYWtDQVFBd0FE...',
+    username: 'system:serviceaccount:default:unauthorized-sa',
+    duration: '8760h',
+    isCA: true,
+    usages: ['cert sign', 'crl sign'],
+  },
+  status: {
+    conditions: [
+      {
+        type: 'Denied',
+        status: 'True',
+        reason: 'policy.cert-manager.io',
+        message:
+          'Request denied by CertificateRequestPolicy: isCA certificates are not allowed by this policy',
+        lastTransitionTime: '2024-01-19T11:01:00Z',
+      },
+      {
+        type: 'Ready',
+        status: 'False',
+        reason: 'Denied',
+        message: 'Certificate request was denied',
+        lastTransitionTime: '2024-01-19T11:01:00Z',
+      },
+    ],
+  },
+  ready: false,
+  approved: 'False',
+  denied: 'True',
+};
+
+const failedRequest: MockCertificateRequestDetail = {
+  metadata: {
+    name: 'failed-request',
+    namespace: 'production',
+    creationTimestamp: '2024-01-18T09:00:00Z',
+    uid: 'cr-4',
+  },
+  spec: {
+    issuerRef: {
+      name: 'letsencrypt-prod',
+      kind: 'ClusterIssuer',
+    },
+    request: 'LS0tLS1CRUdJTiBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0KTUlJQ3dqQ0NBYWtDQVFBd0FE...',
+    username: 'system:serviceaccount:production:api-service',
+    duration: '2160h',
+    isCA: false,
+    usages: ['digital signature', 'key encipherment', 'server auth'],
+  },
+  status: {
+    conditions: [
+      {
+        type: 'Approved',
+        status: 'True',
+        reason: 'cert-manager.io',
+        message: 'Certificate request has been approved',
+        lastTransitionTime: '2024-01-18T09:01:00Z',
+      },
+      {
+        type: 'Ready',
+        status: 'False',
+        reason: 'Failed',
+        message:
+          'The certificate request has failed to complete and will be retried: Error finalizing order: ACME server error: rateLimited',
+        lastTransitionTime: '2024-01-18T09:05:00Z',
+      },
+    ],
+    failureTime: '2024-01-18T09:05:00Z',
+  },
+  ready: false,
+  approved: 'True',
+  denied: 'False',
+};
+
+const caRequest: MockCertificateRequestDetail = {
+  metadata: {
+    name: 'internal-ca-request',
+    namespace: 'cert-manager',
+    creationTimestamp: '2024-01-01T00:00:00Z',
+    uid: 'cr-5',
+  },
+  spec: {
+    issuerRef: {
+      name: 'self-signed-issuer',
+      kind: 'Issuer',
+    },
+    request: 'LS0tLS1CRUdJTiBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0KTUlJQ3dqQ0NBYWtDQVFBd0FE...',
+    username: 'system:serviceaccount:cert-manager:cert-manager',
+    duration: '87600h',
+    isCA: true,
+    usages: ['cert sign', 'crl sign', 'digital signature'],
+  },
+  status: {
+    conditions: [
+      {
+        type: 'Approved',
+        status: 'True',
+        reason: 'cert-manager.io',
+        message: 'Certificate request has been approved',
+        lastTransitionTime: '2024-01-01T00:00:30Z',
+      },
+      {
+        type: 'Ready',
+        status: 'True',
+        reason: 'Issued',
+        message: 'Certificate fetched from issuer successfully',
+        lastTransitionTime: '2024-01-01T00:01:00Z',
+      },
+    ],
+    certificate: 'LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURJVENDQWdtZ0F3SUJBZ0lSQU9GQktrNjJya...',
+  },
+  ready: true,
+  approved: 'True',
+  denied: 'False',
+};
+
+// Stories
+export const ApprovedAndReady = Template.bind({});
+ApprovedAndReady.args = {
+  certificateRequest: approvedAndReadyRequest,
+  isCertManagerInstalled: true,
+};
+
+export const Pending = Template.bind({});
+Pending.args = {
+  certificateRequest: pendingRequest,
+  isCertManagerInstalled: true,
+};
+
+export const Denied = Template.bind({});
+Denied.args = {
+  certificateRequest: deniedRequest,
+  isCertManagerInstalled: true,
+};
+
+export const Failed = Template.bind({});
+Failed.args = {
+  certificateRequest: failedRequest,
+  isCertManagerInstalled: true,
+};
+
+export const CARequest = Template.bind({});
+CARequest.args = {
+  certificateRequest: caRequest,
+  isCertManagerInstalled: true,
+};
+
+export const NotFound = Template.bind({});
+NotFound.args = {
+  certificateRequest: null,
+  isCertManagerInstalled: true,
+};
+
+export const CertManagerNotInstalled = Template.bind({});
+CertManagerNotInstalled.args = {
+  certificateRequest: null,
+  isCertManagerInstalled: false,
+  isLoading: false,
+};
+
+export const Loading = Template.bind({});
+Loading.args = {
+  certificateRequest: null,
+  isCertManagerInstalled: false,
+  isLoading: true,
+};

--- a/cert-manager/src/components/certificateRequests/List.stories.tsx
+++ b/cert-manager/src/components/certificateRequests/List.stories.tsx
@@ -1,0 +1,317 @@
+import {
+  DateLabel,
+  SectionHeader,
+  SimpleTable,
+} from '@kinvolk/headlamp-plugin/lib/components/common';
+import { Box } from '@mui/material';
+import { Meta, StoryFn } from '@storybook/react';
+import { NotInstalledBanner } from '../common/CommonComponents';
+
+// Mock certificate request data structure for stories
+interface MockCertificateRequest {
+  metadata: {
+    name: string;
+    namespace: string;
+    creationTimestamp: string;
+    uid: string;
+  };
+  spec: {
+    issuerRef: {
+      name: string;
+      kind: string;
+    };
+    username?: string;
+    request: string;
+  };
+  status: {
+    conditions: Array<{
+      type: string;
+      status: string;
+      reason?: string;
+      message?: string;
+      lastTransitionTime?: string;
+    }>;
+    certificate?: string;
+    ca?: string;
+  };
+  ready: boolean;
+  approved: string;
+  denied: string;
+}
+
+interface PureCertificateRequestsListProps {
+  certificateRequests: MockCertificateRequest[];
+  isLoading?: boolean;
+  isCertManagerInstalled?: boolean;
+}
+
+// Pure component for Storybook testing
+export function PureCertificateRequestsList({
+  certificateRequests,
+  isLoading = false,
+  isCertManagerInstalled = true,
+}: PureCertificateRequestsListProps) {
+  if (!isCertManagerInstalled) {
+    return <NotInstalledBanner isLoading={isLoading} />;
+  }
+
+  return (
+    <Box>
+      <SectionHeader title="Certificate Requests" />
+      <SimpleTable
+        columns={[
+          {
+            label: 'Name',
+            getter: (item: MockCertificateRequest) => item.metadata.name,
+          },
+          {
+            label: 'Namespace',
+            getter: (item: MockCertificateRequest) => item.metadata.namespace,
+          },
+          {
+            label: 'Approved',
+            getter: (item: MockCertificateRequest) => item.approved,
+          },
+          {
+            label: 'Denied',
+            getter: (item: MockCertificateRequest) => item.denied,
+          },
+          {
+            label: 'Ready',
+            getter: (item: MockCertificateRequest) => (item.ready ? 'True' : 'False'),
+          },
+          {
+            label: 'Issuer',
+            getter: (item: MockCertificateRequest) => item.spec.issuerRef.name,
+          },
+          {
+            label: 'Requester',
+            getter: (item: MockCertificateRequest) => item.spec.username || '-',
+          },
+          {
+            label: 'Age',
+            getter: (item: MockCertificateRequest) => (
+              <DateLabel date={item.metadata.creationTimestamp} format="mini" />
+            ),
+          },
+        ]}
+        data={certificateRequests}
+        emptyMessage="No certificate requests found"
+      />
+    </Box>
+  );
+}
+
+export default {
+  title: 'cert-manager/CertificateRequests/List',
+  component: PureCertificateRequestsList,
+} as Meta;
+
+const Template: StoryFn<PureCertificateRequestsListProps> = args => (
+  <PureCertificateRequestsList {...args} />
+);
+
+// Sample mock data
+const mockCertificateRequests: MockCertificateRequest[] = [
+  {
+    metadata: {
+      name: 'example-com-tls-1',
+      namespace: 'default',
+      creationTimestamp: '2024-01-15T10:30:00Z',
+      uid: 'cr-1',
+    },
+    spec: {
+      issuerRef: {
+        name: 'letsencrypt-prod',
+        kind: 'ClusterIssuer',
+      },
+      username: 'system:serviceaccount:cert-manager:cert-manager',
+      request: 'LS0tLS1CRUdJTiBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0K...',
+    },
+    status: {
+      conditions: [
+        {
+          type: 'Ready',
+          status: 'True',
+          reason: 'Issued',
+          message: 'Certificate fetched from issuer successfully',
+          lastTransitionTime: '2024-01-15T10:35:00Z',
+        },
+        {
+          type: 'Approved',
+          status: 'True',
+          reason: 'cert-manager.io',
+          message: 'Certificate request has been approved by cert-manager.io',
+          lastTransitionTime: '2024-01-15T10:31:00Z',
+        },
+      ],
+      certificate: 'LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t...',
+    },
+    ready: true,
+    approved: 'True',
+    denied: 'False',
+  },
+  {
+    metadata: {
+      name: 'api-tls-request',
+      namespace: 'production',
+      creationTimestamp: '2024-01-16T08:00:00Z',
+      uid: 'cr-2',
+    },
+    spec: {
+      issuerRef: {
+        name: 'letsencrypt-prod',
+        kind: 'ClusterIssuer',
+      },
+      username: 'system:serviceaccount:production:api-service',
+      request: 'LS0tLS1CRUdJTiBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0K...',
+    },
+    status: {
+      conditions: [
+        {
+          type: 'Ready',
+          status: 'True',
+          reason: 'Issued',
+          message: 'Certificate fetched from issuer successfully',
+          lastTransitionTime: '2024-01-16T08:05:00Z',
+        },
+        {
+          type: 'Approved',
+          status: 'True',
+          reason: 'cert-manager.io',
+          message: 'Certificate request has been approved',
+          lastTransitionTime: '2024-01-16T08:01:00Z',
+        },
+      ],
+      certificate: 'LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t...',
+    },
+    ready: true,
+    approved: 'True',
+    denied: 'False',
+  },
+  {
+    metadata: {
+      name: 'pending-request',
+      namespace: 'staging',
+      creationTimestamp: '2024-01-20T14:00:00Z',
+      uid: 'cr-3',
+    },
+    spec: {
+      issuerRef: {
+        name: 'letsencrypt-staging',
+        kind: 'Issuer',
+      },
+      username: 'system:serviceaccount:staging:web-app',
+      request: 'LS0tLS1CRUdJTiBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0K...',
+    },
+    status: {
+      conditions: [
+        {
+          type: 'Ready',
+          status: 'False',
+          reason: 'Pending',
+          message: 'Waiting for certificate to be issued',
+          lastTransitionTime: '2024-01-20T14:00:00Z',
+        },
+        {
+          type: 'Approved',
+          status: 'True',
+          reason: 'cert-manager.io',
+          message: 'Certificate request has been approved',
+          lastTransitionTime: '2024-01-20T14:00:30Z',
+        },
+      ],
+    },
+    ready: false,
+    approved: 'True',
+    denied: 'False',
+  },
+  {
+    metadata: {
+      name: 'denied-request',
+      namespace: 'default',
+      creationTimestamp: '2024-01-19T11:00:00Z',
+      uid: 'cr-4',
+    },
+    spec: {
+      issuerRef: {
+        name: 'restricted-issuer',
+        kind: 'Issuer',
+      },
+      username: 'system:serviceaccount:default:unauthorized-sa',
+      request: 'LS0tLS1CRUdJTiBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0K...',
+    },
+    status: {
+      conditions: [
+        {
+          type: 'Ready',
+          status: 'False',
+          reason: 'Denied',
+          message: 'Certificate request was denied',
+          lastTransitionTime: '2024-01-19T11:01:00Z',
+        },
+        {
+          type: 'Denied',
+          status: 'True',
+          reason: 'policy.cert-manager.io',
+          message: 'Request denied by CertificateRequestPolicy',
+          lastTransitionTime: '2024-01-19T11:01:00Z',
+        },
+      ],
+    },
+    ready: false,
+    approved: 'False',
+    denied: 'True',
+  },
+];
+
+// Stories
+export const Default = Template.bind({});
+Default.args = {
+  certificateRequests: mockCertificateRequests,
+  isCertManagerInstalled: true,
+};
+
+export const Empty = Template.bind({});
+Empty.args = {
+  certificateRequests: [],
+  isCertManagerInstalled: true,
+};
+
+export const AllApproved = Template.bind({});
+AllApproved.args = {
+  certificateRequests: mockCertificateRequests.filter(cr => cr.approved === 'True' && cr.ready),
+  isCertManagerInstalled: true,
+};
+
+export const WithPendingRequests = Template.bind({});
+WithPendingRequests.args = {
+  certificateRequests: mockCertificateRequests.filter(cr => !cr.ready && cr.approved === 'True'),
+  isCertManagerInstalled: true,
+};
+
+export const WithDeniedRequests = Template.bind({});
+WithDeniedRequests.args = {
+  certificateRequests: mockCertificateRequests.filter(cr => cr.denied === 'True'),
+  isCertManagerInstalled: true,
+};
+
+export const MixedStatus = Template.bind({});
+MixedStatus.args = {
+  certificateRequests: mockCertificateRequests,
+  isCertManagerInstalled: true,
+};
+
+export const CertManagerNotInstalled = Template.bind({});
+CertManagerNotInstalled.args = {
+  certificateRequests: [],
+  isCertManagerInstalled: false,
+  isLoading: false,
+};
+
+export const Loading = Template.bind({});
+Loading.args = {
+  certificateRequests: [],
+  isCertManagerInstalled: false,
+  isLoading: true,
+};

--- a/cert-manager/src/components/certificates/Detail.stories.tsx
+++ b/cert-manager/src/components/certificates/Detail.stories.tsx
@@ -1,0 +1,610 @@
+import {
+  NameValueTable,
+  SectionBox,
+  SectionHeader,
+} from '@kinvolk/headlamp-plugin/lib/components/common';
+import { Box } from '@mui/material';
+import { Meta, StoryFn } from '@storybook/react';
+import { BrowserRouter } from 'react-router-dom';
+import { Condition, IssuerReference, SecretKeySelector } from '../../resources/common';
+import {
+  ConditionsTable,
+  IssuerRef,
+  NotInstalledBanner,
+  StringArray,
+} from '../common/CommonComponents';
+
+// Mock certificate data structure for stories
+interface MockCertificateDetail {
+  metadata: {
+    name: string;
+    namespace: string;
+    creationTimestamp: string;
+    uid: string;
+    labels?: Record<string, string>;
+    annotations?: Record<string, string>;
+  };
+  spec: {
+    secretName: string;
+    issuerRef: IssuerReference;
+    commonName?: string;
+    dnsNames?: string[];
+    emailAddresses?: string[];
+    ipAddresses?: string[];
+    uris?: string[];
+    duration?: string;
+    renewBefore?: string;
+    isCA?: boolean;
+    usages?: string[];
+    revisionHistoryLimit?: number;
+    subject?: {
+      organizations?: string[];
+      countries?: string[];
+      organizationalUnits?: string[];
+      localities?: string[];
+      provinces?: string[];
+      streetAddresses?: string[];
+      postalCodes?: string[];
+      serialNumber?: string;
+    };
+    privateKey?: {
+      algorithm?: string;
+      size?: number;
+      encoding?: string;
+      rotationPolicy?: string;
+    };
+    keystores?: {
+      jks?: {
+        create: boolean;
+        passwordSecretRef?: SecretKeySelector;
+      };
+      pkcs12?: {
+        create: boolean;
+        passwordSecretRef?: SecretKeySelector;
+      };
+    };
+  };
+  status: {
+    conditions: Condition[];
+    notBefore?: string;
+    notAfter?: string;
+    renewalTime?: string;
+    revision?: number;
+    nextPrivateKeySecretName?: string;
+  };
+  ready: boolean;
+}
+
+interface PureCertificateDetailProps {
+  certificate: MockCertificateDetail | null;
+  isLoading?: boolean;
+  isCertManagerInstalled?: boolean;
+}
+
+// Pure component for Storybook testing
+export function PureCertificateDetail({
+  certificate,
+  isLoading = false,
+  isCertManagerInstalled = true,
+}: PureCertificateDetailProps) {
+  if (!isCertManagerInstalled) {
+    return <NotInstalledBanner isLoading={isLoading} />;
+  }
+
+  if (!certificate) {
+    return (
+      <Box p={2}>
+        <SectionHeader title="Certificate Details" />
+        <Box>Certificate not found</Box>
+      </Box>
+    );
+  }
+
+  return (
+    <Box>
+      <SectionHeader title={`Certificate: ${certificate.metadata.name}`} />
+
+      {/* Main Info */}
+      <SectionBox title="Info">
+        <NameValueTable
+          rows={[
+            {
+              name: 'Name',
+              value: certificate.metadata.name,
+            },
+            {
+              name: 'Namespace',
+              value: certificate.metadata.namespace,
+            },
+            {
+              name: 'Ready',
+              value: certificate.ready ? 'Ready' : 'Not Ready',
+            },
+            {
+              name: 'Common Name',
+              value: certificate.spec?.commonName || '-',
+            },
+            {
+              name: 'DNS Names',
+              value: <StringArray items={certificate.spec?.dnsNames} />,
+            },
+            {
+              name: 'Email Addresses',
+              value: <StringArray items={certificate.spec?.emailAddresses} />,
+            },
+            {
+              name: 'IP Addresses',
+              value: <StringArray items={certificate.spec?.ipAddresses} />,
+            },
+            {
+              name: 'URIs',
+              value: <StringArray items={certificate.spec?.uris} />,
+            },
+            {
+              name: 'Duration',
+              value: certificate.spec?.duration || '-',
+            },
+            {
+              name: 'Renew Before',
+              value: certificate.spec?.renewBefore || '-',
+            },
+            {
+              name: 'Is CA',
+              value: certificate.spec?.isCA ? 'Yes' : 'No',
+            },
+            {
+              name: 'Usages',
+              value: <StringArray items={certificate.spec?.usages} />,
+            },
+            {
+              name: 'Revision History Limit',
+              value: certificate.spec?.revisionHistoryLimit?.toString() || '-',
+            },
+            {
+              name: 'Secret Name',
+              value: certificate.spec.secretName,
+            },
+            {
+              name: 'Issuer Ref',
+              value: certificate.spec.issuerRef && (
+                <IssuerRef
+                  issuerRef={certificate.spec.issuerRef}
+                  namespace={certificate.metadata.namespace}
+                />
+              ),
+            },
+          ]}
+        />
+      </SectionBox>
+
+      {/* Subject Section */}
+      {certificate.spec.subject && (
+        <SectionBox title="Subject">
+          <NameValueTable
+            rows={[
+              {
+                name: 'Organizations',
+                value: <StringArray items={certificate.spec.subject?.organizations} />,
+              },
+              {
+                name: 'Countries',
+                value: <StringArray items={certificate.spec.subject?.countries} />,
+              },
+              {
+                name: 'Organizational Units',
+                value: <StringArray items={certificate.spec.subject?.organizationalUnits} />,
+              },
+              {
+                name: 'Localities',
+                value: <StringArray items={certificate.spec.subject?.localities} />,
+              },
+              {
+                name: 'Provinces',
+                value: <StringArray items={certificate.spec.subject?.provinces} />,
+              },
+              {
+                name: 'Street Addresses',
+                value: <StringArray items={certificate.spec.subject?.streetAddresses} />,
+              },
+              {
+                name: 'Postal Codes',
+                value: <StringArray items={certificate.spec.subject?.postalCodes} />,
+              },
+              {
+                name: 'Serial Number',
+                value: certificate.spec.subject?.serialNumber || '-',
+              },
+            ]}
+          />
+        </SectionBox>
+      )}
+
+      {/* Private Key Section */}
+      {certificate.spec.privateKey && (
+        <SectionBox title="Private Key">
+          <NameValueTable
+            rows={[
+              {
+                name: 'Algorithm',
+                value: certificate.spec.privateKey?.algorithm || '-',
+              },
+              {
+                name: 'Size',
+                value: certificate.spec.privateKey?.size?.toString() || '-',
+              },
+              {
+                name: 'Encoding',
+                value: certificate.spec.privateKey?.encoding || '-',
+              },
+              {
+                name: 'Rotation Policy',
+                value: certificate.spec.privateKey?.rotationPolicy || '-',
+              },
+            ]}
+          />
+        </SectionBox>
+      )}
+
+      {/* Keystores Section */}
+      {certificate.spec.keystores && (
+        <SectionBox title="Keystores">
+          <NameValueTable
+            rows={[
+              {
+                name: 'JKS',
+                value: certificate.spec.keystores?.jks
+                  ? `Create: ${certificate.spec.keystores.jks.create}`
+                  : '-',
+              },
+              {
+                name: 'PKCS12',
+                value: certificate.spec.keystores?.pkcs12
+                  ? `Create: ${certificate.spec.keystores.pkcs12.create}`
+                  : '-',
+              },
+            ]}
+          />
+        </SectionBox>
+      )}
+
+      {/* Status Section */}
+      {certificate.status && (
+        <SectionBox title="Status">
+          <NameValueTable
+            rows={[
+              {
+                name: 'Not Before',
+                value: certificate.status?.notBefore || '-',
+              },
+              {
+                name: 'Not After',
+                value: certificate.status?.notAfter || '-',
+              },
+              {
+                name: 'Renewal Time',
+                value: certificate.status?.renewalTime || '-',
+              },
+              {
+                name: 'Revision',
+                value: certificate.status?.revision?.toString() || '-',
+              },
+              {
+                name: 'Next Private Key Secret',
+                value: certificate.status?.nextPrivateKeySecretName || '-',
+              },
+            ]}
+          />
+        </SectionBox>
+      )}
+
+      {/* Conditions */}
+      {certificate.status?.conditions && certificate.status.conditions.length > 0 && (
+        <ConditionsTable conditions={certificate.status.conditions} />
+      )}
+    </Box>
+  );
+}
+
+export default {
+  title: 'cert-manager/Certificates/Detail',
+  component: PureCertificateDetail,
+  decorators: [
+    (Story: StoryFn) => (
+      <BrowserRouter>
+        <Story />
+      </BrowserRouter>
+    ),
+  ],
+} as Meta;
+
+const Template: StoryFn<PureCertificateDetailProps> = args => <PureCertificateDetail {...args} />;
+
+// Sample mock data
+const readyCertificate: MockCertificateDetail = {
+  metadata: {
+    name: 'example-com-tls',
+    namespace: 'default',
+    creationTimestamp: '2024-01-15T10:30:00Z',
+    uid: 'cert-1',
+    labels: {
+      app: 'example',
+      environment: 'production',
+    },
+  },
+  spec: {
+    secretName: 'example-com-tls-secret',
+    issuerRef: {
+      name: 'letsencrypt-prod',
+      kind: 'ClusterIssuer',
+      group: 'cert-manager.io',
+    },
+    commonName: 'example.com',
+    dnsNames: ['example.com', 'www.example.com', 'api.example.com'],
+    duration: '2160h',
+    renewBefore: '360h',
+    isCA: false,
+    usages: ['digital signature', 'key encipherment', 'server auth'],
+    revisionHistoryLimit: 1,
+    privateKey: {
+      algorithm: 'RSA',
+      size: 2048,
+      encoding: 'PKCS1',
+      rotationPolicy: 'Never',
+    },
+  },
+  status: {
+    conditions: [
+      {
+        type: 'Ready',
+        status: 'True',
+        reason: 'Ready',
+        message: 'Certificate is up to date and has not expired',
+        lastTransitionTime: '2024-01-15T10:35:00Z',
+      },
+      {
+        type: 'Issuing',
+        status: 'False',
+        reason: 'Issued',
+        message: 'Certificate issued successfully',
+        lastTransitionTime: '2024-01-15T10:34:00Z',
+      },
+    ],
+    notBefore: '2024-01-15T10:30:00Z',
+    notAfter: '2024-04-15T10:30:00Z',
+    renewalTime: '2024-04-01T10:30:00Z',
+    revision: 1,
+  },
+  ready: true,
+};
+
+const caCertificate: MockCertificateDetail = {
+  metadata: {
+    name: 'internal-ca',
+    namespace: 'cert-manager',
+    creationTimestamp: '2024-01-01T00:00:00Z',
+    uid: 'cert-ca-1',
+  },
+  spec: {
+    secretName: 'internal-ca-secret',
+    issuerRef: {
+      name: 'self-signed-issuer',
+      kind: 'Issuer',
+    },
+    commonName: 'Internal CA',
+    duration: '87600h', // 10 years
+    isCA: true,
+    usages: ['cert sign', 'crl sign'],
+    subject: {
+      organizations: ['My Company Inc.'],
+      countries: ['US'],
+      organizationalUnits: ['Security'],
+      localities: ['San Francisco'],
+      provinces: ['California'],
+    },
+    privateKey: {
+      algorithm: 'ECDSA',
+      size: 256,
+      encoding: 'PKCS8',
+    },
+  },
+  status: {
+    conditions: [
+      {
+        type: 'Ready',
+        status: 'True',
+        reason: 'Ready',
+        message: 'Certificate is up to date and has not expired',
+        lastTransitionTime: '2024-01-01T00:05:00Z',
+      },
+    ],
+    notBefore: '2024-01-01T00:00:00Z',
+    notAfter: '2034-01-01T00:00:00Z',
+    revision: 1,
+  },
+  ready: true,
+};
+
+const failedCertificate: MockCertificateDetail = {
+  metadata: {
+    name: 'failed-tls',
+    namespace: 'staging',
+    creationTimestamp: '2024-01-20T14:00:00Z',
+    uid: 'cert-failed-1',
+  },
+  spec: {
+    secretName: 'failed-tls-secret',
+    issuerRef: {
+      name: 'letsencrypt-staging',
+      kind: 'Issuer',
+    },
+    commonName: 'staging.example.com',
+    dnsNames: ['staging.example.com'],
+    duration: '2160h',
+    renewBefore: '360h',
+    isCA: false,
+    usages: ['digital signature', 'key encipherment', 'server auth'],
+  },
+  status: {
+    conditions: [
+      {
+        type: 'Ready',
+        status: 'False',
+        reason: 'Failed',
+        message: 'The certificate request failed: ACME server error: rate limit exceeded',
+        lastTransitionTime: '2024-01-20T14:05:00Z',
+      },
+      {
+        type: 'Issuing',
+        status: 'True',
+        reason: 'Pending',
+        message: 'Issuing certificate as Secret does not contain a certificate',
+        lastTransitionTime: '2024-01-20T14:00:00Z',
+      },
+    ],
+  },
+  ready: false,
+};
+
+const certificateWithKeystores: MockCertificateDetail = {
+  metadata: {
+    name: 'java-app-tls',
+    namespace: 'apps',
+    creationTimestamp: '2024-01-18T08:00:00Z',
+    uid: 'cert-keystore-1',
+  },
+  spec: {
+    secretName: 'java-app-tls-secret',
+    issuerRef: {
+      name: 'internal-ca',
+      kind: 'Issuer',
+    },
+    commonName: 'java-app.apps.svc.cluster.local',
+    dnsNames: ['java-app', 'java-app.apps', 'java-app.apps.svc.cluster.local'],
+    duration: '8760h',
+    renewBefore: '720h',
+    isCA: false,
+    usages: ['digital signature', 'key encipherment', 'server auth', 'client auth'],
+    privateKey: {
+      algorithm: 'RSA',
+      size: 4096,
+      encoding: 'PKCS8',
+      rotationPolicy: 'Always',
+    },
+    keystores: {
+      jks: {
+        create: true,
+        passwordSecretRef: {
+          name: 'keystore-password',
+          key: 'password',
+        },
+      },
+      pkcs12: {
+        create: true,
+        passwordSecretRef: {
+          name: 'keystore-password',
+          key: 'password',
+        },
+      },
+    },
+  },
+  status: {
+    conditions: [
+      {
+        type: 'Ready',
+        status: 'True',
+        reason: 'Ready',
+        message: 'Certificate is up to date and has not expired',
+        lastTransitionTime: '2024-01-18T08:05:00Z',
+      },
+    ],
+    notBefore: '2024-01-18T08:00:00Z',
+    notAfter: '2025-01-18T08:00:00Z',
+    renewalTime: '2024-12-18T08:00:00Z',
+    revision: 3,
+    nextPrivateKeySecretName: 'java-app-tls-next-key',
+  },
+  ready: true,
+};
+
+const minimalCertificate: MockCertificateDetail = {
+  metadata: {
+    name: 'minimal-tls',
+    namespace: 'default',
+    creationTimestamp: '2024-01-22T16:00:00Z',
+    uid: 'cert-minimal-1',
+  },
+  spec: {
+    secretName: 'minimal-tls-secret',
+    issuerRef: {
+      name: 'self-signed',
+      kind: 'Issuer',
+    },
+    dnsNames: ['localhost'],
+  },
+  status: {
+    conditions: [
+      {
+        type: 'Ready',
+        status: 'True',
+        reason: 'Ready',
+        message: 'Certificate is up to date',
+        lastTransitionTime: '2024-01-22T16:01:00Z',
+      },
+    ],
+    notBefore: '2024-01-22T16:00:00Z',
+    notAfter: '2024-04-22T16:00:00Z',
+    revision: 1,
+  },
+  ready: true,
+};
+
+// Stories
+export const Ready = Template.bind({});
+Ready.args = {
+  certificate: readyCertificate,
+  isCertManagerInstalled: true,
+};
+
+export const CACertificate = Template.bind({});
+CACertificate.args = {
+  certificate: caCertificate,
+  isCertManagerInstalled: true,
+};
+
+export const Failed = Template.bind({});
+Failed.args = {
+  certificate: failedCertificate,
+  isCertManagerInstalled: true,
+};
+
+export const WithKeystores = Template.bind({});
+WithKeystores.args = {
+  certificate: certificateWithKeystores,
+  isCertManagerInstalled: true,
+};
+
+export const Minimal = Template.bind({});
+Minimal.args = {
+  certificate: minimalCertificate,
+  isCertManagerInstalled: true,
+};
+
+export const NotFound = Template.bind({});
+NotFound.args = {
+  certificate: null,
+  isCertManagerInstalled: true,
+};
+
+export const CertManagerNotInstalled = Template.bind({});
+CertManagerNotInstalled.args = {
+  certificate: null,
+  isCertManagerInstalled: false,
+  isLoading: false,
+};
+
+export const Loading = Template.bind({});
+Loading.args = {
+  certificate: null,
+  isCertManagerInstalled: false,
+  isLoading: true,
+};

--- a/cert-manager/src/components/certificates/List.stories.tsx
+++ b/cert-manager/src/components/certificates/List.stories.tsx
@@ -1,0 +1,369 @@
+import {
+  DateLabel,
+  SectionHeader,
+  SimpleTable,
+} from '@kinvolk/headlamp-plugin/lib/components/common';
+import { Box } from '@mui/material';
+import { Meta, StoryFn } from '@storybook/react';
+import { NotInstalledBanner } from '../common/CommonComponents';
+
+// Mock certificate data structure for stories
+interface MockCertificate {
+  metadata: {
+    name: string;
+    namespace: string;
+    creationTimestamp: string;
+    uid: string;
+  };
+  spec: {
+    secretName: string;
+    issuerRef: {
+      name: string;
+      kind: string;
+    };
+  };
+  status: {
+    conditions: Array<{
+      type: string;
+      status: string;
+      reason?: string;
+      message?: string;
+      lastTransitionTime?: string;
+    }>;
+    notAfter?: string;
+    notBefore?: string;
+  };
+  ready: boolean;
+}
+
+interface PureCertificatesListProps {
+  certificates: MockCertificate[];
+  isLoading?: boolean;
+  isCertManagerInstalled?: boolean;
+}
+
+// Pure component for Storybook testing
+export function PureCertificatesList({
+  certificates,
+  isLoading = false,
+  isCertManagerInstalled = true,
+}: PureCertificatesListProps) {
+  if (!isCertManagerInstalled) {
+    return <NotInstalledBanner isLoading={isLoading} />;
+  }
+
+  return (
+    <Box>
+      <SectionHeader title="Certificates" />
+      <SimpleTable
+        columns={[
+          {
+            label: 'Name',
+            getter: (item: MockCertificate) => item.metadata.name,
+          },
+          {
+            label: 'Namespace',
+            getter: (item: MockCertificate) => item.metadata.namespace,
+          },
+          {
+            label: 'Ready',
+            getter: (item: MockCertificate) => (item.ready ? 'Ready' : 'Not Ready'),
+          },
+          {
+            label: 'Secret',
+            getter: (item: MockCertificate) => item.spec.secretName,
+          },
+          {
+            label: 'Expires In (Not After)',
+            getter: (item: MockCertificate) =>
+              item.status?.notAfter ? <DateLabel date={item.status.notAfter} format="mini" /> : '-',
+          },
+          {
+            label: 'Age',
+            getter: (item: MockCertificate) => (
+              <DateLabel date={item.metadata.creationTimestamp} format="mini" />
+            ),
+          },
+        ]}
+        data={certificates}
+        emptyMessage="No certificates found"
+      />
+    </Box>
+  );
+}
+
+export default {
+  title: 'cert-manager/Certificates/List',
+  component: PureCertificatesList,
+} as Meta;
+
+const Template: StoryFn<PureCertificatesListProps> = args => <PureCertificatesList {...args} />;
+
+// Sample mock data
+const mockCertificates: MockCertificate[] = [
+  {
+    metadata: {
+      name: 'example-com-tls',
+      namespace: 'default',
+      creationTimestamp: '2024-01-15T10:30:00Z',
+      uid: 'cert-1',
+    },
+    spec: {
+      secretName: 'example-com-tls-secret',
+      issuerRef: {
+        name: 'letsencrypt-prod',
+        kind: 'ClusterIssuer',
+      },
+    },
+    status: {
+      conditions: [
+        {
+          type: 'Ready',
+          status: 'True',
+          reason: 'Ready',
+          message: 'Certificate is up to date and has not expired',
+          lastTransitionTime: '2024-01-15T10:35:00Z',
+        },
+      ],
+      notAfter: '2024-04-15T10:30:00Z',
+      notBefore: '2024-01-15T10:30:00Z',
+    },
+    ready: true,
+  },
+  {
+    metadata: {
+      name: 'api-example-com-tls',
+      namespace: 'production',
+      creationTimestamp: '2024-01-10T08:00:00Z',
+      uid: 'cert-2',
+    },
+    spec: {
+      secretName: 'api-example-com-tls-secret',
+      issuerRef: {
+        name: 'letsencrypt-prod',
+        kind: 'ClusterIssuer',
+      },
+    },
+    status: {
+      conditions: [
+        {
+          type: 'Ready',
+          status: 'True',
+          reason: 'Ready',
+          message: 'Certificate is up to date and has not expired',
+          lastTransitionTime: '2024-01-10T08:05:00Z',
+        },
+      ],
+      notAfter: '2024-04-10T08:00:00Z',
+      notBefore: '2024-01-10T08:00:00Z',
+    },
+    ready: true,
+  },
+  {
+    metadata: {
+      name: 'staging-tls',
+      namespace: 'staging',
+      creationTimestamp: '2024-01-20T14:00:00Z',
+      uid: 'cert-3',
+    },
+    spec: {
+      secretName: 'staging-tls-secret',
+      issuerRef: {
+        name: 'letsencrypt-staging',
+        kind: 'Issuer',
+      },
+    },
+    status: {
+      conditions: [
+        {
+          type: 'Ready',
+          status: 'False',
+          reason: 'Failed',
+          message: 'The certificate request failed: ACME server error',
+          lastTransitionTime: '2024-01-20T14:05:00Z',
+        },
+      ],
+      notAfter: undefined,
+      notBefore: undefined,
+    },
+    ready: false,
+  },
+];
+
+const expiringCertificates: MockCertificate[] = [
+  {
+    metadata: {
+      name: 'expiring-soon-tls',
+      namespace: 'default',
+      creationTimestamp: '2023-10-15T10:30:00Z',
+      uid: 'cert-4',
+    },
+    spec: {
+      secretName: 'expiring-soon-tls-secret',
+      issuerRef: {
+        name: 'letsencrypt-prod',
+        kind: 'ClusterIssuer',
+      },
+    },
+    status: {
+      conditions: [
+        {
+          type: 'Ready',
+          status: 'True',
+          reason: 'Ready',
+          message: 'Certificate is up to date but will expire soon',
+          lastTransitionTime: '2023-10-15T10:35:00Z',
+        },
+      ],
+      notAfter: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(), // 7 days from now
+      notBefore: '2023-10-15T10:30:00Z',
+    },
+    ready: true,
+  },
+  {
+    metadata: {
+      name: 'already-expired-tls',
+      namespace: 'default',
+      creationTimestamp: '2023-07-15T10:30:00Z',
+      uid: 'cert-5',
+    },
+    spec: {
+      secretName: 'already-expired-tls-secret',
+      issuerRef: {
+        name: 'self-signed',
+        kind: 'Issuer',
+      },
+    },
+    status: {
+      conditions: [
+        {
+          type: 'Ready',
+          status: 'False',
+          reason: 'Expired',
+          message: 'Certificate has expired',
+          lastTransitionTime: '2023-10-15T10:30:00Z',
+        },
+      ],
+      notAfter: '2023-10-15T10:30:00Z',
+      notBefore: '2023-07-15T10:30:00Z',
+    },
+    ready: false,
+  },
+];
+
+// Stories
+export const Default = Template.bind({});
+Default.args = {
+  certificates: mockCertificates,
+  isCertManagerInstalled: true,
+};
+
+export const Empty = Template.bind({});
+Empty.args = {
+  certificates: [],
+  isCertManagerInstalled: true,
+};
+
+export const SingleCertificate = Template.bind({});
+SingleCertificate.args = {
+  certificates: [mockCertificates[0]],
+  isCertManagerInstalled: true,
+};
+
+export const AllReady = Template.bind({});
+AllReady.args = {
+  certificates: mockCertificates.filter(c => c.ready),
+  isCertManagerInstalled: true,
+};
+
+export const WithFailedCertificates = Template.bind({});
+WithFailedCertificates.args = {
+  certificates: mockCertificates,
+  isCertManagerInstalled: true,
+};
+
+export const ExpiringAndExpired = Template.bind({});
+ExpiringAndExpired.args = {
+  certificates: expiringCertificates,
+  isCertManagerInstalled: true,
+};
+
+export const CertManagerNotInstalled = Template.bind({});
+CertManagerNotInstalled.args = {
+  certificates: [],
+  isCertManagerInstalled: false,
+  isLoading: false,
+};
+
+export const CheckingCertManagerInstallation = Template.bind({});
+CheckingCertManagerInstallation.args = {
+  certificates: [],
+  isCertManagerInstalled: false,
+  isLoading: true,
+};
+
+export const ManyNamespaces = Template.bind({});
+ManyNamespaces.args = {
+  certificates: [
+    ...mockCertificates,
+    {
+      metadata: {
+        name: 'dev-tls',
+        namespace: 'development',
+        creationTimestamp: '2024-01-18T12:00:00Z',
+        uid: 'cert-6',
+      },
+      spec: {
+        secretName: 'dev-tls-secret',
+        issuerRef: {
+          name: 'letsencrypt-staging',
+          kind: 'ClusterIssuer',
+        },
+      },
+      status: {
+        conditions: [
+          {
+            type: 'Ready',
+            status: 'True',
+            reason: 'Ready',
+            message: 'Certificate is up to date',
+            lastTransitionTime: '2024-01-18T12:05:00Z',
+          },
+        ],
+        notAfter: '2024-04-18T12:00:00Z',
+        notBefore: '2024-01-18T12:00:00Z',
+      },
+      ready: true,
+    },
+    {
+      metadata: {
+        name: 'test-tls',
+        namespace: 'testing',
+        creationTimestamp: '2024-01-19T09:00:00Z',
+        uid: 'cert-7',
+      },
+      spec: {
+        secretName: 'test-tls-secret',
+        issuerRef: {
+          name: 'self-signed',
+          kind: 'Issuer',
+        },
+      },
+      status: {
+        conditions: [
+          {
+            type: 'Ready',
+            status: 'True',
+            reason: 'Ready',
+            message: 'Certificate is up to date',
+            lastTransitionTime: '2024-01-19T09:05:00Z',
+          },
+        ],
+        notAfter: '2025-01-19T09:00:00Z',
+        notBefore: '2024-01-19T09:00:00Z',
+      },
+      ready: true,
+    },
+  ],
+  isCertManagerInstalled: true,
+};

--- a/cert-manager/src/components/challenges/Detail.stories.tsx
+++ b/cert-manager/src/components/challenges/Detail.stories.tsx
@@ -1,0 +1,416 @@
+import {
+  NameValueTable,
+  SectionBox,
+  SectionHeader,
+} from '@kinvolk/headlamp-plugin/lib/components/common';
+import { Box } from '@mui/material';
+import { Meta, StoryFn } from '@storybook/react';
+import { BrowserRouter } from 'react-router-dom';
+import { ACMEChallengeSolver, IssuerReference } from '../../resources/common';
+import {
+  ACMEChallengeSolverComponent,
+  CopyToClipboard,
+  IssuerRef,
+  NotInstalledBanner,
+} from '../common/CommonComponents';
+
+// Mock challenge data structure for stories
+interface MockChallengeDetail {
+  metadata: {
+    name: string;
+    namespace: string;
+    creationTimestamp: string;
+    uid: string;
+    labels?: Record<string, string>;
+    annotations?: Record<string, string>;
+  };
+  spec: {
+    dnsName: string;
+    authorizationURL: string;
+    type: string;
+    issuerRef: IssuerReference;
+    key: string;
+    solver: ACMEChallengeSolver;
+    token: string;
+    url: string;
+    wildcard?: boolean;
+  };
+  status: {
+    state: string;
+    presented: boolean;
+    processing: boolean;
+    reason?: string;
+  };
+}
+
+interface PureChallengeDetailProps {
+  challenge: MockChallengeDetail | null;
+  isLoading?: boolean;
+  isCertManagerInstalled?: boolean;
+}
+
+// Pure component for Storybook testing
+export function PureChallengeDetail({
+  challenge,
+  isLoading = false,
+  isCertManagerInstalled = true,
+}: PureChallengeDetailProps) {
+  if (!isCertManagerInstalled) {
+    return <NotInstalledBanner isLoading={isLoading} />;
+  }
+
+  if (!challenge) {
+    return (
+      <Box p={2}>
+        <SectionHeader title="Challenge Details" />
+        <Box>Challenge not found</Box>
+      </Box>
+    );
+  }
+
+  return (
+    <Box>
+      <SectionHeader title={`Challenge: ${challenge.metadata.name}`} />
+
+      {/* Main Info */}
+      <SectionBox title="Info">
+        <NameValueTable
+          rows={[
+            { name: 'Name', value: challenge.metadata.name },
+            { name: 'Namespace', value: challenge.metadata.namespace },
+            { name: 'DNS Name', value: challenge.spec.dnsName },
+            { name: 'Authorization URL', value: challenge.spec.authorizationURL },
+            { name: 'Type', value: challenge.spec.type },
+            {
+              name: 'Issuer Ref',
+              value: challenge.spec.issuerRef && (
+                <IssuerRef
+                  issuerRef={challenge.spec.issuerRef}
+                  namespace={challenge.metadata.namespace}
+                />
+              ),
+            },
+            {
+              name: 'Key',
+              value: <CopyToClipboard text={challenge.spec.key} />,
+            },
+            {
+              name: 'Solver',
+              value: <ACMEChallengeSolverComponent solver={challenge.spec.solver} />,
+            },
+            { name: 'Token', value: challenge.spec.token },
+            { name: 'URL', value: challenge.spec.url },
+            { name: 'Wildcard', value: challenge.spec?.wildcard?.toString() || 'false' },
+          ]}
+        />
+      </SectionBox>
+
+      {/* Status Section */}
+      {challenge.status && (
+        <SectionBox title="Status">
+          <NameValueTable
+            rows={[
+              { name: 'State', value: challenge.status?.state || '-' },
+              { name: 'Presented', value: challenge.status.presented.toString() },
+              { name: 'Processing', value: challenge.status.processing.toString() },
+              { name: 'Reason', value: challenge.status?.reason || '-' },
+            ]}
+          />
+        </SectionBox>
+      )}
+    </Box>
+  );
+}
+
+export default {
+  title: 'cert-manager/Challenges/Detail',
+  component: PureChallengeDetail,
+  decorators: [
+    (Story: StoryFn) => (
+      <BrowserRouter>
+        <Story />
+      </BrowserRouter>
+    ),
+  ],
+} as Meta;
+
+const Template: StoryFn<PureChallengeDetailProps> = args => <PureChallengeDetail {...args} />;
+
+// Sample mock data
+const pendingHTTP01Challenge: MockChallengeDetail = {
+  metadata: {
+    name: 'example-com-tls-1-123456789-0',
+    namespace: 'default',
+    creationTimestamp: '2024-01-15T10:30:00Z',
+    uid: 'challenge-1',
+    labels: {
+      'acme.cert-manager.io/certificate': 'example-com-tls',
+    },
+  },
+  spec: {
+    dnsName: 'example.com',
+    authorizationURL: 'https://acme-v02.api.letsencrypt.org/acme/authz-v3/123456789',
+    type: 'HTTP-01',
+    issuerRef: {
+      name: 'letsencrypt-prod',
+      kind: 'ClusterIssuer',
+      group: 'cert-manager.io',
+    },
+    key: 'abc123def456.xyz789',
+    solver: {
+      http01: {
+        ingress: {
+          class: 'nginx',
+          serviceType: 'ClusterIP',
+        },
+      },
+    },
+    token: 'abc123def456',
+    url: 'https://acme-v02.api.letsencrypt.org/acme/chall-v3/123456789/abcdef',
+    wildcard: false,
+  },
+  status: {
+    state: 'pending',
+    presented: true,
+    processing: true,
+  },
+};
+
+const validHTTP01Challenge: MockChallengeDetail = {
+  metadata: {
+    name: 'api-example-com-tls-1-987654321-0',
+    namespace: 'production',
+    creationTimestamp: '2024-01-15T10:25:00Z',
+    uid: 'challenge-2',
+  },
+  spec: {
+    dnsName: 'api.example.com',
+    authorizationURL: 'https://acme-v02.api.letsencrypt.org/acme/authz-v3/987654321',
+    type: 'HTTP-01',
+    issuerRef: {
+      name: 'letsencrypt-prod',
+      kind: 'ClusterIssuer',
+    },
+    key: 'ghi789jkl012.mno345',
+    solver: {
+      http01: {
+        ingress: {
+          ingressClassName: 'traefik',
+        },
+      },
+    },
+    token: 'ghi789jkl012',
+    url: 'https://acme-v02.api.letsencrypt.org/acme/chall-v3/987654321/ghijkl',
+    wildcard: false,
+  },
+  status: {
+    state: 'valid',
+    presented: true,
+    processing: false,
+  },
+};
+
+const pendingDNS01Challenge: MockChallengeDetail = {
+  metadata: {
+    name: 'wildcard-example-com-tls-1-111222333-0',
+    namespace: 'default',
+    creationTimestamp: '2024-01-15T10:20:00Z',
+    uid: 'challenge-3',
+  },
+  spec: {
+    dnsName: '*.example.com',
+    authorizationURL: 'https://acme-v02.api.letsencrypt.org/acme/authz-v3/111222333',
+    type: 'DNS-01',
+    issuerRef: {
+      name: 'letsencrypt-dns',
+      kind: 'ClusterIssuer',
+    },
+    key: 'pqr567stu890.vwx123',
+    solver: {
+      dns01: {
+        provider: 'cloudflare',
+        cloudflare: {
+          email: 'admin@example.com',
+        },
+      },
+    },
+    token: 'pqr567stu890',
+    url: 'https://acme-v02.api.letsencrypt.org/acme/chall-v3/111222333/pqrstu',
+    wildcard: true,
+  },
+  status: {
+    state: 'pending',
+    presented: false,
+    processing: true,
+  },
+};
+
+const invalidChallenge: MockChallengeDetail = {
+  metadata: {
+    name: 'staging-tls-1-444555666-0',
+    namespace: 'staging',
+    creationTimestamp: '2024-01-15T10:15:00Z',
+    uid: 'challenge-4',
+  },
+  spec: {
+    dnsName: 'staging.example.com',
+    authorizationURL: 'https://acme-staging-v02.api.letsencrypt.org/acme/authz-v3/444555666',
+    type: 'HTTP-01',
+    issuerRef: {
+      name: 'letsencrypt-staging',
+      kind: 'Issuer',
+    },
+    key: 'yza234bcd567.efg890',
+    solver: {
+      http01: {
+        ingress: {
+          class: 'nginx',
+        },
+      },
+    },
+    token: 'yza234bcd567',
+    url: 'https://acme-staging-v02.api.letsencrypt.org/acme/chall-v3/444555666/yzabcd',
+    wildcard: false,
+  },
+  status: {
+    state: 'invalid',
+    presented: true,
+    processing: false,
+    reason:
+      'Error presenting challenge: The server could not connect to the client to verify the domain',
+  },
+};
+
+const erroredChallenge: MockChallengeDetail = {
+  metadata: {
+    name: 'rate-limited-tls-1-777888999-0',
+    namespace: 'production',
+    creationTimestamp: '2024-01-15T10:10:00Z',
+    uid: 'challenge-5',
+  },
+  spec: {
+    dnsName: 'app.example.com',
+    authorizationURL: 'https://acme-v02.api.letsencrypt.org/acme/authz-v3/777888999',
+    type: 'HTTP-01',
+    issuerRef: {
+      name: 'letsencrypt-prod',
+      kind: 'ClusterIssuer',
+    },
+    key: 'hij123klm456.nop789',
+    solver: {
+      http01: {
+        ingress: {
+          class: 'nginx',
+        },
+      },
+    },
+    token: 'hij123klm456',
+    url: 'https://acme-v02.api.letsencrypt.org/acme/chall-v3/777888999/hijklm',
+    wildcard: false,
+  },
+  status: {
+    state: 'errored',
+    presented: false,
+    processing: false,
+    reason: 'Error accepting authorization: rateLimited: too many failed authorizations recently',
+  },
+};
+
+const dns01Route53Challenge: MockChallengeDetail = {
+  metadata: {
+    name: 'wildcard-route53-tls-1-999000111-0',
+    namespace: 'production',
+    creationTimestamp: '2024-01-15T10:05:00Z',
+    uid: 'challenge-6',
+  },
+  spec: {
+    dnsName: '*.production.example.com',
+    authorizationURL: 'https://acme-v02.api.letsencrypt.org/acme/authz-v3/999000111',
+    type: 'DNS-01',
+    issuerRef: {
+      name: 'letsencrypt-prod',
+      kind: 'ClusterIssuer',
+    },
+    key: 'qrs456tuv789.wxy012',
+    solver: {
+      dns01: {
+        provider: 'route53',
+        route53: {
+          region: 'us-east-1',
+          hostedZoneID: 'Z1234567890ABC',
+        },
+      },
+    },
+    token: 'qrs456tuv789',
+    url: 'https://acme-v02.api.letsencrypt.org/acme/chall-v3/999000111/qrstuv',
+    wildcard: true,
+  },
+  status: {
+    state: 'valid',
+    presented: true,
+    processing: false,
+  },
+};
+
+// Stories
+export const PendingHTTP01 = Template.bind({});
+PendingHTTP01.args = {
+  challenge: pendingHTTP01Challenge,
+  isCertManagerInstalled: true,
+};
+
+export const ValidHTTP01 = Template.bind({});
+ValidHTTP01.args = {
+  challenge: validHTTP01Challenge,
+  isCertManagerInstalled: true,
+};
+
+export const PendingDNS01 = Template.bind({});
+PendingDNS01.args = {
+  challenge: pendingDNS01Challenge,
+  isCertManagerInstalled: true,
+};
+
+export const DNS01Route53 = Template.bind({});
+DNS01Route53.args = {
+  challenge: dns01Route53Challenge,
+  isCertManagerInstalled: true,
+};
+
+export const Invalid = Template.bind({});
+Invalid.args = {
+  challenge: invalidChallenge,
+  isCertManagerInstalled: true,
+};
+
+export const Errored = Template.bind({});
+Errored.args = {
+  challenge: erroredChallenge,
+  isCertManagerInstalled: true,
+};
+
+export const WildcardChallenge = Template.bind({});
+WildcardChallenge.args = {
+  challenge: pendingDNS01Challenge,
+  isCertManagerInstalled: true,
+};
+
+export const NotFound = Template.bind({});
+NotFound.args = {
+  challenge: null,
+  isCertManagerInstalled: true,
+};
+
+export const CertManagerNotInstalled = Template.bind({});
+CertManagerNotInstalled.args = {
+  challenge: null,
+  isCertManagerInstalled: false,
+  isLoading: false,
+};
+
+export const Loading = Template.bind({});
+Loading.args = {
+  challenge: null,
+  isCertManagerInstalled: false,
+  isLoading: true,
+};

--- a/cert-manager/src/components/challenges/List.stories.tsx
+++ b/cert-manager/src/components/challenges/List.stories.tsx
@@ -1,0 +1,260 @@
+import {
+  DateLabel,
+  SectionHeader,
+  SimpleTable,
+} from '@kinvolk/headlamp-plugin/lib/components/common';
+import { Box } from '@mui/material';
+import { Meta, StoryFn } from '@storybook/react';
+import { NotInstalledBanner } from '../common/CommonComponents';
+
+// Mock challenge data structure for stories
+interface MockChallenge {
+  metadata: {
+    name: string;
+    namespace: string;
+    creationTimestamp: string;
+    uid: string;
+  };
+  spec: {
+    dnsName: string;
+    type: string;
+    issuerRef: {
+      name: string;
+      kind: string;
+    };
+  };
+  status: {
+    state: string;
+    presented: boolean;
+    processing: boolean;
+    reason?: string;
+  };
+}
+
+interface PureChallengesListProps {
+  challenges: MockChallenge[];
+  isLoading?: boolean;
+  isCertManagerInstalled?: boolean;
+}
+
+// Pure component for Storybook testing
+export function PureChallengesList({
+  challenges,
+  isLoading = false,
+  isCertManagerInstalled = true,
+}: PureChallengesListProps) {
+  if (!isCertManagerInstalled) {
+    return <NotInstalledBanner isLoading={isLoading} />;
+  }
+
+  return (
+    <Box>
+      <SectionHeader title="Challenges" />
+      <SimpleTable
+        columns={[
+          {
+            label: 'Name',
+            getter: (item: MockChallenge) => item.metadata.name,
+          },
+          {
+            label: 'Namespace',
+            getter: (item: MockChallenge) => item.metadata.namespace,
+          },
+          {
+            label: 'State',
+            getter: (item: MockChallenge) => item.status?.state || '-',
+          },
+          {
+            label: 'Domain',
+            getter: (item: MockChallenge) => item.spec.dnsName,
+          },
+          {
+            label: 'Age',
+            getter: (item: MockChallenge) => (
+              <DateLabel date={item.metadata.creationTimestamp} format="mini" />
+            ),
+          },
+        ]}
+        data={challenges}
+        emptyMessage="No challenges found"
+      />
+    </Box>
+  );
+}
+
+export default {
+  title: 'cert-manager/Challenges/List',
+  component: PureChallengesList,
+} as Meta;
+
+const Template: StoryFn<PureChallengesListProps> = args => <PureChallengesList {...args} />;
+
+// Sample mock data
+const mockChallenges: MockChallenge[] = [
+  {
+    metadata: {
+      name: 'example-com-tls-1-123456789-0',
+      namespace: 'default',
+      creationTimestamp: '2024-01-15T10:30:00Z',
+      uid: 'challenge-1',
+    },
+    spec: {
+      dnsName: 'example.com',
+      type: 'HTTP-01',
+      issuerRef: {
+        name: 'letsencrypt-prod',
+        kind: 'ClusterIssuer',
+      },
+    },
+    status: {
+      state: 'pending',
+      presented: true,
+      processing: true,
+    },
+  },
+  {
+    metadata: {
+      name: 'api-example-com-tls-1-987654321-0',
+      namespace: 'production',
+      creationTimestamp: '2024-01-15T10:25:00Z',
+      uid: 'challenge-2',
+    },
+    spec: {
+      dnsName: 'api.example.com',
+      type: 'HTTP-01',
+      issuerRef: {
+        name: 'letsencrypt-prod',
+        kind: 'ClusterIssuer',
+      },
+    },
+    status: {
+      state: 'valid',
+      presented: true,
+      processing: false,
+    },
+  },
+  {
+    metadata: {
+      name: 'wildcard-example-com-tls-1-111222333-0',
+      namespace: 'default',
+      creationTimestamp: '2024-01-15T10:20:00Z',
+      uid: 'challenge-3',
+    },
+    spec: {
+      dnsName: '*.example.com',
+      type: 'DNS-01',
+      issuerRef: {
+        name: 'letsencrypt-dns',
+        kind: 'ClusterIssuer',
+      },
+    },
+    status: {
+      state: 'pending',
+      presented: false,
+      processing: true,
+    },
+  },
+  {
+    metadata: {
+      name: 'staging-tls-1-444555666-0',
+      namespace: 'staging',
+      creationTimestamp: '2024-01-15T10:15:00Z',
+      uid: 'challenge-4',
+    },
+    spec: {
+      dnsName: 'staging.example.com',
+      type: 'HTTP-01',
+      issuerRef: {
+        name: 'letsencrypt-staging',
+        kind: 'Issuer',
+      },
+    },
+    status: {
+      state: 'invalid',
+      presented: true,
+      processing: false,
+      reason: 'Error presenting challenge: incorrect TXT record',
+    },
+  },
+  {
+    metadata: {
+      name: 'rate-limited-tls-1-777888999-0',
+      namespace: 'production',
+      creationTimestamp: '2024-01-15T10:10:00Z',
+      uid: 'challenge-5',
+    },
+    spec: {
+      dnsName: 'app.example.com',
+      type: 'HTTP-01',
+      issuerRef: {
+        name: 'letsencrypt-prod',
+        kind: 'ClusterIssuer',
+      },
+    },
+    status: {
+      state: 'errored',
+      presented: false,
+      processing: false,
+      reason: 'Error accepting authorization: rateLimited',
+    },
+  },
+];
+
+// Stories
+export const Default = Template.bind({});
+Default.args = {
+  challenges: mockChallenges,
+  isCertManagerInstalled: true,
+};
+
+export const Empty = Template.bind({});
+Empty.args = {
+  challenges: [],
+  isCertManagerInstalled: true,
+};
+
+export const PendingChallenges = Template.bind({});
+PendingChallenges.args = {
+  challenges: mockChallenges.filter(c => c.status.state === 'pending'),
+  isCertManagerInstalled: true,
+};
+
+export const ValidChallenges = Template.bind({});
+ValidChallenges.args = {
+  challenges: mockChallenges.filter(c => c.status.state === 'valid'),
+  isCertManagerInstalled: true,
+};
+
+export const FailedChallenges = Template.bind({});
+FailedChallenges.args = {
+  challenges: mockChallenges.filter(
+    c => c.status.state === 'invalid' || c.status.state === 'errored'
+  ),
+  isCertManagerInstalled: true,
+};
+
+export const MixedStates = Template.bind({});
+MixedStates.args = {
+  challenges: mockChallenges,
+  isCertManagerInstalled: true,
+};
+
+export const DNS01Challenges = Template.bind({});
+DNS01Challenges.args = {
+  challenges: mockChallenges.filter(c => c.spec.type === 'DNS-01'),
+  isCertManagerInstalled: true,
+};
+
+export const CertManagerNotInstalled = Template.bind({});
+CertManagerNotInstalled.args = {
+  challenges: [],
+  isCertManagerInstalled: false,
+  isLoading: false,
+};
+
+export const Loading = Template.bind({});
+Loading.args = {
+  challenges: [],
+  isCertManagerInstalled: false,
+  isLoading: true,
+};

--- a/cert-manager/src/components/clusterIssuers/Detail.stories.tsx
+++ b/cert-manager/src/components/clusterIssuers/Detail.stories.tsx
@@ -1,0 +1,513 @@
+import {
+  NameValueTable,
+  SectionBox,
+  SectionHeader,
+} from '@kinvolk/headlamp-plugin/lib/components/common';
+import { Box } from '@mui/material';
+import { Meta, StoryFn } from '@storybook/react';
+import { BrowserRouter } from 'react-router-dom';
+import { ACMEIssuerStatus, Condition, IssuerSpec } from '../../resources/common';
+import {
+  ACMEChallengeSolverComponent,
+  ACMEIssuerStatusComponent,
+  ConditionsTable,
+  NotInstalledBanner,
+  SecretKeySelectorComponent,
+  StringArray,
+} from '../common/CommonComponents';
+
+// Mock cluster issuer data structure for stories
+interface MockClusterIssuerDetail {
+  metadata: {
+    name: string;
+    creationTimestamp: string;
+    uid: string;
+    labels?: Record<string, string>;
+    annotations?: Record<string, string>;
+  };
+  spec: IssuerSpec;
+  status: {
+    conditions?: Condition[];
+    acme?: ACMEIssuerStatus;
+  };
+  ready: boolean;
+}
+
+interface PureClusterIssuerDetailProps {
+  clusterIssuer: MockClusterIssuerDetail | null;
+  isLoading?: boolean;
+  isCertManagerInstalled?: boolean;
+}
+
+// Helper function to render issuer type specific info
+function renderIssuerTypeInfo(spec: IssuerSpec) {
+  if (spec.acme) {
+    return (
+      <SectionBox title="ACME Configuration">
+        <NameValueTable
+          rows={[
+            { name: 'Email', value: spec.acme.email || '-' },
+            { name: 'Server', value: spec.acme.server || '-' },
+            { name: 'Preferred Chain', value: spec.acme.preferredChain || '-' },
+            { name: 'Skip TLS Verify', value: spec.acme.skipTLSVerify?.toString() || 'false' },
+            {
+              name: 'Private Key Secret Ref',
+              value: spec.acme.privateKeySecretRef ? (
+                <SecretKeySelectorComponent selector={spec.acme.privateKeySecretRef} />
+              ) : (
+                '-'
+              ),
+            },
+            {
+              name: 'Solvers',
+              value:
+                spec.acme.solvers?.map((solver, index) => (
+                  <Box key={index} mb={2}>
+                    <ACMEChallengeSolverComponent solver={solver} />
+                  </Box>
+                )) || '-',
+            },
+          ]}
+        />
+      </SectionBox>
+    );
+  }
+
+  if (spec.ca) {
+    return (
+      <SectionBox title="CA Configuration">
+        <NameValueTable
+          rows={[
+            { name: 'Secret Name', value: spec.ca.secretName || '-' },
+            {
+              name: 'CRL Distribution Points',
+              value: <StringArray items={spec.ca.crlDistributionPoints} />,
+            },
+          ]}
+        />
+      </SectionBox>
+    );
+  }
+
+  if (spec.selfSigned) {
+    return (
+      <SectionBox title="Self-Signed Configuration">
+        <NameValueTable
+          rows={[
+            {
+              name: 'CRL Distribution Points',
+              value: <StringArray items={spec.selfSigned.crlDistributionPoints} />,
+            },
+          ]}
+        />
+      </SectionBox>
+    );
+  }
+
+  if (spec.vault) {
+    return (
+      <SectionBox title="Vault Configuration">
+        <NameValueTable
+          rows={[
+            { name: 'Server', value: spec.vault.server || '-' },
+            { name: 'Path', value: spec.vault.path || '-' },
+            { name: 'Namespace', value: spec.vault.namespace || '-' },
+            { name: 'CA Bundle', value: spec.vault.caBundle ? 'Configured' : '-' },
+            {
+              name: 'Auth Method',
+              value: spec.vault.auth?.tokenSecretRef
+                ? 'Token'
+                : spec.vault.auth?.appRole
+                ? 'AppRole'
+                : spec.vault.auth?.kubernetes
+                ? 'Kubernetes'
+                : '-',
+            },
+          ]}
+        />
+      </SectionBox>
+    );
+  }
+
+  if (spec.venafi) {
+    return (
+      <SectionBox title="Venafi Configuration">
+        <NameValueTable
+          rows={[
+            { name: 'Zone', value: spec.venafi.zone || '-' },
+            {
+              name: 'TPP URL',
+              value: spec.venafi.tpp?.url || '-',
+            },
+            {
+              name: 'Cloud URL',
+              value: spec.venafi.cloud?.url || '-',
+            },
+          ]}
+        />
+      </SectionBox>
+    );
+  }
+
+  return null;
+}
+
+// Pure component for Storybook testing
+export function PureClusterIssuerDetail({
+  clusterIssuer,
+  isLoading = false,
+  isCertManagerInstalled = true,
+}: PureClusterIssuerDetailProps) {
+  if (!isCertManagerInstalled) {
+    return <NotInstalledBanner isLoading={isLoading} />;
+  }
+
+  if (!clusterIssuer) {
+    return (
+      <Box p={2}>
+        <SectionHeader title="Cluster Issuer Details" />
+        <Box>Cluster Issuer not found</Box>
+      </Box>
+    );
+  }
+
+  const issuerType = clusterIssuer.spec.acme
+    ? 'ACME'
+    : clusterIssuer.spec.ca
+    ? 'CA'
+    : clusterIssuer.spec.selfSigned
+    ? 'Self-Signed'
+    : clusterIssuer.spec.vault
+    ? 'Vault'
+    : clusterIssuer.spec.venafi
+    ? 'Venafi'
+    : 'Unknown';
+
+  return (
+    <Box>
+      <SectionHeader title={`Cluster Issuer: ${clusterIssuer.metadata.name}`} />
+
+      {/* Main Info */}
+      <SectionBox title="Info">
+        <NameValueTable
+          rows={[
+            { name: 'Name', value: clusterIssuer.metadata.name },
+            { name: 'Ready', value: clusterIssuer.ready ? 'Ready' : 'Not Ready' },
+            { name: 'Type', value: issuerType },
+          ]}
+        />
+      </SectionBox>
+
+      {/* Issuer Type Configuration */}
+      {renderIssuerTypeInfo(clusterIssuer.spec)}
+
+      {/* ACME Status (if applicable) */}
+      {clusterIssuer.status?.acme && (
+        <SectionBox title="ACME Status">
+          <ACMEIssuerStatusComponent status={clusterIssuer.status.acme} />
+        </SectionBox>
+      )}
+
+      {/* Conditions */}
+      {clusterIssuer.status?.conditions && clusterIssuer.status.conditions.length > 0 && (
+        <ConditionsTable conditions={clusterIssuer.status.conditions} />
+      )}
+    </Box>
+  );
+}
+
+export default {
+  title: 'cert-manager/ClusterIssuers/Detail',
+  component: PureClusterIssuerDetail,
+  decorators: [
+    (Story: StoryFn) => (
+      <BrowserRouter>
+        <Story />
+      </BrowserRouter>
+    ),
+  ],
+} as Meta;
+
+const Template: StoryFn<PureClusterIssuerDetailProps> = args => (
+  <PureClusterIssuerDetail {...args} />
+);
+
+// Sample mock data for different cluster issuer types
+const acmeClusterIssuer: MockClusterIssuerDetail = {
+  metadata: {
+    name: 'letsencrypt-prod',
+    creationTimestamp: '2024-01-01T00:00:00Z',
+    uid: 'cluster-issuer-acme-1',
+  },
+  spec: {
+    acme: {
+      email: 'admin@example.com',
+      server: 'https://acme-v02.api.letsencrypt.org/directory',
+      privateKeySecretRef: {
+        name: 'letsencrypt-prod-account-key',
+        key: 'tls.key',
+      },
+      solvers: [
+        {
+          http01: {
+            ingress: {
+              class: 'nginx',
+            },
+          },
+        },
+      ],
+    },
+  },
+  status: {
+    conditions: [
+      {
+        type: 'Ready',
+        status: 'True',
+        reason: 'ACMEAccountRegistered',
+        message: 'The ACME account was registered with the ACME server',
+        lastTransitionTime: '2024-01-01T00:05:00Z',
+      },
+    ],
+    acme: {
+      uri: 'https://acme-v02.api.letsencrypt.org/acme/acct/123456789',
+      lastRegisteredEmail: 'admin@example.com',
+      lastPrivateKeyHash: 'sha256:abc123def456...',
+    },
+  },
+  ready: true,
+};
+
+const stagingClusterIssuer: MockClusterIssuerDetail = {
+  metadata: {
+    name: 'letsencrypt-staging',
+    creationTimestamp: '2024-01-01T00:00:00Z',
+    uid: 'cluster-issuer-acme-2',
+  },
+  spec: {
+    acme: {
+      email: 'dev@example.com',
+      server: 'https://acme-staging-v02.api.letsencrypt.org/directory',
+      privateKeySecretRef: {
+        name: 'letsencrypt-staging-account-key',
+        key: 'tls.key',
+      },
+      solvers: [
+        {
+          http01: {
+            ingress: {
+              ingressClassName: 'traefik',
+            },
+          },
+        },
+      ],
+    },
+  },
+  status: {
+    conditions: [
+      {
+        type: 'Ready',
+        status: 'True',
+        reason: 'ACMEAccountRegistered',
+        message: 'The ACME account was registered with the ACME server',
+        lastTransitionTime: '2024-01-01T00:05:00Z',
+      },
+    ],
+    acme: {
+      uri: 'https://acme-staging-v02.api.letsencrypt.org/acme/acct/987654321',
+      lastRegisteredEmail: 'dev@example.com',
+    },
+  },
+  ready: true,
+};
+
+const selfSignedClusterIssuer: MockClusterIssuerDetail = {
+  metadata: {
+    name: 'self-signed-cluster',
+    creationTimestamp: '2024-01-02T00:00:00Z',
+    uid: 'cluster-issuer-selfsigned-1',
+  },
+  spec: {
+    selfSigned: {},
+  },
+  status: {
+    conditions: [
+      {
+        type: 'Ready',
+        status: 'True',
+        reason: 'IsReady',
+        message: 'Issuer is ready',
+        lastTransitionTime: '2024-01-02T00:01:00Z',
+      },
+    ],
+  },
+  ready: true,
+};
+
+const caClusterIssuer: MockClusterIssuerDetail = {
+  metadata: {
+    name: 'cluster-ca-issuer',
+    creationTimestamp: '2024-01-03T00:00:00Z',
+    uid: 'cluster-issuer-ca-1',
+  },
+  spec: {
+    ca: {
+      secretName: 'cluster-ca-key-pair',
+      crlDistributionPoints: ['http://crl.example.com/cluster-ca.crl'],
+    },
+  },
+  status: {
+    conditions: [
+      {
+        type: 'Ready',
+        status: 'True',
+        reason: 'KeyPairVerified',
+        message: 'Signing CA verified',
+        lastTransitionTime: '2024-01-03T00:05:00Z',
+      },
+    ],
+  },
+  ready: true,
+};
+
+const failedClusterIssuer: MockClusterIssuerDetail = {
+  metadata: {
+    name: 'vault-cluster-issuer',
+    creationTimestamp: '2024-01-04T00:00:00Z',
+    uid: 'cluster-issuer-vault-1',
+  },
+  spec: {
+    vault: {
+      server: 'https://vault.example.com',
+      path: 'pki/sign/cluster-role',
+      auth: {
+        kubernetes: {
+          role: 'cert-manager',
+          mountPath: '/v1/auth/kubernetes',
+        },
+      },
+    },
+  },
+  status: {
+    conditions: [
+      {
+        type: 'Ready',
+        status: 'False',
+        reason: 'VaultVerifyError',
+        message: 'Vault server returned error: connection refused',
+        lastTransitionTime: '2024-01-04T00:02:00Z',
+      },
+    ],
+  },
+  ready: false,
+};
+
+const acmeWithDNS01ClusterIssuer: MockClusterIssuerDetail = {
+  metadata: {
+    name: 'letsencrypt-dns-cluster',
+    creationTimestamp: '2024-01-05T00:00:00Z',
+    uid: 'cluster-issuer-acme-dns-1',
+  },
+  spec: {
+    acme: {
+      email: 'admin@example.com',
+      server: 'https://acme-v02.api.letsencrypt.org/directory',
+      privateKeySecretRef: {
+        name: 'letsencrypt-dns-account-key',
+        key: 'tls.key',
+      },
+      solvers: [
+        {
+          dns01: {
+            provider: 'route53',
+            route53: {
+              region: 'us-east-1',
+            },
+          },
+          selector: {
+            dnsZones: ['example.com', 'example.org'],
+          },
+        },
+        {
+          http01: {
+            ingress: {
+              class: 'nginx',
+            },
+          },
+        },
+      ],
+    },
+  },
+  status: {
+    conditions: [
+      {
+        type: 'Ready',
+        status: 'True',
+        reason: 'ACMEAccountRegistered',
+        message: 'The ACME account was registered with the ACME server',
+        lastTransitionTime: '2024-01-05T00:05:00Z',
+      },
+    ],
+    acme: {
+      uri: 'https://acme-v02.api.letsencrypt.org/acme/acct/555555555',
+      lastRegisteredEmail: 'admin@example.com',
+    },
+  },
+  ready: true,
+};
+
+// Stories
+export const ACMEProd = Template.bind({});
+ACMEProd.args = {
+  clusterIssuer: acmeClusterIssuer,
+  isCertManagerInstalled: true,
+};
+
+export const ACMEStaging = Template.bind({});
+ACMEStaging.args = {
+  clusterIssuer: stagingClusterIssuer,
+  isCertManagerInstalled: true,
+};
+
+export const ACMEWithDNS01 = Template.bind({});
+ACMEWithDNS01.args = {
+  clusterIssuer: acmeWithDNS01ClusterIssuer,
+  isCertManagerInstalled: true,
+};
+
+export const SelfSigned = Template.bind({});
+SelfSigned.args = {
+  clusterIssuer: selfSignedClusterIssuer,
+  isCertManagerInstalled: true,
+};
+
+export const CA = Template.bind({});
+CA.args = {
+  clusterIssuer: caClusterIssuer,
+  isCertManagerInstalled: true,
+};
+
+export const Failed = Template.bind({});
+Failed.args = {
+  clusterIssuer: failedClusterIssuer,
+  isCertManagerInstalled: true,
+};
+
+export const NotFound = Template.bind({});
+NotFound.args = {
+  clusterIssuer: null,
+  isCertManagerInstalled: true,
+};
+
+export const CertManagerNotInstalled = Template.bind({});
+CertManagerNotInstalled.args = {
+  clusterIssuer: null,
+  isCertManagerInstalled: false,
+  isLoading: false,
+};
+
+export const Loading = Template.bind({});
+Loading.args = {
+  clusterIssuer: null,
+  isCertManagerInstalled: false,
+  isLoading: true,
+};

--- a/cert-manager/src/components/clusterIssuers/List.stories.tsx
+++ b/cert-manager/src/components/clusterIssuers/List.stories.tsx
@@ -1,0 +1,235 @@
+import {
+  DateLabel,
+  SectionHeader,
+  SimpleTable,
+} from '@kinvolk/headlamp-plugin/lib/components/common';
+import { Box } from '@mui/material';
+import { Meta, StoryFn } from '@storybook/react';
+import { NotInstalledBanner } from '../common/CommonComponents';
+
+// Mock cluster issuer data structure for stories
+interface MockClusterIssuer {
+  metadata: {
+    name: string;
+    creationTimestamp: string;
+    uid: string;
+  };
+  spec: {
+    acme?: {
+      email: string;
+      server: string;
+    };
+    ca?: {
+      secretName: string;
+    };
+    selfSigned?: {};
+    vault?: {
+      server: string;
+      path: string;
+    };
+    venafi?: {
+      zone: string;
+    };
+  };
+  status: {
+    conditions: Array<{
+      type: string;
+      status: string;
+      reason?: string;
+      message?: string;
+      lastTransitionTime?: string;
+    }>;
+  };
+}
+
+interface PureClusterIssuersListProps {
+  clusterIssuers: MockClusterIssuer[];
+  isLoading?: boolean;
+  isCertManagerInstalled?: boolean;
+}
+
+// Pure component for Storybook testing
+export function PureClusterIssuersList({
+  clusterIssuers,
+  isLoading = false,
+  isCertManagerInstalled = true,
+}: PureClusterIssuersListProps) {
+  if (!isCertManagerInstalled) {
+    return <NotInstalledBanner isLoading={isLoading} />;
+  }
+
+  return (
+    <Box>
+      <SectionHeader title="Cluster Issuers" />
+      <SimpleTable
+        columns={[
+          {
+            label: 'Name',
+            getter: (item: MockClusterIssuer) => item.metadata.name,
+          },
+          {
+            label: 'Status',
+            getter: (item: MockClusterIssuer) => item.status?.conditions?.[0]?.status || '-',
+          },
+          {
+            label: 'Age',
+            getter: (item: MockClusterIssuer) => (
+              <DateLabel date={item.metadata.creationTimestamp} format="mini" />
+            ),
+          },
+        ]}
+        data={clusterIssuers}
+        emptyMessage="No cluster issuers found"
+      />
+    </Box>
+  );
+}
+
+export default {
+  title: 'cert-manager/ClusterIssuers/List',
+  component: PureClusterIssuersList,
+} as Meta;
+
+const Template: StoryFn<PureClusterIssuersListProps> = args => <PureClusterIssuersList {...args} />;
+
+// Sample mock data
+const mockClusterIssuers: MockClusterIssuer[] = [
+  {
+    metadata: {
+      name: 'letsencrypt-prod',
+      creationTimestamp: '2024-01-01T00:00:00Z',
+      uid: 'cluster-issuer-1',
+    },
+    spec: {
+      acme: {
+        email: 'admin@example.com',
+        server: 'https://acme-v02.api.letsencrypt.org/directory',
+      },
+    },
+    status: {
+      conditions: [
+        {
+          type: 'Ready',
+          status: 'True',
+          reason: 'ACMEAccountRegistered',
+          message: 'The ACME account was registered with the ACME server',
+          lastTransitionTime: '2024-01-01T00:05:00Z',
+        },
+      ],
+    },
+  },
+  {
+    metadata: {
+      name: 'letsencrypt-staging',
+      creationTimestamp: '2024-01-01T00:00:00Z',
+      uid: 'cluster-issuer-2',
+    },
+    spec: {
+      acme: {
+        email: 'admin@example.com',
+        server: 'https://acme-staging-v02.api.letsencrypt.org/directory',
+      },
+    },
+    status: {
+      conditions: [
+        {
+          type: 'Ready',
+          status: 'True',
+          reason: 'ACMEAccountRegistered',
+          message: 'The ACME account was registered with the ACME server',
+          lastTransitionTime: '2024-01-01T00:05:00Z',
+        },
+      ],
+    },
+  },
+  {
+    metadata: {
+      name: 'self-signed-cluster',
+      creationTimestamp: '2024-01-02T00:00:00Z',
+      uid: 'cluster-issuer-3',
+    },
+    spec: {
+      selfSigned: {},
+    },
+    status: {
+      conditions: [
+        {
+          type: 'Ready',
+          status: 'True',
+          reason: 'IsReady',
+          message: 'Issuer is ready',
+          lastTransitionTime: '2024-01-02T00:01:00Z',
+        },
+      ],
+    },
+  },
+  {
+    metadata: {
+      name: 'vault-cluster-issuer',
+      creationTimestamp: '2024-01-03T00:00:00Z',
+      uid: 'cluster-issuer-4',
+    },
+    spec: {
+      vault: {
+        server: 'https://vault.example.com',
+        path: 'pki/sign/cluster-role',
+      },
+    },
+    status: {
+      conditions: [
+        {
+          type: 'Ready',
+          status: 'False',
+          reason: 'VaultVerifyError',
+          message: 'Vault server returned error: connection refused',
+          lastTransitionTime: '2024-01-03T00:02:00Z',
+        },
+      ],
+    },
+  },
+];
+
+// Stories
+export const Default = Template.bind({});
+Default.args = {
+  clusterIssuers: mockClusterIssuers,
+  isCertManagerInstalled: true,
+};
+
+export const Empty = Template.bind({});
+Empty.args = {
+  clusterIssuers: [],
+  isCertManagerInstalled: true,
+};
+
+export const AllReady = Template.bind({});
+AllReady.args = {
+  clusterIssuers: mockClusterIssuers.filter(ci => ci.status?.conditions?.[0]?.status === 'True'),
+  isCertManagerInstalled: true,
+};
+
+export const WithNotReady = Template.bind({});
+WithNotReady.args = {
+  clusterIssuers: mockClusterIssuers,
+  isCertManagerInstalled: true,
+};
+
+export const SingleACMEClusterIssuer = Template.bind({});
+SingleACMEClusterIssuer.args = {
+  clusterIssuers: [mockClusterIssuers[0]],
+  isCertManagerInstalled: true,
+};
+
+export const CertManagerNotInstalled = Template.bind({});
+CertManagerNotInstalled.args = {
+  clusterIssuers: [],
+  isCertManagerInstalled: false,
+  isLoading: false,
+};
+
+export const Loading = Template.bind({});
+Loading.args = {
+  clusterIssuers: [],
+  isCertManagerInstalled: false,
+  isLoading: true,
+};

--- a/cert-manager/src/components/common/CommonComponents.stories.tsx
+++ b/cert-manager/src/components/common/CommonComponents.stories.tsx
@@ -1,0 +1,358 @@
+import { Meta, StoryFn } from '@storybook/react';
+import { BrowserRouter } from 'react-router-dom';
+import {
+  ACMEChallengeSolver,
+  ACMEIssuerStatus,
+  Condition,
+  IssuerReference,
+  SecretKeySelector,
+} from '../../resources/common';
+import {
+  ACMEChallengeSolverComponent,
+  ACMEIssuerStatusComponent,
+  ConditionsTable,
+  CopyToClipboard,
+  IssuerRef,
+  NotInstalledBanner,
+  SecretKeySelectorComponent,
+  StringArray,
+} from './CommonComponents';
+
+// =============================================================================
+// CopyToClipboard Stories
+// =============================================================================
+
+export default {
+  title: 'cert-manager/Common/CopyToClipboard',
+  component: CopyToClipboard,
+} as Meta;
+
+const CopyToClipboardTemplate: StoryFn<{ text: string; maxDisplayLength?: number }> = args => (
+  <CopyToClipboard {...args} />
+);
+
+export const ShortText = CopyToClipboardTemplate.bind({});
+ShortText.args = {
+  text: 'short-certificate-text',
+};
+
+export const LongText = CopyToClipboardTemplate.bind({});
+LongText.args = {
+  text: 'LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURGekNDQWYrZ0F3SUJBZ0lSQU...',
+  maxDisplayLength: 30,
+};
+
+export const CustomMaxLength = CopyToClipboardTemplate.bind({});
+CustomMaxLength.args = {
+  text: 'This is a medium length certificate text that will be truncated',
+  maxDisplayLength: 20,
+};
+
+// =============================================================================
+// IssuerRef Stories
+// =============================================================================
+
+export const IssuerRefStory = {
+  title: 'cert-manager/Common/IssuerRef',
+  component: IssuerRef,
+  decorators: [
+    (Story: StoryFn) => (
+      <BrowserRouter>
+        <Story />
+      </BrowserRouter>
+    ),
+  ],
+};
+
+const IssuerRefTemplate: StoryFn<{ issuerRef: IssuerReference; namespace: string }> = args => (
+  <IssuerRef {...args} />
+);
+
+export const NamespacedIssuer = IssuerRefTemplate.bind({});
+NamespacedIssuer.args = {
+  issuerRef: {
+    name: 'letsencrypt-prod',
+    kind: 'Issuer',
+    group: 'cert-manager.io',
+  },
+  namespace: 'default',
+};
+NamespacedIssuer.decorators = [
+  (Story: StoryFn) => (
+    <BrowserRouter>
+      <Story />
+    </BrowserRouter>
+  ),
+];
+
+export const ClusterIssuerRef = IssuerRefTemplate.bind({});
+ClusterIssuerRef.args = {
+  issuerRef: {
+    name: 'letsencrypt-cluster-issuer',
+    kind: 'ClusterIssuer',
+    group: 'cert-manager.io',
+  },
+  namespace: 'default',
+};
+ClusterIssuerRef.decorators = [
+  (Story: StoryFn) => (
+    <BrowserRouter>
+      <Story />
+    </BrowserRouter>
+  ),
+];
+
+export const IssuerRefWithoutKind = IssuerRefTemplate.bind({});
+IssuerRefWithoutKind.args = {
+  issuerRef: {
+    name: 'my-issuer',
+  },
+  namespace: 'cert-manager',
+};
+IssuerRefWithoutKind.decorators = [
+  (Story: StoryFn) => (
+    <BrowserRouter>
+      <Story />
+    </BrowserRouter>
+  ),
+];
+
+// =============================================================================
+// ConditionsTable Stories
+// =============================================================================
+
+const ConditionsTableTemplate: StoryFn<{ conditions: Condition[] }> = args => (
+  <ConditionsTable {...args} />
+);
+
+export const SingleConditionReady = ConditionsTableTemplate.bind({});
+SingleConditionReady.args = {
+  conditions: [
+    {
+      type: 'Ready',
+      status: 'True',
+      reason: 'Ready',
+      message: 'Certificate is up to date and has not expired',
+      lastTransitionTime: '2024-01-15T10:30:00Z',
+    },
+  ],
+};
+
+export const MultipleConditions = ConditionsTableTemplate.bind({});
+MultipleConditions.args = {
+  conditions: [
+    {
+      type: 'Ready',
+      status: 'True',
+      reason: 'Ready',
+      message: 'Certificate is up to date and has not expired',
+      lastTransitionTime: '2024-01-15T10:30:00Z',
+    },
+    {
+      type: 'Issuing',
+      status: 'False',
+      reason: 'Issued',
+      message: 'Certificate issued successfully',
+      lastTransitionTime: '2024-01-15T10:29:00Z',
+    },
+  ],
+};
+
+export const ConditionWithError = ConditionsTableTemplate.bind({});
+ConditionWithError.args = {
+  conditions: [
+    {
+      type: 'Ready',
+      status: 'False',
+      reason: 'Failed',
+      message: 'The certificate could not be issued: ACME server error',
+      lastTransitionTime: '2024-01-15T10:30:00Z',
+    },
+    {
+      type: 'Issuing',
+      status: 'True',
+      reason: 'Pending',
+      message: 'Waiting for certificate issuance',
+      lastTransitionTime: '2024-01-15T10:25:00Z',
+    },
+  ],
+};
+
+export const EmptyConditions = ConditionsTableTemplate.bind({});
+EmptyConditions.args = {
+  conditions: [],
+};
+
+// =============================================================================
+// SecretKeySelectorComponent Stories
+// =============================================================================
+
+const SecretKeySelectorTemplate: StoryFn<{ selector: SecretKeySelector }> = args => (
+  <SecretKeySelectorComponent {...args} />
+);
+
+export const SecretKeySelectorDefault = SecretKeySelectorTemplate.bind({});
+SecretKeySelectorDefault.args = {
+  selector: {
+    name: 'letsencrypt-account-key',
+    key: 'tls.key',
+  },
+};
+
+export const SecretKeySelectorWithoutKey = SecretKeySelectorTemplate.bind({});
+SecretKeySelectorWithoutKey.args = {
+  selector: {
+    name: 'my-secret',
+  },
+};
+
+// =============================================================================
+// ACMEChallengeSolverComponent Stories
+// =============================================================================
+
+const ACMEChallengeSolverTemplate: StoryFn<{ solver: ACMEChallengeSolver }> = args => (
+  <ACMEChallengeSolverComponent {...args} />
+);
+
+export const HTTP01Solver = ACMEChallengeSolverTemplate.bind({});
+HTTP01Solver.args = {
+  solver: {
+    http01: {
+      ingress: {
+        class: 'nginx',
+        serviceType: 'ClusterIP',
+      },
+    },
+  },
+};
+
+export const HTTP01SolverWithIngressClassName = ACMEChallengeSolverTemplate.bind({});
+HTTP01SolverWithIngressClassName.args = {
+  solver: {
+    http01: {
+      ingress: {
+        ingressClassName: 'nginx',
+        serviceType: 'NodePort',
+      },
+    },
+  },
+};
+
+export const HTTP01SolverWithPodTemplate = ACMEChallengeSolverTemplate.bind({});
+HTTP01SolverWithPodTemplate.args = {
+  solver: {
+    http01: {
+      ingress: {
+        class: 'traefik',
+        podTemplate: {
+          spec: {
+            nodeSelector: {
+              'kubernetes.io/os': 'linux',
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+export const DNS01Solver = ACMEChallengeSolverTemplate.bind({});
+DNS01Solver.args = {
+  solver: {
+    dns01: {
+      provider: 'cloudflare',
+      cloudflare: {
+        email: 'admin@example.com',
+      },
+    },
+  },
+};
+
+export const DNS01SolverRoute53 = ACMEChallengeSolverTemplate.bind({});
+DNS01SolverRoute53.args = {
+  solver: {
+    dns01: {
+      provider: 'route53',
+      route53: {
+        region: 'us-east-1',
+        hostedZoneID: 'Z1234567890ABC',
+      },
+    },
+  },
+};
+
+// =============================================================================
+// ACMEIssuerStatusComponent Stories
+// =============================================================================
+
+const ACMEIssuerStatusTemplate: StoryFn<{ status: ACMEIssuerStatus }> = args => (
+  <ACMEIssuerStatusComponent {...args} />
+);
+
+export const ACMEIssuerStatusComplete = ACMEIssuerStatusTemplate.bind({});
+ACMEIssuerStatusComplete.args = {
+  status: {
+    uri: 'https://acme-v02.api.letsencrypt.org/acme/acct/123456789',
+    lastRegisteredEmail: 'admin@example.com',
+    lastPrivateKeyHash: 'sha256:abc123def456...',
+  },
+};
+
+export const ACMEIssuerStatusPartial = ACMEIssuerStatusTemplate.bind({});
+ACMEIssuerStatusPartial.args = {
+  status: {
+    uri: 'https://acme-staging-v02.api.letsencrypt.org/acme/acct/987654321',
+  },
+};
+
+// =============================================================================
+// StringArray Stories
+// =============================================================================
+
+const StringArrayTemplate: StoryFn<{ items?: string[]; emptyText?: string }> = args => (
+  <StringArray {...args} />
+);
+
+export const StringArrayWithItems = StringArrayTemplate.bind({});
+StringArrayWithItems.args = {
+  items: ['example.com', 'www.example.com', 'api.example.com'],
+};
+
+export const StringArraySingleItem = StringArrayTemplate.bind({});
+StringArraySingleItem.args = {
+  items: ['localhost'],
+};
+
+export const StringArrayEmpty = StringArrayTemplate.bind({});
+StringArrayEmpty.args = {
+  items: [],
+};
+
+export const StringArrayEmptyWithCustomText = StringArrayTemplate.bind({});
+StringArrayEmptyWithCustomText.args = {
+  items: [],
+  emptyText: 'No DNS names configured',
+};
+
+export const StringArrayUndefined = StringArrayTemplate.bind({});
+StringArrayUndefined.args = {
+  items: undefined,
+};
+
+// =============================================================================
+// NotInstalledBanner Stories
+// =============================================================================
+
+const NotInstalledBannerTemplate: StoryFn<{ isLoading?: boolean }> = args => (
+  <NotInstalledBanner {...args} />
+);
+
+export const NotInstalledBannerDefault = NotInstalledBannerTemplate.bind({});
+NotInstalledBannerDefault.args = {
+  isLoading: false,
+};
+
+export const NotInstalledBannerLoading = NotInstalledBannerTemplate.bind({});
+NotInstalledBannerLoading.args = {
+  isLoading: true,
+};

--- a/cert-manager/src/components/issuers/Detail.stories.tsx
+++ b/cert-manager/src/components/issuers/Detail.stories.tsx
@@ -1,0 +1,542 @@
+import {
+  NameValueTable,
+  SectionBox,
+  SectionHeader,
+} from '@kinvolk/headlamp-plugin/lib/components/common';
+import { Box } from '@mui/material';
+import { Meta, StoryFn } from '@storybook/react';
+import { BrowserRouter } from 'react-router-dom';
+import { ACMEIssuerStatus, Condition, IssuerSpec } from '../../resources/common';
+import {
+  ACMEChallengeSolverComponent,
+  ACMEIssuerStatusComponent,
+  ConditionsTable,
+  NotInstalledBanner,
+  SecretKeySelectorComponent,
+  StringArray,
+} from '../common/CommonComponents';
+
+// Mock issuer data structure for stories
+interface MockIssuerDetail {
+  metadata: {
+    name: string;
+    namespace: string;
+    creationTimestamp: string;
+    uid: string;
+    labels?: Record<string, string>;
+    annotations?: Record<string, string>;
+  };
+  spec: IssuerSpec;
+  status: {
+    conditions?: Condition[];
+    acme?: ACMEIssuerStatus;
+  };
+  ready: boolean;
+}
+
+interface PureIssuerDetailProps {
+  issuer: MockIssuerDetail | null;
+  isLoading?: boolean;
+  isCertManagerInstalled?: boolean;
+}
+
+// Helper function to render issuer type specific info
+function renderIssuerTypeInfo(spec: IssuerSpec) {
+  if (spec.acme) {
+    return (
+      <SectionBox title="ACME Configuration">
+        <NameValueTable
+          rows={[
+            { name: 'Email', value: spec.acme.email || '-' },
+            { name: 'Server', value: spec.acme.server || '-' },
+            { name: 'Preferred Chain', value: spec.acme.preferredChain || '-' },
+            { name: 'Skip TLS Verify', value: spec.acme.skipTLSVerify?.toString() || 'false' },
+            {
+              name: 'Private Key Secret Ref',
+              value: spec.acme.privateKeySecretRef ? (
+                <SecretKeySelectorComponent selector={spec.acme.privateKeySecretRef} />
+              ) : (
+                '-'
+              ),
+            },
+            {
+              name: 'Solvers',
+              value:
+                spec.acme.solvers?.map((solver, index) => (
+                  <Box key={index} mb={2}>
+                    <ACMEChallengeSolverComponent solver={solver} />
+                  </Box>
+                )) || '-',
+            },
+          ]}
+        />
+      </SectionBox>
+    );
+  }
+
+  if (spec.ca) {
+    return (
+      <SectionBox title="CA Configuration">
+        <NameValueTable
+          rows={[
+            { name: 'Secret Name', value: spec.ca.secretName || '-' },
+            {
+              name: 'CRL Distribution Points',
+              value: <StringArray items={spec.ca.crlDistributionPoints} />,
+            },
+          ]}
+        />
+      </SectionBox>
+    );
+  }
+
+  if (spec.selfSigned) {
+    return (
+      <SectionBox title="Self-Signed Configuration">
+        <NameValueTable
+          rows={[
+            {
+              name: 'CRL Distribution Points',
+              value: <StringArray items={spec.selfSigned.crlDistributionPoints} />,
+            },
+          ]}
+        />
+      </SectionBox>
+    );
+  }
+
+  if (spec.vault) {
+    return (
+      <SectionBox title="Vault Configuration">
+        <NameValueTable
+          rows={[
+            { name: 'Server', value: spec.vault.server || '-' },
+            { name: 'Path', value: spec.vault.path || '-' },
+            { name: 'Namespace', value: spec.vault.namespace || '-' },
+            { name: 'CA Bundle', value: spec.vault.caBundle ? 'Configured' : '-' },
+            {
+              name: 'Auth Method',
+              value: spec.vault.auth?.tokenSecretRef
+                ? 'Token'
+                : spec.vault.auth?.appRole
+                ? 'AppRole'
+                : spec.vault.auth?.kubernetes
+                ? 'Kubernetes'
+                : '-',
+            },
+          ]}
+        />
+      </SectionBox>
+    );
+  }
+
+  if (spec.venafi) {
+    return (
+      <SectionBox title="Venafi Configuration">
+        <NameValueTable
+          rows={[
+            { name: 'Zone', value: spec.venafi.zone || '-' },
+            {
+              name: 'TPP URL',
+              value: spec.venafi.tpp?.url || '-',
+            },
+            {
+              name: 'Cloud URL',
+              value: spec.venafi.cloud?.url || '-',
+            },
+          ]}
+        />
+      </SectionBox>
+    );
+  }
+
+  return null;
+}
+
+// Pure component for Storybook testing
+export function PureIssuerDetail({
+  issuer,
+  isLoading = false,
+  isCertManagerInstalled = true,
+}: PureIssuerDetailProps) {
+  if (!isCertManagerInstalled) {
+    return <NotInstalledBanner isLoading={isLoading} />;
+  }
+
+  if (!issuer) {
+    return (
+      <Box p={2}>
+        <SectionHeader title="Issuer Details" />
+        <Box>Issuer not found</Box>
+      </Box>
+    );
+  }
+
+  const issuerType = issuer.spec.acme
+    ? 'ACME'
+    : issuer.spec.ca
+    ? 'CA'
+    : issuer.spec.selfSigned
+    ? 'Self-Signed'
+    : issuer.spec.vault
+    ? 'Vault'
+    : issuer.spec.venafi
+    ? 'Venafi'
+    : 'Unknown';
+
+  return (
+    <Box>
+      <SectionHeader title={`Issuer: ${issuer.metadata.name}`} />
+
+      {/* Main Info */}
+      <SectionBox title="Info">
+        <NameValueTable
+          rows={[
+            { name: 'Name', value: issuer.metadata.name },
+            { name: 'Namespace', value: issuer.metadata.namespace },
+            { name: 'Ready', value: issuer.ready ? 'Ready' : 'Not Ready' },
+            { name: 'Type', value: issuerType },
+          ]}
+        />
+      </SectionBox>
+
+      {/* Issuer Type Configuration */}
+      {renderIssuerTypeInfo(issuer.spec)}
+
+      {/* ACME Status (if applicable) */}
+      {issuer.status?.acme && (
+        <SectionBox title="ACME Status">
+          <ACMEIssuerStatusComponent status={issuer.status.acme} />
+        </SectionBox>
+      )}
+
+      {/* Conditions */}
+      {issuer.status?.conditions && issuer.status.conditions.length > 0 && (
+        <ConditionsTable conditions={issuer.status.conditions} />
+      )}
+    </Box>
+  );
+}
+
+export default {
+  title: 'cert-manager/Issuers/Detail',
+  component: PureIssuerDetail,
+  decorators: [
+    (Story: StoryFn) => (
+      <BrowserRouter>
+        <Story />
+      </BrowserRouter>
+    ),
+  ],
+} as Meta;
+
+const Template: StoryFn<PureIssuerDetailProps> = args => <PureIssuerDetail {...args} />;
+
+// Sample mock data for different issuer types
+const acmeIssuer: MockIssuerDetail = {
+  metadata: {
+    name: 'letsencrypt-prod',
+    namespace: 'cert-manager',
+    creationTimestamp: '2024-01-01T00:00:00Z',
+    uid: 'issuer-acme-1',
+  },
+  spec: {
+    acme: {
+      email: 'admin@example.com',
+      server: 'https://acme-v02.api.letsencrypt.org/directory',
+      privateKeySecretRef: {
+        name: 'letsencrypt-account-key',
+        key: 'tls.key',
+      },
+      solvers: [
+        {
+          http01: {
+            ingress: {
+              class: 'nginx',
+              serviceType: 'ClusterIP',
+            },
+          },
+        },
+      ],
+    },
+  },
+  status: {
+    conditions: [
+      {
+        type: 'Ready',
+        status: 'True',
+        reason: 'ACMEAccountRegistered',
+        message: 'The ACME account was registered with the ACME server',
+        lastTransitionTime: '2024-01-01T00:05:00Z',
+      },
+    ],
+    acme: {
+      uri: 'https://acme-v02.api.letsencrypt.org/acme/acct/123456789',
+      lastRegisteredEmail: 'admin@example.com',
+      lastPrivateKeyHash: 'sha256:abc123def456...',
+    },
+  },
+  ready: true,
+};
+
+const selfSignedIssuer: MockIssuerDetail = {
+  metadata: {
+    name: 'self-signed-issuer',
+    namespace: 'default',
+    creationTimestamp: '2024-01-02T00:00:00Z',
+    uid: 'issuer-selfsigned-1',
+  },
+  spec: {
+    selfSigned: {},
+  },
+  status: {
+    conditions: [
+      {
+        type: 'Ready',
+        status: 'True',
+        reason: 'IsReady',
+        message: 'Issuer is ready',
+        lastTransitionTime: '2024-01-02T00:01:00Z',
+      },
+    ],
+  },
+  ready: true,
+};
+
+const caIssuer: MockIssuerDetail = {
+  metadata: {
+    name: 'internal-ca-issuer',
+    namespace: 'cert-manager',
+    creationTimestamp: '2024-01-03T00:00:00Z',
+    uid: 'issuer-ca-1',
+  },
+  spec: {
+    ca: {
+      secretName: 'internal-ca-key-pair',
+      crlDistributionPoints: ['http://crl.example.com/ca.crl'],
+    },
+  },
+  status: {
+    conditions: [
+      {
+        type: 'Ready',
+        status: 'True',
+        reason: 'KeyPairVerified',
+        message: 'Signing CA verified',
+        lastTransitionTime: '2024-01-03T00:05:00Z',
+      },
+    ],
+  },
+  ready: true,
+};
+
+const vaultIssuer: MockIssuerDetail = {
+  metadata: {
+    name: 'vault-issuer',
+    namespace: 'production',
+    creationTimestamp: '2024-01-04T00:00:00Z',
+    uid: 'issuer-vault-1',
+  },
+  spec: {
+    vault: {
+      server: 'https://vault.example.com',
+      path: 'pki/sign/my-issuing-role',
+      namespace: 'admin',
+      auth: {
+        kubernetes: {
+          role: 'cert-manager',
+          mountPath: '/v1/auth/kubernetes',
+        },
+      },
+    },
+  },
+  status: {
+    conditions: [
+      {
+        type: 'Ready',
+        status: 'True',
+        reason: 'VaultVerified',
+        message: 'Vault verified',
+        lastTransitionTime: '2024-01-04T00:03:00Z',
+      },
+    ],
+  },
+  ready: true,
+};
+
+const vaultIssuerFailed: MockIssuerDetail = {
+  metadata: {
+    name: 'vault-issuer-failed',
+    namespace: 'staging',
+    creationTimestamp: '2024-01-04T00:00:00Z',
+    uid: 'issuer-vault-2',
+  },
+  spec: {
+    vault: {
+      server: 'https://vault.example.com',
+      path: 'pki/sign/wrong-role',
+      auth: {
+        tokenSecretRef: {
+          name: 'vault-token',
+          key: 'token',
+        },
+      },
+    },
+  },
+  status: {
+    conditions: [
+      {
+        type: 'Ready',
+        status: 'False',
+        reason: 'VaultVerifyError',
+        message: 'Vault server returned error: permission denied',
+        lastTransitionTime: '2024-01-04T00:02:00Z',
+      },
+    ],
+  },
+  ready: false,
+};
+
+const venafiIssuer: MockIssuerDetail = {
+  metadata: {
+    name: 'venafi-issuer',
+    namespace: 'enterprise',
+    creationTimestamp: '2024-01-05T00:00:00Z',
+    uid: 'issuer-venafi-1',
+  },
+  spec: {
+    venafi: {
+      zone: 'My Application\\Certificate Policy',
+      tpp: {
+        url: 'https://tpp.venafi.example.com/vedsdk',
+        credentialsRef: {
+          name: 'venafi-tpp-credentials',
+          key: 'access-token',
+        },
+      },
+    },
+  },
+  status: {
+    conditions: [
+      {
+        type: 'Ready',
+        status: 'True',
+        reason: 'Verified',
+        message: 'Venafi issuer verified',
+        lastTransitionTime: '2024-01-05T00:03:00Z',
+      },
+    ],
+  },
+  ready: true,
+};
+
+const acmeIssuerWithDNS01: MockIssuerDetail = {
+  metadata: {
+    name: 'letsencrypt-dns',
+    namespace: 'cert-manager',
+    creationTimestamp: '2024-01-06T00:00:00Z',
+    uid: 'issuer-acme-dns-1',
+  },
+  spec: {
+    acme: {
+      email: 'admin@example.com',
+      server: 'https://acme-v02.api.letsencrypt.org/directory',
+      privateKeySecretRef: {
+        name: 'letsencrypt-account-key',
+        key: 'tls.key',
+      },
+      solvers: [
+        {
+          dns01: {
+            provider: 'cloudflare',
+            cloudflare: {
+              email: 'admin@example.com',
+            },
+          },
+          selector: {
+            dnsZones: ['example.com'],
+          },
+        },
+      ],
+    },
+  },
+  status: {
+    conditions: [
+      {
+        type: 'Ready',
+        status: 'True',
+        reason: 'ACMEAccountRegistered',
+        message: 'The ACME account was registered with the ACME server',
+        lastTransitionTime: '2024-01-06T00:05:00Z',
+      },
+    ],
+    acme: {
+      uri: 'https://acme-v02.api.letsencrypt.org/acme/acct/987654321',
+      lastRegisteredEmail: 'admin@example.com',
+    },
+  },
+  ready: true,
+};
+
+// Stories
+export const ACMEIssuer = Template.bind({});
+ACMEIssuer.args = {
+  issuer: acmeIssuer,
+  isCertManagerInstalled: true,
+};
+
+export const ACMEIssuerWithDNS01 = Template.bind({});
+ACMEIssuerWithDNS01.args = {
+  issuer: acmeIssuerWithDNS01,
+  isCertManagerInstalled: true,
+};
+
+export const SelfSignedIssuer = Template.bind({});
+SelfSignedIssuer.args = {
+  issuer: selfSignedIssuer,
+  isCertManagerInstalled: true,
+};
+
+export const CAIssuer = Template.bind({});
+CAIssuer.args = {
+  issuer: caIssuer,
+  isCertManagerInstalled: true,
+};
+
+export const VaultIssuer = Template.bind({});
+VaultIssuer.args = {
+  issuer: vaultIssuer,
+  isCertManagerInstalled: true,
+};
+
+export const VaultIssuerFailed = Template.bind({});
+VaultIssuerFailed.args = {
+  issuer: vaultIssuerFailed,
+  isCertManagerInstalled: true,
+};
+
+export const VenafiIssuer = Template.bind({});
+VenafiIssuer.args = {
+  issuer: venafiIssuer,
+  isCertManagerInstalled: true,
+};
+
+export const NotFound = Template.bind({});
+NotFound.args = {
+  issuer: null,
+  isCertManagerInstalled: true,
+};
+
+export const CertManagerNotInstalled = Template.bind({});
+CertManagerNotInstalled.args = {
+  issuer: null,
+  isCertManagerInstalled: false,
+  isLoading: false,
+};
+
+export const Loading = Template.bind({});
+Loading.args = {
+  issuer: null,
+  isCertManagerInstalled: false,
+  isLoading: true,
+};

--- a/cert-manager/src/components/issuers/List.stories.tsx
+++ b/cert-manager/src/components/issuers/List.stories.tsx
@@ -1,0 +1,279 @@
+import {
+  DateLabel,
+  SectionHeader,
+  SimpleTable,
+} from '@kinvolk/headlamp-plugin/lib/components/common';
+import { Box } from '@mui/material';
+import { Meta, StoryFn } from '@storybook/react';
+import { NotInstalledBanner } from '../common/CommonComponents';
+
+// Mock issuer data structure for stories
+interface MockIssuer {
+  metadata: {
+    name: string;
+    namespace: string;
+    creationTimestamp: string;
+    uid: string;
+  };
+  spec: {
+    acme?: {
+      email: string;
+      server: string;
+    };
+    ca?: {
+      secretName: string;
+    };
+    selfSigned?: {};
+    vault?: {
+      server: string;
+      path: string;
+    };
+    venafi?: {
+      zone: string;
+    };
+  };
+  status: {
+    conditions: Array<{
+      type: string;
+      status: string;
+      reason?: string;
+      message?: string;
+      lastTransitionTime?: string;
+    }>;
+  };
+  ready: boolean;
+}
+
+interface PureIssuersListProps {
+  issuers: MockIssuer[];
+  isLoading?: boolean;
+  isCertManagerInstalled?: boolean;
+}
+
+// Pure component for Storybook testing
+export function PureIssuersList({
+  issuers,
+  isLoading = false,
+  isCertManagerInstalled = true,
+}: PureIssuersListProps) {
+  if (!isCertManagerInstalled) {
+    return <NotInstalledBanner isLoading={isLoading} />;
+  }
+
+  return (
+    <Box>
+      <SectionHeader title="Issuers" />
+      <SimpleTable
+        columns={[
+          {
+            label: 'Name',
+            getter: (item: MockIssuer) => item.metadata.name,
+          },
+          {
+            label: 'Namespace',
+            getter: (item: MockIssuer) => item.metadata.namespace,
+          },
+          {
+            label: 'Ready',
+            getter: (item: MockIssuer) => (item.ready ? 'Ready' : 'Not Ready'),
+          },
+          {
+            label: 'Age',
+            getter: (item: MockIssuer) => (
+              <DateLabel date={item.metadata.creationTimestamp} format="mini" />
+            ),
+          },
+        ]}
+        data={issuers}
+        emptyMessage="No issuers found"
+      />
+    </Box>
+  );
+}
+
+export default {
+  title: 'cert-manager/Issuers/List',
+  component: PureIssuersList,
+} as Meta;
+
+const Template: StoryFn<PureIssuersListProps> = args => <PureIssuersList {...args} />;
+
+// Sample mock data
+const mockIssuers: MockIssuer[] = [
+  {
+    metadata: {
+      name: 'letsencrypt-staging',
+      namespace: 'default',
+      creationTimestamp: '2024-01-01T00:00:00Z',
+      uid: 'issuer-1',
+    },
+    spec: {
+      acme: {
+        email: 'admin@example.com',
+        server: 'https://acme-staging-v02.api.letsencrypt.org/directory',
+      },
+    },
+    status: {
+      conditions: [
+        {
+          type: 'Ready',
+          status: 'True',
+          reason: 'ACMEAccountRegistered',
+          message: 'The ACME account was registered with the ACME server',
+          lastTransitionTime: '2024-01-01T00:05:00Z',
+        },
+      ],
+    },
+    ready: true,
+  },
+  {
+    metadata: {
+      name: 'self-signed',
+      namespace: 'default',
+      creationTimestamp: '2024-01-02T00:00:00Z',
+      uid: 'issuer-2',
+    },
+    spec: {
+      selfSigned: {},
+    },
+    status: {
+      conditions: [
+        {
+          type: 'Ready',
+          status: 'True',
+          reason: 'IsReady',
+          message: 'Issuer is ready',
+          lastTransitionTime: '2024-01-02T00:01:00Z',
+        },
+      ],
+    },
+    ready: true,
+  },
+  {
+    metadata: {
+      name: 'internal-ca',
+      namespace: 'cert-manager',
+      creationTimestamp: '2024-01-03T00:00:00Z',
+      uid: 'issuer-3',
+    },
+    spec: {
+      ca: {
+        secretName: 'internal-ca-secret',
+      },
+    },
+    status: {
+      conditions: [
+        {
+          type: 'Ready',
+          status: 'True',
+          reason: 'KeyPairVerified',
+          message: 'Signing CA verified',
+          lastTransitionTime: '2024-01-03T00:05:00Z',
+        },
+      ],
+    },
+    ready: true,
+  },
+  {
+    metadata: {
+      name: 'vault-issuer',
+      namespace: 'production',
+      creationTimestamp: '2024-01-04T00:00:00Z',
+      uid: 'issuer-4',
+    },
+    spec: {
+      vault: {
+        server: 'https://vault.example.com',
+        path: 'pki/sign/my-role',
+      },
+    },
+    status: {
+      conditions: [
+        {
+          type: 'Ready',
+          status: 'False',
+          reason: 'VaultVerifyError',
+          message: 'Vault server returned error: permission denied',
+          lastTransitionTime: '2024-01-04T00:02:00Z',
+        },
+      ],
+    },
+    ready: false,
+  },
+  {
+    metadata: {
+      name: 'venafi-issuer',
+      namespace: 'enterprise',
+      creationTimestamp: '2024-01-05T00:00:00Z',
+      uid: 'issuer-5',
+    },
+    spec: {
+      venafi: {
+        zone: 'My Application\\Certificate Policy',
+      },
+    },
+    status: {
+      conditions: [
+        {
+          type: 'Ready',
+          status: 'True',
+          reason: 'Verified',
+          message: 'Venafi Zone verified',
+          lastTransitionTime: '2024-01-05T00:03:00Z',
+        },
+      ],
+    },
+    ready: true,
+  },
+];
+
+// Stories
+export const Default = Template.bind({});
+Default.args = {
+  issuers: mockIssuers,
+  isCertManagerInstalled: true,
+};
+
+export const Empty = Template.bind({});
+Empty.args = {
+  issuers: [],
+  isCertManagerInstalled: true,
+};
+
+export const AllReady = Template.bind({});
+AllReady.args = {
+  issuers: mockIssuers.filter(i => i.ready),
+  isCertManagerInstalled: true,
+};
+
+export const WithNotReady = Template.bind({});
+WithNotReady.args = {
+  issuers: mockIssuers,
+  isCertManagerInstalled: true,
+};
+
+export const SingleACMEIssuer = Template.bind({});
+SingleACMEIssuer.args = {
+  issuers: [mockIssuers[0]],
+  isCertManagerInstalled: true,
+};
+
+export const SingleSelfSignedIssuer = Template.bind({});
+SingleSelfSignedIssuer.args = {
+  issuers: [mockIssuers[1]],
+  isCertManagerInstalled: true,
+};
+
+export const CertManagerNotInstalled = Template.bind({});
+CertManagerNotInstalled.args = {
+  issuers: [],
+  isCertManagerInstalled: false,
+  isLoading: false,
+};
+
+export const Loading = Template.bind({});
+Loading.args = {
+  issuers: [],
+  isCertManagerInstalled: false,
+  isLoading: true,
+};

--- a/cert-manager/src/components/orders/Detail.stories.tsx
+++ b/cert-manager/src/components/orders/Detail.stories.tsx
@@ -1,0 +1,507 @@
+import {
+  NameValueTable,
+  SectionBox,
+  SectionHeader,
+  SimpleTable,
+} from '@kinvolk/headlamp-plugin/lib/components/common';
+import { Box } from '@mui/material';
+import { Meta, StoryFn } from '@storybook/react';
+import { BrowserRouter } from 'react-router-dom';
+import { IssuerReference } from '../../resources/common';
+import {
+  CopyToClipboard,
+  IssuerRef,
+  NotInstalledBanner,
+  StringArray,
+} from '../common/CommonComponents';
+
+// Mock order authorization and challenge types
+interface MockChallenge {
+  type: string;
+  token: string;
+  url: string;
+}
+
+interface MockAuthorization {
+  identifier: string;
+  initialState: string;
+  url: string;
+  wildcard: boolean;
+  challenges: MockChallenge[];
+}
+
+// Mock order data structure for stories
+interface MockOrderDetail {
+  metadata: {
+    name: string;
+    namespace: string;
+    creationTimestamp: string;
+    uid: string;
+    labels?: Record<string, string>;
+    annotations?: Record<string, string>;
+  };
+  spec: {
+    request: string;
+    issuerRef: IssuerReference;
+    commonName?: string;
+    dnsNames?: string[];
+    ipAddresses?: string[];
+    duration?: string;
+  };
+  status: {
+    state: string;
+    url?: string;
+    finalizeURL?: string;
+    certificate?: string;
+    failureTime?: string;
+    reason?: string;
+    authorizations?: MockAuthorization[];
+  };
+}
+
+interface PureOrderDetailProps {
+  order: MockOrderDetail | null;
+  isLoading?: boolean;
+  isCertManagerInstalled?: boolean;
+}
+
+// Pure component for Storybook testing
+export function PureOrderDetail({
+  order,
+  isLoading = false,
+  isCertManagerInstalled = true,
+}: PureOrderDetailProps) {
+  if (!isCertManagerInstalled) {
+    return <NotInstalledBanner isLoading={isLoading} />;
+  }
+
+  if (!order) {
+    return (
+      <Box p={2}>
+        <SectionHeader title="Order Details" />
+        <Box>Order not found</Box>
+      </Box>
+    );
+  }
+
+  return (
+    <Box>
+      <SectionHeader title={`Order: ${order.metadata.name}`} />
+
+      {/* Main Info */}
+      <SectionBox title="Info">
+        <NameValueTable
+          rows={[
+            { name: 'Name', value: order.metadata.name },
+            { name: 'Namespace', value: order.metadata.namespace },
+            { name: 'Common Name', value: order.spec?.commonName || '-' },
+            {
+              name: 'DNS Names',
+              value: <StringArray items={order.spec?.dnsNames} />,
+            },
+            {
+              name: 'IP Addresses',
+              value: <StringArray items={order.spec?.ipAddresses} />,
+            },
+            { name: 'Duration', value: order.spec?.duration || '-' },
+            {
+              name: 'Issuer Ref',
+              value: order.spec.issuerRef && (
+                <IssuerRef issuerRef={order.spec.issuerRef} namespace={order.metadata.namespace} />
+              ),
+            },
+            {
+              name: 'Request',
+              value: <CopyToClipboard text={order.spec.request} />,
+            },
+          ]}
+        />
+      </SectionBox>
+
+      {/* Authorizations Section */}
+      {order.status?.authorizations && order.status.authorizations.length > 0 && (
+        <SectionBox title="Authorizations">
+          {order.status.authorizations.map((auth, index) => (
+            <Box key={index} mb={3}>
+              <NameValueTable
+                rows={[
+                  { name: 'Identifier', value: auth.identifier },
+                  { name: 'Initial State', value: auth?.initialState || '-' },
+                  { name: 'URL', value: auth.url },
+                  { name: 'Wildcard', value: auth.wildcard.toString() },
+                  {
+                    name: 'Challenges',
+                    value: (
+                      <SimpleTable
+                        columns={[
+                          {
+                            label: 'Type',
+                            getter: (challenge: MockChallenge) => challenge.type,
+                          },
+                          {
+                            label: 'Token',
+                            getter: (challenge: MockChallenge) => challenge.token,
+                          },
+                          {
+                            label: 'URL',
+                            getter: (challenge: MockChallenge) => challenge.url,
+                          },
+                        ]}
+                        data={auth.challenges}
+                      />
+                    ),
+                  },
+                ]}
+              />
+            </Box>
+          ))}
+        </SectionBox>
+      )}
+
+      {/* Status Section */}
+      {order.status && (
+        <SectionBox title="Status">
+          <NameValueTable
+            rows={[
+              { name: 'State', value: order.status?.state || '-' },
+              { name: 'URL', value: order.status?.url || '-' },
+              { name: 'Finalize URL', value: order.status?.finalizeURL || '-' },
+              {
+                name: 'Certificate',
+                value: order.status?.certificate ? (
+                  <CopyToClipboard text={order.status.certificate} />
+                ) : (
+                  '-'
+                ),
+              },
+              { name: 'Failure Time', value: order.status?.failureTime || '-' },
+              { name: 'Reason', value: order.status?.reason || '-' },
+            ]}
+          />
+        </SectionBox>
+      )}
+    </Box>
+  );
+}
+
+export default {
+  title: 'cert-manager/Orders/Detail',
+  component: PureOrderDetail,
+  decorators: [
+    (Story: StoryFn) => (
+      <BrowserRouter>
+        <Story />
+      </BrowserRouter>
+    ),
+  ],
+} as Meta;
+
+const Template: StoryFn<PureOrderDetailProps> = args => <PureOrderDetail {...args} />;
+
+// Sample mock data
+const pendingOrder: MockOrderDetail = {
+  metadata: {
+    name: 'example-com-tls-1-123456789',
+    namespace: 'default',
+    creationTimestamp: '2024-01-15T10:30:00Z',
+    uid: 'order-1',
+    labels: {
+      'acme.cert-manager.io/certificate': 'example-com-tls',
+    },
+  },
+  spec: {
+    request: 'LS0tLS1CRUdJTiBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0KTUlJQ3dqQ0NBYWtDQVFBd0FE...',
+    issuerRef: {
+      name: 'letsencrypt-prod',
+      kind: 'ClusterIssuer',
+      group: 'cert-manager.io',
+    },
+    commonName: 'example.com',
+    dnsNames: ['example.com', 'www.example.com'],
+    duration: '2160h',
+  },
+  status: {
+    state: 'pending',
+    url: 'https://acme-v02.api.letsencrypt.org/acme/order/123456789',
+    finalizeURL: 'https://acme-v02.api.letsencrypt.org/acme/finalize/123456789',
+    authorizations: [
+      {
+        identifier: 'example.com',
+        initialState: 'pending',
+        url: 'https://acme-v02.api.letsencrypt.org/acme/authz-v3/123456789',
+        wildcard: false,
+        challenges: [
+          {
+            type: 'http-01',
+            token: 'abc123def456',
+            url: 'https://acme-v02.api.letsencrypt.org/acme/chall-v3/123456789/http01',
+          },
+          {
+            type: 'dns-01',
+            token: 'abc123def456',
+            url: 'https://acme-v02.api.letsencrypt.org/acme/chall-v3/123456789/dns01',
+          },
+        ],
+      },
+      {
+        identifier: 'www.example.com',
+        initialState: 'pending',
+        url: 'https://acme-v02.api.letsencrypt.org/acme/authz-v3/987654321',
+        wildcard: false,
+        challenges: [
+          {
+            type: 'http-01',
+            token: 'ghi789jkl012',
+            url: 'https://acme-v02.api.letsencrypt.org/acme/chall-v3/987654321/http01',
+          },
+        ],
+      },
+    ],
+  },
+};
+
+const validOrder: MockOrderDetail = {
+  metadata: {
+    name: 'api-example-com-tls-1-987654321',
+    namespace: 'production',
+    creationTimestamp: '2024-01-15T10:25:00Z',
+    uid: 'order-2',
+  },
+  spec: {
+    request: 'LS0tLS1CRUdJTiBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0KTUlJQ3dqQ0NBYWtDQVFBd0FE...',
+    issuerRef: {
+      name: 'letsencrypt-prod',
+      kind: 'ClusterIssuer',
+    },
+    commonName: 'api.example.com',
+    dnsNames: ['api.example.com'],
+    duration: '2160h',
+  },
+  status: {
+    state: 'valid',
+    url: 'https://acme-v02.api.letsencrypt.org/acme/order/987654321',
+    finalizeURL: 'https://acme-v02.api.letsencrypt.org/acme/finalize/987654321',
+    certificate: 'LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURJVENDQWdtZ0F3SUJBZ0lSQU9GQktr...',
+    authorizations: [
+      {
+        identifier: 'api.example.com',
+        initialState: 'valid',
+        url: 'https://acme-v02.api.letsencrypt.org/acme/authz-v3/555666777',
+        wildcard: false,
+        challenges: [
+          {
+            type: 'http-01',
+            token: 'mno345pqr678',
+            url: 'https://acme-v02.api.letsencrypt.org/acme/chall-v3/555666777/http01',
+          },
+        ],
+      },
+    ],
+  },
+};
+
+const wildcardOrder: MockOrderDetail = {
+  metadata: {
+    name: 'wildcard-example-com-tls-1-111222333',
+    namespace: 'default',
+    creationTimestamp: '2024-01-15T10:20:00Z',
+    uid: 'order-3',
+  },
+  spec: {
+    request: 'LS0tLS1CRUdJTiBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0KTUlJQ3dqQ0NBYWtDQVFBd0FE...',
+    issuerRef: {
+      name: 'letsencrypt-dns',
+      kind: 'ClusterIssuer',
+    },
+    dnsNames: ['*.example.com', 'example.com'],
+    duration: '2160h',
+  },
+  status: {
+    state: 'ready',
+    url: 'https://acme-v02.api.letsencrypt.org/acme/order/111222333',
+    finalizeURL: 'https://acme-v02.api.letsencrypt.org/acme/finalize/111222333',
+    authorizations: [
+      {
+        identifier: '*.example.com',
+        initialState: 'valid',
+        url: 'https://acme-v02.api.letsencrypt.org/acme/authz-v3/111222333',
+        wildcard: true,
+        challenges: [
+          {
+            type: 'dns-01',
+            token: 'stu901vwx234',
+            url: 'https://acme-v02.api.letsencrypt.org/acme/chall-v3/111222333/dns01',
+          },
+        ],
+      },
+      {
+        identifier: 'example.com',
+        initialState: 'valid',
+        url: 'https://acme-v02.api.letsencrypt.org/acme/authz-v3/444555666',
+        wildcard: false,
+        challenges: [
+          {
+            type: 'dns-01',
+            token: 'yza567bcd890',
+            url: 'https://acme-v02.api.letsencrypt.org/acme/chall-v3/444555666/dns01',
+          },
+        ],
+      },
+    ],
+  },
+};
+
+const failedOrder: MockOrderDetail = {
+  metadata: {
+    name: 'staging-tls-1-444555666',
+    namespace: 'staging',
+    creationTimestamp: '2024-01-15T10:15:00Z',
+    uid: 'order-4',
+  },
+  spec: {
+    request: 'LS0tLS1CRUdJTiBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0KTUlJQ3dqQ0NBYWtDQVFBd0FE...',
+    issuerRef: {
+      name: 'letsencrypt-staging',
+      kind: 'Issuer',
+    },
+    commonName: 'staging.example.com',
+    dnsNames: ['staging.example.com'],
+    duration: '2160h',
+  },
+  status: {
+    state: 'invalid',
+    url: 'https://acme-staging-v02.api.letsencrypt.org/acme/order/444555666',
+    finalizeURL: 'https://acme-staging-v02.api.letsencrypt.org/acme/finalize/444555666',
+    failureTime: '2024-01-15T10:20:00Z',
+    reason:
+      'Failed to finalize Order: The server could not connect to the client to verify the domain',
+    authorizations: [
+      {
+        identifier: 'staging.example.com',
+        initialState: 'invalid',
+        url: 'https://acme-staging-v02.api.letsencrypt.org/acme/authz-v3/777888999',
+        wildcard: false,
+        challenges: [
+          {
+            type: 'http-01',
+            token: 'efg123hij456',
+            url: 'https://acme-staging-v02.api.letsencrypt.org/acme/chall-v3/777888999/http01',
+          },
+        ],
+      },
+    ],
+  },
+};
+
+const erroredOrder: MockOrderDetail = {
+  metadata: {
+    name: 'rate-limited-tls-1-777888999',
+    namespace: 'production',
+    creationTimestamp: '2024-01-15T10:10:00Z',
+    uid: 'order-5',
+  },
+  spec: {
+    request: 'LS0tLS1CRUdJTiBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0KTUlJQ3dqQ0NBYWtDQVFBd0FE...',
+    issuerRef: {
+      name: 'letsencrypt-prod',
+      kind: 'ClusterIssuer',
+    },
+    commonName: 'app.example.com',
+    dnsNames: ['app.example.com'],
+    duration: '2160h',
+  },
+  status: {
+    state: 'errored',
+    failureTime: '2024-01-15T10:15:00Z',
+    reason: 'Error creating new order: rateLimited: too many orders recently',
+  },
+};
+
+const minimalOrder: MockOrderDetail = {
+  metadata: {
+    name: 'minimal-tls-1-000111222',
+    namespace: 'default',
+    creationTimestamp: '2024-01-15T10:05:00Z',
+    uid: 'order-6',
+  },
+  spec: {
+    request: 'LS0tLS1CRUdJTiBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0KTUlJQ3dqQ0NBYWtDQVFBd0FE...',
+    issuerRef: {
+      name: 'self-signed',
+      kind: 'Issuer',
+    },
+    dnsNames: ['localhost'],
+  },
+  status: {
+    state: 'valid',
+  },
+};
+
+// Stories
+export const Pending = Template.bind({});
+Pending.args = {
+  order: pendingOrder,
+  isCertManagerInstalled: true,
+};
+
+export const Valid = Template.bind({});
+Valid.args = {
+  order: validOrder,
+  isCertManagerInstalled: true,
+};
+
+export const Ready = Template.bind({});
+Ready.args = {
+  order: wildcardOrder,
+  isCertManagerInstalled: true,
+};
+
+export const WildcardOrder = Template.bind({});
+WildcardOrder.args = {
+  order: wildcardOrder,
+  isCertManagerInstalled: true,
+};
+
+export const Invalid = Template.bind({});
+Invalid.args = {
+  order: failedOrder,
+  isCertManagerInstalled: true,
+};
+
+export const Errored = Template.bind({});
+Errored.args = {
+  order: erroredOrder,
+  isCertManagerInstalled: true,
+};
+
+export const Minimal = Template.bind({});
+Minimal.args = {
+  order: minimalOrder,
+  isCertManagerInstalled: true,
+};
+
+export const MultipleAuthorizations = Template.bind({});
+MultipleAuthorizations.args = {
+  order: pendingOrder,
+  isCertManagerInstalled: true,
+};
+
+export const NotFound = Template.bind({});
+NotFound.args = {
+  order: null,
+  isCertManagerInstalled: true,
+};
+
+export const CertManagerNotInstalled = Template.bind({});
+CertManagerNotInstalled.args = {
+  order: null,
+  isCertManagerInstalled: false,
+  isLoading: false,
+};
+
+export const Loading = Template.bind({});
+Loading.args = {
+  order: null,
+  isCertManagerInstalled: false,
+  isLoading: true,
+};

--- a/cert-manager/src/components/orders/List.stories.tsx
+++ b/cert-manager/src/components/orders/List.stories.tsx
@@ -1,0 +1,244 @@
+import {
+  DateLabel,
+  SectionHeader,
+  SimpleTable,
+} from '@kinvolk/headlamp-plugin/lib/components/common';
+import { Box } from '@mui/material';
+import { Meta, StoryFn } from '@storybook/react';
+import { NotInstalledBanner } from '../common/CommonComponents';
+
+// Mock order data structure for stories
+interface MockOrder {
+  metadata: {
+    name: string;
+    namespace: string;
+    creationTimestamp: string;
+    uid: string;
+  };
+  spec: {
+    request: string;
+    issuerRef: {
+      name: string;
+      kind: string;
+    };
+    dnsNames?: string[];
+  };
+  status: {
+    state: string;
+    url?: string;
+  };
+}
+
+interface PureOrdersListProps {
+  orders: MockOrder[];
+  isLoading?: boolean;
+  isCertManagerInstalled?: boolean;
+}
+
+// Pure component for Storybook testing
+export function PureOrdersList({
+  orders,
+  isLoading = false,
+  isCertManagerInstalled = true,
+}: PureOrdersListProps) {
+  if (!isCertManagerInstalled) {
+    return <NotInstalledBanner isLoading={isLoading} />;
+  }
+
+  return (
+    <Box>
+      <SectionHeader title="Orders" />
+      <SimpleTable
+        columns={[
+          {
+            label: 'Name',
+            getter: (item: MockOrder) => item.metadata.name,
+          },
+          {
+            label: 'Namespace',
+            getter: (item: MockOrder) => item.metadata.namespace,
+          },
+          {
+            label: 'State',
+            getter: (item: MockOrder) => item.status?.state || '-',
+          },
+          {
+            label: 'Age',
+            getter: (item: MockOrder) => (
+              <DateLabel date={item.metadata.creationTimestamp} format="mini" />
+            ),
+          },
+        ]}
+        data={orders}
+        emptyMessage="No orders found"
+      />
+    </Box>
+  );
+}
+
+export default {
+  title: 'cert-manager/Orders/List',
+  component: PureOrdersList,
+} as Meta;
+
+const Template: StoryFn<PureOrdersListProps> = args => <PureOrdersList {...args} />;
+
+// Sample mock data
+const mockOrders: MockOrder[] = [
+  {
+    metadata: {
+      name: 'example-com-tls-1-123456789',
+      namespace: 'default',
+      creationTimestamp: '2024-01-15T10:30:00Z',
+      uid: 'order-1',
+    },
+    spec: {
+      request: 'LS0tLS1CRUdJTiBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0K...',
+      issuerRef: {
+        name: 'letsencrypt-prod',
+        kind: 'ClusterIssuer',
+      },
+      dnsNames: ['example.com', 'www.example.com'],
+    },
+    status: {
+      state: 'pending',
+      url: 'https://acme-v02.api.letsencrypt.org/acme/order/123456789',
+    },
+  },
+  {
+    metadata: {
+      name: 'api-example-com-tls-1-987654321',
+      namespace: 'production',
+      creationTimestamp: '2024-01-15T10:25:00Z',
+      uid: 'order-2',
+    },
+    spec: {
+      request: 'LS0tLS1CRUdJTiBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0K...',
+      issuerRef: {
+        name: 'letsencrypt-prod',
+        kind: 'ClusterIssuer',
+      },
+      dnsNames: ['api.example.com'],
+    },
+    status: {
+      state: 'valid',
+      url: 'https://acme-v02.api.letsencrypt.org/acme/order/987654321',
+    },
+  },
+  {
+    metadata: {
+      name: 'wildcard-example-com-tls-1-111222333',
+      namespace: 'default',
+      creationTimestamp: '2024-01-15T10:20:00Z',
+      uid: 'order-3',
+    },
+    spec: {
+      request: 'LS0tLS1CRUdJTiBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0K...',
+      issuerRef: {
+        name: 'letsencrypt-dns',
+        kind: 'ClusterIssuer',
+      },
+      dnsNames: ['*.example.com'],
+    },
+    status: {
+      state: 'ready',
+      url: 'https://acme-v02.api.letsencrypt.org/acme/order/111222333',
+    },
+  },
+  {
+    metadata: {
+      name: 'staging-tls-1-444555666',
+      namespace: 'staging',
+      creationTimestamp: '2024-01-15T10:15:00Z',
+      uid: 'order-4',
+    },
+    spec: {
+      request: 'LS0tLS1CRUdJTiBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0K...',
+      issuerRef: {
+        name: 'letsencrypt-staging',
+        kind: 'Issuer',
+      },
+      dnsNames: ['staging.example.com'],
+    },
+    status: {
+      state: 'invalid',
+      url: 'https://acme-staging-v02.api.letsencrypt.org/acme/order/444555666',
+    },
+  },
+  {
+    metadata: {
+      name: 'rate-limited-tls-1-777888999',
+      namespace: 'production',
+      creationTimestamp: '2024-01-15T10:10:00Z',
+      uid: 'order-5',
+    },
+    spec: {
+      request: 'LS0tLS1CRUdJTiBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0K...',
+      issuerRef: {
+        name: 'letsencrypt-prod',
+        kind: 'ClusterIssuer',
+      },
+      dnsNames: ['app.example.com'],
+    },
+    status: {
+      state: 'errored',
+    },
+  },
+];
+
+// Stories
+export const Default = Template.bind({});
+Default.args = {
+  orders: mockOrders,
+  isCertManagerInstalled: true,
+};
+
+export const Empty = Template.bind({});
+Empty.args = {
+  orders: [],
+  isCertManagerInstalled: true,
+};
+
+export const PendingOrders = Template.bind({});
+PendingOrders.args = {
+  orders: mockOrders.filter(o => o.status.state === 'pending'),
+  isCertManagerInstalled: true,
+};
+
+export const ValidOrders = Template.bind({});
+ValidOrders.args = {
+  orders: mockOrders.filter(o => o.status.state === 'valid'),
+  isCertManagerInstalled: true,
+};
+
+export const ReadyOrders = Template.bind({});
+ReadyOrders.args = {
+  orders: mockOrders.filter(o => o.status.state === 'ready'),
+  isCertManagerInstalled: true,
+};
+
+export const FailedOrders = Template.bind({});
+FailedOrders.args = {
+  orders: mockOrders.filter(o => o.status.state === 'invalid' || o.status.state === 'errored'),
+  isCertManagerInstalled: true,
+};
+
+export const MixedStates = Template.bind({});
+MixedStates.args = {
+  orders: mockOrders,
+  isCertManagerInstalled: true,
+};
+
+export const CertManagerNotInstalled = Template.bind({});
+CertManagerNotInstalled.args = {
+  orders: [],
+  isCertManagerInstalled: false,
+  isLoading: false,
+};
+
+export const Loading = Template.bind({});
+Loading.args = {
+  orders: [],
+  isCertManagerInstalled: false,
+  isLoading: true,
+};


### PR DESCRIPTION
Add comprehensive Storybook stories for the cert-manager plugin to enable manual UI testing and automated regression testing of presentational parts.