### PR TITLE
Make releaser tool update via a dir

### DIFF
--- a/tools/releaser/src/commands/artifacthub.ts
+++ b/tools/releaser/src/commands/artifacthub.ts
@@ -1,3 +1,5 @@
+import path from 'path';
+import fs from 'fs';
 import chalk from 'chalk';
 import { getPluginPath, getPluginInfo, findTarball } from '../utils/plugin.js';
 import { sanitizeVersion, validateVersion } from '../utils/version.js';
@@ -11,7 +13,7 @@ import {
 interface UpdateArtifactHubOptions {
   tarball?: string;
   template?: boolean;
-  noCommit?: boolean;
+  commit?: boolean;
 }
 
 export function updateArtifactHub(
@@ -34,7 +36,7 @@ export function updateArtifactHub(
   console.log(chalk.blue(`🔧 Updating artifacthub-pkg.yml for plugin "${pluginName}" version ${targetVersion}...\n`));
 
   // Check git status if we're going to commit
-  if (!options.noCommit && !checkGitStatus()) {
+  if (options.commit && !checkGitStatus()) {
     console.error(chalk.red('Error: Working directory is not clean. Please commit or stash your changes first.'));
     console.error(chalk.red('Or use --no-commit to skip git commit.'));
     process.exit(1);
@@ -52,7 +54,7 @@ export function updateArtifactHub(
       createArtifactHubTemplate(pluginName);
       console.log(chalk.green('✅ Created artifacthub-pkg.yml template'));
 
-      if (!options.noCommit) {
+      if (options.commit) {
         console.log(chalk.blue('📝 Committing changes...'));
         commitArtifactHubChange(pluginName, targetVersion, true);
         console.log(chalk.green(`✅ Changes committed`));
@@ -82,8 +84,8 @@ export function updateArtifactHub(
   let tarballPath: string;
 
   if (options.tarball) {
-    tarballPath = require('path').resolve(options.tarball);
-    if (!require('fs').existsSync(tarballPath)) {
+    tarballPath = path.resolve(options.tarball);
+    if (!fs.existsSync(tarballPath)) {
       console.error(chalk.red(`❌ Specified tarball does not exist: ${tarballPath}`));
       process.exit(1);
     }
@@ -100,13 +102,13 @@ export function updateArtifactHub(
 
   console.log(chalk.dim(`Plugin: ${info.name}`));
   console.log(chalk.dim(`Version: ${targetVersion}`));
-  console.log(chalk.dim(`Tarball: ${require('path').basename(tarballPath)}\n`));
+  console.log(chalk.dim(`Tarball: ${path.basename(tarballPath)}\n`));
 
   try {
     updateArtifactHubConfig(pluginName, targetVersion, tarballPath);
     console.log(chalk.green('✅ artifacthub-pkg.yml updated successfully!'));
 
-    if (!options.noCommit) {
+    if (options.commit) {
       console.log(chalk.blue('📝 Committing changes...'));
       commitArtifactHubChange(pluginName, targetVersion, false);
       console.log(chalk.green(`✅ Changes committed`));

--- a/tools/releaser/src/commands/artifacthub.ts
+++ b/tools/releaser/src/commands/artifacthub.ts
@@ -44,8 +44,8 @@ export function updateArtifactHub(
 
   // If template option is provided, create a new template
   if (options.template) {
-    if (hasArtifactHubFile(pluginName)) {
-      console.error(chalk.red(`❌ artifacthub-pkg.yml already exists for ${pluginName}`));
+    if (hasArtifactHubFile(pluginName, targetVersion)) {
+      console.error(chalk.red(`❌ artifacthub-pkg.yml already exists for ${pluginName} v${targetVersion}`));
       console.error(chalk.red('Remove the existing file first or use without --template to update it'));
       process.exit(1);
     }

--- a/tools/releaser/src/utils/artifacthub.ts
+++ b/tools/releaser/src/utils/artifacthub.ts
@@ -32,31 +32,72 @@ function calculateChecksum(filePath: string): string {
 }
 
 /**
- * Check if plugin has an artifacthub-pkg.yml file
+ * Get the versioned directory path for a plugin release.
+ * Layout: <plugin>/<version>/artifacthub-pkg.yml
  */
-export function hasArtifactHubFile(pluginName: string): boolean {
+export function getVersionDir(pluginName: string, version: string): string {
   const pluginPath = getPluginPath(pluginName);
-  const artifactHubPath = path.join(pluginPath, 'artifacthub-pkg.yml');
-  return fs.existsSync(artifactHubPath);
+  return path.join(pluginPath, version);
 }
 
 /**
- * Get the path to the artifacthub-pkg.yml file for a plugin
+ * Check if plugin has an artifacthub-pkg.yml file for the given version.
+ * Falls back to checking the legacy top-level location.
  */
-export function getArtifactHubPath(pluginName: string): string {
+export function hasArtifactHubFile(pluginName: string, version?: string): boolean {
+  if (version) {
+    const versionDir = getVersionDir(pluginName, version);
+    return fs.existsSync(path.join(versionDir, 'artifacthub-pkg.yml'));
+  }
+
+  // Check for any version directory containing an artifacthub-pkg.yml
+  const pluginPath = getPluginPath(pluginName);
+  const entries = fs.readdirSync(pluginPath, { withFileTypes: true });
+  for (const entry of entries) {
+    if (entry.isDirectory() && fs.existsSync(path.join(pluginPath, entry.name, 'artifacthub-pkg.yml'))) {
+      return true;
+    }
+  }
+
+  // Legacy: check top-level
+  return fs.existsSync(path.join(pluginPath, 'artifacthub-pkg.yml'));
+}
+
+/**
+ * Get the path to the artifacthub-pkg.yml file for a plugin version.
+ */
+export function getArtifactHubPath(pluginName: string, version?: string): string {
+  if (version) {
+    return path.join(getVersionDir(pluginName, version), 'artifacthub-pkg.yml');
+  }
+
+  // Legacy fallback
   const pluginPath = getPluginPath(pluginName);
   return path.join(pluginPath, 'artifacthub-pkg.yml');
 }
 
 /**
- * Read and parse the artifacthub-pkg.yml file
+ * Find the latest version directory for a plugin by reading existing version folders.
  */
-export function readArtifactHubConfig(pluginName: string): ArtifactHubConfig | null {
-  if (!hasArtifactHubFile(pluginName)) {
+export function getLatestArtifactHubVersion(pluginName: string): string | null {
+  const pluginPath = getPluginPath(pluginName);
+  const entries = fs.readdirSync(pluginPath, { withFileTypes: true });
+  const versions = entries
+    .filter(e => e.isDirectory() && fs.existsSync(path.join(pluginPath, e.name, 'artifacthub-pkg.yml')))
+    .map(e => e.name)
+    .sort();
+  return versions.length > 0 ? versions[versions.length - 1] : null;
+}
+
+/**
+ * Read and parse the artifacthub-pkg.yml file for a given version.
+ */
+export function readArtifactHubConfig(pluginName: string, version?: string): ArtifactHubConfig | null {
+  const artifactHubPath = getArtifactHubPath(pluginName, version);
+  if (!fs.existsSync(artifactHubPath)) {
     return null;
   }
 
-  const artifactHubPath = getArtifactHubPath(pluginName);
   try {
     const content = fs.readFileSync(artifactHubPath, 'utf-8');
     return yaml.load(content) as ArtifactHubConfig;
@@ -68,16 +109,22 @@ export function readArtifactHubConfig(pluginName: string): ArtifactHubConfig | n
 }
 
 /**
- * Update the artifacthub-pkg.yml file with new version and tarball information
+ * Update the artifacthub-pkg.yml file with new version and tarball information.
+ * Creates a version directory (<plugin>/<version>/) and copies the README into it.
  */
 export function updateArtifactHubConfig(
   pluginName: string,
   version: string,
   tarballPath: string
 ): void {
-  const artifactHubPath = getArtifactHubPath(pluginName);
-  const pluginInfo = getPluginInfo(getPluginPath(pluginName));
+  const pluginPath = getPluginPath(pluginName);
+  const pluginInfo = getPluginInfo(pluginPath);
   const { owner, repo } = getOwnerAndRepo();
+
+  const versionDir = getVersionDir(pluginName, version);
+  fs.mkdirSync(versionDir, { recursive: true });
+
+  const artifactHubPath = path.join(versionDir, 'artifacthub-pkg.yml');
 
   // Calculate checksum of the tarball
   const checksum = calculateChecksum(tarballPath);
@@ -88,14 +135,16 @@ export function updateArtifactHubConfig(
 
   let config: ArtifactHubConfig;
 
-  if (hasArtifactHubFile(pluginName)) {
-    // Update existing config
-    config = readArtifactHubConfig(pluginName)!;
+  // Try reading an existing config for this version, then fall back to the latest version
+  const existingConfig = readArtifactHubConfig(pluginName, version)
+    ?? readArtifactHubConfig(pluginName, getLatestArtifactHubVersion(pluginName) ?? undefined);
+
+  if (existingConfig) {
+    config = existingConfig;
     config.version = version;
     config.annotations['headlamp/plugin/archive-url'] = archiveUrl;
     config.annotations['headlamp/plugin/archive-checksum'] = `SHA256:${checksum}`;
   } else {
-    // Create new config
     config = {
       version,
       name: `headlamp_${pluginName.replace(/-/g, '_')}`,
@@ -118,21 +167,40 @@ export function updateArtifactHubConfig(
   });
 
   fs.writeFileSync(artifactHubPath, yamlContent);
+
+  // Remove legacy top-level artifacthub-pkg.yml if it exists
+  const legacyPath = path.join(pluginPath, 'artifacthub-pkg.yml');
+  if (fs.existsSync(legacyPath)) {
+    fs.unlinkSync(legacyPath);
+    console.log(chalk.dim('Removed legacy top-level artifacthub-pkg.yml'));
+  }
+
+  // Copy README.md into the version directory
+  const readmeSrc = path.join(pluginPath, 'README.md');
+  if (fs.existsSync(readmeSrc)) {
+    fs.copyFileSync(readmeSrc, path.join(versionDir, 'README.md'));
+  }
 }
 
 /**
- * Create a template artifacthub-pkg.yml file for a plugin
+ * Create a template artifacthub-pkg.yml file for a plugin in a version directory.
  */
 export function createArtifactHubTemplate(pluginName: string): void {
-  const artifactHubPath = getArtifactHubPath(pluginName);
-  const pluginInfo = getPluginInfo(getPluginPath(pluginName));
+  const pluginPath = getPluginPath(pluginName);
+  const pluginInfo = getPluginInfo(pluginPath);
+  const version = pluginInfo.version;
+
+  const versionDir = getVersionDir(pluginName, version);
+  const artifactHubPath = path.join(versionDir, 'artifacthub-pkg.yml');
 
   if (fs.existsSync(artifactHubPath)) {
-    throw new Error(`artifacthub-pkg.yml already exists for ${pluginName}`);
+    throw new Error(`artifacthub-pkg.yml already exists for ${pluginName} v${version}`);
   }
 
+  fs.mkdirSync(versionDir, { recursive: true });
+
   const template: Partial<ArtifactHubConfig> = {
-    version: pluginInfo.version,
+    version,
     name: `headlamp_${pluginName.replace(/-/g, '_')}`,
     displayName: pluginInfo.name,
     createdAt: new Date().toISOString(),
@@ -152,4 +220,10 @@ export function createArtifactHubTemplate(pluginName: string): void {
   });
 
   fs.writeFileSync(artifactHubPath, yamlContent);
+
+  // Copy README.md into the version directory
+  const readmeSrc = path.join(pluginPath, 'README.md');
+  if (fs.existsSync(readmeSrc)) {
+    fs.copyFileSync(readmeSrc, path.join(versionDir, 'README.md'));
+  }
 }

--- a/tools/releaser/src/utils/git.ts
+++ b/tools/releaser/src/utils/git.ts
@@ -48,11 +48,20 @@ export function commitPluginVersionChange(pluginName: string, version: string): 
 
 export function commitArtifactHubChange(pluginName: string, version: string, isTemplate: boolean = false): void {
   const repoRoot = getRepoRoot();
-  const pluginPath = path.join(repoRoot, pluginName);
-  const artifactHubPath = path.join(pluginPath, 'artifacthub-pkg.yml');
+  const versionDir = path.join(repoRoot, pluginName, version);
+  const legacyPath = path.join(repoRoot, pluginName, 'artifacthub-pkg.yml');
 
   try {
-    execFileSync('git', ['add', artifactHubPath], { cwd: repoRoot });
+    execFileSync('git', ['add', versionDir], { cwd: repoRoot });
+
+    // Stage removal of legacy top-level file if it was tracked
+    if (!fs.existsSync(legacyPath)) {
+      try {
+        execFileSync('git', ['rm', '--cached', '--ignore-unmatch', legacyPath], { cwd: repoRoot });
+      } catch (_) {
+        // Safe to ignore: file was never tracked
+      }
+    }
 
     const action = isTemplate ? 'Create' : 'Update';
     const message = `${pluginName}: ${action} artifacthub-pkg.yml for version ${version}`;


### PR DESCRIPTION
This PR changes the releaser to use version based releases. It also updates the existing file based releases.

## How to test

```bash
cd tools/releaser && npm run build
```

### 1. Test migration from legacy flat layout

This verifies that a plugin with a top-level `artifacthub-pkg.yml` gets migrated to a version directory.

```bash
# Pick a plugin that still has the old layout (e.g. app-catalog)
# Ensure it has a tarball first:
plugin-releaser package app-catalog

# Run with --no-commit so we can inspect the result
plugin-releaser artifacthub app-catalog --no-commit
```

Verify:
- `app-catalog/<version>/artifacthub-pkg.yml` exists with correct content
- `app-catalog/<version>/README.md` was copied in
- `app-catalog/artifacthub-pkg.yml` (top-level) was removed
- Console printed "Removed legacy top-level artifacthub-pkg.yml"

Clean up: `git checkout -- app-catalog/`

### 2. Test creating a new template

```bash
# Use a plugin that has no artifacthub-pkg.yml at all
plugin-releaser artifacthub <plugin-without-artifacthub> --template --no-commit
```

Verify:
- `<plugin>/<version>/artifacthub-pkg.yml` was created with TBD placeholders
- `<plugin>/<version>/README.md` was copied in
- No top-level `artifacthub-pkg.yml` was created

Clean up: `rm -rf <plugin>/<version>/`

### 3. Test updating an already-versioned plugin

This verifies it works correctly when the plugin already uses the new layout (like flux after our earlier commit).

```bash
# flux already has 0.5.0/ and 0.6.0/ directories
plugin-releaser artifacthub flux 0.6.0 --tarball flux/headlamp-k8s-flux-0.6.0.tar.gz --no-commit
```

Verify:
- `flux/0.6.0/artifacthub-pkg.yml` was updated (checksum/URL match the tarball)
- `flux/0.6.0/README.md` exists
- No top-level `flux/artifacthub-pkg.yml` was created

Clean up: `git checkout -- flux/0.6.0/`

### 4. Test duplicate template is rejected

```bash
plugin-releaser artifacthub flux --template --no-commit
```

Verify: exits with error "artifacthub-pkg.yml already exists for flux v0.6.0"