### PR TITLE
fix(prometheus): handle plain text response in Prometheus connection test

### DIFF
--- a/prometheus/src/components/Settings/Settings.tsx
+++ b/prometheus/src/components/Settings/Settings.tsx
@@ -116,7 +116,10 @@ export function Settings(props: SettingsProps) {
       }
 
       const proxyUrl = `/clusters/${selectedCluster}/api/v1/namespaces/${namespace}/services/${service}:${port}/proxy${subPath}/-/healthy`;
-      await request(proxyUrl);
+      await request(proxyUrl, {
+        method: 'GET',
+        isJSON: false,
+      });
 
       setTestStatus('success');
       setTestMessage(t('Connection successful!'));


### PR DESCRIPTION
In the Prometheus plugin settings page, after manually configuring the Prometheus Service Address and clicking Test Connection, the frontend calls the Prometheus /-/healthy endpoint. That endpoint returns plain text, such as `'Prometheus Server is Healthy'`.but the current implementation handles the response using the default JSON parsing path. As a result, the frontend throws` Unexpected token 'P' during parsing and incorrectly reports the connection as failed`.

This fix updates the connection test logic to handle the response as a raw HTTP response instead of forcing JSON parsing, and determines success based on the HTTP status code. This makes the test compatible with Prometheus health check endpoints that return plain text.