### PR TITLE
ai-assistant: Add DeepSeek provider support

### DIFF
--- a/ai-assistant/package-lock.json
+++ b/ai-assistant/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@langchain/anthropic": "^1.3.16",
         "@langchain/core": "^1.1.20",
+        "@langchain/deepseek": "1.0.8",
         "@langchain/google-genai": "^2.1.16",
         "@langchain/mistralai": "^1.0.4",
         "@langchain/ollama": "^1.2.2",
@@ -2006,6 +2007,38 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@langchain/deepseek": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmmirror.com/@langchain/deepseek/-/deepseek-1.0.8.tgz",
+      "integrity": "sha512-FE+j62PAKxsBRLrJafwzE8Ebi7UHXFrMgRGEn1Jnbb0oxp0DNYWPj73qWOMsHZGBCZnOSynCb6nWJ97U8bg8lg==",
+      "license": "MIT",
+      "dependencies": {
+        "@langchain/openai": "1.2.4"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.0.0"
+      }
+    },
+    "node_modules/@langchain/deepseek/node_modules/@langchain/openai": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmmirror.com/@langchain/openai/-/openai-1.2.4.tgz",
+      "integrity": "sha512-3ThBOIXAJ6eXuqGGO41XDgr4rp/qpl/RpZmGcjv1S3+CRLS4UQBgXkZEab7mun85HfdsUWLs/v1+pDwbMFixcA==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tiktoken": "^1.0.12",
+        "openai": "^6.16.0",
+        "zod": "^3.25.76 || ^4"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.0.0"
       }
     },
     "node_modules/@langchain/google-genai": {

--- a/ai-assistant/package.json
+++ b/ai-assistant/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "@langchain/anthropic": "^1.3.16",
     "@langchain/core": "^1.1.20",
+    "@langchain/deepseek": "1.0.8",
     "@langchain/google-genai": "^2.1.16",
     "@langchain/mistralai": "^1.0.4",
     "@langchain/ollama": "^1.2.2",

--- a/ai-assistant/src/config/modelConfig.ts
+++ b/ai-assistant/src/config/modelConfig.ts
@@ -184,6 +184,29 @@ export const modelProviders: ModelProvider[] = [
     ],
   },
   {
+    id: 'deepseek',
+    name: 'DeepSeek',
+    icon: 'ai-providers:deepseek',
+    description: 'Integration with DeepSeek models',
+    fields: [
+      {
+        name: 'apiKey',
+        label: 'API Key',
+        type: 'text',
+        required: true,
+        placeholder: 'Your DeepSeek API key',
+      },
+      {
+        name: 'model',
+        label: 'Model',
+        type: 'select',
+        required: true,
+        options: ['deepseek-chat', 'deepseek-reasoner'],
+        default: 'deepseek-chat',
+      },
+    ],
+  },
+  {
     id: 'local',
     name: 'Local Models',
     icon: 'ai-providers:local',

--- a/ai-assistant/src/langchain/LangChainManager.ts
+++ b/ai-assistant/src/langchain/LangChainManager.ts
@@ -11,6 +11,7 @@ import {
 import { StringOutputParser } from '@langchain/core/output_parsers';
 import { ChatPromptTemplate, MessagesPlaceholder } from '@langchain/core/prompts';
 import { RunnablePassthrough, RunnableSequence } from '@langchain/core/runnables';
+import { ChatDeepSeek } from '@langchain/deepseek';
 import { ChatGoogleGenerativeAI } from '@langchain/google-genai';
 import { ChatMistralAI } from '@langchain/mistralai';
 import { ChatOllama } from '@langchain/ollama';
@@ -182,6 +183,16 @@ export default class LangChainManager extends AIManager {
             throw new Error('API key is required for Google Gemini');
           }
           return new ChatGoogleGenerativeAI({
+            apiKey: sanitizedConfig.apiKey,
+            model: sanitizedConfig.model,
+            verbose: true,
+          });
+        }
+        case 'deepseek': {
+          if (!sanitizedConfig.apiKey) {
+            throw new Error('API key is required for DeepSeek');
+          }
+          return new ChatDeepSeek({
             apiKey: sanitizedConfig.apiKey,
             model: sanitizedConfig.model,
             verbose: true,

--- a/ai-assistant/src/utils/icons.ts
+++ b/ai-assistant/src/utils/icons.ts
@@ -23,6 +23,9 @@ const aiProviderIcons = {
     google: {
       body: '<path fill="currentColor" d="M21.996 12.018a10.65 10.65 0 0 0-9.98 9.98h-.04c-.32-5.364-4.613-9.656-9.976-9.98v-.04c5.363-.32 9.656-4.613 9.98-9.976h.04c.324 5.363 4.617 9.656 9.98 9.98v.036z"/>',
     },
+    deepseek: {
+      body: '<path fill="currentColor" d="M5 4h6.5a6.5 6.5 0 0 1 0 16H5zm3 3v10h3.3a4 4 0 0 0 0-10z"/>',
+    },
     azure: {
       body: '<path fill="currentColor" d="M12.903 4.032L7 9.13l-5 9.065h4.548zm.839 1.226l-2.516 7.097L16 18.387l-9.355 1.58H22z"/>',
     },


### PR DESCRIPTION
Add DeepSeek provider support:

package.json: Added the @langchain/deepseek dependency.
src/config/modelConfig.ts: Added a DeepSeek provider configuration (API key + model selection: deepseek-chat, deepseek-reasoner).
src/langchain/LangChainManager.ts: Added a deepseek provider branch that instantiates ChatDeepSeek with API key and model.
src/utils/icons.ts: Added the ai-providers:deepseek icon for offline provider rendering.