### PR TITLE
flux: fix api versions

### DIFF
--- a/flux/src/common/Resources.tsx
+++ b/flux/src/common/Resources.tsx
@@ -24,7 +24,7 @@ export class GitRepository extends KubeObject {
 export class OCIRepository extends KubeObject {
   static kind = 'OCIRepository';
   static apiName = 'ocirepositories';
-  static apiVersion = 'source.toolkit.fluxcd.io/v1beta2';
+  static apiVersion = ['source.toolkit.fluxcd.io/v1', 'source.toolkit.fluxcd.io/v1beta2'];
   static isNamespaced = true;
 }
 
@@ -80,9 +80,9 @@ export class ReceiverNotification extends KubeObject {
   static kind = 'Receiver';
   static apiName = 'receivers';
   static apiVersion = [
+    'notification.toolkit.fluxcd.io/v1',
     'notification.toolkit.fluxcd.io/v1beta3',
     'notification.toolkit.fluxcd.io/v1beta2',
-    'notification.toolkit.fluxcd.io/v1',
   ];
   static isNamespaced = true;
 }


### PR DESCRIPTION
Add missing `OCIRepository` v1 and prever v1 for `Receiver`

- closes #537
