### PR TITLE
fix: re-detect Kyverno CRDs on cluster switch

### DIFF
--- a/kyverno/src/hooks/useKyvernoCRDs.ts
+++ b/kyverno/src/hooks/useKyvernoCRDs.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ApiProxy } from '@kinvolk/headlamp-plugin/lib';
+import { ApiProxy, K8s } from '@kinvolk/headlamp-plugin/lib';
 import { useEffect, useState } from 'react';
 
 export interface KyvernoCRDStatus {
@@ -36,6 +36,7 @@ async function checkAPIGroup(path: string): Promise<boolean> {
 }
 
 export function useKyvernoCRDs(): KyvernoCRDStatus {
+  const cluster = K8s.useCluster();
   const [status, setStatus] = useState<KyvernoCRDStatus>({
     legacy: false,
     cel: false,
@@ -46,6 +47,9 @@ export function useKyvernoCRDs(): KyvernoCRDStatus {
   });
 
   useEffect(() => {
+    let isCancelled = false;
+    setStatus(prev => ({ ...prev, loading: true }));
+
     async function detect() {
       const [legacy, cel, reports] = await Promise.all([
         checkAPIGroup('/apis/kyverno.io/v1'),
@@ -64,11 +68,17 @@ export function useKyvernoCRDs(): KyvernoCRDStatus {
         }
       }
 
-      setStatus({ legacy, cel, cleanup, reports, exceptions, loading: false });
+      if (!isCancelled) {
+        setStatus({ legacy, cel, cleanup, reports, exceptions, loading: false });
+      }
     }
 
     detect();
-  }, []);
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [cluster]);
 
   return status;
 }


### PR DESCRIPTION
**Summary**
The useKyvernoCRDs hook was only running once on plugin mount. This meant that if the user switched between different Kubernetes clusters (where Kyverno might or might not be installed), the plugin's status (and sidebar visibility) would remain stale from the first detected cluster.

**Changes**
1.Integrated K8s.useCluster() hook to track active cluster changes.
2.Added cluster as a dependency to the detection useEffect.
3.Implemented a loading state reset on cluster switch to ensure fresh CRD detection.