### PR TITLE
Add Strimzi Headlamp plugin to external plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Please see [headlamp plugins on Artifact Hub](https://artifacthub.io/packages/se
 | [KubeVirt](https://github.com/buttahtoast/headlamp-plugins/tree/main/kubevirt) | A plugin for managing KubeVirt virtual machines within a Kubernetes cluster. |   | [@buttahtoast](https://github.com/buttahtoast) |
 | [Gatekeeper](https://github.com/sozercan/gatekeeper-headlamp-plugin) | A Headlamp plugin for managing [Gatekeeper](https://open-policy-agent.github.io/gatekeeper/) policies, violations, and a library of community-sourced policies. | | [@sozercan](https://github.com/sozercan) |
 | [KAITO](https://github.com/kaito-project/headlamp-kaito) | Enhances the KAITO AKS extension with a visual interface in Headlamp for model deployment and GPU provisioning. | |[@chloe608](https://github.com/chloe608), [@chewong](https://github.com/chewong)|
+| [Strimzi](https://github.com/cesaroangelo/strimzi-headlamp) | A Headlamp plugin for managing Strimzi (Apache Kafka on Kubernetes) resources. | [Demo](https://www.youtube.com/watch?v=MNt28s6b5d8) | [@cesaroangelo](https://github.com/cesaroangelo) |
 
 
 


### PR DESCRIPTION
Adds [Strimzi Headlamp Plugin](https://github.com/cesaroangelo/strimzi-headlamp) to the External plugins section.

A Headlamp plugin for managing Strimzi (Apache Kafka on Kubernetes) resources — Kafka clusters, topics, and users — directly from the Headlamp UI.

- Demo: https://www.youtube.com/watch?v=MNt28s6b5d8
- Artifact Hub: https://artifacthub.io/packages/search?repo=strimzi-headlamp