### PR TITLE
Bump headlamp-plugin to 0.13.1

### DIFF
--- a/app-catalog/package-lock.json
+++ b/app-catalog/package-lock.json
@@ -13,7 +13,7 @@
         "semver": "^6.3.1"
       },
       "devDependencies": {
-        "@kinvolk/headlamp-plugin": "^0.13.0"
+        "@kinvolk/headlamp-plugin": "^0.13.1"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -1774,9 +1774,9 @@
       }
     },
     "node_modules/@kinvolk/headlamp-plugin": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@kinvolk/headlamp-plugin/-/headlamp-plugin-0.13.0.tgz",
-      "integrity": "sha512-T0PGETnMXcUSOXKy/MEUeprDLzoqYxsJNqfNIL9DCW5WmmFDKcJX5Gify2RWB+oJbWIAaaRZ7zQGqeYeqa5KTA==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@kinvolk/headlamp-plugin/-/headlamp-plugin-0.13.1.tgz",
+      "integrity": "sha512-aoAGs5w8HIS43p3YBcjzkIWZZlh18b/e02d+r/rr6+99vc48vOd9tKAIBZMVg4j+cVzbPtL1+t1tDE/UdeHcWQ==",
       "dev": true,
       "license": "Apache 2.0",
       "dependencies": {
@@ -1795,13 +1795,12 @@
         "@mui/x-date-pickers": "^7.15.0",
         "@mui/x-tree-view": "^6.17.0",
         "@reduxjs/toolkit": "^2.2.7",
-        "@storybook/addon-docs": "^9.1.2",
-        "@storybook/addon-links": "^9.1.2",
+        "@storybook/addon-docs": "^9.1.17",
+        "@storybook/addon-links": "^9.1.17",
         "@storybook/addon-webpack5-compiler-swc": "^3.0.0",
-        "@storybook/react-vite": "^9.1.2",
-        "@storybook/react-webpack5": "^9.1.2",
+        "@storybook/react-vite": "^9.1.17",
+        "@storybook/react-webpack5": "^9.1.17",
         "@tanstack/react-query": "^5.51.24",
-        "@tanstack/react-query-devtools": "^5.51.24",
         "@testing-library/dom": "^10.1.0",
         "@testing-library/jest-dom": "^6.4.8",
         "@testing-library/react": "^16.0.0",
@@ -1836,6 +1835,7 @@
         "eslint-plugin-react-hooks": "^4.6.2",
         "eslint-plugin-simple-import-sort": "^12.1.1",
         "eslint-plugin-unused-imports": "^4.1.3",
+        "fast-check": "^4.5.3",
         "fs-extra": "^11.2.0",
         "fuse.js": "^7.0.0",
         "humanize-duration": "^3.27.2",
@@ -1846,7 +1846,7 @@
         "js-yaml": "^4.1.1",
         "jsdom": "^24.0.0",
         "jsonpath-plus": "^10.3.0",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.23",
         "material-react-table": "^2.13.3",
         "monaco-editor": "^0.52.0",
         "msw": "2.4.9",
@@ -1870,9 +1870,9 @@
         "shx": "^0.4.0",
         "simple-eval": "^2.0.0",
         "spacetime": "^7.4.0",
-        "storybook": "^9.1.2",
+        "storybook": "^9.1.17",
         "table": "^6.8.2",
-        "tar": "^7.4.3",
+        "tar": "^7.5.7",
         "ts-loader": "^9.5.2",
         "typescript": "5.6.2",
         "validate-npm-package-name": "^3.0.0",
@@ -2886,16 +2886,16 @@
       "license": "MIT"
     },
     "node_modules/@storybook/addon-docs": {
-      "version": "9.1.13",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-9.1.13.tgz",
-      "integrity": "sha512-V1nCo7bfC3kQ5VNVq0VDcHsIhQf507m+BxMA5SIYiwdJHljH2BXpW2fL3FFn9gv9Wp57AEEzhm+wh4zANaJgkg==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-9.1.17.tgz",
+      "integrity": "sha512-yc4hlgkrwNi045qk210dRuIMijkgbLmo3ft6F4lOdpPRn4IUnPDj7FfZR8syGzUzKidxRfNtLx5m0yHIz83xtA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@mdx-js/react": "^3.0.0",
-        "@storybook/csf-plugin": "9.1.13",
+        "@storybook/csf-plugin": "9.1.17",
         "@storybook/icons": "^1.4.0",
-        "@storybook/react-dom-shim": "9.1.13",
+        "@storybook/react-dom-shim": "9.1.17",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "ts-dedent": "^2.0.0"
@@ -2905,13 +2905,13 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.1.13"
+        "storybook": "^9.1.17"
       }
     },
     "node_modules/@storybook/addon-links": {
-      "version": "9.1.13",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-9.1.13.tgz",
-      "integrity": "sha512-wx33RA5PPRSepVAjR0hMFp2IXoPgjwNAHIP92aoi2QQFS3+NHlf1I4vXEPpHU6lc0WBwM43qvLSI0qTAyZd8Nw==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-9.1.17.tgz",
+      "integrity": "sha512-LqtrDXRJrdMfZJ0om38SjmY2lQUGmpL8Zt2xTZtQjUy1V+ZiQpuUx7+TJZIOWujzRp75fxhM4AB0HuLDsemlcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2923,7 +2923,7 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.13"
+        "storybook": "^9.1.17"
       },
       "peerDependenciesMeta": {
         "react": {
@@ -2946,13 +2946,13 @@
       }
     },
     "node_modules/@storybook/builder-vite": {
-      "version": "9.1.13",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-9.1.13.tgz",
-      "integrity": "sha512-pmtIjU02ASJOZKdL8DoxWXJgZnpTDgD5WmMnjKJh9FaWmc2YiCW2Y6VRxPox96OM655jYHQe5+UIbk3Cwtwb4A==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-9.1.17.tgz",
+      "integrity": "sha512-OQCYaFWoTBvovN2IJmkAW+7FgHMJiih1WA/xqgpKIx0ImZjB4z5FrKgzQeXsrYcLEsynyaj+xN3JFUKsz5bzGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/csf-plugin": "9.1.13",
+        "@storybook/csf-plugin": "9.1.17",
         "ts-dedent": "^2.0.0"
       },
       "funding": {
@@ -2960,18 +2960,18 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.1.13",
+        "storybook": "^9.1.17",
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/@storybook/builder-webpack5": {
-      "version": "9.1.13",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-webpack5/-/builder-webpack5-9.1.13.tgz",
-      "integrity": "sha512-BoFXrTlc22ryLl6U5QwgV/gHVbHBcXeVSjYOyu6XZ9SPV5GGbw5T/G7NJYJAZcsz1ZxuMEYYSMFryfZ5qcjRsA==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-webpack5/-/builder-webpack5-9.1.17.tgz",
+      "integrity": "sha512-lgfq5R3WrK3HM/i7nX2b5rsnBgekoJr3Pu04KAGrEa/bgj7UW1n1bTodCUl+rVEM6aMPqXcLQFIVx/AEFNT4sQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/core-webpack": "9.1.13",
+        "@storybook/core-webpack": "9.1.17",
         "case-sensitive-paths-webpack-plugin": "^2.4.0",
         "cjs-module-lexer": "^1.2.3",
         "css-loader": "^6.7.1",
@@ -2992,7 +2992,7 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.1.13"
+        "storybook": "^9.1.17"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -3001,9 +3001,9 @@
       }
     },
     "node_modules/@storybook/core-webpack": {
-      "version": "9.1.13",
-      "resolved": "https://registry.npmjs.org/@storybook/core-webpack/-/core-webpack-9.1.13.tgz",
-      "integrity": "sha512-HtBZ+ZVgeqlhyMiT/Tdb/vpKrCSiZEi6p4s7y/qk04SaX8XIPSufEeqLI/ELSz2hOcuCy6smU/tE1JkqVz/4uA==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/core-webpack/-/core-webpack-9.1.17.tgz",
+      "integrity": "sha512-qJRWZEgWjNoGKcHOYFgGlUkmf/dIeQ3T01SJh9H4icZChVhyWRLC+y1HITmxRPPRHZXYyBHbTzmhFmuZM3i2YQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3014,13 +3014,13 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.1.13"
+        "storybook": "^9.1.17"
       }
     },
     "node_modules/@storybook/csf-plugin": {
-      "version": "9.1.13",
-      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-9.1.13.tgz",
-      "integrity": "sha512-EMpzYuyt9FDcxxfBChWzfId50y8QMpdenviEQ8m+pa6c+ANx3pC5J6t7y0khD8TQu815sTy+nc6cc8PC45dPUA==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-9.1.17.tgz",
+      "integrity": "sha512-o+ebQDdSfZHDRDhu2hNDGhCLIazEB4vEAqJcHgz1VsURq+l++bgZUcKojPMCAbeblptSEz2bwS0eYAOvG7aSXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3031,7 +3031,7 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.1.13"
+        "storybook": "^9.1.17"
       }
     },
     "node_modules/@storybook/global": {
@@ -3056,13 +3056,13 @@
       }
     },
     "node_modules/@storybook/preset-react-webpack": {
-      "version": "9.1.13",
-      "resolved": "https://registry.npmjs.org/@storybook/preset-react-webpack/-/preset-react-webpack-9.1.13.tgz",
-      "integrity": "sha512-2bWRdGSYvXWaE1QnrKFeE7EbTj+/Y0D8DHZ/OlKCB3xtNM7koMDrTnnI27hVlMjXqcX8RvOwb/N31FGBRgkiNg==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/preset-react-webpack/-/preset-react-webpack-9.1.17.tgz",
+      "integrity": "sha512-3ixo+4yywVy/a6nHLN5eefISw43717NHKXORWbaXJUOpa7ka9l3OejEDhVmSYKfJhTK+IVbrVYTIvrgqrUWQYg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/core-webpack": "9.1.13",
+        "@storybook/core-webpack": "9.1.17",
         "@storybook/react-docgen-typescript-plugin": "1.0.6--canary.9.0c3f3b7.0",
         "@types/semver": "^7.3.4",
         "find-up": "^7.0.0",
@@ -3083,7 +3083,7 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.13"
+        "storybook": "^9.1.17"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -3114,9 +3114,9 @@
       }
     },
     "node_modules/@storybook/preset-react-webpack/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -3127,14 +3127,14 @@
       }
     },
     "node_modules/@storybook/react": {
-      "version": "9.1.13",
-      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-9.1.13.tgz",
-      "integrity": "sha512-B0UpYikKf29t8QGcdmumWojSQQ0phSDy/Ne2HYdrpNIxnUvHHUVOlGpq4lFcIDt52Ip5YG5GuAwJg3+eR4LCRg==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-9.1.17.tgz",
+      "integrity": "sha512-TZCplpep5BwjHPIIcUOMHebc/2qKadJHYPisRn5Wppl014qgT3XkFLpYkFgY1BaRXtqw8Mn3gqq4M/49rQ7Iww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@storybook/global": "^5.0.0",
-        "@storybook/react-dom-shim": "9.1.13"
+        "@storybook/react-dom-shim": "9.1.17"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -3146,7 +3146,7 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.13",
+        "storybook": "^9.1.17",
         "typescript": ">= 4.9.x"
       },
       "peerDependenciesMeta": {
@@ -3176,9 +3176,9 @@
       }
     },
     "node_modules/@storybook/react-dom-shim": {
-      "version": "9.1.13",
-      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-9.1.13.tgz",
-      "integrity": "sha512-/tMr9TmV3+98GEQO0S03k4gtKHGCpv9+k9Dmnv+TJK3TBz7QsaFEzMwe3gCgoTaebLACyVveDiZkWnCYAWB6NA==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-9.1.17.tgz",
+      "integrity": "sha512-Ss/lNvAy0Ziynu+KniQIByiNuyPz3dq7tD62hqSC/pHw190X+M7TKU3zcZvXhx2AQx1BYyxtdSHIZapb+P5mxQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -3188,20 +3188,20 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.13"
+        "storybook": "^9.1.17"
       }
     },
     "node_modules/@storybook/react-vite": {
-      "version": "9.1.13",
-      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-9.1.13.tgz",
-      "integrity": "sha512-mV1bZ1bpkNQygnuDo1xMGAS5ZXuoXFF0WGmr/BzNDGmRhZ1K1HQh42kC0w3PklckFBUwCFxmP58ZwTFzf+/dJA==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-9.1.17.tgz",
+      "integrity": "sha512-RZHsqD1mnTMo4MCJw68t3swS5BTMSTpeRhlelMwjoTEe7jJCPa+qx00uMlWliR1QBN1hMO8Y1dkchxSiUS9otA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@joshwooding/vite-plugin-react-docgen-typescript": "0.6.1",
         "@rollup/pluginutils": "^5.0.2",
-        "@storybook/builder-vite": "9.1.13",
-        "@storybook/react": "9.1.13",
+        "@storybook/builder-vite": "9.1.17",
+        "@storybook/react": "9.1.17",
         "find-up": "^7.0.0",
         "magic-string": "^0.30.0",
         "react-docgen": "^8.0.0",
@@ -3218,20 +3218,20 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.13",
+        "storybook": "^9.1.17",
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/@storybook/react-webpack5": {
-      "version": "9.1.13",
-      "resolved": "https://registry.npmjs.org/@storybook/react-webpack5/-/react-webpack5-9.1.13.tgz",
-      "integrity": "sha512-gsVWXbaodo22j6LcxA/55K6iQ83+MVObE76lSBsgOAWLe6gL9fiU4HBbi0B6/mrCN3Kqe7n95zM8QdOg4WbKeg==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/react-webpack5/-/react-webpack5-9.1.17.tgz",
+      "integrity": "sha512-GDOYMUzAj1dqFyrD1XbJaekcCrFZOIz0wVimbLeqRPwn+BNIZ9sylgvMiLxbiGMHWzVwJOyWDG/XVbuqXGfzWw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/builder-webpack5": "9.1.13",
-        "@storybook/preset-react-webpack": "9.1.13",
-        "@storybook/react": "9.1.13"
+        "@storybook/builder-webpack5": "9.1.17",
+        "@storybook/preset-react-webpack": "9.1.17",
+        "@storybook/react": "9.1.17"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -3243,7 +3243,7 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.13",
+        "storybook": "^9.1.17",
         "typescript": ">= 4.9.x"
       },
       "peerDependenciesMeta": {
@@ -3748,20 +3748,9 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.90.5",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.5.tgz",
-      "integrity": "sha512-wLamYp7FaDq6ZnNehypKI5fNvxHPfTYylE0m/ZpuuzJfJqhR5Pxg9gvGBHZx4n7J+V5Rg5mZxHHTlv25Zt5u+w==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      }
-    },
-    "node_modules/@tanstack/query-devtools": {
-      "version": "5.90.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.90.1.tgz",
-      "integrity": "sha512-GtINOPjPUH0OegJExZ70UahT9ykmAhmtNVcmtdnOZbxLwT7R5OmRztR5Ahe3/Cu7LArEmR6/588tAycuaWb1xQ==",
+      "version": "5.90.20",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.20.tgz",
+      "integrity": "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -3770,37 +3759,19 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.90.5",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.5.tgz",
-      "integrity": "sha512-pN+8UWpxZkEJ/Rnnj2v2Sxpx1WFlaa9L6a4UO89p6tTQbeo+m0MS8oYDjbggrR8QcTyjKoYWKS3xJQGr3ExT8Q==",
+      "version": "5.90.20",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.20.tgz",
+      "integrity": "sha512-vXBxa+qeyveVO7OA0jX1z+DeyCA4JKnThKv411jd5SORpBKgkcVnYKCiBgECvADvniBX7tobwBmg01qq9JmMJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.90.5"
+        "@tanstack/query-core": "5.90.20"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
-        "react": "^18 || ^19"
-      }
-    },
-    "node_modules/@tanstack/react-query-devtools": {
-      "version": "5.90.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.90.2.tgz",
-      "integrity": "sha512-vAXJzZuBXtCQtrY3F/yUNJCV4obT/A/n81kb3+YqLbro5Z2+phdAbceO+deU3ywPw8B42oyJlp4FhO0SoivDFQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/query-devtools": "5.90.1"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "@tanstack/react-query": "^5.90.2",
         "react": "^18 || ^19"
       }
     },
@@ -6866,9 +6837,9 @@
       }
     },
     "node_modules/css-loader/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -8812,6 +8783,29 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
+    "node_modules/fast-check": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.5.3.tgz",
+      "integrity": "sha512-IE9csY7lnhxBnA8g/WI5eg/hygA6MGWJMSNfFRrBlXUciADEhS1EDB0SIsMSvzubzIlOBbVITSsypCsW717poA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -9151,9 +9145,9 @@
       }
     },
     "node_modules/fork-ts-checker-webpack-plugin/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -10063,9 +10057,9 @@
       }
     },
     "node_modules/html-webpack-plugin": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.4.tgz",
-      "integrity": "sha512-V/PZeWsqhfpE27nKeX9EO2sbR+D17A+tLf6qU+ht66jdUsN0QLKJN27Z+1+gHrVMKgndBahes0PU6rRihDgHTw==",
+      "version": "5.6.6",
+      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.6.tgz",
+      "integrity": "sha512-bLjW01UTrvoWTJQL5LsMRo1SypHW80FTm12OJRSnr3v6YHNhfe+1r0MYUZJMACxnCHURVnBWRwAsWs2yPU9Ezw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14008,9 +14002,9 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-      "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14221,6 +14215,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
+      "integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/qs": {
       "version": "6.14.0",
@@ -16085,9 +16096,9 @@
       }
     },
     "node_modules/storybook": {
-      "version": "9.1.13",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-9.1.13.tgz",
-      "integrity": "sha512-G3KZ36EVzXyHds72B/qtWiJnhUpM0xOUeYlDcO9DSHL1bDTv15cW4+upBl+mcBZrDvU838cn7Bv4GpF+O5MCfw==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-9.1.17.tgz",
+      "integrity": "sha512-kfr6kxQAjA96ADlH6FMALJwJ+eM80UqXy106yVHNgdsAP/CdzkkicglRAhZAvUycXK9AeadF6KZ00CWLtVMN4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16121,9 +16132,9 @@
       }
     },
     "node_modules/storybook/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -16683,11 +16694,11 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.3.tgz",
-      "integrity": "sha512-ENg5JUHUm2rDD7IvKNFGzyElLXNjachNLp6RaGf4+JOgxXHkqA+gq81ZAMCUmtMtqBsoU62lcp6S27g1LCYGGQ==",
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
+      "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
@@ -18622,9 +18633,9 @@
       }
     },
     "node_modules/yocto-queue": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
-      "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/app-catalog/package.json
+++ b/app-catalog/package.json
@@ -55,7 +55,7 @@
     ]
   },
   "devDependencies": {
-    "@kinvolk/headlamp-plugin": "^0.13.0"
+    "@kinvolk/headlamp-plugin": "^0.13.1"
   },
   "dependencies": {
     "react-syntax-highlighter": "^15.6.6",

--- a/backstage/package-lock.json
+++ b/backstage/package-lock.json
@@ -11,7 +11,7 @@
         "tar": "^7.5.3"
       },
       "devDependencies": {
-        "@kinvolk/headlamp-plugin": "^0.13.0"
+        "@kinvolk/headlamp-plugin": "^0.13.1"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -1779,9 +1779,9 @@
       }
     },
     "node_modules/@kinvolk/headlamp-plugin": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@kinvolk/headlamp-plugin/-/headlamp-plugin-0.13.0.tgz",
-      "integrity": "sha512-T0PGETnMXcUSOXKy/MEUeprDLzoqYxsJNqfNIL9DCW5WmmFDKcJX5Gify2RWB+oJbWIAaaRZ7zQGqeYeqa5KTA==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@kinvolk/headlamp-plugin/-/headlamp-plugin-0.13.1.tgz",
+      "integrity": "sha512-aoAGs5w8HIS43p3YBcjzkIWZZlh18b/e02d+r/rr6+99vc48vOd9tKAIBZMVg4j+cVzbPtL1+t1tDE/UdeHcWQ==",
       "dev": true,
       "license": "Apache 2.0",
       "dependencies": {
@@ -1800,13 +1800,12 @@
         "@mui/x-date-pickers": "^7.15.0",
         "@mui/x-tree-view": "^6.17.0",
         "@reduxjs/toolkit": "^2.2.7",
-        "@storybook/addon-docs": "^9.1.2",
-        "@storybook/addon-links": "^9.1.2",
+        "@storybook/addon-docs": "^9.1.17",
+        "@storybook/addon-links": "^9.1.17",
         "@storybook/addon-webpack5-compiler-swc": "^3.0.0",
-        "@storybook/react-vite": "^9.1.2",
-        "@storybook/react-webpack5": "^9.1.2",
+        "@storybook/react-vite": "^9.1.17",
+        "@storybook/react-webpack5": "^9.1.17",
         "@tanstack/react-query": "^5.51.24",
-        "@tanstack/react-query-devtools": "^5.51.24",
         "@testing-library/dom": "^10.1.0",
         "@testing-library/jest-dom": "^6.4.8",
         "@testing-library/react": "^16.0.0",
@@ -1841,6 +1840,7 @@
         "eslint-plugin-react-hooks": "^4.6.2",
         "eslint-plugin-simple-import-sort": "^12.1.1",
         "eslint-plugin-unused-imports": "^4.1.3",
+        "fast-check": "^4.5.3",
         "fs-extra": "^11.2.0",
         "fuse.js": "^7.0.0",
         "humanize-duration": "^3.27.2",
@@ -1851,7 +1851,7 @@
         "js-yaml": "^4.1.1",
         "jsdom": "^24.0.0",
         "jsonpath-plus": "^10.3.0",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.23",
         "material-react-table": "^2.13.3",
         "monaco-editor": "^0.52.0",
         "msw": "2.4.9",
@@ -1875,9 +1875,9 @@
         "shx": "^0.4.0",
         "simple-eval": "^2.0.0",
         "spacetime": "^7.4.0",
-        "storybook": "^9.1.2",
+        "storybook": "^9.1.17",
         "table": "^6.8.2",
-        "tar": "^7.4.3",
+        "tar": "^7.5.7",
         "ts-loader": "^9.5.2",
         "typescript": "5.6.2",
         "validate-npm-package-name": "^3.0.0",
@@ -2878,16 +2878,16 @@
       "license": "MIT"
     },
     "node_modules/@storybook/addon-docs": {
-      "version": "9.1.13",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-9.1.13.tgz",
-      "integrity": "sha512-V1nCo7bfC3kQ5VNVq0VDcHsIhQf507m+BxMA5SIYiwdJHljH2BXpW2fL3FFn9gv9Wp57AEEzhm+wh4zANaJgkg==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-9.1.17.tgz",
+      "integrity": "sha512-yc4hlgkrwNi045qk210dRuIMijkgbLmo3ft6F4lOdpPRn4IUnPDj7FfZR8syGzUzKidxRfNtLx5m0yHIz83xtA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@mdx-js/react": "^3.0.0",
-        "@storybook/csf-plugin": "9.1.13",
+        "@storybook/csf-plugin": "9.1.17",
         "@storybook/icons": "^1.4.0",
-        "@storybook/react-dom-shim": "9.1.13",
+        "@storybook/react-dom-shim": "9.1.17",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "ts-dedent": "^2.0.0"
@@ -2897,13 +2897,13 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.1.13"
+        "storybook": "^9.1.17"
       }
     },
     "node_modules/@storybook/addon-links": {
-      "version": "9.1.13",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-9.1.13.tgz",
-      "integrity": "sha512-wx33RA5PPRSepVAjR0hMFp2IXoPgjwNAHIP92aoi2QQFS3+NHlf1I4vXEPpHU6lc0WBwM43qvLSI0qTAyZd8Nw==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-9.1.17.tgz",
+      "integrity": "sha512-LqtrDXRJrdMfZJ0om38SjmY2lQUGmpL8Zt2xTZtQjUy1V+ZiQpuUx7+TJZIOWujzRp75fxhM4AB0HuLDsemlcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2915,7 +2915,7 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.13"
+        "storybook": "^9.1.17"
       },
       "peerDependenciesMeta": {
         "react": {
@@ -2938,13 +2938,13 @@
       }
     },
     "node_modules/@storybook/builder-vite": {
-      "version": "9.1.13",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-9.1.13.tgz",
-      "integrity": "sha512-pmtIjU02ASJOZKdL8DoxWXJgZnpTDgD5WmMnjKJh9FaWmc2YiCW2Y6VRxPox96OM655jYHQe5+UIbk3Cwtwb4A==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-9.1.17.tgz",
+      "integrity": "sha512-OQCYaFWoTBvovN2IJmkAW+7FgHMJiih1WA/xqgpKIx0ImZjB4z5FrKgzQeXsrYcLEsynyaj+xN3JFUKsz5bzGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/csf-plugin": "9.1.13",
+        "@storybook/csf-plugin": "9.1.17",
         "ts-dedent": "^2.0.0"
       },
       "funding": {
@@ -2952,18 +2952,18 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.1.13",
+        "storybook": "^9.1.17",
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/@storybook/builder-webpack5": {
-      "version": "9.1.13",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-webpack5/-/builder-webpack5-9.1.13.tgz",
-      "integrity": "sha512-BoFXrTlc22ryLl6U5QwgV/gHVbHBcXeVSjYOyu6XZ9SPV5GGbw5T/G7NJYJAZcsz1ZxuMEYYSMFryfZ5qcjRsA==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-webpack5/-/builder-webpack5-9.1.17.tgz",
+      "integrity": "sha512-lgfq5R3WrK3HM/i7nX2b5rsnBgekoJr3Pu04KAGrEa/bgj7UW1n1bTodCUl+rVEM6aMPqXcLQFIVx/AEFNT4sQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/core-webpack": "9.1.13",
+        "@storybook/core-webpack": "9.1.17",
         "case-sensitive-paths-webpack-plugin": "^2.4.0",
         "cjs-module-lexer": "^1.2.3",
         "css-loader": "^6.7.1",
@@ -2984,7 +2984,7 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.1.13"
+        "storybook": "^9.1.17"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -2993,9 +2993,9 @@
       }
     },
     "node_modules/@storybook/core-webpack": {
-      "version": "9.1.13",
-      "resolved": "https://registry.npmjs.org/@storybook/core-webpack/-/core-webpack-9.1.13.tgz",
-      "integrity": "sha512-HtBZ+ZVgeqlhyMiT/Tdb/vpKrCSiZEi6p4s7y/qk04SaX8XIPSufEeqLI/ELSz2hOcuCy6smU/tE1JkqVz/4uA==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/core-webpack/-/core-webpack-9.1.17.tgz",
+      "integrity": "sha512-qJRWZEgWjNoGKcHOYFgGlUkmf/dIeQ3T01SJh9H4icZChVhyWRLC+y1HITmxRPPRHZXYyBHbTzmhFmuZM3i2YQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3006,13 +3006,13 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.1.13"
+        "storybook": "^9.1.17"
       }
     },
     "node_modules/@storybook/csf-plugin": {
-      "version": "9.1.13",
-      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-9.1.13.tgz",
-      "integrity": "sha512-EMpzYuyt9FDcxxfBChWzfId50y8QMpdenviEQ8m+pa6c+ANx3pC5J6t7y0khD8TQu815sTy+nc6cc8PC45dPUA==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-9.1.17.tgz",
+      "integrity": "sha512-o+ebQDdSfZHDRDhu2hNDGhCLIazEB4vEAqJcHgz1VsURq+l++bgZUcKojPMCAbeblptSEz2bwS0eYAOvG7aSXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3023,7 +3023,7 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.1.13"
+        "storybook": "^9.1.17"
       }
     },
     "node_modules/@storybook/global": {
@@ -3048,13 +3048,13 @@
       }
     },
     "node_modules/@storybook/preset-react-webpack": {
-      "version": "9.1.13",
-      "resolved": "https://registry.npmjs.org/@storybook/preset-react-webpack/-/preset-react-webpack-9.1.13.tgz",
-      "integrity": "sha512-2bWRdGSYvXWaE1QnrKFeE7EbTj+/Y0D8DHZ/OlKCB3xtNM7koMDrTnnI27hVlMjXqcX8RvOwb/N31FGBRgkiNg==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/preset-react-webpack/-/preset-react-webpack-9.1.17.tgz",
+      "integrity": "sha512-3ixo+4yywVy/a6nHLN5eefISw43717NHKXORWbaXJUOpa7ka9l3OejEDhVmSYKfJhTK+IVbrVYTIvrgqrUWQYg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/core-webpack": "9.1.13",
+        "@storybook/core-webpack": "9.1.17",
         "@storybook/react-docgen-typescript-plugin": "1.0.6--canary.9.0c3f3b7.0",
         "@types/semver": "^7.3.4",
         "find-up": "^7.0.0",
@@ -3075,7 +3075,7 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.13"
+        "storybook": "^9.1.17"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -3106,14 +3106,14 @@
       }
     },
     "node_modules/@storybook/react": {
-      "version": "9.1.13",
-      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-9.1.13.tgz",
-      "integrity": "sha512-B0UpYikKf29t8QGcdmumWojSQQ0phSDy/Ne2HYdrpNIxnUvHHUVOlGpq4lFcIDt52Ip5YG5GuAwJg3+eR4LCRg==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-9.1.17.tgz",
+      "integrity": "sha512-TZCplpep5BwjHPIIcUOMHebc/2qKadJHYPisRn5Wppl014qgT3XkFLpYkFgY1BaRXtqw8Mn3gqq4M/49rQ7Iww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@storybook/global": "^5.0.0",
-        "@storybook/react-dom-shim": "9.1.13"
+        "@storybook/react-dom-shim": "9.1.17"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -3125,7 +3125,7 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.13",
+        "storybook": "^9.1.17",
         "typescript": ">= 4.9.x"
       },
       "peerDependenciesMeta": {
@@ -3155,9 +3155,9 @@
       }
     },
     "node_modules/@storybook/react-dom-shim": {
-      "version": "9.1.13",
-      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-9.1.13.tgz",
-      "integrity": "sha512-/tMr9TmV3+98GEQO0S03k4gtKHGCpv9+k9Dmnv+TJK3TBz7QsaFEzMwe3gCgoTaebLACyVveDiZkWnCYAWB6NA==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-9.1.17.tgz",
+      "integrity": "sha512-Ss/lNvAy0Ziynu+KniQIByiNuyPz3dq7tD62hqSC/pHw190X+M7TKU3zcZvXhx2AQx1BYyxtdSHIZapb+P5mxQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -3167,20 +3167,20 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.13"
+        "storybook": "^9.1.17"
       }
     },
     "node_modules/@storybook/react-vite": {
-      "version": "9.1.13",
-      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-9.1.13.tgz",
-      "integrity": "sha512-mV1bZ1bpkNQygnuDo1xMGAS5ZXuoXFF0WGmr/BzNDGmRhZ1K1HQh42kC0w3PklckFBUwCFxmP58ZwTFzf+/dJA==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-9.1.17.tgz",
+      "integrity": "sha512-RZHsqD1mnTMo4MCJw68t3swS5BTMSTpeRhlelMwjoTEe7jJCPa+qx00uMlWliR1QBN1hMO8Y1dkchxSiUS9otA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@joshwooding/vite-plugin-react-docgen-typescript": "0.6.1",
         "@rollup/pluginutils": "^5.0.2",
-        "@storybook/builder-vite": "9.1.13",
-        "@storybook/react": "9.1.13",
+        "@storybook/builder-vite": "9.1.17",
+        "@storybook/react": "9.1.17",
         "find-up": "^7.0.0",
         "magic-string": "^0.30.0",
         "react-docgen": "^8.0.0",
@@ -3197,20 +3197,20 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.13",
+        "storybook": "^9.1.17",
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/@storybook/react-webpack5": {
-      "version": "9.1.13",
-      "resolved": "https://registry.npmjs.org/@storybook/react-webpack5/-/react-webpack5-9.1.13.tgz",
-      "integrity": "sha512-gsVWXbaodo22j6LcxA/55K6iQ83+MVObE76lSBsgOAWLe6gL9fiU4HBbi0B6/mrCN3Kqe7n95zM8QdOg4WbKeg==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/react-webpack5/-/react-webpack5-9.1.17.tgz",
+      "integrity": "sha512-GDOYMUzAj1dqFyrD1XbJaekcCrFZOIz0wVimbLeqRPwn+BNIZ9sylgvMiLxbiGMHWzVwJOyWDG/XVbuqXGfzWw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/builder-webpack5": "9.1.13",
-        "@storybook/preset-react-webpack": "9.1.13",
-        "@storybook/react": "9.1.13"
+        "@storybook/builder-webpack5": "9.1.17",
+        "@storybook/preset-react-webpack": "9.1.17",
+        "@storybook/react": "9.1.17"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -3222,7 +3222,7 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.13",
+        "storybook": "^9.1.17",
         "typescript": ">= 4.9.x"
       },
       "peerDependenciesMeta": {
@@ -3727,20 +3727,9 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.90.5",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.5.tgz",
-      "integrity": "sha512-wLamYp7FaDq6ZnNehypKI5fNvxHPfTYylE0m/ZpuuzJfJqhR5Pxg9gvGBHZx4n7J+V5Rg5mZxHHTlv25Zt5u+w==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      }
-    },
-    "node_modules/@tanstack/query-devtools": {
-      "version": "5.90.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.90.1.tgz",
-      "integrity": "sha512-GtINOPjPUH0OegJExZ70UahT9ykmAhmtNVcmtdnOZbxLwT7R5OmRztR5Ahe3/Cu7LArEmR6/588tAycuaWb1xQ==",
+      "version": "5.90.20",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.20.tgz",
+      "integrity": "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -3749,37 +3738,19 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.90.5",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.5.tgz",
-      "integrity": "sha512-pN+8UWpxZkEJ/Rnnj2v2Sxpx1WFlaa9L6a4UO89p6tTQbeo+m0MS8oYDjbggrR8QcTyjKoYWKS3xJQGr3ExT8Q==",
+      "version": "5.90.20",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.20.tgz",
+      "integrity": "sha512-vXBxa+qeyveVO7OA0jX1z+DeyCA4JKnThKv411jd5SORpBKgkcVnYKCiBgECvADvniBX7tobwBmg01qq9JmMJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.90.5"
+        "@tanstack/query-core": "5.90.20"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
-        "react": "^18 || ^19"
-      }
-    },
-    "node_modules/@tanstack/react-query-devtools": {
-      "version": "5.90.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.90.2.tgz",
-      "integrity": "sha512-vAXJzZuBXtCQtrY3F/yUNJCV4obT/A/n81kb3+YqLbro5Z2+phdAbceO+deU3ywPw8B42oyJlp4FhO0SoivDFQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/query-devtools": "5.90.1"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "@tanstack/react-query": "^5.90.2",
         "react": "^18 || ^19"
       }
     },
@@ -8797,6 +8768,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-check": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.5.3.tgz",
+      "integrity": "sha512-IE9csY7lnhxBnA8g/WI5eg/hygA6MGWJMSNfFRrBlXUciADEhS1EDB0SIsMSvzubzIlOBbVITSsypCsW717poA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -9924,9 +9918,9 @@
       }
     },
     "node_modules/html-webpack-plugin": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.4.tgz",
-      "integrity": "sha512-V/PZeWsqhfpE27nKeX9EO2sbR+D17A+tLf6qU+ht66jdUsN0QLKJN27Z+1+gHrVMKgndBahes0PU6rRihDgHTw==",
+      "version": "5.6.6",
+      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.6.tgz",
+      "integrity": "sha512-bLjW01UTrvoWTJQL5LsMRo1SypHW80FTm12OJRSnr3v6YHNhfe+1r0MYUZJMACxnCHURVnBWRwAsWs2yPU9Ezw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13607,9 +13601,9 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-      "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13811,6 +13805,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
+      "integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/qs": {
       "version": "6.14.0",
@@ -15524,9 +15535,9 @@
       }
     },
     "node_modules/storybook": {
-      "version": "9.1.13",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-9.1.13.tgz",
-      "integrity": "sha512-G3KZ36EVzXyHds72B/qtWiJnhUpM0xOUeYlDcO9DSHL1bDTv15cW4+upBl+mcBZrDvU838cn7Bv4GpF+O5MCfw==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-9.1.17.tgz",
+      "integrity": "sha512-kfr6kxQAjA96ADlH6FMALJwJ+eM80UqXy106yVHNgdsAP/CdzkkicglRAhZAvUycXK9AeadF6KZ00CWLtVMN4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16109,10 +16120,10 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.3.tgz",
-      "integrity": "sha512-ENg5JUHUm2rDD7IvKNFGzyElLXNjachNLp6RaGf4+JOgxXHkqA+gq81ZAMCUmtMtqBsoU62lcp6S27g1LCYGGQ==",
-      "license": "ISC",
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
+      "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
@@ -18040,9 +18051,9 @@
       }
     },
     "node_modules/yocto-queue": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
-      "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/backstage/package.json
+++ b/backstage/package.json
@@ -32,7 +32,7 @@
     ]
   },
   "devDependencies": {
-    "@kinvolk/headlamp-plugin": "^0.13.0"
+    "@kinvolk/headlamp-plugin": "^0.13.1"
   },
   "dependencies": {
     "tar": "^7.5.3"

--- a/karpenter/package-lock.json
+++ b/karpenter/package-lock.json
@@ -11,7 +11,7 @@
         "ajv-formats": "^3.0.1"
       },
       "devDependencies": {
-        "@kinvolk/headlamp-plugin": "^0.13.0"
+        "@kinvolk/headlamp-plugin": "^0.13.1"
       },
       "engines": {
         "headlamp": ">=0.20.0"
@@ -1783,9 +1783,9 @@
       }
     },
     "node_modules/@kinvolk/headlamp-plugin": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@kinvolk/headlamp-plugin/-/headlamp-plugin-0.13.0.tgz",
-      "integrity": "sha512-T0PGETnMXcUSOXKy/MEUeprDLzoqYxsJNqfNIL9DCW5WmmFDKcJX5Gify2RWB+oJbWIAaaRZ7zQGqeYeqa5KTA==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@kinvolk/headlamp-plugin/-/headlamp-plugin-0.13.1.tgz",
+      "integrity": "sha512-aoAGs5w8HIS43p3YBcjzkIWZZlh18b/e02d+r/rr6+99vc48vOd9tKAIBZMVg4j+cVzbPtL1+t1tDE/UdeHcWQ==",
       "dev": true,
       "license": "Apache 2.0",
       "dependencies": {
@@ -1804,13 +1804,12 @@
         "@mui/x-date-pickers": "^7.15.0",
         "@mui/x-tree-view": "^6.17.0",
         "@reduxjs/toolkit": "^2.2.7",
-        "@storybook/addon-docs": "^9.1.2",
-        "@storybook/addon-links": "^9.1.2",
+        "@storybook/addon-docs": "^9.1.17",
+        "@storybook/addon-links": "^9.1.17",
         "@storybook/addon-webpack5-compiler-swc": "^3.0.0",
-        "@storybook/react-vite": "^9.1.2",
-        "@storybook/react-webpack5": "^9.1.2",
+        "@storybook/react-vite": "^9.1.17",
+        "@storybook/react-webpack5": "^9.1.17",
         "@tanstack/react-query": "^5.51.24",
-        "@tanstack/react-query-devtools": "^5.51.24",
         "@testing-library/dom": "^10.1.0",
         "@testing-library/jest-dom": "^6.4.8",
         "@testing-library/react": "^16.0.0",
@@ -1845,6 +1844,7 @@
         "eslint-plugin-react-hooks": "^4.6.2",
         "eslint-plugin-simple-import-sort": "^12.1.1",
         "eslint-plugin-unused-imports": "^4.1.3",
+        "fast-check": "^4.5.3",
         "fs-extra": "^11.2.0",
         "fuse.js": "^7.0.0",
         "humanize-duration": "^3.27.2",
@@ -1855,7 +1855,7 @@
         "js-yaml": "^4.1.1",
         "jsdom": "^24.0.0",
         "jsonpath-plus": "^10.3.0",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.23",
         "material-react-table": "^2.13.3",
         "monaco-editor": "^0.52.0",
         "msw": "2.4.9",
@@ -1879,9 +1879,9 @@
         "shx": "^0.4.0",
         "simple-eval": "^2.0.0",
         "spacetime": "^7.4.0",
-        "storybook": "^9.1.2",
+        "storybook": "^9.1.17",
         "table": "^6.8.2",
-        "tar": "^7.4.3",
+        "tar": "^7.5.7",
         "ts-loader": "^9.5.2",
         "typescript": "5.6.2",
         "validate-npm-package-name": "^3.0.0",
@@ -2882,16 +2882,16 @@
       "license": "MIT"
     },
     "node_modules/@storybook/addon-docs": {
-      "version": "9.1.16",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-9.1.16.tgz",
-      "integrity": "sha512-JfaUD6fC7ySLg5duRdaWZ0FUUXrgUvqbZe/agCbSyOaIHOtJdhGaPjOC3vuXTAcV8/8/wWmbu0iXFMD08iKvdw==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-9.1.17.tgz",
+      "integrity": "sha512-yc4hlgkrwNi045qk210dRuIMijkgbLmo3ft6F4lOdpPRn4IUnPDj7FfZR8syGzUzKidxRfNtLx5m0yHIz83xtA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@mdx-js/react": "^3.0.0",
-        "@storybook/csf-plugin": "9.1.16",
+        "@storybook/csf-plugin": "9.1.17",
         "@storybook/icons": "^1.4.0",
-        "@storybook/react-dom-shim": "9.1.16",
+        "@storybook/react-dom-shim": "9.1.17",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "ts-dedent": "^2.0.0"
@@ -2901,13 +2901,13 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.1.16"
+        "storybook": "^9.1.17"
       }
     },
     "node_modules/@storybook/addon-links": {
-      "version": "9.1.16",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-9.1.16.tgz",
-      "integrity": "sha512-21SJAEuOX4Fh/5VSeakuiJJeSH2ezXBia0cZMTkKYz6GOtoojeGigo3tuebVlsn9myqnkMZxiufnnRa7Zne8vg==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-9.1.17.tgz",
+      "integrity": "sha512-LqtrDXRJrdMfZJ0om38SjmY2lQUGmpL8Zt2xTZtQjUy1V+ZiQpuUx7+TJZIOWujzRp75fxhM4AB0HuLDsemlcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2919,7 +2919,7 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.16"
+        "storybook": "^9.1.17"
       },
       "peerDependenciesMeta": {
         "react": {
@@ -2942,13 +2942,13 @@
       }
     },
     "node_modules/@storybook/builder-vite": {
-      "version": "9.1.16",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-9.1.16.tgz",
-      "integrity": "sha512-CyvYA5w1BKeSVaRavKi+euWxLffshq0v9Rz/5E9MKCitbYtjwkDH6UMIYmcbTs906mEBuYqrbz3nygDP0ppodw==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-9.1.17.tgz",
+      "integrity": "sha512-OQCYaFWoTBvovN2IJmkAW+7FgHMJiih1WA/xqgpKIx0ImZjB4z5FrKgzQeXsrYcLEsynyaj+xN3JFUKsz5bzGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/csf-plugin": "9.1.16",
+        "@storybook/csf-plugin": "9.1.17",
         "ts-dedent": "^2.0.0"
       },
       "funding": {
@@ -2956,18 +2956,18 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.1.16",
+        "storybook": "^9.1.17",
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/@storybook/builder-webpack5": {
-      "version": "9.1.16",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-webpack5/-/builder-webpack5-9.1.16.tgz",
-      "integrity": "sha512-AkhGTLze11XMPTtEpQXFc9pUCCPnWeO3rxwbRKB+H42+WKq0YXFx0rlPVpd1HIaQ6qbBmonasRBa0bvI04O/Rg==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-webpack5/-/builder-webpack5-9.1.17.tgz",
+      "integrity": "sha512-lgfq5R3WrK3HM/i7nX2b5rsnBgekoJr3Pu04KAGrEa/bgj7UW1n1bTodCUl+rVEM6aMPqXcLQFIVx/AEFNT4sQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/core-webpack": "9.1.16",
+        "@storybook/core-webpack": "9.1.17",
         "case-sensitive-paths-webpack-plugin": "^2.4.0",
         "cjs-module-lexer": "^1.2.3",
         "css-loader": "^6.7.1",
@@ -2988,7 +2988,7 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.1.16"
+        "storybook": "^9.1.17"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -2997,9 +2997,9 @@
       }
     },
     "node_modules/@storybook/core-webpack": {
-      "version": "9.1.16",
-      "resolved": "https://registry.npmjs.org/@storybook/core-webpack/-/core-webpack-9.1.16.tgz",
-      "integrity": "sha512-LyvG/MS8PFyZI+PQB6NQK5k5jjLKImxQBl37Yztbb3SjFrB0jQhSccmal1CcNH9RgaSLqUI1DKLeosGylAcbxQ==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/core-webpack/-/core-webpack-9.1.17.tgz",
+      "integrity": "sha512-qJRWZEgWjNoGKcHOYFgGlUkmf/dIeQ3T01SJh9H4icZChVhyWRLC+y1HITmxRPPRHZXYyBHbTzmhFmuZM3i2YQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3010,13 +3010,13 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.1.16"
+        "storybook": "^9.1.17"
       }
     },
     "node_modules/@storybook/csf-plugin": {
-      "version": "9.1.16",
-      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-9.1.16.tgz",
-      "integrity": "sha512-GKlNNlmWeFBQxhQY5hZOSnFGbeKq69jal0dYNWoSImTjor28eYRHb9iQkDzRpijLPizBaB9MlxLsLrgFDp7adA==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-9.1.17.tgz",
+      "integrity": "sha512-o+ebQDdSfZHDRDhu2hNDGhCLIazEB4vEAqJcHgz1VsURq+l++bgZUcKojPMCAbeblptSEz2bwS0eYAOvG7aSXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3027,7 +3027,7 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.1.16"
+        "storybook": "^9.1.17"
       }
     },
     "node_modules/@storybook/global": {
@@ -3052,13 +3052,13 @@
       }
     },
     "node_modules/@storybook/preset-react-webpack": {
-      "version": "9.1.16",
-      "resolved": "https://registry.npmjs.org/@storybook/preset-react-webpack/-/preset-react-webpack-9.1.16.tgz",
-      "integrity": "sha512-OuU9i1d9y7PcWYClcaiStrJ2dUXPR1sCdK9m7OKs1Bhh6EpqVdQa1cRPgx8sP0UXEa33TkY2PCuVcIyw7wImwg==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/preset-react-webpack/-/preset-react-webpack-9.1.17.tgz",
+      "integrity": "sha512-3ixo+4yywVy/a6nHLN5eefISw43717NHKXORWbaXJUOpa7ka9l3OejEDhVmSYKfJhTK+IVbrVYTIvrgqrUWQYg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/core-webpack": "9.1.16",
+        "@storybook/core-webpack": "9.1.17",
         "@storybook/react-docgen-typescript-plugin": "1.0.6--canary.9.0c3f3b7.0",
         "@types/semver": "^7.3.4",
         "find-up": "^7.0.0",
@@ -3079,7 +3079,7 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.16"
+        "storybook": "^9.1.17"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -3110,14 +3110,14 @@
       }
     },
     "node_modules/@storybook/react": {
-      "version": "9.1.16",
-      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-9.1.16.tgz",
-      "integrity": "sha512-M/SkHJJdtiGpodBJq9+DYmSkEOD+VqlPxKI+FvbHESTNs//1IgqFIjEWetd8quhd9oj/gvo4ICBAPu+UmD6M9w==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-9.1.17.tgz",
+      "integrity": "sha512-TZCplpep5BwjHPIIcUOMHebc/2qKadJHYPisRn5Wppl014qgT3XkFLpYkFgY1BaRXtqw8Mn3gqq4M/49rQ7Iww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@storybook/global": "^5.0.0",
-        "@storybook/react-dom-shim": "9.1.16"
+        "@storybook/react-dom-shim": "9.1.17"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -3129,7 +3129,7 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.16",
+        "storybook": "^9.1.17",
         "typescript": ">= 4.9.x"
       },
       "peerDependenciesMeta": {
@@ -3159,9 +3159,9 @@
       }
     },
     "node_modules/@storybook/react-dom-shim": {
-      "version": "9.1.16",
-      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-9.1.16.tgz",
-      "integrity": "sha512-MsI4qTxdT6lMXQmo3IXhw3EaCC+vsZboyEZBx4pOJ+K/5cDJ6ZoQ3f0d4yGpVhumDxaxlnNAg954+f8WWXE1rQ==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-9.1.17.tgz",
+      "integrity": "sha512-Ss/lNvAy0Ziynu+KniQIByiNuyPz3dq7tD62hqSC/pHw190X+M7TKU3zcZvXhx2AQx1BYyxtdSHIZapb+P5mxQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -3171,20 +3171,20 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.16"
+        "storybook": "^9.1.17"
       }
     },
     "node_modules/@storybook/react-vite": {
-      "version": "9.1.16",
-      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-9.1.16.tgz",
-      "integrity": "sha512-WRKSq0XfQ/Qx66aKisQCfa/1UKwN9HjVbY6xrmsX7kI5zBdITxIcKInq6PWoPv91SJD7+Et956yX+F86R1aEXw==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-9.1.17.tgz",
+      "integrity": "sha512-RZHsqD1mnTMo4MCJw68t3swS5BTMSTpeRhlelMwjoTEe7jJCPa+qx00uMlWliR1QBN1hMO8Y1dkchxSiUS9otA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@joshwooding/vite-plugin-react-docgen-typescript": "0.6.1",
         "@rollup/pluginutils": "^5.0.2",
-        "@storybook/builder-vite": "9.1.16",
-        "@storybook/react": "9.1.16",
+        "@storybook/builder-vite": "9.1.17",
+        "@storybook/react": "9.1.17",
         "find-up": "^7.0.0",
         "magic-string": "^0.30.0",
         "react-docgen": "^8.0.0",
@@ -3201,20 +3201,20 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.16",
+        "storybook": "^9.1.17",
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/@storybook/react-webpack5": {
-      "version": "9.1.16",
-      "resolved": "https://registry.npmjs.org/@storybook/react-webpack5/-/react-webpack5-9.1.16.tgz",
-      "integrity": "sha512-ibc2OnxeI6sEZ7lLWSG2pI3tpxCR7aXno+dFMbsKKhGQukoHY4oLqS6aSUvESSoaPGwvGNfGEaRqr35PSTnuRQ==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/react-webpack5/-/react-webpack5-9.1.17.tgz",
+      "integrity": "sha512-GDOYMUzAj1dqFyrD1XbJaekcCrFZOIz0wVimbLeqRPwn+BNIZ9sylgvMiLxbiGMHWzVwJOyWDG/XVbuqXGfzWw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/builder-webpack5": "9.1.16",
-        "@storybook/preset-react-webpack": "9.1.16",
-        "@storybook/react": "9.1.16"
+        "@storybook/builder-webpack5": "9.1.17",
+        "@storybook/preset-react-webpack": "9.1.17",
+        "@storybook/react": "9.1.17"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -3226,7 +3226,7 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.16",
+        "storybook": "^9.1.17",
         "typescript": ">= 4.9.x"
       },
       "peerDependenciesMeta": {
@@ -3731,20 +3731,9 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.90.10",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.10.tgz",
-      "integrity": "sha512-EhZVFu9rl7GfRNuJLJ3Y7wtbTnENsvzp+YpcAV7kCYiXni1v8qZh++lpw4ch4rrwC0u/EZRnBHIehzCGzwXDSQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      }
-    },
-    "node_modules/@tanstack/query-devtools": {
-      "version": "5.90.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.90.1.tgz",
-      "integrity": "sha512-GtINOPjPUH0OegJExZ70UahT9ykmAhmtNVcmtdnOZbxLwT7R5OmRztR5Ahe3/Cu7LArEmR6/588tAycuaWb1xQ==",
+      "version": "5.90.20",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.20.tgz",
+      "integrity": "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -3753,37 +3742,19 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.90.10",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.10.tgz",
-      "integrity": "sha512-BKLss9Y8PQ9IUjPYQiv3/Zmlx92uxffUOX8ZZNoQlCIZBJPT5M+GOMQj7xislvVQ6l1BstBjcX0XB/aHfFYVNw==",
+      "version": "5.90.20",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.20.tgz",
+      "integrity": "sha512-vXBxa+qeyveVO7OA0jX1z+DeyCA4JKnThKv411jd5SORpBKgkcVnYKCiBgECvADvniBX7tobwBmg01qq9JmMJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.90.10"
+        "@tanstack/query-core": "5.90.20"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
-        "react": "^18 || ^19"
-      }
-    },
-    "node_modules/@tanstack/react-query-devtools": {
-      "version": "5.90.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.90.2.tgz",
-      "integrity": "sha512-vAXJzZuBXtCQtrY3F/yUNJCV4obT/A/n81kb3+YqLbro5Z2+phdAbceO+deU3ywPw8B42oyJlp4FhO0SoivDFQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/query-devtools": "5.90.1"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "@tanstack/react-query": "^5.90.2",
         "react": "^18 || ^19"
       }
     },
@@ -8800,6 +8771,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-check": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.5.3.tgz",
+      "integrity": "sha512-IE9csY7lnhxBnA8g/WI5eg/hygA6MGWJMSNfFRrBlXUciADEhS1EDB0SIsMSvzubzIlOBbVITSsypCsW717poA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -9925,9 +9919,9 @@
       }
     },
     "node_modules/html-webpack-plugin": {
-      "version": "5.6.5",
-      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.5.tgz",
-      "integrity": "sha512-4xynFbKNNk+WlzXeQQ+6YYsH2g7mpfPszQZUi3ovKlj+pDmngQ7vRXjrrmGROabmKwyQkcgcX5hqfOwHbFmK5g==",
+      "version": "5.6.6",
+      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.6.tgz",
+      "integrity": "sha512-bLjW01UTrvoWTJQL5LsMRo1SypHW80FTm12OJRSnr3v6YHNhfe+1r0MYUZJMACxnCHURVnBWRwAsWs2yPU9Ezw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13609,9 +13603,9 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-      "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13813,6 +13807,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
+      "integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/qs": {
       "version": "6.14.0",
@@ -15525,9 +15536,9 @@
       }
     },
     "node_modules/storybook": {
-      "version": "9.1.16",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-9.1.16.tgz",
-      "integrity": "sha512-339U14K6l46EFyRvaPS2ZlL7v7Pb+LlcXT8KAETrGPxq8v1sAjj2HAOB6zrlAK3M+0+ricssfAwsLCwt7Eg8TQ==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-9.1.17.tgz",
+      "integrity": "sha512-kfr6kxQAjA96ADlH6FMALJwJ+eM80UqXy106yVHNgdsAP/CdzkkicglRAhZAvUycXK9AeadF6KZ00CWLtVMN4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16110,9 +16121,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.3.tgz",
-      "integrity": "sha512-ENg5JUHUm2rDD7IvKNFGzyElLXNjachNLp6RaGf4+JOgxXHkqA+gq81ZAMCUmtMtqBsoU62lcp6S27g1LCYGGQ==",
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
+      "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {

--- a/karpenter/package.json
+++ b/karpenter/package.json
@@ -36,7 +36,7 @@
     "typescript": "5.6.2"
   },
   "devDependencies": {
-    "@kinvolk/headlamp-plugin": "^0.13.0"
+    "@kinvolk/headlamp-plugin": "^0.13.1"
   },
   "engines": {
     "headlamp": ">=0.20.0"

--- a/keda/package-lock.json
+++ b/keda/package-lock.json
@@ -9,13 +9,13 @@
       "version": "0.1.1-beta",
       "devDependencies": {
         "@headlamp-k8s/eslint-config": "^0.7.0",
-        "@kinvolk/headlamp-plugin": "^0.13.0"
+        "@kinvolk/headlamp-plugin": "^0.13.1"
       }
     },
     "node_modules/@adobe/css-tools": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.2.tgz",
-      "integrity": "sha512-baYZExFpsdkBNuvGKTKWCwKH57HRZLVtycZS05WTQNVOiXVSeAki3nU35zlRbToeMW8aHlJfyS+1C4BOv27q0A==",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1765,10 +1765,11 @@
       }
     },
     "node_modules/@kinvolk/headlamp-plugin": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@kinvolk/headlamp-plugin/-/headlamp-plugin-0.13.0.tgz",
-      "integrity": "sha512-T0PGETnMXcUSOXKy/MEUeprDLzoqYxsJNqfNIL9DCW5WmmFDKcJX5Gify2RWB+oJbWIAaaRZ7zQGqeYeqa5KTA==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@kinvolk/headlamp-plugin/-/headlamp-plugin-0.13.1.tgz",
+      "integrity": "sha512-aoAGs5w8HIS43p3YBcjzkIWZZlh18b/e02d+r/rr6+99vc48vOd9tKAIBZMVg4j+cVzbPtL1+t1tDE/UdeHcWQ==",
       "dev": true,
+      "license": "Apache 2.0",
       "dependencies": {
         "@apidevtools/swagger-parser": "^10.0.3",
         "@emotion/react": "^11.11.1",
@@ -1785,13 +1786,12 @@
         "@mui/x-date-pickers": "^7.15.0",
         "@mui/x-tree-view": "^6.17.0",
         "@reduxjs/toolkit": "^2.2.7",
-        "@storybook/addon-docs": "^9.1.2",
-        "@storybook/addon-links": "^9.1.2",
+        "@storybook/addon-docs": "^9.1.17",
+        "@storybook/addon-links": "^9.1.17",
         "@storybook/addon-webpack5-compiler-swc": "^3.0.0",
-        "@storybook/react-vite": "^9.1.2",
-        "@storybook/react-webpack5": "^9.1.2",
+        "@storybook/react-vite": "^9.1.17",
+        "@storybook/react-webpack5": "^9.1.17",
         "@tanstack/react-query": "^5.51.24",
-        "@tanstack/react-query-devtools": "^5.51.24",
         "@testing-library/dom": "^10.1.0",
         "@testing-library/jest-dom": "^6.4.8",
         "@testing-library/react": "^16.0.0",
@@ -1826,6 +1826,7 @@
         "eslint-plugin-react-hooks": "^4.6.2",
         "eslint-plugin-simple-import-sort": "^12.1.1",
         "eslint-plugin-unused-imports": "^4.1.3",
+        "fast-check": "^4.5.3",
         "fs-extra": "^11.2.0",
         "fuse.js": "^7.0.0",
         "humanize-duration": "^3.27.2",
@@ -1836,7 +1837,7 @@
         "js-yaml": "^4.1.1",
         "jsdom": "^24.0.0",
         "jsonpath-plus": "^10.3.0",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.23",
         "material-react-table": "^2.13.3",
         "monaco-editor": "^0.52.0",
         "msw": "2.4.9",
@@ -1860,9 +1861,9 @@
         "shx": "^0.4.0",
         "simple-eval": "^2.0.0",
         "spacetime": "^7.4.0",
-        "storybook": "^9.1.2",
+        "storybook": "^9.1.17",
         "table": "^6.8.2",
-        "tar": "^7.4.3",
+        "tar": "^7.5.7",
         "ts-loader": "^9.5.2",
         "typescript": "5.6.2",
         "validate-npm-package-name": "^3.0.0",
@@ -2958,15 +2959,16 @@
       "license": "MIT"
     },
     "node_modules/@storybook/addon-docs": {
-      "version": "9.1.16",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-9.1.16.tgz",
-      "integrity": "sha512-JfaUD6fC7ySLg5duRdaWZ0FUUXrgUvqbZe/agCbSyOaIHOtJdhGaPjOC3vuXTAcV8/8/wWmbu0iXFMD08iKvdw==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-9.1.17.tgz",
+      "integrity": "sha512-yc4hlgkrwNi045qk210dRuIMijkgbLmo3ft6F4lOdpPRn4IUnPDj7FfZR8syGzUzKidxRfNtLx5m0yHIz83xtA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@mdx-js/react": "^3.0.0",
-        "@storybook/csf-plugin": "9.1.16",
+        "@storybook/csf-plugin": "9.1.17",
         "@storybook/icons": "^1.4.0",
-        "@storybook/react-dom-shim": "9.1.16",
+        "@storybook/react-dom-shim": "9.1.17",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "ts-dedent": "^2.0.0"
@@ -2976,14 +2978,15 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.1.16"
+        "storybook": "^9.1.17"
       }
     },
     "node_modules/@storybook/addon-links": {
-      "version": "9.1.16",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-9.1.16.tgz",
-      "integrity": "sha512-21SJAEuOX4Fh/5VSeakuiJJeSH2ezXBia0cZMTkKYz6GOtoojeGigo3tuebVlsn9myqnkMZxiufnnRa7Zne8vg==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-9.1.17.tgz",
+      "integrity": "sha512-LqtrDXRJrdMfZJ0om38SjmY2lQUGmpL8Zt2xTZtQjUy1V+ZiQpuUx7+TJZIOWujzRp75fxhM4AB0HuLDsemlcA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@storybook/global": "^5.0.0"
       },
@@ -2993,7 +2996,7 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.16"
+        "storybook": "^9.1.17"
       },
       "peerDependenciesMeta": {
         "react": {
@@ -3015,12 +3018,13 @@
       }
     },
     "node_modules/@storybook/builder-vite": {
-      "version": "9.1.16",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-9.1.16.tgz",
-      "integrity": "sha512-CyvYA5w1BKeSVaRavKi+euWxLffshq0v9Rz/5E9MKCitbYtjwkDH6UMIYmcbTs906mEBuYqrbz3nygDP0ppodw==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-9.1.17.tgz",
+      "integrity": "sha512-OQCYaFWoTBvovN2IJmkAW+7FgHMJiih1WA/xqgpKIx0ImZjB4z5FrKgzQeXsrYcLEsynyaj+xN3JFUKsz5bzGQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@storybook/csf-plugin": "9.1.16",
+        "@storybook/csf-plugin": "9.1.17",
         "ts-dedent": "^2.0.0"
       },
       "funding": {
@@ -3028,17 +3032,18 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.1.16",
+        "storybook": "^9.1.17",
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/@storybook/builder-webpack5": {
-      "version": "9.1.16",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-webpack5/-/builder-webpack5-9.1.16.tgz",
-      "integrity": "sha512-AkhGTLze11XMPTtEpQXFc9pUCCPnWeO3rxwbRKB+H42+WKq0YXFx0rlPVpd1HIaQ6qbBmonasRBa0bvI04O/Rg==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-webpack5/-/builder-webpack5-9.1.17.tgz",
+      "integrity": "sha512-lgfq5R3WrK3HM/i7nX2b5rsnBgekoJr3Pu04KAGrEa/bgj7UW1n1bTodCUl+rVEM6aMPqXcLQFIVx/AEFNT4sQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@storybook/core-webpack": "9.1.16",
+        "@storybook/core-webpack": "9.1.17",
         "case-sensitive-paths-webpack-plugin": "^2.4.0",
         "cjs-module-lexer": "^1.2.3",
         "css-loader": "^6.7.1",
@@ -3059,7 +3064,7 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.1.16"
+        "storybook": "^9.1.17"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -3068,10 +3073,11 @@
       }
     },
     "node_modules/@storybook/core-webpack": {
-      "version": "9.1.16",
-      "resolved": "https://registry.npmjs.org/@storybook/core-webpack/-/core-webpack-9.1.16.tgz",
-      "integrity": "sha512-LyvG/MS8PFyZI+PQB6NQK5k5jjLKImxQBl37Yztbb3SjFrB0jQhSccmal1CcNH9RgaSLqUI1DKLeosGylAcbxQ==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/core-webpack/-/core-webpack-9.1.17.tgz",
+      "integrity": "sha512-qJRWZEgWjNoGKcHOYFgGlUkmf/dIeQ3T01SJh9H4icZChVhyWRLC+y1HITmxRPPRHZXYyBHbTzmhFmuZM3i2YQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ts-dedent": "^2.0.0"
       },
@@ -3080,14 +3086,15 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.1.16"
+        "storybook": "^9.1.17"
       }
     },
     "node_modules/@storybook/csf-plugin": {
-      "version": "9.1.16",
-      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-9.1.16.tgz",
-      "integrity": "sha512-GKlNNlmWeFBQxhQY5hZOSnFGbeKq69jal0dYNWoSImTjor28eYRHb9iQkDzRpijLPizBaB9MlxLsLrgFDp7adA==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-9.1.17.tgz",
+      "integrity": "sha512-o+ebQDdSfZHDRDhu2hNDGhCLIazEB4vEAqJcHgz1VsURq+l++bgZUcKojPMCAbeblptSEz2bwS0eYAOvG7aSXg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "unplugin": "^1.3.1"
       },
@@ -3096,7 +3103,7 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.1.16"
+        "storybook": "^9.1.17"
       }
     },
     "node_modules/@storybook/global": {
@@ -3119,12 +3126,13 @@
       }
     },
     "node_modules/@storybook/preset-react-webpack": {
-      "version": "9.1.16",
-      "resolved": "https://registry.npmjs.org/@storybook/preset-react-webpack/-/preset-react-webpack-9.1.16.tgz",
-      "integrity": "sha512-OuU9i1d9y7PcWYClcaiStrJ2dUXPR1sCdK9m7OKs1Bhh6EpqVdQa1cRPgx8sP0UXEa33TkY2PCuVcIyw7wImwg==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/preset-react-webpack/-/preset-react-webpack-9.1.17.tgz",
+      "integrity": "sha512-3ixo+4yywVy/a6nHLN5eefISw43717NHKXORWbaXJUOpa7ka9l3OejEDhVmSYKfJhTK+IVbrVYTIvrgqrUWQYg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@storybook/core-webpack": "9.1.16",
+        "@storybook/core-webpack": "9.1.17",
         "@storybook/react-docgen-typescript-plugin": "1.0.6--canary.9.0c3f3b7.0",
         "@types/semver": "^7.3.4",
         "find-up": "^7.0.0",
@@ -3145,7 +3153,7 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.16"
+        "storybook": "^9.1.17"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -3258,13 +3266,14 @@
       }
     },
     "node_modules/@storybook/react": {
-      "version": "9.1.16",
-      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-9.1.16.tgz",
-      "integrity": "sha512-M/SkHJJdtiGpodBJq9+DYmSkEOD+VqlPxKI+FvbHESTNs//1IgqFIjEWetd8quhd9oj/gvo4ICBAPu+UmD6M9w==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-9.1.17.tgz",
+      "integrity": "sha512-TZCplpep5BwjHPIIcUOMHebc/2qKadJHYPisRn5Wppl014qgT3XkFLpYkFgY1BaRXtqw8Mn3gqq4M/49rQ7Iww==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@storybook/global": "^5.0.0",
-        "@storybook/react-dom-shim": "9.1.16"
+        "@storybook/react-dom-shim": "9.1.17"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -3276,7 +3285,7 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.16",
+        "storybook": "^9.1.17",
         "typescript": ">= 4.9.x"
       },
       "peerDependenciesMeta": {
@@ -3305,10 +3314,11 @@
       }
     },
     "node_modules/@storybook/react-dom-shim": {
-      "version": "9.1.16",
-      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-9.1.16.tgz",
-      "integrity": "sha512-MsI4qTxdT6lMXQmo3IXhw3EaCC+vsZboyEZBx4pOJ+K/5cDJ6ZoQ3f0d4yGpVhumDxaxlnNAg954+f8WWXE1rQ==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-9.1.17.tgz",
+      "integrity": "sha512-Ss/lNvAy0Ziynu+KniQIByiNuyPz3dq7tD62hqSC/pHw190X+M7TKU3zcZvXhx2AQx1BYyxtdSHIZapb+P5mxQ==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"
@@ -3316,19 +3326,20 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.16"
+        "storybook": "^9.1.17"
       }
     },
     "node_modules/@storybook/react-vite": {
-      "version": "9.1.16",
-      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-9.1.16.tgz",
-      "integrity": "sha512-WRKSq0XfQ/Qx66aKisQCfa/1UKwN9HjVbY6xrmsX7kI5zBdITxIcKInq6PWoPv91SJD7+Et956yX+F86R1aEXw==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-9.1.17.tgz",
+      "integrity": "sha512-RZHsqD1mnTMo4MCJw68t3swS5BTMSTpeRhlelMwjoTEe7jJCPa+qx00uMlWliR1QBN1hMO8Y1dkchxSiUS9otA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@joshwooding/vite-plugin-react-docgen-typescript": "0.6.1",
         "@rollup/pluginutils": "^5.0.2",
-        "@storybook/builder-vite": "9.1.16",
-        "@storybook/react": "9.1.16",
+        "@storybook/builder-vite": "9.1.17",
+        "@storybook/react": "9.1.17",
         "find-up": "^7.0.0",
         "magic-string": "^0.30.0",
         "react-docgen": "^8.0.0",
@@ -3345,7 +3356,7 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.16",
+        "storybook": "^9.1.17",
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
@@ -3433,14 +3444,15 @@
       }
     },
     "node_modules/@storybook/react-webpack5": {
-      "version": "9.1.16",
-      "resolved": "https://registry.npmjs.org/@storybook/react-webpack5/-/react-webpack5-9.1.16.tgz",
-      "integrity": "sha512-ibc2OnxeI6sEZ7lLWSG2pI3tpxCR7aXno+dFMbsKKhGQukoHY4oLqS6aSUvESSoaPGwvGNfGEaRqr35PSTnuRQ==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/react-webpack5/-/react-webpack5-9.1.17.tgz",
+      "integrity": "sha512-GDOYMUzAj1dqFyrD1XbJaekcCrFZOIz0wVimbLeqRPwn+BNIZ9sylgvMiLxbiGMHWzVwJOyWDG/XVbuqXGfzWw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@storybook/builder-webpack5": "9.1.16",
-        "@storybook/preset-react-webpack": "9.1.16",
-        "@storybook/react": "9.1.16"
+        "@storybook/builder-webpack5": "9.1.17",
+        "@storybook/preset-react-webpack": "9.1.17",
+        "@storybook/react": "9.1.17"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -3452,7 +3464,7 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.16",
+        "storybook": "^9.1.17",
         "typescript": ">= 4.9.x"
       },
       "peerDependenciesMeta": {
@@ -3944,20 +3956,9 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.67.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.67.2.tgz",
-      "integrity": "sha512-+iaFJ/pt8TaApCk6LuZ0WHS/ECVfTzrxDOEL9HH9Dayyb5OVuomLzDXeSaI2GlGT/8HN7bDGiRXDts3LV+u6ww==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      }
-    },
-    "node_modules/@tanstack/query-devtools": {
-      "version": "5.67.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.67.2.tgz",
-      "integrity": "sha512-O4QXFFd7xqp6EX7sdvc9tsVO8nm4lpWBqwpgjpVLW5g7IeOY6VnS/xvs/YzbRhBVkKTMaJMOUGU7NhSX+YGoNg==",
+      "version": "5.90.20",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.20.tgz",
+      "integrity": "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -3966,37 +3967,19 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.67.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.67.2.tgz",
-      "integrity": "sha512-6Sa+BVNJWhAV4QHvIqM73norNeGRWGC3ftN0Ix87cmMvI215I1wyJ44KUTt/9a0V9YimfGcg25AITaYVel71Og==",
+      "version": "5.90.20",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.20.tgz",
+      "integrity": "sha512-vXBxa+qeyveVO7OA0jX1z+DeyCA4JKnThKv411jd5SORpBKgkcVnYKCiBgECvADvniBX7tobwBmg01qq9JmMJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.67.2"
+        "@tanstack/query-core": "5.90.20"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
-        "react": "^18 || ^19"
-      }
-    },
-    "node_modules/@tanstack/react-query-devtools": {
-      "version": "5.67.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.67.2.tgz",
-      "integrity": "sha512-cmj2DxBc+/9btQ66n5xI8wTtAma2BLVa403K7zIYiguzJ/kV201jnGensYqJeu1Rd8uRMLLRM74jLVMLDWNRJA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/query-devtools": "5.67.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "@tanstack/react-query": "^5.67.2",
         "react": "^18 || ^19"
       }
     },
@@ -4085,38 +4068,23 @@
       }
     },
     "node_modules/@testing-library/jest-dom": {
-      "version": "6.6.3",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.6.3.tgz",
-      "integrity": "sha512-IteBhl4XqYNkM54f4ejhLRJiZNqcSCoXUOG2CPK7qbD322KjQozM4kHQOfkG2oln9b9HTYqs+Sae8vBATubxxA==",
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@adobe/css-tools": "^4.4.0",
         "aria-query": "^5.0.0",
-        "chalk": "^3.0.0",
         "css.escape": "^1.5.1",
         "dom-accessibility-api": "^0.6.3",
-        "lodash": "^4.17.21",
+        "picocolors": "^1.1.1",
         "redent": "^3.0.0"
       },
       "engines": {
         "node": ">=14",
         "npm": ">=6",
         "yarn": ">=1"
-      }
-    },
-    "node_modules/@testing-library/jest-dom/node_modules/chalk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
@@ -4641,9 +4609,9 @@
       "license": "MIT"
     },
     "node_modules/@types/semver": {
-      "version": "7.5.8",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
-      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
       "dev": true,
       "license": "MIT"
     },
@@ -8898,6 +8866,29 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "dev": true
     },
+    "node_modules/fast-check": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.5.3.tgz",
+      "integrity": "sha512-IE9csY7lnhxBnA8g/WI5eg/hygA6MGWJMSNfFRrBlXUciADEhS1EDB0SIsMSvzubzIlOBbVITSsypCsW717poA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -10081,10 +10072,11 @@
       }
     },
     "node_modules/html-webpack-plugin": {
-      "version": "5.6.5",
-      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.5.tgz",
-      "integrity": "sha512-4xynFbKNNk+WlzXeQQ+6YYsH2g7mpfPszQZUi3ovKlj+pDmngQ7vRXjrrmGROabmKwyQkcgcX5hqfOwHbFmK5g==",
+      "version": "5.6.6",
+      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.6.tgz",
+      "integrity": "sha512-bLjW01UTrvoWTJQL5LsMRo1SypHW80FTm12OJRSnr3v6YHNhfe+1r0MYUZJMACxnCHURVnBWRwAsWs2yPU9Ezw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/html-minifier-terser": "^6.0.0",
         "html-minifier-terser": "^6.0.2",
@@ -13723,6 +13715,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/pure-rand": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
+      "integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/qs": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
@@ -15365,10 +15374,11 @@
       "license": "MIT"
     },
     "node_modules/storybook": {
-      "version": "9.1.16",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-9.1.16.tgz",
-      "integrity": "sha512-339U14K6l46EFyRvaPS2ZlL7v7Pb+LlcXT8KAETrGPxq8v1sAjj2HAOB6zrlAK3M+0+ricssfAwsLCwt7Eg8TQ==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-9.1.17.tgz",
+      "integrity": "sha512-kfr6kxQAjA96ADlH6FMALJwJ+eM80UqXy106yVHNgdsAP/CdzkkicglRAhZAvUycXK9AeadF6KZ00CWLtVMN4w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@testing-library/jest-dom": "^6.6.3",
@@ -15976,11 +15986,11 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.3.tgz",
-      "integrity": "sha512-ENg5JUHUm2rDD7IvKNFGzyElLXNjachNLp6RaGf4+JOgxXHkqA+gq81ZAMCUmtMtqBsoU62lcp6S27g1LCYGGQ==",
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
+      "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",

--- a/keda/package.json
+++ b/keda/package.json
@@ -32,6 +32,6 @@
   },
   "devDependencies": {
     "@headlamp-k8s/eslint-config": "^0.7.0",
-    "@kinvolk/headlamp-plugin": "^0.13.0"
+    "@kinvolk/headlamp-plugin": "^0.13.1"
   }
 }

--- a/knative/package-lock.json
+++ b/knative/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@headlamp-k8s/knative",
       "version": "0.2.0-alpha",
       "devDependencies": {
-        "@kinvolk/headlamp-plugin": "^0.13.0",
+        "@kinvolk/headlamp-plugin": "^0.13.1",
         "knip": "^5.68.0"
       }
     },
@@ -1819,9 +1819,9 @@
       }
     },
     "node_modules/@kinvolk/headlamp-plugin": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@kinvolk/headlamp-plugin/-/headlamp-plugin-0.13.0.tgz",
-      "integrity": "sha512-T0PGETnMXcUSOXKy/MEUeprDLzoqYxsJNqfNIL9DCW5WmmFDKcJX5Gify2RWB+oJbWIAaaRZ7zQGqeYeqa5KTA==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@kinvolk/headlamp-plugin/-/headlamp-plugin-0.13.1.tgz",
+      "integrity": "sha512-aoAGs5w8HIS43p3YBcjzkIWZZlh18b/e02d+r/rr6+99vc48vOd9tKAIBZMVg4j+cVzbPtL1+t1tDE/UdeHcWQ==",
       "dev": true,
       "license": "Apache 2.0",
       "dependencies": {
@@ -1840,13 +1840,12 @@
         "@mui/x-date-pickers": "^7.15.0",
         "@mui/x-tree-view": "^6.17.0",
         "@reduxjs/toolkit": "^2.2.7",
-        "@storybook/addon-docs": "^9.1.2",
-        "@storybook/addon-links": "^9.1.2",
+        "@storybook/addon-docs": "^9.1.17",
+        "@storybook/addon-links": "^9.1.17",
         "@storybook/addon-webpack5-compiler-swc": "^3.0.0",
-        "@storybook/react-vite": "^9.1.2",
-        "@storybook/react-webpack5": "^9.1.2",
+        "@storybook/react-vite": "^9.1.17",
+        "@storybook/react-webpack5": "^9.1.17",
         "@tanstack/react-query": "^5.51.24",
-        "@tanstack/react-query-devtools": "^5.51.24",
         "@testing-library/dom": "^10.1.0",
         "@testing-library/jest-dom": "^6.4.8",
         "@testing-library/react": "^16.0.0",
@@ -1881,6 +1880,7 @@
         "eslint-plugin-react-hooks": "^4.6.2",
         "eslint-plugin-simple-import-sort": "^12.1.1",
         "eslint-plugin-unused-imports": "^4.1.3",
+        "fast-check": "^4.5.3",
         "fs-extra": "^11.2.0",
         "fuse.js": "^7.0.0",
         "humanize-duration": "^3.27.2",
@@ -1891,7 +1891,7 @@
         "js-yaml": "^4.1.1",
         "jsdom": "^24.0.0",
         "jsonpath-plus": "^10.3.0",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.23",
         "material-react-table": "^2.13.3",
         "monaco-editor": "^0.52.0",
         "msw": "2.4.9",
@@ -1915,9 +1915,9 @@
         "shx": "^0.4.0",
         "simple-eval": "^2.0.0",
         "spacetime": "^7.4.0",
-        "storybook": "^9.1.2",
+        "storybook": "^9.1.17",
         "table": "^6.8.2",
-        "tar": "^7.4.3",
+        "tar": "^7.5.7",
         "ts-loader": "^9.5.2",
         "typescript": "5.6.2",
         "validate-npm-package-name": "^3.0.0",
@@ -3231,16 +3231,16 @@
       "license": "MIT"
     },
     "node_modules/@storybook/addon-docs": {
-      "version": "9.1.16",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-9.1.16.tgz",
-      "integrity": "sha512-JfaUD6fC7ySLg5duRdaWZ0FUUXrgUvqbZe/agCbSyOaIHOtJdhGaPjOC3vuXTAcV8/8/wWmbu0iXFMD08iKvdw==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-9.1.17.tgz",
+      "integrity": "sha512-yc4hlgkrwNi045qk210dRuIMijkgbLmo3ft6F4lOdpPRn4IUnPDj7FfZR8syGzUzKidxRfNtLx5m0yHIz83xtA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@mdx-js/react": "^3.0.0",
-        "@storybook/csf-plugin": "9.1.16",
+        "@storybook/csf-plugin": "9.1.17",
         "@storybook/icons": "^1.4.0",
-        "@storybook/react-dom-shim": "9.1.16",
+        "@storybook/react-dom-shim": "9.1.17",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "ts-dedent": "^2.0.0"
@@ -3250,13 +3250,13 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.1.16"
+        "storybook": "^9.1.17"
       }
     },
     "node_modules/@storybook/addon-links": {
-      "version": "9.1.16",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-9.1.16.tgz",
-      "integrity": "sha512-21SJAEuOX4Fh/5VSeakuiJJeSH2ezXBia0cZMTkKYz6GOtoojeGigo3tuebVlsn9myqnkMZxiufnnRa7Zne8vg==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-9.1.17.tgz",
+      "integrity": "sha512-LqtrDXRJrdMfZJ0om38SjmY2lQUGmpL8Zt2xTZtQjUy1V+ZiQpuUx7+TJZIOWujzRp75fxhM4AB0HuLDsemlcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3268,7 +3268,7 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.16"
+        "storybook": "^9.1.17"
       },
       "peerDependenciesMeta": {
         "react": {
@@ -3291,13 +3291,13 @@
       }
     },
     "node_modules/@storybook/builder-vite": {
-      "version": "9.1.16",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-9.1.16.tgz",
-      "integrity": "sha512-CyvYA5w1BKeSVaRavKi+euWxLffshq0v9Rz/5E9MKCitbYtjwkDH6UMIYmcbTs906mEBuYqrbz3nygDP0ppodw==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-9.1.17.tgz",
+      "integrity": "sha512-OQCYaFWoTBvovN2IJmkAW+7FgHMJiih1WA/xqgpKIx0ImZjB4z5FrKgzQeXsrYcLEsynyaj+xN3JFUKsz5bzGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/csf-plugin": "9.1.16",
+        "@storybook/csf-plugin": "9.1.17",
         "ts-dedent": "^2.0.0"
       },
       "funding": {
@@ -3305,18 +3305,18 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.1.16",
+        "storybook": "^9.1.17",
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/@storybook/builder-webpack5": {
-      "version": "9.1.16",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-webpack5/-/builder-webpack5-9.1.16.tgz",
-      "integrity": "sha512-AkhGTLze11XMPTtEpQXFc9pUCCPnWeO3rxwbRKB+H42+WKq0YXFx0rlPVpd1HIaQ6qbBmonasRBa0bvI04O/Rg==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-webpack5/-/builder-webpack5-9.1.17.tgz",
+      "integrity": "sha512-lgfq5R3WrK3HM/i7nX2b5rsnBgekoJr3Pu04KAGrEa/bgj7UW1n1bTodCUl+rVEM6aMPqXcLQFIVx/AEFNT4sQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/core-webpack": "9.1.16",
+        "@storybook/core-webpack": "9.1.17",
         "case-sensitive-paths-webpack-plugin": "^2.4.0",
         "cjs-module-lexer": "^1.2.3",
         "css-loader": "^6.7.1",
@@ -3337,7 +3337,7 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.1.16"
+        "storybook": "^9.1.17"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -3346,9 +3346,9 @@
       }
     },
     "node_modules/@storybook/core-webpack": {
-      "version": "9.1.16",
-      "resolved": "https://registry.npmjs.org/@storybook/core-webpack/-/core-webpack-9.1.16.tgz",
-      "integrity": "sha512-LyvG/MS8PFyZI+PQB6NQK5k5jjLKImxQBl37Yztbb3SjFrB0jQhSccmal1CcNH9RgaSLqUI1DKLeosGylAcbxQ==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/core-webpack/-/core-webpack-9.1.17.tgz",
+      "integrity": "sha512-qJRWZEgWjNoGKcHOYFgGlUkmf/dIeQ3T01SJh9H4icZChVhyWRLC+y1HITmxRPPRHZXYyBHbTzmhFmuZM3i2YQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3359,13 +3359,13 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.1.16"
+        "storybook": "^9.1.17"
       }
     },
     "node_modules/@storybook/csf-plugin": {
-      "version": "9.1.16",
-      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-9.1.16.tgz",
-      "integrity": "sha512-GKlNNlmWeFBQxhQY5hZOSnFGbeKq69jal0dYNWoSImTjor28eYRHb9iQkDzRpijLPizBaB9MlxLsLrgFDp7adA==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-9.1.17.tgz",
+      "integrity": "sha512-o+ebQDdSfZHDRDhu2hNDGhCLIazEB4vEAqJcHgz1VsURq+l++bgZUcKojPMCAbeblptSEz2bwS0eYAOvG7aSXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3376,7 +3376,7 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.1.16"
+        "storybook": "^9.1.17"
       }
     },
     "node_modules/@storybook/global": {
@@ -3401,13 +3401,13 @@
       }
     },
     "node_modules/@storybook/preset-react-webpack": {
-      "version": "9.1.16",
-      "resolved": "https://registry.npmjs.org/@storybook/preset-react-webpack/-/preset-react-webpack-9.1.16.tgz",
-      "integrity": "sha512-OuU9i1d9y7PcWYClcaiStrJ2dUXPR1sCdK9m7OKs1Bhh6EpqVdQa1cRPgx8sP0UXEa33TkY2PCuVcIyw7wImwg==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/preset-react-webpack/-/preset-react-webpack-9.1.17.tgz",
+      "integrity": "sha512-3ixo+4yywVy/a6nHLN5eefISw43717NHKXORWbaXJUOpa7ka9l3OejEDhVmSYKfJhTK+IVbrVYTIvrgqrUWQYg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/core-webpack": "9.1.16",
+        "@storybook/core-webpack": "9.1.17",
         "@storybook/react-docgen-typescript-plugin": "1.0.6--canary.9.0c3f3b7.0",
         "@types/semver": "^7.3.4",
         "find-up": "^7.0.0",
@@ -3428,7 +3428,7 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.16"
+        "storybook": "^9.1.17"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -3548,14 +3548,14 @@
       }
     },
     "node_modules/@storybook/react": {
-      "version": "9.1.16",
-      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-9.1.16.tgz",
-      "integrity": "sha512-M/SkHJJdtiGpodBJq9+DYmSkEOD+VqlPxKI+FvbHESTNs//1IgqFIjEWetd8quhd9oj/gvo4ICBAPu+UmD6M9w==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-9.1.17.tgz",
+      "integrity": "sha512-TZCplpep5BwjHPIIcUOMHebc/2qKadJHYPisRn5Wppl014qgT3XkFLpYkFgY1BaRXtqw8Mn3gqq4M/49rQ7Iww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@storybook/global": "^5.0.0",
-        "@storybook/react-dom-shim": "9.1.16"
+        "@storybook/react-dom-shim": "9.1.17"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -3567,7 +3567,7 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.16",
+        "storybook": "^9.1.17",
         "typescript": ">= 4.9.x"
       },
       "peerDependenciesMeta": {
@@ -3597,9 +3597,9 @@
       }
     },
     "node_modules/@storybook/react-dom-shim": {
-      "version": "9.1.16",
-      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-9.1.16.tgz",
-      "integrity": "sha512-MsI4qTxdT6lMXQmo3IXhw3EaCC+vsZboyEZBx4pOJ+K/5cDJ6ZoQ3f0d4yGpVhumDxaxlnNAg954+f8WWXE1rQ==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-9.1.17.tgz",
+      "integrity": "sha512-Ss/lNvAy0Ziynu+KniQIByiNuyPz3dq7tD62hqSC/pHw190X+M7TKU3zcZvXhx2AQx1BYyxtdSHIZapb+P5mxQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -3609,20 +3609,20 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.16"
+        "storybook": "^9.1.17"
       }
     },
     "node_modules/@storybook/react-vite": {
-      "version": "9.1.16",
-      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-9.1.16.tgz",
-      "integrity": "sha512-WRKSq0XfQ/Qx66aKisQCfa/1UKwN9HjVbY6xrmsX7kI5zBdITxIcKInq6PWoPv91SJD7+Et956yX+F86R1aEXw==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-9.1.17.tgz",
+      "integrity": "sha512-RZHsqD1mnTMo4MCJw68t3swS5BTMSTpeRhlelMwjoTEe7jJCPa+qx00uMlWliR1QBN1hMO8Y1dkchxSiUS9otA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@joshwooding/vite-plugin-react-docgen-typescript": "0.6.1",
         "@rollup/pluginutils": "^5.0.2",
-        "@storybook/builder-vite": "9.1.16",
-        "@storybook/react": "9.1.16",
+        "@storybook/builder-vite": "9.1.17",
+        "@storybook/react": "9.1.17",
         "find-up": "^7.0.0",
         "magic-string": "^0.30.0",
         "react-docgen": "^8.0.0",
@@ -3639,7 +3639,7 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.16",
+        "storybook": "^9.1.17",
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
@@ -3733,15 +3733,15 @@
       }
     },
     "node_modules/@storybook/react-webpack5": {
-      "version": "9.1.16",
-      "resolved": "https://registry.npmjs.org/@storybook/react-webpack5/-/react-webpack5-9.1.16.tgz",
-      "integrity": "sha512-ibc2OnxeI6sEZ7lLWSG2pI3tpxCR7aXno+dFMbsKKhGQukoHY4oLqS6aSUvESSoaPGwvGNfGEaRqr35PSTnuRQ==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/react-webpack5/-/react-webpack5-9.1.17.tgz",
+      "integrity": "sha512-GDOYMUzAj1dqFyrD1XbJaekcCrFZOIz0wVimbLeqRPwn+BNIZ9sylgvMiLxbiGMHWzVwJOyWDG/XVbuqXGfzWw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/builder-webpack5": "9.1.16",
-        "@storybook/preset-react-webpack": "9.1.16",
-        "@storybook/react": "9.1.16"
+        "@storybook/builder-webpack5": "9.1.17",
+        "@storybook/preset-react-webpack": "9.1.17",
+        "@storybook/react": "9.1.17"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -3753,7 +3753,7 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.16",
+        "storybook": "^9.1.17",
         "typescript": ">= 4.9.x"
       },
       "peerDependenciesMeta": {
@@ -4258,20 +4258,9 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.90.12",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.12.tgz",
-      "integrity": "sha512-T1/8t5DhV/SisWjDnaiU2drl6ySvsHj1bHBCWNXd+/T+Hh1cf6JodyEYMd5sgwm+b/mETT4EV3H+zCVczCU5hg==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      }
-    },
-    "node_modules/@tanstack/query-devtools": {
-      "version": "5.91.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.91.1.tgz",
-      "integrity": "sha512-l8bxjk6BMsCaVQH6NzQEE/bEgFy1hAs5qbgXl0xhzezlaQbPk6Mgz9BqEg2vTLPOHD8N4k+w/gdgCbEzecGyNg==",
+      "version": "5.90.20",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.20.tgz",
+      "integrity": "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -4280,37 +4269,19 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.90.12",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.12.tgz",
-      "integrity": "sha512-graRZspg7EoEaw0a8faiUASCyJrqjKPdqJ9EwuDRUF9mEYJ1YPczI9H+/agJ0mOJkPCJDk0lsz5QTrLZ/jQ2rg==",
+      "version": "5.90.20",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.20.tgz",
+      "integrity": "sha512-vXBxa+qeyveVO7OA0jX1z+DeyCA4JKnThKv411jd5SORpBKgkcVnYKCiBgECvADvniBX7tobwBmg01qq9JmMJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.90.12"
+        "@tanstack/query-core": "5.90.20"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
-        "react": "^18 || ^19"
-      }
-    },
-    "node_modules/@tanstack/react-query-devtools": {
-      "version": "5.91.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.91.1.tgz",
-      "integrity": "sha512-tRnJYwEbH0kAOuToy8Ew7bJw1lX3AjkkgSlf/vzb+NpnqmHPdWM+lA2DSdGQSLi1SU0PDRrrCI1vnZnci96CsQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/query-devtools": "5.91.1"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "@tanstack/react-query": "^5.90.10",
         "react": "^18 || ^19"
       }
     },
@@ -9251,6 +9222,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-check": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.5.3.tgz",
+      "integrity": "sha512-IE9csY7lnhxBnA8g/WI5eg/hygA6MGWJMSNfFRrBlXUciADEhS1EDB0SIsMSvzubzIlOBbVITSsypCsW717poA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -10508,9 +10502,9 @@
       }
     },
     "node_modules/html-webpack-plugin": {
-      "version": "5.6.5",
-      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.5.tgz",
-      "integrity": "sha512-4xynFbKNNk+WlzXeQQ+6YYsH2g7mpfPszQZUi3ovKlj+pDmngQ7vRXjrrmGROabmKwyQkcgcX5hqfOwHbFmK5g==",
+      "version": "5.6.6",
+      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.6.tgz",
+      "integrity": "sha512-bLjW01UTrvoWTJQL5LsMRo1SypHW80FTm12OJRSnr3v6YHNhfe+1r0MYUZJMACxnCHURVnBWRwAsWs2yPU9Ezw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14292,6 +14286,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/pure-rand": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
+      "integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/qs": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
@@ -16565,9 +16576,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.3.tgz",
-      "integrity": "sha512-ENg5JUHUm2rDD7IvKNFGzyElLXNjachNLp6RaGf4+JOgxXHkqA+gq81ZAMCUmtMtqBsoU62lcp6S27g1LCYGGQ==",
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
+      "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {

--- a/knative/package.json
+++ b/knative/package.json
@@ -36,7 +36,7 @@
     "typescript": "5.6.2"
   },
   "devDependencies": {
-    "@kinvolk/headlamp-plugin": "^0.13.0",
+    "@kinvolk/headlamp-plugin": "^0.13.1",
     "knip": "^5.68.0"
   },
   "dependencies": {},

--- a/kompose/package-lock.json
+++ b/kompose/package-lock.json
@@ -11,13 +11,13 @@
         "js-yaml": "^4.1.0"
       },
       "devDependencies": {
-        "@kinvolk/headlamp-plugin": "^0.13.0"
+        "@kinvolk/headlamp-plugin": "^0.13.1"
       }
     },
     "node_modules/@adobe/css-tools": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.3.tgz",
-      "integrity": "sha512-VQKMkwriZbaOgVCby1UDY/LDk5fIjhQicCvVPFqfe+69fWaPWydbWJ3wRt59/YzIwda1I81loas3oCoHxnqvdA==",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1785,10 +1785,11 @@
       }
     },
     "node_modules/@kinvolk/headlamp-plugin": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@kinvolk/headlamp-plugin/-/headlamp-plugin-0.13.0.tgz",
-      "integrity": "sha512-T0PGETnMXcUSOXKy/MEUeprDLzoqYxsJNqfNIL9DCW5WmmFDKcJX5Gify2RWB+oJbWIAaaRZ7zQGqeYeqa5KTA==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@kinvolk/headlamp-plugin/-/headlamp-plugin-0.13.1.tgz",
+      "integrity": "sha512-aoAGs5w8HIS43p3YBcjzkIWZZlh18b/e02d+r/rr6+99vc48vOd9tKAIBZMVg4j+cVzbPtL1+t1tDE/UdeHcWQ==",
       "dev": true,
+      "license": "Apache 2.0",
       "dependencies": {
         "@apidevtools/swagger-parser": "^10.0.3",
         "@emotion/react": "^11.11.1",
@@ -1805,13 +1806,12 @@
         "@mui/x-date-pickers": "^7.15.0",
         "@mui/x-tree-view": "^6.17.0",
         "@reduxjs/toolkit": "^2.2.7",
-        "@storybook/addon-docs": "^9.1.2",
-        "@storybook/addon-links": "^9.1.2",
+        "@storybook/addon-docs": "^9.1.17",
+        "@storybook/addon-links": "^9.1.17",
         "@storybook/addon-webpack5-compiler-swc": "^3.0.0",
-        "@storybook/react-vite": "^9.1.2",
-        "@storybook/react-webpack5": "^9.1.2",
+        "@storybook/react-vite": "^9.1.17",
+        "@storybook/react-webpack5": "^9.1.17",
         "@tanstack/react-query": "^5.51.24",
-        "@tanstack/react-query-devtools": "^5.51.24",
         "@testing-library/dom": "^10.1.0",
         "@testing-library/jest-dom": "^6.4.8",
         "@testing-library/react": "^16.0.0",
@@ -1846,6 +1846,7 @@
         "eslint-plugin-react-hooks": "^4.6.2",
         "eslint-plugin-simple-import-sort": "^12.1.1",
         "eslint-plugin-unused-imports": "^4.1.3",
+        "fast-check": "^4.5.3",
         "fs-extra": "^11.2.0",
         "fuse.js": "^7.0.0",
         "humanize-duration": "^3.27.2",
@@ -1856,7 +1857,7 @@
         "js-yaml": "^4.1.1",
         "jsdom": "^24.0.0",
         "jsonpath-plus": "^10.3.0",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.23",
         "material-react-table": "^2.13.3",
         "monaco-editor": "^0.52.0",
         "msw": "2.4.9",
@@ -1880,9 +1881,9 @@
         "shx": "^0.4.0",
         "simple-eval": "^2.0.0",
         "spacetime": "^7.4.0",
-        "storybook": "^9.1.2",
+        "storybook": "^9.1.17",
         "table": "^6.8.2",
-        "tar": "^7.4.3",
+        "tar": "^7.5.7",
         "ts-loader": "^9.5.2",
         "typescript": "5.6.2",
         "validate-npm-package-name": "^3.0.0",
@@ -2846,15 +2847,16 @@
       "license": "MIT"
     },
     "node_modules/@storybook/addon-docs": {
-      "version": "9.1.16",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-9.1.16.tgz",
-      "integrity": "sha512-JfaUD6fC7ySLg5duRdaWZ0FUUXrgUvqbZe/agCbSyOaIHOtJdhGaPjOC3vuXTAcV8/8/wWmbu0iXFMD08iKvdw==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-9.1.17.tgz",
+      "integrity": "sha512-yc4hlgkrwNi045qk210dRuIMijkgbLmo3ft6F4lOdpPRn4IUnPDj7FfZR8syGzUzKidxRfNtLx5m0yHIz83xtA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@mdx-js/react": "^3.0.0",
-        "@storybook/csf-plugin": "9.1.16",
+        "@storybook/csf-plugin": "9.1.17",
         "@storybook/icons": "^1.4.0",
-        "@storybook/react-dom-shim": "9.1.16",
+        "@storybook/react-dom-shim": "9.1.17",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "ts-dedent": "^2.0.0"
@@ -2864,14 +2866,15 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.1.16"
+        "storybook": "^9.1.17"
       }
     },
     "node_modules/@storybook/addon-links": {
-      "version": "9.1.16",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-9.1.16.tgz",
-      "integrity": "sha512-21SJAEuOX4Fh/5VSeakuiJJeSH2ezXBia0cZMTkKYz6GOtoojeGigo3tuebVlsn9myqnkMZxiufnnRa7Zne8vg==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-9.1.17.tgz",
+      "integrity": "sha512-LqtrDXRJrdMfZJ0om38SjmY2lQUGmpL8Zt2xTZtQjUy1V+ZiQpuUx7+TJZIOWujzRp75fxhM4AB0HuLDsemlcA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@storybook/global": "^5.0.0"
       },
@@ -2881,7 +2884,7 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.16"
+        "storybook": "^9.1.17"
       },
       "peerDependenciesMeta": {
         "react": {
@@ -2903,12 +2906,13 @@
       }
     },
     "node_modules/@storybook/builder-vite": {
-      "version": "9.1.16",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-9.1.16.tgz",
-      "integrity": "sha512-CyvYA5w1BKeSVaRavKi+euWxLffshq0v9Rz/5E9MKCitbYtjwkDH6UMIYmcbTs906mEBuYqrbz3nygDP0ppodw==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-9.1.17.tgz",
+      "integrity": "sha512-OQCYaFWoTBvovN2IJmkAW+7FgHMJiih1WA/xqgpKIx0ImZjB4z5FrKgzQeXsrYcLEsynyaj+xN3JFUKsz5bzGQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@storybook/csf-plugin": "9.1.16",
+        "@storybook/csf-plugin": "9.1.17",
         "ts-dedent": "^2.0.0"
       },
       "funding": {
@@ -2916,17 +2920,18 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.1.16",
+        "storybook": "^9.1.17",
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/@storybook/builder-webpack5": {
-      "version": "9.1.16",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-webpack5/-/builder-webpack5-9.1.16.tgz",
-      "integrity": "sha512-AkhGTLze11XMPTtEpQXFc9pUCCPnWeO3rxwbRKB+H42+WKq0YXFx0rlPVpd1HIaQ6qbBmonasRBa0bvI04O/Rg==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-webpack5/-/builder-webpack5-9.1.17.tgz",
+      "integrity": "sha512-lgfq5R3WrK3HM/i7nX2b5rsnBgekoJr3Pu04KAGrEa/bgj7UW1n1bTodCUl+rVEM6aMPqXcLQFIVx/AEFNT4sQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@storybook/core-webpack": "9.1.16",
+        "@storybook/core-webpack": "9.1.17",
         "case-sensitive-paths-webpack-plugin": "^2.4.0",
         "cjs-module-lexer": "^1.2.3",
         "css-loader": "^6.7.1",
@@ -2947,7 +2952,7 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.1.16"
+        "storybook": "^9.1.17"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -2956,10 +2961,11 @@
       }
     },
     "node_modules/@storybook/core-webpack": {
-      "version": "9.1.16",
-      "resolved": "https://registry.npmjs.org/@storybook/core-webpack/-/core-webpack-9.1.16.tgz",
-      "integrity": "sha512-LyvG/MS8PFyZI+PQB6NQK5k5jjLKImxQBl37Yztbb3SjFrB0jQhSccmal1CcNH9RgaSLqUI1DKLeosGylAcbxQ==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/core-webpack/-/core-webpack-9.1.17.tgz",
+      "integrity": "sha512-qJRWZEgWjNoGKcHOYFgGlUkmf/dIeQ3T01SJh9H4icZChVhyWRLC+y1HITmxRPPRHZXYyBHbTzmhFmuZM3i2YQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ts-dedent": "^2.0.0"
       },
@@ -2968,14 +2974,15 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.1.16"
+        "storybook": "^9.1.17"
       }
     },
     "node_modules/@storybook/csf-plugin": {
-      "version": "9.1.16",
-      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-9.1.16.tgz",
-      "integrity": "sha512-GKlNNlmWeFBQxhQY5hZOSnFGbeKq69jal0dYNWoSImTjor28eYRHb9iQkDzRpijLPizBaB9MlxLsLrgFDp7adA==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-9.1.17.tgz",
+      "integrity": "sha512-o+ebQDdSfZHDRDhu2hNDGhCLIazEB4vEAqJcHgz1VsURq+l++bgZUcKojPMCAbeblptSEz2bwS0eYAOvG7aSXg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "unplugin": "^1.3.1"
       },
@@ -2984,7 +2991,7 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.1.16"
+        "storybook": "^9.1.17"
       }
     },
     "node_modules/@storybook/global": {
@@ -3007,12 +3014,13 @@
       }
     },
     "node_modules/@storybook/preset-react-webpack": {
-      "version": "9.1.16",
-      "resolved": "https://registry.npmjs.org/@storybook/preset-react-webpack/-/preset-react-webpack-9.1.16.tgz",
-      "integrity": "sha512-OuU9i1d9y7PcWYClcaiStrJ2dUXPR1sCdK9m7OKs1Bhh6EpqVdQa1cRPgx8sP0UXEa33TkY2PCuVcIyw7wImwg==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/preset-react-webpack/-/preset-react-webpack-9.1.17.tgz",
+      "integrity": "sha512-3ixo+4yywVy/a6nHLN5eefISw43717NHKXORWbaXJUOpa7ka9l3OejEDhVmSYKfJhTK+IVbrVYTIvrgqrUWQYg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@storybook/core-webpack": "9.1.16",
+        "@storybook/core-webpack": "9.1.17",
         "@storybook/react-docgen-typescript-plugin": "1.0.6--canary.9.0c3f3b7.0",
         "@types/semver": "^7.3.4",
         "find-up": "^7.0.0",
@@ -3033,7 +3041,7 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.16"
+        "storybook": "^9.1.17"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -3146,13 +3154,14 @@
       }
     },
     "node_modules/@storybook/react": {
-      "version": "9.1.16",
-      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-9.1.16.tgz",
-      "integrity": "sha512-M/SkHJJdtiGpodBJq9+DYmSkEOD+VqlPxKI+FvbHESTNs//1IgqFIjEWetd8quhd9oj/gvo4ICBAPu+UmD6M9w==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-9.1.17.tgz",
+      "integrity": "sha512-TZCplpep5BwjHPIIcUOMHebc/2qKadJHYPisRn5Wppl014qgT3XkFLpYkFgY1BaRXtqw8Mn3gqq4M/49rQ7Iww==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@storybook/global": "^5.0.0",
-        "@storybook/react-dom-shim": "9.1.16"
+        "@storybook/react-dom-shim": "9.1.17"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -3164,7 +3173,7 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.16",
+        "storybook": "^9.1.17",
         "typescript": ">= 4.9.x"
       },
       "peerDependenciesMeta": {
@@ -3193,10 +3202,11 @@
       }
     },
     "node_modules/@storybook/react-dom-shim": {
-      "version": "9.1.16",
-      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-9.1.16.tgz",
-      "integrity": "sha512-MsI4qTxdT6lMXQmo3IXhw3EaCC+vsZboyEZBx4pOJ+K/5cDJ6ZoQ3f0d4yGpVhumDxaxlnNAg954+f8WWXE1rQ==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-9.1.17.tgz",
+      "integrity": "sha512-Ss/lNvAy0Ziynu+KniQIByiNuyPz3dq7tD62hqSC/pHw190X+M7TKU3zcZvXhx2AQx1BYyxtdSHIZapb+P5mxQ==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"
@@ -3204,19 +3214,20 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.16"
+        "storybook": "^9.1.17"
       }
     },
     "node_modules/@storybook/react-vite": {
-      "version": "9.1.16",
-      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-9.1.16.tgz",
-      "integrity": "sha512-WRKSq0XfQ/Qx66aKisQCfa/1UKwN9HjVbY6xrmsX7kI5zBdITxIcKInq6PWoPv91SJD7+Et956yX+F86R1aEXw==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-9.1.17.tgz",
+      "integrity": "sha512-RZHsqD1mnTMo4MCJw68t3swS5BTMSTpeRhlelMwjoTEe7jJCPa+qx00uMlWliR1QBN1hMO8Y1dkchxSiUS9otA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@joshwooding/vite-plugin-react-docgen-typescript": "0.6.1",
         "@rollup/pluginutils": "^5.0.2",
-        "@storybook/builder-vite": "9.1.16",
-        "@storybook/react": "9.1.16",
+        "@storybook/builder-vite": "9.1.17",
+        "@storybook/react": "9.1.17",
         "find-up": "^7.0.0",
         "magic-string": "^0.30.0",
         "react-docgen": "^8.0.0",
@@ -3233,7 +3244,7 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.16",
+        "storybook": "^9.1.17",
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
@@ -3321,14 +3332,15 @@
       }
     },
     "node_modules/@storybook/react-webpack5": {
-      "version": "9.1.16",
-      "resolved": "https://registry.npmjs.org/@storybook/react-webpack5/-/react-webpack5-9.1.16.tgz",
-      "integrity": "sha512-ibc2OnxeI6sEZ7lLWSG2pI3tpxCR7aXno+dFMbsKKhGQukoHY4oLqS6aSUvESSoaPGwvGNfGEaRqr35PSTnuRQ==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/react-webpack5/-/react-webpack5-9.1.17.tgz",
+      "integrity": "sha512-GDOYMUzAj1dqFyrD1XbJaekcCrFZOIz0wVimbLeqRPwn+BNIZ9sylgvMiLxbiGMHWzVwJOyWDG/XVbuqXGfzWw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@storybook/builder-webpack5": "9.1.16",
-        "@storybook/preset-react-webpack": "9.1.16",
-        "@storybook/react": "9.1.16"
+        "@storybook/builder-webpack5": "9.1.17",
+        "@storybook/preset-react-webpack": "9.1.17",
+        "@storybook/react": "9.1.17"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -3340,7 +3352,7 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.16",
+        "storybook": "^9.1.17",
         "typescript": ">= 4.9.x"
       },
       "peerDependenciesMeta": {
@@ -3832,20 +3844,9 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.76.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.76.0.tgz",
-      "integrity": "sha512-FN375hb8ctzfNAlex5gHI6+WDXTNpe0nbxp/d2YJtnP+IBM6OUm7zcaoCW6T63BawGOYZBbKC0iPvr41TteNVg==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      }
-    },
-    "node_modules/@tanstack/query-devtools": {
-      "version": "5.76.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.76.0.tgz",
-      "integrity": "sha512-1p92nqOBPYVqVDU0Ua5nzHenC6EGZNrLnB2OZphYw8CNA1exuvI97FVgIKON7Uug3uQqvH/QY8suUKpQo8qHNQ==",
+      "version": "5.90.20",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.20.tgz",
+      "integrity": "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -3854,37 +3855,19 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.76.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.76.1.tgz",
-      "integrity": "sha512-YxdLZVGN4QkT5YT1HKZQWiIlcgauIXEIsMOTSjvyD5wLYK8YVvKZUPAysMqossFJJfDpJW3pFn7WNZuPOqq+fw==",
+      "version": "5.90.20",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.20.tgz",
+      "integrity": "sha512-vXBxa+qeyveVO7OA0jX1z+DeyCA4JKnThKv411jd5SORpBKgkcVnYKCiBgECvADvniBX7tobwBmg01qq9JmMJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.76.0"
+        "@tanstack/query-core": "5.90.20"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
-        "react": "^18 || ^19"
-      }
-    },
-    "node_modules/@tanstack/react-query-devtools": {
-      "version": "5.76.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.76.1.tgz",
-      "integrity": "sha512-LFVWgk/VtXPkerNLfYIeuGHh0Aim/k9PFGA+JxLdRaUiroQ4j4eoEqBrUpQ1Pd/KXoG4AB9vVE/M6PUQ9vwxBQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/query-devtools": "5.76.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "@tanstack/react-query": "^5.76.1",
         "react": "^18 || ^19"
       }
     },
@@ -3973,38 +3956,23 @@
       }
     },
     "node_modules/@testing-library/jest-dom": {
-      "version": "6.6.3",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.6.3.tgz",
-      "integrity": "sha512-IteBhl4XqYNkM54f4ejhLRJiZNqcSCoXUOG2CPK7qbD322KjQozM4kHQOfkG2oln9b9HTYqs+Sae8vBATubxxA==",
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@adobe/css-tools": "^4.4.0",
         "aria-query": "^5.0.0",
-        "chalk": "^3.0.0",
         "css.escape": "^1.5.1",
         "dom-accessibility-api": "^0.6.3",
-        "lodash": "^4.17.21",
+        "picocolors": "^1.1.1",
         "redent": "^3.0.0"
       },
       "engines": {
         "node": ">=14",
         "npm": ">=6",
         "yarn": ">=1"
-      }
-    },
-    "node_modules/@testing-library/jest-dom/node_modules/chalk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
@@ -4530,9 +4498,9 @@
       "license": "MIT"
     },
     "node_modules/@types/semver": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.0.tgz",
-      "integrity": "sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
       "dev": true,
       "license": "MIT"
     },
@@ -8790,6 +8758,29 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "dev": true
     },
+    "node_modules/fast-check": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.5.3.tgz",
+      "integrity": "sha512-IE9csY7lnhxBnA8g/WI5eg/hygA6MGWJMSNfFRrBlXUciADEhS1EDB0SIsMSvzubzIlOBbVITSsypCsW717poA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -9973,10 +9964,11 @@
       }
     },
     "node_modules/html-webpack-plugin": {
-      "version": "5.6.5",
-      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.5.tgz",
-      "integrity": "sha512-4xynFbKNNk+WlzXeQQ+6YYsH2g7mpfPszQZUi3ovKlj+pDmngQ7vRXjrrmGROabmKwyQkcgcX5hqfOwHbFmK5g==",
+      "version": "5.6.6",
+      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.6.tgz",
+      "integrity": "sha512-bLjW01UTrvoWTJQL5LsMRo1SypHW80FTm12OJRSnr3v6YHNhfe+1r0MYUZJMACxnCHURVnBWRwAsWs2yPU9Ezw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/html-minifier-terser": "^6.0.0",
         "html-minifier-terser": "^6.0.2",
@@ -13630,6 +13622,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/pure-rand": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
+      "integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/qs": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
@@ -15273,10 +15282,11 @@
       "license": "MIT"
     },
     "node_modules/storybook": {
-      "version": "9.1.16",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-9.1.16.tgz",
-      "integrity": "sha512-339U14K6l46EFyRvaPS2ZlL7v7Pb+LlcXT8KAETrGPxq8v1sAjj2HAOB6zrlAK3M+0+ricssfAwsLCwt7Eg8TQ==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-9.1.17.tgz",
+      "integrity": "sha512-kfr6kxQAjA96ADlH6FMALJwJ+eM80UqXy106yVHNgdsAP/CdzkkicglRAhZAvUycXK9AeadF6KZ00CWLtVMN4w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@testing-library/jest-dom": "^6.6.3",
@@ -15885,11 +15895,11 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.3.tgz",
-      "integrity": "sha512-ENg5JUHUm2rDD7IvKNFGzyElLXNjachNLp6RaGf4+JOgxXHkqA+gq81ZAMCUmtMtqBsoU62lcp6S27g1LCYGGQ==",
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
+      "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",

--- a/kompose/package.json
+++ b/kompose/package.json
@@ -31,7 +31,7 @@
     ]
   },
   "devDependencies": {
-    "@kinvolk/headlamp-plugin": "^0.13.0"
+    "@kinvolk/headlamp-plugin": "^0.13.1"
   },
   "dependencies": {
     "js-yaml": "^4.1.0"

--- a/minikube/package-lock.json
+++ b/minikube/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@headlamp-k8s/minikube",
       "version": "0.3.0",
       "devDependencies": {
-        "@kinvolk/headlamp-plugin": "^0.13.0"
+        "@kinvolk/headlamp-plugin": "^0.13.1"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/minikube/package.json
+++ b/minikube/package.json
@@ -41,6 +41,6 @@
     "typescript": "5.6.2"
   },
   "devDependencies": {
-    "@kinvolk/headlamp-plugin": "^0.13.0"
+    "@kinvolk/headlamp-plugin": "^0.13.1"
   }
 }

--- a/opencost/package-lock.json
+++ b/opencost/package-lock.json
@@ -11,7 +11,7 @@
         "use-between": "^1.3.5"
       },
       "devDependencies": {
-        "@kinvolk/headlamp-plugin": "^0.13.0"
+        "@kinvolk/headlamp-plugin": "^0.13.1"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -1780,9 +1780,9 @@
       }
     },
     "node_modules/@kinvolk/headlamp-plugin": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@kinvolk/headlamp-plugin/-/headlamp-plugin-0.13.0.tgz",
-      "integrity": "sha512-T0PGETnMXcUSOXKy/MEUeprDLzoqYxsJNqfNIL9DCW5WmmFDKcJX5Gify2RWB+oJbWIAaaRZ7zQGqeYeqa5KTA==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@kinvolk/headlamp-plugin/-/headlamp-plugin-0.13.1.tgz",
+      "integrity": "sha512-aoAGs5w8HIS43p3YBcjzkIWZZlh18b/e02d+r/rr6+99vc48vOd9tKAIBZMVg4j+cVzbPtL1+t1tDE/UdeHcWQ==",
       "dev": true,
       "license": "Apache 2.0",
       "dependencies": {
@@ -1801,13 +1801,12 @@
         "@mui/x-date-pickers": "^7.15.0",
         "@mui/x-tree-view": "^6.17.0",
         "@reduxjs/toolkit": "^2.2.7",
-        "@storybook/addon-docs": "^9.1.2",
-        "@storybook/addon-links": "^9.1.2",
+        "@storybook/addon-docs": "^9.1.17",
+        "@storybook/addon-links": "^9.1.17",
         "@storybook/addon-webpack5-compiler-swc": "^3.0.0",
-        "@storybook/react-vite": "^9.1.2",
-        "@storybook/react-webpack5": "^9.1.2",
+        "@storybook/react-vite": "^9.1.17",
+        "@storybook/react-webpack5": "^9.1.17",
         "@tanstack/react-query": "^5.51.24",
-        "@tanstack/react-query-devtools": "^5.51.24",
         "@testing-library/dom": "^10.1.0",
         "@testing-library/jest-dom": "^6.4.8",
         "@testing-library/react": "^16.0.0",
@@ -1842,6 +1841,7 @@
         "eslint-plugin-react-hooks": "^4.6.2",
         "eslint-plugin-simple-import-sort": "^12.1.1",
         "eslint-plugin-unused-imports": "^4.1.3",
+        "fast-check": "^4.5.3",
         "fs-extra": "^11.2.0",
         "fuse.js": "^7.0.0",
         "humanize-duration": "^3.27.2",
@@ -1852,7 +1852,7 @@
         "js-yaml": "^4.1.1",
         "jsdom": "^24.0.0",
         "jsonpath-plus": "^10.3.0",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.23",
         "material-react-table": "^2.13.3",
         "monaco-editor": "^0.52.0",
         "msw": "2.4.9",
@@ -1876,9 +1876,9 @@
         "shx": "^0.4.0",
         "simple-eval": "^2.0.0",
         "spacetime": "^7.4.0",
-        "storybook": "^9.1.2",
+        "storybook": "^9.1.17",
         "table": "^6.8.2",
-        "tar": "^7.4.3",
+        "tar": "^7.5.7",
         "ts-loader": "^9.5.2",
         "typescript": "5.6.2",
         "validate-npm-package-name": "^3.0.0",
@@ -2889,16 +2889,16 @@
       "license": "MIT"
     },
     "node_modules/@storybook/addon-docs": {
-      "version": "9.1.6",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-9.1.6.tgz",
-      "integrity": "sha512-4ZE/T2Ayw77/v2ersAk/VM7vlvqV2zCNFwt0uvOzUR1VZ9VqZCHhsfy/IyBPeKt6Otax3EpfE1LkH4slfceB0g==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-9.1.17.tgz",
+      "integrity": "sha512-yc4hlgkrwNi045qk210dRuIMijkgbLmo3ft6F4lOdpPRn4IUnPDj7FfZR8syGzUzKidxRfNtLx5m0yHIz83xtA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@mdx-js/react": "^3.0.0",
-        "@storybook/csf-plugin": "9.1.6",
+        "@storybook/csf-plugin": "9.1.17",
         "@storybook/icons": "^1.4.0",
-        "@storybook/react-dom-shim": "9.1.6",
+        "@storybook/react-dom-shim": "9.1.17",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "ts-dedent": "^2.0.0"
@@ -2908,13 +2908,13 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.1.6"
+        "storybook": "^9.1.17"
       }
     },
     "node_modules/@storybook/addon-links": {
-      "version": "9.1.6",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-9.1.6.tgz",
-      "integrity": "sha512-TY9d3MVylNHNQswlwsvXMaGNZXGaEr8RMvV9BES65BC4GAPnHM6W1I9mEf1ckg+uSFBf43ZMOsYulSMo86ddpQ==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-9.1.17.tgz",
+      "integrity": "sha512-LqtrDXRJrdMfZJ0om38SjmY2lQUGmpL8Zt2xTZtQjUy1V+ZiQpuUx7+TJZIOWujzRp75fxhM4AB0HuLDsemlcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2926,7 +2926,7 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.6"
+        "storybook": "^9.1.17"
       },
       "peerDependenciesMeta": {
         "react": {
@@ -2949,13 +2949,13 @@
       }
     },
     "node_modules/@storybook/builder-vite": {
-      "version": "9.1.6",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-9.1.6.tgz",
-      "integrity": "sha512-AUoSjXr4MvtkFQkfFfZSXrqVM0z80DX0sebm80nODu/qFhsJIU5trNP+XDYY8ClODERXd5QSZJyOyH9nOz60SA==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-9.1.17.tgz",
+      "integrity": "sha512-OQCYaFWoTBvovN2IJmkAW+7FgHMJiih1WA/xqgpKIx0ImZjB4z5FrKgzQeXsrYcLEsynyaj+xN3JFUKsz5bzGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/csf-plugin": "9.1.6",
+        "@storybook/csf-plugin": "9.1.17",
         "ts-dedent": "^2.0.0"
       },
       "funding": {
@@ -2963,18 +2963,18 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.1.6",
+        "storybook": "^9.1.17",
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/@storybook/builder-webpack5": {
-      "version": "9.1.6",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-webpack5/-/builder-webpack5-9.1.6.tgz",
-      "integrity": "sha512-+GX6+w8ma8RzMRxZuGVEPnpNx7r7+qeLcAYn9E19GFQUaFRb6oDVxCYI8ngwxLDRrz4HxZTMAbm6GBksShVb1g==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-webpack5/-/builder-webpack5-9.1.17.tgz",
+      "integrity": "sha512-lgfq5R3WrK3HM/i7nX2b5rsnBgekoJr3Pu04KAGrEa/bgj7UW1n1bTodCUl+rVEM6aMPqXcLQFIVx/AEFNT4sQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/core-webpack": "9.1.6",
+        "@storybook/core-webpack": "9.1.17",
         "case-sensitive-paths-webpack-plugin": "^2.4.0",
         "cjs-module-lexer": "^1.2.3",
         "css-loader": "^6.7.1",
@@ -2995,7 +2995,7 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.1.6"
+        "storybook": "^9.1.17"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -3004,9 +3004,9 @@
       }
     },
     "node_modules/@storybook/core-webpack": {
-      "version": "9.1.6",
-      "resolved": "https://registry.npmjs.org/@storybook/core-webpack/-/core-webpack-9.1.6.tgz",
-      "integrity": "sha512-NaDXVS7QaSYfFB3CDbcrXPFBSyWPxhrMOOqnHAcvxvKSoABlWhvNBDLOOxeFUs6yqdHexNcLGQNgKKQrUSqaSg==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/core-webpack/-/core-webpack-9.1.17.tgz",
+      "integrity": "sha512-qJRWZEgWjNoGKcHOYFgGlUkmf/dIeQ3T01SJh9H4icZChVhyWRLC+y1HITmxRPPRHZXYyBHbTzmhFmuZM3i2YQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3017,13 +3017,13 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.1.6"
+        "storybook": "^9.1.17"
       }
     },
     "node_modules/@storybook/csf-plugin": {
-      "version": "9.1.6",
-      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-9.1.6.tgz",
-      "integrity": "sha512-cz4Y+OYCtuovFNwoLkIKk0T62clrRTYf26Bbo1gdIGuX/W3JPP/LnN97sP2/0nfF6heZqCdEwb47k7RubkxXZg==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-9.1.17.tgz",
+      "integrity": "sha512-o+ebQDdSfZHDRDhu2hNDGhCLIazEB4vEAqJcHgz1VsURq+l++bgZUcKojPMCAbeblptSEz2bwS0eYAOvG7aSXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3034,7 +3034,7 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.1.6"
+        "storybook": "^9.1.17"
       }
     },
     "node_modules/@storybook/global": {
@@ -3045,9 +3045,9 @@
       "license": "MIT"
     },
     "node_modules/@storybook/icons": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@storybook/icons/-/icons-1.4.0.tgz",
-      "integrity": "sha512-Td73IeJxOyalzvjQL+JXx72jlIYHgs+REaHiREOqfpo3A2AYYG71AUbcv+lg7mEDIweKVCxsMQ0UKo634c8XeA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@storybook/icons/-/icons-1.6.0.tgz",
+      "integrity": "sha512-hcFZIjW8yQz8O8//2WTIXylm5Xsgc+lW9ISLgUk1xGmptIJQRdlhVIXCpSyLrQaaRiyhQRaVg7l3BD9S216BHw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3059,13 +3059,13 @@
       }
     },
     "node_modules/@storybook/preset-react-webpack": {
-      "version": "9.1.6",
-      "resolved": "https://registry.npmjs.org/@storybook/preset-react-webpack/-/preset-react-webpack-9.1.6.tgz",
-      "integrity": "sha512-vuM9zH/gT66M5raauswCxkx4ztERkj5V/6s1sIe4ptv4F2l4Zy8bCzxlheio4b2K3joGxGXFiZWyrfrcAFfVfQ==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/preset-react-webpack/-/preset-react-webpack-9.1.17.tgz",
+      "integrity": "sha512-3ixo+4yywVy/a6nHLN5eefISw43717NHKXORWbaXJUOpa7ka9l3OejEDhVmSYKfJhTK+IVbrVYTIvrgqrUWQYg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/core-webpack": "9.1.6",
+        "@storybook/core-webpack": "9.1.17",
         "@storybook/react-docgen-typescript-plugin": "1.0.6--canary.9.0c3f3b7.0",
         "@types/semver": "^7.3.4",
         "find-up": "^7.0.0",
@@ -3086,7 +3086,7 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.6"
+        "storybook": "^9.1.17"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -3117,14 +3117,14 @@
       }
     },
     "node_modules/@storybook/react": {
-      "version": "9.1.6",
-      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-9.1.6.tgz",
-      "integrity": "sha512-BGf3MQaXj6LmYnYpSwHUoWH0RP6kaqBoPc2u5opSU2ajw34enIL5w2sFaXzL+k2ap0aHnCYYlyBINBBvtD6NIA==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-9.1.17.tgz",
+      "integrity": "sha512-TZCplpep5BwjHPIIcUOMHebc/2qKadJHYPisRn5Wppl014qgT3XkFLpYkFgY1BaRXtqw8Mn3gqq4M/49rQ7Iww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@storybook/global": "^5.0.0",
-        "@storybook/react-dom-shim": "9.1.6"
+        "@storybook/react-dom-shim": "9.1.17"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -3136,7 +3136,7 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.6",
+        "storybook": "^9.1.17",
         "typescript": ">= 4.9.x"
       },
       "peerDependenciesMeta": {
@@ -3166,9 +3166,9 @@
       }
     },
     "node_modules/@storybook/react-dom-shim": {
-      "version": "9.1.6",
-      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-9.1.6.tgz",
-      "integrity": "sha512-Px4duzPMTPqI3kes6eUyYjWpEeJ0AOCCeSDCBDm9rzlf4a+eXlxfhkcVWft3viCDiIkc0vtYagb2Yu7bcSIypg==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-9.1.17.tgz",
+      "integrity": "sha512-Ss/lNvAy0Ziynu+KniQIByiNuyPz3dq7tD62hqSC/pHw190X+M7TKU3zcZvXhx2AQx1BYyxtdSHIZapb+P5mxQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -3178,20 +3178,20 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.6"
+        "storybook": "^9.1.17"
       }
     },
     "node_modules/@storybook/react-vite": {
-      "version": "9.1.6",
-      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-9.1.6.tgz",
-      "integrity": "sha512-YNKQZcz5Vtv8OdHUJ65Wx4PbfZMrPPbtL+OYAR0We+EEoTDofi3VogXyOUw99Jppp1HIq5IiDF5qyZPEpC5k0A==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-9.1.17.tgz",
+      "integrity": "sha512-RZHsqD1mnTMo4MCJw68t3swS5BTMSTpeRhlelMwjoTEe7jJCPa+qx00uMlWliR1QBN1hMO8Y1dkchxSiUS9otA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@joshwooding/vite-plugin-react-docgen-typescript": "0.6.1",
         "@rollup/pluginutils": "^5.0.2",
-        "@storybook/builder-vite": "9.1.6",
-        "@storybook/react": "9.1.6",
+        "@storybook/builder-vite": "9.1.17",
+        "@storybook/react": "9.1.17",
         "find-up": "^7.0.0",
         "magic-string": "^0.30.0",
         "react-docgen": "^8.0.0",
@@ -3208,20 +3208,20 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.6",
+        "storybook": "^9.1.17",
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/@storybook/react-webpack5": {
-      "version": "9.1.6",
-      "resolved": "https://registry.npmjs.org/@storybook/react-webpack5/-/react-webpack5-9.1.6.tgz",
-      "integrity": "sha512-i2VSGBTB3zbFGY5M56/oWEbsuBGemRj5YS3Z63OwUO4cg6Vbhx5qQNfyDlRyawr4zoccjjG825at6Zd3j0sE1A==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/react-webpack5/-/react-webpack5-9.1.17.tgz",
+      "integrity": "sha512-GDOYMUzAj1dqFyrD1XbJaekcCrFZOIz0wVimbLeqRPwn+BNIZ9sylgvMiLxbiGMHWzVwJOyWDG/XVbuqXGfzWw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/builder-webpack5": "9.1.6",
-        "@storybook/preset-react-webpack": "9.1.6",
-        "@storybook/react": "9.1.6"
+        "@storybook/builder-webpack5": "9.1.17",
+        "@storybook/preset-react-webpack": "9.1.17",
+        "@storybook/react": "9.1.17"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -3233,7 +3233,7 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.6",
+        "storybook": "^9.1.17",
         "typescript": ">= 4.9.x"
       },
       "peerDependenciesMeta": {
@@ -3738,20 +3738,9 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.87.4",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.87.4.tgz",
-      "integrity": "sha512-uNsg6zMxraEPDVO2Bn+F3/ctHi+Zsk+MMpcN8h6P7ozqD088F6mFY5TfGM7zuyIrL7HKpDyu6QHfLWiDxh3cuw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      }
-    },
-    "node_modules/@tanstack/query-devtools": {
-      "version": "5.87.3",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.87.3.tgz",
-      "integrity": "sha512-LkzxzSr2HS1ALHTgDmJH5eGAVsSQiuwz//VhFW5OqNk0OQ+Fsqba0Tsf+NzWRtXYvpgUqwQr4b2zdFZwxHcGvg==",
+      "version": "5.90.20",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.20.tgz",
+      "integrity": "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -3760,37 +3749,19 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.87.4",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.87.4.tgz",
-      "integrity": "sha512-T5GT/1ZaNsUXf5I3RhcYuT17I4CPlbZgyLxc/ZGv7ciS6esytlbjb3DgUFO6c8JWYMDpdjSWInyGZUErgzqhcA==",
+      "version": "5.90.20",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.20.tgz",
+      "integrity": "sha512-vXBxa+qeyveVO7OA0jX1z+DeyCA4JKnThKv411jd5SORpBKgkcVnYKCiBgECvADvniBX7tobwBmg01qq9JmMJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.87.4"
+        "@tanstack/query-core": "5.90.20"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
-        "react": "^18 || ^19"
-      }
-    },
-    "node_modules/@tanstack/react-query-devtools": {
-      "version": "5.87.4",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.87.4.tgz",
-      "integrity": "sha512-JYcnVJBBW1DCPyNGM0S2CyrLpe6KFiL2gpYd/k9tAp62Du7+Y27zkzd+dKFyxpFadYaTxsx4kUA7YvnkMLVUoQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/query-devtools": "5.87.3"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "@tanstack/react-query": "^5.87.4",
         "react": "^18 || ^19"
       }
     },
@@ -3879,9 +3850,9 @@
       }
     },
     "node_modules/@testing-library/jest-dom": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.8.0.tgz",
-      "integrity": "sha512-WgXcWzVM6idy5JaftTVC8Vs83NKRmGJz4Hqs4oyOuO2J4r/y79vvKZsb+CaGyCSEbUPI6OsewfPd0G1A0/TUZQ==",
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8791,6 +8762,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-check": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.5.3.tgz",
+      "integrity": "sha512-IE9csY7lnhxBnA8g/WI5eg/hygA6MGWJMSNfFRrBlXUciADEhS1EDB0SIsMSvzubzIlOBbVITSsypCsW717poA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -9908,9 +9902,9 @@
       }
     },
     "node_modules/html-webpack-plugin": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.4.tgz",
-      "integrity": "sha512-V/PZeWsqhfpE27nKeX9EO2sbR+D17A+tLf6qU+ht66jdUsN0QLKJN27Z+1+gHrVMKgndBahes0PU6rRihDgHTw==",
+      "version": "5.6.6",
+      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.6.tgz",
+      "integrity": "sha512-bLjW01UTrvoWTJQL5LsMRo1SypHW80FTm12OJRSnr3v6YHNhfe+1r0MYUZJMACxnCHURVnBWRwAsWs2yPU9Ezw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13659,9 +13653,9 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-      "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13864,6 +13858,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/pure-rand": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
+      "integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/qs": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
@@ -14033,9 +14044,9 @@
       }
     },
     "node_modules/react-docgen": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-8.0.1.tgz",
-      "integrity": "sha512-kQKsqPLplY3Hx4jGnM3jpQcG3FQDt7ySz32uTHt3C9HAe45kNXG+3o16Eqn3Fw1GtMfHoN3b4J/z2e6cZJCmqQ==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-8.0.2.tgz",
+      "integrity": "sha512-+NRMYs2DyTP4/tqWz371Oo50JqmWltR1h2gcdgUMAWZJIAvrd0/SqlCfx7tpzpl/s36rzw6qH2MjoNrxtRNYhA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15555,9 +15566,9 @@
       }
     },
     "node_modules/storybook": {
-      "version": "9.1.6",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-9.1.6.tgz",
-      "integrity": "sha512-iIcMaDKkjR5nN+JYBy9hhoxZhjX4TXhyJgUBed+toJOlfrl+QvxpBjImAi7qKyLR3hng3uoigEP0P8+vYtXpOg==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-9.1.17.tgz",
+      "integrity": "sha512-kfr6kxQAjA96ADlH6FMALJwJ+eM80UqXy106yVHNgdsAP/CdzkkicglRAhZAvUycXK9AeadF6KZ00CWLtVMN4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15938,9 +15949,9 @@
       }
     },
     "node_modules/strip-indent": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.1.0.tgz",
-      "integrity": "sha512-OA95x+JPmL7kc7zCu+e+TeYxEiaIyndRx0OrBcK2QPPH09oAndr2ALvymxWA+Lx1PYYvFUm4O63pRkdJAaW96w==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.1.1.tgz",
+      "integrity": "sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -16142,11 +16153,11 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.3.tgz",
-      "integrity": "sha512-ENg5JUHUm2rDD7IvKNFGzyElLXNjachNLp6RaGf4+JOgxXHkqA+gq81ZAMCUmtMtqBsoU62lcp6S27g1LCYGGQ==",
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
+      "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
@@ -17585,9 +17596,9 @@
       }
     },
     "node_modules/webpack-dev-middleware/node_modules/schema-utils": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.2.tgz",
-      "integrity": "sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -18085,9 +18096,9 @@
       }
     },
     "node_modules/yocto-queue": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
-      "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/opencost/package.json
+++ b/opencost/package.json
@@ -32,7 +32,7 @@
     ]
   },
   "devDependencies": {
-    "@kinvolk/headlamp-plugin": "^0.13.0"
+    "@kinvolk/headlamp-plugin": "^0.13.1"
   },
   "dependencies": {
     "use-between": "^1.3.5"

--- a/plugin-catalog/package-lock.json
+++ b/plugin-catalog/package-lock.json
@@ -11,7 +11,7 @@
         "markdown-to-jsx": "^7.4.7"
       },
       "devDependencies": {
-        "@kinvolk/headlamp-plugin": "^0.13.0"
+        "@kinvolk/headlamp-plugin": "^0.13.1"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -1785,9 +1785,9 @@
       }
     },
     "node_modules/@kinvolk/headlamp-plugin": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@kinvolk/headlamp-plugin/-/headlamp-plugin-0.13.0.tgz",
-      "integrity": "sha512-T0PGETnMXcUSOXKy/MEUeprDLzoqYxsJNqfNIL9DCW5WmmFDKcJX5Gify2RWB+oJbWIAaaRZ7zQGqeYeqa5KTA==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@kinvolk/headlamp-plugin/-/headlamp-plugin-0.13.1.tgz",
+      "integrity": "sha512-aoAGs5w8HIS43p3YBcjzkIWZZlh18b/e02d+r/rr6+99vc48vOd9tKAIBZMVg4j+cVzbPtL1+t1tDE/UdeHcWQ==",
       "dev": true,
       "license": "Apache 2.0",
       "dependencies": {
@@ -1806,13 +1806,12 @@
         "@mui/x-date-pickers": "^7.15.0",
         "@mui/x-tree-view": "^6.17.0",
         "@reduxjs/toolkit": "^2.2.7",
-        "@storybook/addon-docs": "^9.1.2",
-        "@storybook/addon-links": "^9.1.2",
+        "@storybook/addon-docs": "^9.1.17",
+        "@storybook/addon-links": "^9.1.17",
         "@storybook/addon-webpack5-compiler-swc": "^3.0.0",
-        "@storybook/react-vite": "^9.1.2",
-        "@storybook/react-webpack5": "^9.1.2",
+        "@storybook/react-vite": "^9.1.17",
+        "@storybook/react-webpack5": "^9.1.17",
         "@tanstack/react-query": "^5.51.24",
-        "@tanstack/react-query-devtools": "^5.51.24",
         "@testing-library/dom": "^10.1.0",
         "@testing-library/jest-dom": "^6.4.8",
         "@testing-library/react": "^16.0.0",
@@ -1847,6 +1846,7 @@
         "eslint-plugin-react-hooks": "^4.6.2",
         "eslint-plugin-simple-import-sort": "^12.1.1",
         "eslint-plugin-unused-imports": "^4.1.3",
+        "fast-check": "^4.5.3",
         "fs-extra": "^11.2.0",
         "fuse.js": "^7.0.0",
         "humanize-duration": "^3.27.2",
@@ -1857,7 +1857,7 @@
         "js-yaml": "^4.1.1",
         "jsdom": "^24.0.0",
         "jsonpath-plus": "^10.3.0",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.23",
         "material-react-table": "^2.13.3",
         "monaco-editor": "^0.52.0",
         "msw": "2.4.9",
@@ -1881,9 +1881,9 @@
         "shx": "^0.4.0",
         "simple-eval": "^2.0.0",
         "spacetime": "^7.4.0",
-        "storybook": "^9.1.2",
+        "storybook": "^9.1.17",
         "table": "^6.8.2",
-        "tar": "^7.4.3",
+        "tar": "^7.5.7",
         "ts-loader": "^9.5.2",
         "typescript": "5.6.2",
         "validate-npm-package-name": "^3.0.0",
@@ -2888,16 +2888,16 @@
       "license": "MIT"
     },
     "node_modules/@storybook/addon-docs": {
-      "version": "9.1.10",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-9.1.10.tgz",
-      "integrity": "sha512-LYK3oXy/0PgY39FhkYVd9D0bzatLGTsMhaPPwSjBOmZgK0f0yBLqaePy7urUFeHYm/rjwAaRmDJNBqUnGTVoig==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-9.1.17.tgz",
+      "integrity": "sha512-yc4hlgkrwNi045qk210dRuIMijkgbLmo3ft6F4lOdpPRn4IUnPDj7FfZR8syGzUzKidxRfNtLx5m0yHIz83xtA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@mdx-js/react": "^3.0.0",
-        "@storybook/csf-plugin": "9.1.10",
+        "@storybook/csf-plugin": "9.1.17",
         "@storybook/icons": "^1.4.0",
-        "@storybook/react-dom-shim": "9.1.10",
+        "@storybook/react-dom-shim": "9.1.17",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "ts-dedent": "^2.0.0"
@@ -2907,13 +2907,13 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.1.10"
+        "storybook": "^9.1.17"
       }
     },
     "node_modules/@storybook/addon-links": {
-      "version": "9.1.10",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-9.1.10.tgz",
-      "integrity": "sha512-MG0vktKX/qH+hSRnX2/TfEtSpO87G++H5D95PaBtPYwV+JqgZI5Qpq+ikC+s0wvCxlRgm3qy+NkeoHGze29T0g==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-9.1.17.tgz",
+      "integrity": "sha512-LqtrDXRJrdMfZJ0om38SjmY2lQUGmpL8Zt2xTZtQjUy1V+ZiQpuUx7+TJZIOWujzRp75fxhM4AB0HuLDsemlcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2925,7 +2925,7 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.10"
+        "storybook": "^9.1.17"
       },
       "peerDependenciesMeta": {
         "react": {
@@ -2948,13 +2948,13 @@
       }
     },
     "node_modules/@storybook/builder-vite": {
-      "version": "9.1.10",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-9.1.10.tgz",
-      "integrity": "sha512-0ogI+toZJYaFptcFpRcRPOZ9/NrFUYhiaI09ggeEB1FF9ygHMVsobp4eaj4HjZI6V3x7cQwkd2ZmxAMQDBQuMA==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-9.1.17.tgz",
+      "integrity": "sha512-OQCYaFWoTBvovN2IJmkAW+7FgHMJiih1WA/xqgpKIx0ImZjB4z5FrKgzQeXsrYcLEsynyaj+xN3JFUKsz5bzGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/csf-plugin": "9.1.10",
+        "@storybook/csf-plugin": "9.1.17",
         "ts-dedent": "^2.0.0"
       },
       "funding": {
@@ -2962,18 +2962,18 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.1.10",
+        "storybook": "^9.1.17",
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/@storybook/builder-webpack5": {
-      "version": "9.1.10",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-webpack5/-/builder-webpack5-9.1.10.tgz",
-      "integrity": "sha512-6Cw0lJ0SxGPGhBPx5zOozxEtu7Nm3rOMCuYGQy3OYUbAmznk82NB6pnQ4cdCIBmX61ZyGykhXShLjtCWHh/8tw==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-webpack5/-/builder-webpack5-9.1.17.tgz",
+      "integrity": "sha512-lgfq5R3WrK3HM/i7nX2b5rsnBgekoJr3Pu04KAGrEa/bgj7UW1n1bTodCUl+rVEM6aMPqXcLQFIVx/AEFNT4sQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/core-webpack": "9.1.10",
+        "@storybook/core-webpack": "9.1.17",
         "case-sensitive-paths-webpack-plugin": "^2.4.0",
         "cjs-module-lexer": "^1.2.3",
         "css-loader": "^6.7.1",
@@ -2994,7 +2994,7 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.1.10"
+        "storybook": "^9.1.17"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -3003,9 +3003,9 @@
       }
     },
     "node_modules/@storybook/core-webpack": {
-      "version": "9.1.10",
-      "resolved": "https://registry.npmjs.org/@storybook/core-webpack/-/core-webpack-9.1.10.tgz",
-      "integrity": "sha512-zborBOQtZBkGl0NcOgNygRdiPFqseh9UnLWVV1yLZglCZN5BTnXjEGhpRFHBOhPux3gdHNcvrvgYSgcitFpEPA==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/core-webpack/-/core-webpack-9.1.17.tgz",
+      "integrity": "sha512-qJRWZEgWjNoGKcHOYFgGlUkmf/dIeQ3T01SJh9H4icZChVhyWRLC+y1HITmxRPPRHZXYyBHbTzmhFmuZM3i2YQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3016,13 +3016,13 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.1.10"
+        "storybook": "^9.1.17"
       }
     },
     "node_modules/@storybook/csf-plugin": {
-      "version": "9.1.10",
-      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-9.1.10.tgz",
-      "integrity": "sha512-247F/JU0Naxm/RIUnQYpqXeCL0wG8UNJkZe+/GkLjdqzsyML0lb+8OwBsWFfG8zfj6fkjmRU2mF44TnNkzoQcg==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-9.1.17.tgz",
+      "integrity": "sha512-o+ebQDdSfZHDRDhu2hNDGhCLIazEB4vEAqJcHgz1VsURq+l++bgZUcKojPMCAbeblptSEz2bwS0eYAOvG7aSXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3033,7 +3033,7 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.1.10"
+        "storybook": "^9.1.17"
       }
     },
     "node_modules/@storybook/global": {
@@ -3058,13 +3058,13 @@
       }
     },
     "node_modules/@storybook/preset-react-webpack": {
-      "version": "9.1.10",
-      "resolved": "https://registry.npmjs.org/@storybook/preset-react-webpack/-/preset-react-webpack-9.1.10.tgz",
-      "integrity": "sha512-2fiFqaWP8yl5WW9nDi++chmcy3A69DRU8UM1w7JtByw147GC7PCY+mt6L8k8TMZtAcqvLgZEx9j+llsbv0AemQ==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/preset-react-webpack/-/preset-react-webpack-9.1.17.tgz",
+      "integrity": "sha512-3ixo+4yywVy/a6nHLN5eefISw43717NHKXORWbaXJUOpa7ka9l3OejEDhVmSYKfJhTK+IVbrVYTIvrgqrUWQYg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/core-webpack": "9.1.10",
+        "@storybook/core-webpack": "9.1.17",
         "@storybook/react-docgen-typescript-plugin": "1.0.6--canary.9.0c3f3b7.0",
         "@types/semver": "^7.3.4",
         "find-up": "^7.0.0",
@@ -3085,7 +3085,7 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.10"
+        "storybook": "^9.1.17"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -3116,14 +3116,14 @@
       }
     },
     "node_modules/@storybook/react": {
-      "version": "9.1.10",
-      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-9.1.10.tgz",
-      "integrity": "sha512-flG3Gn3EHZnxn92C7vrA2U4aGqpOKdf85fL43+J/2k9HF5AIyOFGlcv4LGVyKZ3LOAow/nGBVSXL9961h+ICRA==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-9.1.17.tgz",
+      "integrity": "sha512-TZCplpep5BwjHPIIcUOMHebc/2qKadJHYPisRn5Wppl014qgT3XkFLpYkFgY1BaRXtqw8Mn3gqq4M/49rQ7Iww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@storybook/global": "^5.0.0",
-        "@storybook/react-dom-shim": "9.1.10"
+        "@storybook/react-dom-shim": "9.1.17"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -3135,7 +3135,7 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.10",
+        "storybook": "^9.1.17",
         "typescript": ">= 4.9.x"
       },
       "peerDependenciesMeta": {
@@ -3165,9 +3165,9 @@
       }
     },
     "node_modules/@storybook/react-dom-shim": {
-      "version": "9.1.10",
-      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-9.1.10.tgz",
-      "integrity": "sha512-cxy8GTj73RMJIFPrgqdnMXePGX5iFohM5pDCZ63Te5m5GtzKqsILRXtBBLO6Ouexm/ZYRVznkKiwNKX/Fu24fQ==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-9.1.17.tgz",
+      "integrity": "sha512-Ss/lNvAy0Ziynu+KniQIByiNuyPz3dq7tD62hqSC/pHw190X+M7TKU3zcZvXhx2AQx1BYyxtdSHIZapb+P5mxQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -3177,20 +3177,20 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.10"
+        "storybook": "^9.1.17"
       }
     },
     "node_modules/@storybook/react-vite": {
-      "version": "9.1.10",
-      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-9.1.10.tgz",
-      "integrity": "sha512-k0wWlfoWakoHL3NZ1+38oxRH3WYyprFFX+WUb/4W8axrvpKogvdnxKCul/YB1HH5FcTagIfguamsPjKwB1ZkJg==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-9.1.17.tgz",
+      "integrity": "sha512-RZHsqD1mnTMo4MCJw68t3swS5BTMSTpeRhlelMwjoTEe7jJCPa+qx00uMlWliR1QBN1hMO8Y1dkchxSiUS9otA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@joshwooding/vite-plugin-react-docgen-typescript": "0.6.1",
         "@rollup/pluginutils": "^5.0.2",
-        "@storybook/builder-vite": "9.1.10",
-        "@storybook/react": "9.1.10",
+        "@storybook/builder-vite": "9.1.17",
+        "@storybook/react": "9.1.17",
         "find-up": "^7.0.0",
         "magic-string": "^0.30.0",
         "react-docgen": "^8.0.0",
@@ -3207,20 +3207,20 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.10",
+        "storybook": "^9.1.17",
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/@storybook/react-webpack5": {
-      "version": "9.1.10",
-      "resolved": "https://registry.npmjs.org/@storybook/react-webpack5/-/react-webpack5-9.1.10.tgz",
-      "integrity": "sha512-jJ5B704R2iIpF1gxlGaaV4I3feAFV2Bwva+/KaGEIHqG7yfvlX+0u4Mki2/xFxhLdHlIzx5FEZjfh41QlBsqxQ==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/react-webpack5/-/react-webpack5-9.1.17.tgz",
+      "integrity": "sha512-GDOYMUzAj1dqFyrD1XbJaekcCrFZOIz0wVimbLeqRPwn+BNIZ9sylgvMiLxbiGMHWzVwJOyWDG/XVbuqXGfzWw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/builder-webpack5": "9.1.10",
-        "@storybook/preset-react-webpack": "9.1.10",
-        "@storybook/react": "9.1.10"
+        "@storybook/builder-webpack5": "9.1.17",
+        "@storybook/preset-react-webpack": "9.1.17",
+        "@storybook/react": "9.1.17"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -3232,7 +3232,7 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.10",
+        "storybook": "^9.1.17",
         "typescript": ">= 4.9.x"
       },
       "peerDependenciesMeta": {
@@ -3738,20 +3738,9 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.90.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.2.tgz",
-      "integrity": "sha512-k/TcR3YalnzibscALLwxeiLUub6jN5EDLwKDiO7q5f4ICEoptJ+n9+7vcEFy5/x/i6Q+Lb/tXrsKCggf5uQJXQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      }
-    },
-    "node_modules/@tanstack/query-devtools": {
-      "version": "5.90.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.90.1.tgz",
-      "integrity": "sha512-GtINOPjPUH0OegJExZ70UahT9ykmAhmtNVcmtdnOZbxLwT7R5OmRztR5Ahe3/Cu7LArEmR6/588tAycuaWb1xQ==",
+      "version": "5.90.20",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.20.tgz",
+      "integrity": "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -3760,38 +3749,19 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.90.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.2.tgz",
-      "integrity": "sha512-CLABiR+h5PYfOWr/z+vWFt5VsOA2ekQeRQBFSKlcoW6Ndx/f8rfyVmq4LbgOM4GG2qtxAxjLYLOpCNTYm4uKzw==",
+      "version": "5.90.20",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.20.tgz",
+      "integrity": "sha512-vXBxa+qeyveVO7OA0jX1z+DeyCA4JKnThKv411jd5SORpBKgkcVnYKCiBgECvADvniBX7tobwBmg01qq9JmMJw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@tanstack/query-core": "5.90.2"
+        "@tanstack/query-core": "5.90.20"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
-        "react": "^18 || ^19"
-      }
-    },
-    "node_modules/@tanstack/react-query-devtools": {
-      "version": "5.90.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.90.2.tgz",
-      "integrity": "sha512-vAXJzZuBXtCQtrY3F/yUNJCV4obT/A/n81kb3+YqLbro5Z2+phdAbceO+deU3ywPw8B42oyJlp4FhO0SoivDFQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/query-devtools": "5.90.1"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "@tanstack/react-query": "^5.90.2",
         "react": "^18 || ^19"
       }
     },
@@ -8829,6 +8799,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-check": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.5.3.tgz",
+      "integrity": "sha512-IE9csY7lnhxBnA8g/WI5eg/hygA6MGWJMSNfFRrBlXUciADEhS1EDB0SIsMSvzubzIlOBbVITSsypCsW717poA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -9956,9 +9949,9 @@
       }
     },
     "node_modules/html-webpack-plugin": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.4.tgz",
-      "integrity": "sha512-V/PZeWsqhfpE27nKeX9EO2sbR+D17A+tLf6qU+ht66jdUsN0QLKJN27Z+1+gHrVMKgndBahes0PU6rRihDgHTw==",
+      "version": "5.6.6",
+      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.6.tgz",
+      "integrity": "sha512-bLjW01UTrvoWTJQL5LsMRo1SypHW80FTm12OJRSnr3v6YHNhfe+1r0MYUZJMACxnCHURVnBWRwAsWs2yPU9Ezw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13664,9 +13657,9 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-      "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13869,6 +13862,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
+      "integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/qs": {
       "version": "6.14.0",
@@ -15588,12 +15598,11 @@
       }
     },
     "node_modules/storybook": {
-      "version": "9.1.10",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-9.1.10.tgz",
-      "integrity": "sha512-4+U7gF9hMpGilQmdVJwQaVZZEkD7XwC4ZDmBa51mobaPYelELEMoMfNM2hLyvB2x12gk1IJui1DnwOE4t+MXhw==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-9.1.17.tgz",
+      "integrity": "sha512-kfr6kxQAjA96ADlH6FMALJwJ+eM80UqXy106yVHNgdsAP/CdzkkicglRAhZAvUycXK9AeadF6KZ00CWLtVMN4w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@testing-library/jest-dom": "^6.6.3",
@@ -15970,9 +15979,9 @@
       }
     },
     "node_modules/strip-indent": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.1.0.tgz",
-      "integrity": "sha512-OA95x+JPmL7kc7zCu+e+TeYxEiaIyndRx0OrBcK2QPPH09oAndr2ALvymxWA+Lx1PYYvFUm4O63pRkdJAaW96w==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.1.1.tgz",
+      "integrity": "sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -16174,11 +16183,11 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.3.tgz",
-      "integrity": "sha512-ENg5JUHUm2rDD7IvKNFGzyElLXNjachNLp6RaGf4+JOgxXHkqA+gq81ZAMCUmtMtqBsoU62lcp6S27g1LCYGGQ==",
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
+      "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
@@ -18113,9 +18122,9 @@
       }
     },
     "node_modules/yocto-queue": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
-      "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/plugin-catalog/package.json
+++ b/plugin-catalog/package.json
@@ -32,7 +32,7 @@
     ]
   },
   "devDependencies": {
-    "@kinvolk/headlamp-plugin": "^0.13.0"
+    "@kinvolk/headlamp-plugin": "^0.13.1"
   },
   "dependencies": {
     "markdown-to-jsx": "^7.4.7"


### PR DESCRIPTION
Changes:
- **app-catalog: Bump headlamp-plugin to 0.13.1**
- **backstage: Bump headlamp-plugin to 0.13.1**
- **cert-manager: Bump headlamp-plugin to 0.13.1**
- **flux: Bump headlamp-plugin to 0.13.1**
- **karpenter: Bump headlamp-plugin to 0.13.1**
- **keda: Bump headlamp-plugin to 0.13.1**
- **knative: Bump headlamp-plugin to 0.13.1**
- **kompose: Bump headlamp-plugin to 0.13.1**
- **minikube: Bump headlamp-plugin to 0.13.1**
- **opencost: Bump headlamp-plugin to 0.13.1**
- **plugin-catalog: Bump headlamp-plugin to 0.13.1**