### PR TITLE
knative: Memoize ResourceListView headerProps and actions

### DIFF
--- a/knative/src/components/kservices/List.tsx
+++ b/knative/src/components/kservices/List.tsx
@@ -24,7 +24,7 @@ import { Link } from '@kinvolk/headlamp-plugin/lib/components/common';
 import ConfigMap from '@kinvolk/headlamp-plugin/lib/k8s/configMap';
 import Pod from '@kinvolk/headlamp-plugin/lib/k8s/pod';
 import { Chip, Stack, Typography } from '@mui/material';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { formatIngressClass, INGRESS_CLASS_GATEWAY_API } from '../../config/ingress';
 import { useAuthorization } from '../../hooks/useAuthorization';
 import { useClusters } from '../../hooks/useClusters';
@@ -500,7 +500,7 @@ function KServicesListContents({ clusters }: KServicesListContentsProps) {
     return cols;
   }, [showClusterColumn, domainByServiceKey]);
 
-  const headerProps = React.useMemo(
+  const headerProps = useMemo(
     () => ({
       noNamespaceFilter: false,
       subtitle: !ingressClassLoading && (
@@ -551,15 +551,11 @@ function KServicesListContents({ clusters }: KServicesListContentsProps) {
     [ingressClassLoading, ingressClassLabel, ingressClasses, domainMappingsError, clusters.length]
   );
 
-  type ResourceListActions = React.ComponentProps<typeof ResourceListView>['actions'];
-  type ResourceListAction = NonNullable<ResourceListActions>[number];
-  type ResourceListActionContext = Parameters<ResourceListAction['action']>[0];
-
-  const actions: ResourceListActions = React.useMemo(
+  const actions: React.ComponentProps<typeof ResourceListView>['actions'] = useMemo(
     () => [
       {
         id: 'knative.kservice-actions',
-        action: (context: ResourceListActionContext) => (
+        action: context => (
           <KServiceRowActions kservice={context.item as KService} closeMenu={context.closeMenu} />
         ),
       },


### PR DESCRIPTION
### Refactor: stabilize ResourceListView props in KServices list

This PR memoizes `headerProps` and `actions` passed to `ResourceListView` in the KServices list.

Previously, these props were defined inline, causing new object/array references on every render.  
This refactor improves referential stability and enables better render optimizations in child components.

- No functional or UI changes
- Improves maintainability and consistency with React best practices

Fixes #501
