### PR TITLE
cluster-api: sidebar fixes - order resources and show icons

### DIFF
--- a/cluster-api/src/index.tsx
+++ b/cluster-api/src/index.tsx
@@ -99,15 +99,7 @@ registerSidebarEntry({
 
 const clusterApiResources: ResourceRegistrationConfig[] = [
   {
-    name: 'Cluster Classes',
-    kind: 'ClusterClass',
-    path: 'clusterclasses',
-    DetailComponent: ClusterClassDetail,
-    ListComponent: ClusterClassesList,
-    icon: 'mdi:cloud-print-outline',
-  },
-  {
-    name: 'Clusters ', // Use a trailing space because "Clusters" is taken
+    name: 'Clusters ', // Trailing space: "Clusters" is reserved in Headlamp
     kind: 'Cluster',
     path: 'capiclusters',
     DetailComponent: ClusterDetail,
@@ -115,20 +107,12 @@ const clusterApiResources: ResourceRegistrationConfig[] = [
     icon: 'mdi:cloud',
   },
   {
-    name: 'Kubeadm Configs',
-    kind: 'KubeadmConfig',
-    path: 'kubeadmconfigs',
-    DetailComponent: KubeadmConfigDetail,
-    ListComponent: KubeadmConfigsList,
-    icon: 'mdi:list-box',
-  },
-  {
-    name: 'Kubeadm Config Templates',
-    kind: 'KubeadmConfigTemplate',
-    path: 'kubeadmconfigtemplates',
-    DetailComponent: KubeadmConfigTemplateDetail,
-    ListComponent: KubeadmConfigTemplatesList,
-    icon: 'mdi:list-box-outline',
+    name: 'Cluster Classes',
+    kind: 'ClusterClass',
+    path: 'clusterclasses',
+    DetailComponent: ClusterClassDetail,
+    ListComponent: ClusterClassesList,
+    icon: 'mdi:cloud-print-outline',
   },
   {
     name: 'Kubeadm Control Planes',
@@ -147,36 +131,12 @@ const clusterApiResources: ResourceRegistrationConfig[] = [
     icon: 'mdi:controller-classic-outline',
   },
   {
-    name: 'Machines',
-    kind: 'Machine',
-    path: 'machines',
-    DetailComponent: MachineDetail,
-    ListComponent: MachinesList,
-    icon: 'mdi:desktop-classic',
-  },
-  {
     name: 'Machine Deployments',
     kind: 'MachineDeployment',
     path: 'machinedeployments',
     DetailComponent: MachineDeploymentDetail,
     ListComponent: MachineDeploymentsList,
     icon: 'mdi:knob',
-  },
-  {
-    name: 'Machine Drain Rules',
-    kind: 'MachineDrainRule',
-    path: 'machinedrainrules',
-    DetailComponent: MachineDrainRuleDetail,
-    ListComponent: MachineDrainRulesList,
-    icon: 'mdi:vacuum-outline',
-  },
-  {
-    name: 'Machine Health Checks',
-    kind: 'MachineHealthCheck',
-    path: 'machinehealthchecks',
-    DetailComponent: MachineHealthCheckDetail,
-    ListComponent: MachineHealthChecksList,
-    icon: 'mdi:bottle-tonic-plus',
   },
   {
     name: 'Machine Pools',
@@ -193,6 +153,46 @@ const clusterApiResources: ResourceRegistrationConfig[] = [
     DetailComponent: MachineSetDetail,
     ListComponent: MachineSetsList,
     icon: 'mdi:set-split',
+  },
+  {
+    name: 'Machines',
+    kind: 'Machine',
+    path: 'machines',
+    DetailComponent: MachineDetail,
+    ListComponent: MachinesList,
+    icon: 'mdi:desktop-classic',
+  },
+  {
+    name: 'Kubeadm Config Templates',
+    kind: 'KubeadmConfigTemplate',
+    path: 'kubeadmconfigtemplates',
+    DetailComponent: KubeadmConfigTemplateDetail,
+    ListComponent: KubeadmConfigTemplatesList,
+    icon: 'mdi:list-box-outline',
+  },
+  {
+    name: 'Kubeadm Configs',
+    kind: 'KubeadmConfig',
+    path: 'kubeadmconfigs',
+    DetailComponent: KubeadmConfigDetail,
+    ListComponent: KubeadmConfigsList,
+    icon: 'mdi:list-box',
+  },
+  {
+    name: 'Machine Health Checks',
+    kind: 'MachineHealthCheck',
+    path: 'machinehealthchecks',
+    DetailComponent: MachineHealthCheckDetail,
+    ListComponent: MachineHealthChecksList,
+    icon: 'mdi:bottle-tonic-plus',
+  },
+  {
+    name: 'Machine Drain Rules',
+    kind: 'MachineDrainRule',
+    path: 'machinedrainrules',
+    DetailComponent: MachineDrainRuleDetail,
+    ListComponent: MachineDrainRulesList,
+    icon: 'mdi:vacuum-outline',
   },
 ];
 


### PR DESCRIPTION
## Changes
- Reorder Cluster API sidebar: Clusters first, then Cluster Classes, control plane, worker scaling (MD, Pools, Sets, Machines), bootstrap config, operations

- Pass icon to registerSidebarEntry for each child so icons appear in sidebar


<img width="307" height="648" alt="image" src="https://github.com/user-attachments/assets/7e155933-b2cc-415b-ae9a-78725076a795" />


Note: This fixes the visibility of icons; the icon set itself may still need further updates.