### PR TITLE
knative: Add unit tests for time and nullable utilities

### DIFF
--- a/knative/src/utils/nullable.test.ts
+++ b/knative/src/utils/nullable.test.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isNullable } from './nullable';
+
+describe('isNullable', () => {
+  it('should return true for null', () => {
+    expect(isNullable(null)).toBe(true);
+  });
+
+  it('should return true for undefined', () => {
+    expect(isNullable(undefined)).toBe(true);
+  });
+
+  it('should return false for false boolean', () => {
+    expect(isNullable(false)).toBe(false);
+  });
+
+  it('should return false for zero number', () => {
+    expect(isNullable(0)).toBe(false);
+  });
+
+  it('should return false for empty string', () => {
+    expect(isNullable('')).toBe(false);
+  });
+
+  it('should return false for objects', () => {
+    expect(isNullable({})).toBe(false);
+  });
+
+  it('should return false for arrays', () => {
+    expect(isNullable([])).toBe(false);
+  });
+});

--- a/knative/src/utils/time.test.ts
+++ b/knative/src/utils/time.test.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { vi } from 'vitest';
+import { getAge } from './time';
+
+describe('getAge', () => {
+  const MOCK_NOW = 1704067200000; // 2024-01-01T00:00:00.000Z
+
+  beforeAll(() => {
+    vi.spyOn(Date, 'now').mockReturnValue(MOCK_NOW);
+  });
+
+  afterAll(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should return empty string for undefined timestamp', () => {
+    expect(getAge(undefined)).toBe('');
+  });
+
+  it('should return empty string for empty string input', () => {
+    expect(getAge('')).toBe('');
+  });
+
+  it('should treat current time as 0m', () => {
+    const nowStr = new Date(MOCK_NOW).toISOString();
+    expect(getAge(nowStr)).toBe('0m');
+  });
+
+  it('should return minutes for duration < 60 mins', () => {
+    const fiftyNineMinsAgo = MOCK_NOW - 59 * 60 * 1000;
+    expect(getAge(new Date(fiftyNineMinsAgo).toISOString())).toBe('59m');
+  });
+
+  it('should return hours for duration >= 60 mins and < 48 hours', () => {
+    const sixtyMinsAgo = MOCK_NOW - 60 * 60 * 1000;
+    expect(getAge(new Date(sixtyMinsAgo).toISOString())).toBe('1h');
+
+    const fortySevenHoursAgo = MOCK_NOW - 47 * 60 * 60 * 1000;
+    expect(getAge(new Date(fortySevenHoursAgo).toISOString())).toBe('47h');
+  });
+
+  it('should return days for duration >= 48 hours', () => {
+    const fortyEightHoursAgo = MOCK_NOW - 48 * 60 * 60 * 1000;
+    expect(getAge(new Date(fortyEightHoursAgo).toISOString())).toBe('2d');
+
+    const fiveDaysAgo = MOCK_NOW - 5 * 24 * 60 * 60 * 1000;
+    expect(getAge(new Date(fiveDaysAgo).toISOString())).toBe('5d');
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds unit test coverage for shared utility functions used by the Knative plugin:
- `getAge` (time formatting helper)
- `isNullable` (null/undefined guard helper)

## Fixed
#500 

These utilities are used across Knative views to format resource age and safely handle nullable API fields. Adding tests ensures deterministic behavior and guards against regressions during future refactors.

## Scope

- No functional or UI changes
- Tests only
