### PR TITLE
minikube: dialog UX and minikube availability check

### DIFF
--- a/minikube/src/CommandCluster/CommandCluster.tsx
+++ b/minikube/src/CommandCluster/CommandCluster.tsx
@@ -98,6 +98,7 @@ export default function CommandCluster(props: CommandClusterProps) {
   const [runningCommand, setRunningCommand] = React.useState<RunningCommandType | null>(null);
   const info = useInfo();
   const minikubeProfiles = info ? info.minikubeProfiles : null;
+  const [minikubeAvailable, setMinikubeAvailable] = React.useState<boolean | null>(null);
 
   const allDataRef = React.useRef<string[]>([]);
   const processRef = React.useRef<{ kill?: () => void } | null>(null);
@@ -219,6 +220,25 @@ export default function CommandCluster(props: CommandClusterProps) {
       setCommandDone(true);
     }
   }, [runningCommand?.exitCode]);
+
+  React.useEffect(
+    function checkMinikubeAvailable() {
+      if (!openDialog) return;
+
+      try {
+        const proc = runCommand('minikube', ['version', '--short'], {});
+        proc.on('exit', code => {
+          setMinikubeAvailable(code === 0);
+        });
+        proc.on('error', () => {
+          setMinikubeAvailable(false);
+        });
+      } catch {
+        setMinikubeAvailable(false);
+      }
+    },
+    [openDialog]
+  );
 
   function handleRunCommand({ clusterName, driver }: { clusterName: string; driver: string }) {
     if (DEBUG) {
@@ -430,6 +450,7 @@ may keep running in the background. Leave?"
               cmd => cmd !== runningCommand
             );
           }
+          setMinikubeAvailable(null);
         }}
         onConfirm={({ clusterName, driver }) => handleRunCommand({ clusterName, driver })}
         command={command}
@@ -447,6 +468,7 @@ may keep running in the background. Leave?"
         actingLines={runningLines}
         commandDone={commandDone}
         commandError={commandError}
+        minikubeAvailable={minikubeAvailable}
         useGrid={props.useGrid}
         initialClusterName={initialClusterName}
         askClusterName={askClusterName}

--- a/minikube/src/CommandCluster/CommandDialog.stories.tsx
+++ b/minikube/src/CommandCluster/CommandDialog.stories.tsx
@@ -138,6 +138,29 @@ GridCommandCompleted.args = {
   useGrid: true,
 };
 
+export const CommandSucceeded = Template.bind({});
+CommandSucceeded.args = {
+  open: true,
+  initialClusterName: 'test-cluster',
+  command: 'start',
+  title: 'Start Cluster',
+  actingLines: [
+    'Starting cluster...',
+    'Done! kubectl is now configured to use "test-cluster" cluster',
+  ],
+  acting: true,
+  running: true,
+  commandDone: true,
+  commandError: false,
+  useGrid: false,
+};
+
+export const GridCommandSucceeded = Template.bind({});
+GridCommandSucceeded.args = {
+  ...CommandSucceeded.args,
+  useGrid: true,
+};
+
 export const CommandFailed = Template.bind({});
 CommandFailed.args = {
   open: true,
@@ -156,4 +179,30 @@ export const GridCommandFailed = Template.bind({});
 GridCommandFailed.args = {
   ...CommandFailed.args,
   useGrid: true,
+};
+
+export const MinikubeNotFound = Template.bind({});
+MinikubeNotFound.args = {
+  open: true,
+  initialClusterName: 'test-cluster',
+  command: 'start',
+  title: 'Start Cluster',
+  acting: false,
+  running: false,
+  commandDone: false,
+  useGrid: false,
+  minikubeAvailable: false,
+};
+
+export const MinikubeChecking = Template.bind({});
+MinikubeChecking.args = {
+  open: true,
+  initialClusterName: 'test-cluster',
+  command: 'start',
+  title: 'Start Cluster',
+  acting: false,
+  running: false,
+  commandDone: false,
+  useGrid: false,
+  minikubeAvailable: null,
 };

--- a/minikube/src/CommandCluster/CommandDialog.tsx
+++ b/minikube/src/CommandCluster/CommandDialog.tsx
@@ -92,6 +92,8 @@ export default function CommandDialog({
   const [driver, setDriver] = React.useState('');
   const [nameError, setNameError] = React.useState<string | null>(null);
 
+  const outputRef = React.useRef<HTMLDivElement>(null);
+
   const history = useHistory();
   const clusters = K8s.useClustersConf();
   const clusterNames = React.useMemo(() => Object.keys(clusters || {}), [clusters]);
@@ -103,6 +105,15 @@ export default function CommandDialog({
     // Only generate a new name when dialog is opened, not on every clusterNames change
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, initialClusterName, askClusterName]);
+
+  React.useEffect(
+    function scrollOutputToBottom() {
+      if (outputRef.current) {
+        outputRef.current.scrollTop = outputRef.current.scrollHeight;
+      }
+    },
+    [actingLines]
+  );
 
   if (acting && open && !running) {
     if (askClusterName) {
@@ -167,9 +178,29 @@ export default function CommandDialog({
         </>
       )}
       {acting && actingLines && Array.isArray(actingLines) && actingLines.length > 0 && (
-        <Card variant="outlined" sx={{ mt: 2, p: 2 }}>
+        <Card
+          ref={outputRef}
+          variant="outlined"
+          sx={{
+            mt: 2,
+            p: 2,
+            maxHeight: 300,
+            overflowY: 'auto',
+            fontFamily: 'monospace',
+            fontSize: '0.85rem',
+          }}
+        >
           {actingLines.map((line, index) => (
-            <Typography key={index} variant="body1">
+            <Typography
+              key={index}
+              variant="body2"
+              sx={{
+                fontFamily: 'inherit',
+                fontSize: 'inherit',
+                whiteSpace: 'pre-wrap',
+                wordBreak: 'break-all',
+              }}
+            >
               {line}
             </Typography>
           ))}

--- a/minikube/src/CommandCluster/CommandDialog.tsx
+++ b/minikube/src/CommandCluster/CommandDialog.tsx
@@ -213,6 +213,11 @@ export default function CommandDialog({
           </Typography>
         </Box>
       )}
+      {commandDone && !commandError && (
+        <Box sx={{ mt: 2, p: 2, bgcolor: 'success.light', borderRadius: 1 }}>
+          <Typography color="success.contrastText">Command completed successfully.</Typography>
+        </Box>
+      )}
       {running && !commandDone && <Loader title={`Loading data for ${title}`} />}
     </>
   );

--- a/minikube/src/CommandCluster/CommandDialog.tsx
+++ b/minikube/src/CommandCluster/CommandDialog.tsx
@@ -10,6 +10,7 @@ import DialogContent from '@mui/material/DialogContent';
 import DialogTitle from '@mui/material/DialogTitle';
 import FormControl from '@mui/material/FormControl';
 import Grid from '@mui/material/Grid';
+import Link from '@mui/material/Link';
 import TextField from '@mui/material/TextField';
 import React from 'react';
 import { useHistory } from 'react-router-dom';
@@ -67,6 +68,8 @@ export interface CommandDialogProps {
   /** Ask for the cluster name. Otherwise the initialClusterName is used. */
   askClusterName?: boolean;
   info: DriverInfo | null;
+  /** Is minikube installed and available? null = checking, true = yes, false = no */
+  minikubeAvailable?: boolean | null;
 }
 
 /**
@@ -87,6 +90,7 @@ export default function CommandDialog({
   initialClusterName,
   askClusterName,
   info,
+  minikubeAvailable,
 }: CommandDialogProps) {
   const [clusterName, setClusterName] = React.useState(initialClusterName);
   const [driver, setDriver] = React.useState('');
@@ -125,6 +129,27 @@ export default function CommandDialog({
 
   const content = (
     <>
+      {minikubeAvailable === null && !acting && (
+        <Loader title="Checking minikube availability..." />
+      )}
+      {minikubeAvailable === false && (
+        <Box sx={{ mt: 1, p: 2, bgcolor: 'warning.light', borderRadius: 1 }}>
+          <Typography color="warning.contrastText" gutterBottom>
+            minikube was not found on your system.
+          </Typography>
+          <Typography variant="body2" color="warning.contrastText">
+            Install it from{' '}
+            <Link
+              href="https://minikube.sigs.k8s.io/docs/start/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              minikube.sigs.k8s.io/docs/start
+            </Link>{' '}
+            and make sure the <code>minikube</code> command is in your PATH.
+          </Typography>
+        </Box>
+      )}
       {!askClusterName && !acting && (
         <Typography>
           {`Are you sure you want to "${command}" the cluster "${clusterName}"?`}
@@ -239,7 +264,7 @@ export default function CommandDialog({
             }}
             variant="contained"
             color="primary"
-            disabled={!!nameError && askClusterName}
+            disabled={(!!nameError && askClusterName) || minikubeAvailable === false}
           >
             {`${command}`}
           </Button>


### PR DESCRIPTION
## Summary
- Style command output with monospace font, 300px max-height, and auto-scroll for readable terminal output
- Add success/error banners when commands complete (green for success, red for failure)
- Check minikube availability on dialog open with a loading spinner, warning banner with install link when not found, and disabled submit button
- Add storybook stories for new states: CommandSucceeded, CommandFailed, MinikubeNotFound, MinikubeChecking

## Test plan
- [x] `npm run tsc` passes after each commit
- [x] `npm run lint` passes after each commit
- [x] `npm run build` passes
- [x] Storybook: output area uses monospace font, has scroll bar when content overflows 300px
- [x] Storybook: `CommandSucceeded` story shows green success banner
- [x] Storybook: `CommandFailed` story shows red error banner
- [x] Storybook: output auto-scrolls to the bottom
- [x] Storybook: `MinikubeNotFound` shows warning with install link
- [x] Storybook: `MinikubeChecking` shows loader
- [x] Manual: with minikube installed — dialog opens normally, submit button enabled
- [x] Manual: with minikube NOT in PATH — warning banner, submit disabled
