### PR TITLE
minikube: fix DriverSelect value prop and deprecated navigator.platform

### DIFF
--- a/minikube/src/CommandCluster/DriverSelect.tsx
+++ b/minikube/src/CommandCluster/DriverSelect.tsx
@@ -49,8 +49,12 @@ const driverLists = {
   unknown: [{ value: '', label: 'Autodetect' }],
 };
 
-function detectOS() {
-  const platform = navigator.platform.toLowerCase();
+function detectOS(): 'macos' | 'windows' | 'linux' | 'unknown' {
+  // Modern API (Chromium-based browsers / Electron)
+  const uaPlatform = (navigator as any).userAgentData?.platform?.toLowerCase();
+  // Fallback to deprecated navigator.platform
+  const platform = uaPlatform || navigator.platform?.toLowerCase() || '';
+
   if (platform.includes('mac')) return 'macos';
   if (platform.includes('win')) return 'windows';
   if (platform.includes('linux')) return 'linux';
@@ -70,8 +74,8 @@ interface DriverSelectProps {
 export default function DriverSelect({ setDriver, driver }: DriverSelectProps) {
   const drivers = driverLists[detectOS()];
 
-  function handleChange(event: SelectChangeEvent<{ value: string }>) {
-    setDriver(event.target.value as string);
+  function handleChange(event: SelectChangeEvent<string>) {
+    setDriver(event.target.value);
   }
 
   return (
@@ -84,7 +88,7 @@ export default function DriverSelect({ setDriver, driver }: DriverSelectProps) {
           <Select
             labelId="driver-select-label"
             id="driver-select"
-            value={{ value: driver }}
+            value={driver}
             label="Driver"
             displayEmpty
             onChange={handleChange}


### PR DESCRIPTION
## Summary
- Fix MUI `<Select>` `value` prop passing an object instead of a plain string, which caused the dropdown to never highlight the selected item
- Fix `handleChange` type signature to match the corrected value type (`SelectChangeEvent<string>`)
- Replace deprecated `navigator.platform` with `navigator.userAgentData?.platform` (with fallback) in the `detectOS` function

## Test plan
- [x] `npm run tsc` passes
- [x] `npm run lint` passes
- [x] Manual: open the DriverSelect dropdown, select a driver, confirm the selected value displays correctly
- [x] Manual: confirm driver list is appropriate for the current OS

