### PR TITLE
fix(kyverno): show 100% compliance when no reports exist

### DIFF
--- a/kyverno/src/components/ComplianceBadge.tsx
+++ b/kyverno/src/components/ComplianceBadge.tsx
@@ -78,7 +78,7 @@ export function ComplianceBadge() {
 
   const violationCount = counts.fail + counts.error + counts.warn;
   const total = counts.pass + counts.fail + counts.warn + counts.error + counts.skip;
-  const compliancePct = total > 0 ? Math.round((counts.pass / total) * 100) : 0;
+  const compliancePct = total > 0 ? Math.round((counts.pass / total) * 100) : 100;
 
   const badgeColor = violationCount > 0 ? 'error' : 'success';
 


### PR DESCRIPTION
**Summary**
Currently, the ComplianceBadge shows 0% compliant when no policy reports are found in the cluster. This is inconsistent with the Dashboard view and can be misleading to users (making it look like a total compliance failure).

**Changes**
Updated the compliance percentage calculation in ComplianceBadge.tsx to return 100% when the total number of results is zero.
Ensures consistency between the App Bar badge and the Kyverno Dashboard.