### PR TITLE
feat(ai-assistant): make Holmes service configurable

### DIFF
--- a/ai-assistant/src/agent/holmesClient.ts
+++ b/ai-assistant/src/agent/holmesClient.ts
@@ -1,5 +1,6 @@
 import { HttpAgent } from '@ag-ui/client';
 import { clusterRequest } from '@kinvolk/headlamp-plugin/lib/ApiProxy';
+import type { PluginConfig } from '../utils';
 
 /**
  * Default base URL for the Holmes ag-ui server (direct / port-forward fallback).
@@ -14,6 +15,27 @@ export const HOLMES_SERVICE_NAME = 'holmesgpt-holmes';
 export const HOLMES_SERVICE_PORT = 80;
 export const HOLMES_SERVICE_NAMESPACE = 'default';
 
+function normalizeConfigString(value: string | undefined, fallback: string): string {
+  const normalized = value?.trim();
+  return normalized || fallback;
+}
+
+function normalizeConfigPort(value: number | undefined, fallback: number): number {
+  return Number.isInteger(value) && value >= 1 && value <= 65535 ? value : fallback;
+}
+
+function getHolmesServiceConfig(config?: PluginConfig): {
+  namespace: string;
+  serviceName: string;
+  servicePort: number;
+} {
+  return {
+    namespace: normalizeConfigString(config?.holmesNamespace, HOLMES_SERVICE_NAMESPACE),
+    serviceName: normalizeConfigString(config?.holmesServiceName, HOLMES_SERVICE_NAME),
+    servicePort: normalizeConfigPort(config?.holmesPort, HOLMES_SERVICE_PORT),
+  };
+}
+
 /**
  * Build the K8s API path that proxies to the Holmes service.
  *
@@ -22,12 +44,8 @@ export const HOLMES_SERVICE_NAMESPACE = 'default';
  *
  * This path can be used with Headlamp's `clusterRequest()` directly.
  */
-export function getHolmesServiceProxyPath(
-  subPath = '',
-  namespace: string = HOLMES_SERVICE_NAMESPACE,
-  serviceName: string = HOLMES_SERVICE_NAME,
-  servicePort: number = HOLMES_SERVICE_PORT
-): string {
+export function getHolmesServiceProxyPath(config?: PluginConfig, subPath = ''): string {
+  const { namespace, serviceName, servicePort } = getHolmesServiceConfig(config);
   const base = `/api/v1/namespaces/${namespace}/services/${serviceName}:${servicePort}/proxy`;
   return subPath ? `${base}/${subPath.replace(/^\//, '')}` : base;
 }
@@ -40,9 +58,16 @@ export function getHolmesServiceProxyPath(
  * We probe the root path (/) which uvicorn will respond to (even with 404/405)
  * rather than /healthz which the experimental server may not implement.
  */
-export async function checkHolmesAgentHealth(cluster: string): Promise<boolean> {
+export async function checkHolmesAgentHealth(
+  cluster: string,
+  config?: PluginConfig
+): Promise<boolean> {
   try {
-    await clusterRequest(getHolmesServiceProxyPath(''), { cluster, isJSON: false, timeout: 5000 });
+    await clusterRequest(getHolmesServiceProxyPath(config, ''), {
+      cluster,
+      isJSON: false,
+      timeout: 5000,
+    });
     return true;
   } catch (err: any) {
     // A 404/405 from the Holmes server itself means the pod IS reachable
@@ -101,12 +126,7 @@ function getHeadlampBackendOrigin(): string {
  * The returned URL is absolute (includes the Headlamp backend origin) so that
  * it can be passed directly to `HttpAgent` / `fetch`.
  */
-export function getHolmesProxyBaseUrl(
-  cluster: string,
-  namespace: string = HOLMES_SERVICE_NAMESPACE,
-  serviceName: string = HOLMES_SERVICE_NAME,
-  servicePort: number = HOLMES_SERVICE_PORT
-): string {
+export function getHolmesProxyBaseUrl(cluster: string, config?: PluginConfig): string {
   const origin = getHeadlampBackendOrigin();
   // Respect any base URL prefix (e.g. /headlamp)
   let baseUrlPrefix = '';
@@ -116,12 +136,7 @@ export function getHolmesProxyBaseUrl(
       baseUrlPrefix = raw;
     }
   }
-  return `${origin}${baseUrlPrefix}/clusters/${cluster}${getHolmesServiceProxyPath(
-    '',
-    namespace,
-    serviceName,
-    servicePort
-  )}`;
+  return `${origin}${baseUrlPrefix}/clusters/${cluster}${getHolmesServiceProxyPath(config, '')}`;
 }
 
 /**
@@ -129,7 +144,7 @@ export function getHolmesProxyBaseUrl(
  * Holmes ag-ui server via SSE.
  *
  * Usage:
- *   const agent = new HolmesAgent(getHolmesProxyBaseUrl(cluster));
+ *   const agent = new HolmesAgent(getHolmesProxyBaseUrl(cluster, pluginSettings));
  *   agent.subscribe({ onTextMessageContentEvent: ... });
  *   agent.addMessage({ id: '1', role: 'user', content: 'What pods are failing?' });
  *   await agent.runAgent({ runId: 'run-1' });

--- a/ai-assistant/src/components/settings/HolmesAgentSettings.tsx
+++ b/ai-assistant/src/components/settings/HolmesAgentSettings.tsx
@@ -1,0 +1,96 @@
+import { SectionBox } from '@kinvolk/headlamp-plugin/lib/components/common';
+import { Box, TextField, Typography } from '@mui/material';
+import React from 'react';
+import {
+  HOLMES_SERVICE_NAME,
+  HOLMES_SERVICE_NAMESPACE,
+  HOLMES_SERVICE_PORT,
+} from '../../agent/holmesClient';
+import type { PluginConfig } from '../../utils';
+import { pluginStore } from '../../utils';
+
+function normalizeTextSetting(value: string | undefined, fallback: string): string {
+  return value?.trim() || fallback;
+}
+
+function normalizePortSetting(value: number | undefined): number {
+  return Number.isInteger(value) && value >= 1 && value <= 65535 ? value : HOLMES_SERVICE_PORT;
+}
+
+export function HolmesAgentSettings(props: { config: PluginConfig | null | undefined }) {
+  const config = props.config;
+
+  const holmesNamespace = normalizeTextSetting(config?.holmesNamespace, HOLMES_SERVICE_NAMESPACE);
+  const holmesServiceName = normalizeTextSetting(config?.holmesServiceName, HOLMES_SERVICE_NAME);
+  const holmesPort = normalizePortSetting(config?.holmesPort);
+
+  const updateConfig = (patch: Partial<PluginConfig>) => {
+    const current = pluginStore.get() || {};
+    pluginStore.update({
+      ...current,
+      ...patch,
+    });
+  };
+
+  const handleNamespaceChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    updateConfig({
+      holmesNamespace: event.target.value.trim() || HOLMES_SERVICE_NAMESPACE,
+    });
+  };
+
+  const handleServiceNameChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    updateConfig({
+      holmesServiceName: event.target.value.trim() || HOLMES_SERVICE_NAME,
+    });
+  };
+
+  const handlePortChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value.trim();
+
+    if (value === '') {
+      updateConfig({ holmesPort: HOLMES_SERVICE_PORT });
+      return;
+    }
+
+    const n = Number(value);
+    updateConfig({
+      holmesPort: Number.isInteger(n) && n >= 1 && n <= 65535 ? n : HOLMES_SERVICE_PORT,
+    });
+  };
+
+  return (
+    <SectionBox title="Holmes Agent">
+      <Typography variant="body2" color="textSecondary" sx={{ mb: 2 }}>
+        Configure how the plugin reaches the HolmesGPT service through the Kubernetes API service
+        proxy.
+      </Typography>
+
+      <Box display="flex" flexDirection="column" gap={2} sx={{ ml: 1, maxWidth: 480 }}>
+        <TextField
+          label="Namespace"
+          value={holmesNamespace}
+          helperText='Namespace where HolmesGPT is deployed (default: "default")'
+          onChange={handleNamespaceChange}
+          size="small"
+        />
+
+        <TextField
+          label="Service name"
+          value={holmesServiceName}
+          helperText='Kubernetes Service name for HolmesGPT (default: "holmesgpt-holmes")'
+          onChange={handleServiceNameChange}
+          size="small"
+        />
+
+        <TextField
+          label="Port"
+          type="number"
+          value={holmesPort}
+          helperText="Service port (default: 80)"
+          onChange={handlePortChange}
+          size="small"
+        />
+      </Box>
+    </SectionBox>
+  );
+}

--- a/ai-assistant/src/components/settings/index.ts
+++ b/ai-assistant/src/components/settings/index.ts
@@ -1,3 +1,4 @@
 export { default as ModelSelector } from './ModelSelector';
 export { default as TermsDialog } from './TermsDialog';
 export { MCPSettings } from './MCPSettings';
+export { HolmesAgentSettings } from './HolmesAgentSettings';

--- a/ai-assistant/src/index.tsx
+++ b/ai-assistant/src/index.tsx
@@ -5,6 +5,7 @@ import {
   registerPluginSettings,
   registerUIPanel,
 } from '@kinvolk/headlamp-plugin/lib';
+import { useSelectedClusters } from '@kinvolk/headlamp-plugin/lib/k8s';
 // @todo: this HeadlampEventType import is weird. Maybe fix in headlamp to be better.
 import { DefaultHeadlampEvents as HeadlampEventType } from '@kinvolk/headlamp-plugin/lib/plugin/registry';
 import { getCluster } from '@kinvolk/headlamp-plugin/lib/Utils';
@@ -26,7 +27,7 @@ import React from 'react';
 import { useHistory } from 'react-router-dom';
 import { checkHolmesAgentHealth } from './agent/holmesClient';
 import { ModelSelector } from './components';
-import { MCPSettings } from './components/settings';
+import { HolmesAgentSettings, MCPSettings } from './components/settings';
 import { getDefaultConfig } from './config/modelConfig';
 import { PromptWidthProvider } from './contexts/PromptWidthContext';
 import { isTestModeCheck } from './helper';
@@ -155,6 +156,7 @@ registerUIPanel({
 function HeadlampAIPrompt() {
   const pluginState = useGlobalState();
   const savedConfigs = usePluginConfig();
+  const selectedClusters = useSelectedClusters();
   const history = useHistory();
   const [popoverAnchor, setPopoverAnchor] = React.useState<HTMLElement | null>(null);
   const [showPopover, setShowPopover] = React.useState(false);
@@ -167,23 +169,34 @@ function HeadlampAIPrompt() {
   }, [savedConfigs]);
 
   const hasAnyValidConfig = savedConfigData.providers && savedConfigData.providers.length > 0;
+  const currentCluster =
+    (selectedClusters && selectedClusters.length > 0 ? selectedClusters[0] : null) ||
+    getCluster() ||
+    null;
+  const holmesServiceConfig = React.useMemo(
+    () => ({
+      holmesNamespace: savedConfigs?.holmesNamespace,
+      holmesServiceName: savedConfigs?.holmesServiceName,
+      holmesPort: savedConfigs?.holmesPort,
+    }),
+    [savedConfigs?.holmesNamespace, savedConfigs?.holmesServiceName, savedConfigs?.holmesPort]
+  );
 
   // Check if the Holmes agent is available via K8s service proxy
   const [isAgentAvailable, setIsAgentAvailable] = React.useState(false);
   React.useEffect(() => {
     let cancelled = false;
-    const cluster = getCluster();
-    if (!cluster) {
+    if (!currentCluster) {
       setIsAgentAvailable(false);
       return;
     }
-    checkHolmesAgentHealth(cluster).then(available => {
+    checkHolmesAgentHealth(currentCluster, holmesServiceConfig).then(available => {
       if (!cancelled) setIsAgentAvailable(available);
     });
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [currentCluster, holmesServiceConfig]);
 
   // Reset popover shown state when configurations change from none to some
   React.useEffect(() => {
@@ -532,6 +545,10 @@ function Settings() {
       {/* MCP Servers Section */}
       <Divider sx={{ my: 3 }} />
       <MCPSettings />
+
+      {/* Holmes Agent Section */}
+      <Divider sx={{ my: 3 }} />
+      <HolmesAgentSettings config={savedConfigs} />
 
       {/* MCP Tool Configuration Section */}
       <Divider sx={{ my: 3 }} />

--- a/ai-assistant/src/modal.tsx
+++ b/ai-assistant/src/modal.tsx
@@ -801,219 +801,220 @@ export default function AIPrompt(props: {
     return false;
   };
 
-  const handleToggleAgentMode = React.useCallback(async (enabled: boolean) => {
-    if (enabled) {
-      setAgentModeStatus('found');
-      setIsAgentMode(true);
+  const handleToggleAgentMode = React.useCallback(
+    async (enabled: boolean) => {
+      if (enabled) {
+        setAgentModeStatus('found');
+        setIsAgentMode(true);
 
-      // Create the HolmesAgent routing through K8s service proxy
-      const cluster = getCluster();
-      if (!cluster) {
-        console.error('[AgentMode] No cluster available');
-        return;
-      }
-      const agent = new HolmesAgent(getHolmesProxyBaseUrl(cluster));
-      agent.subscribe({
-        onEvent: ({ event }) => {
-          console.log('[AgentMode] onEvent:', event.type, event);
-        },
-        onRunInitialized: () => {
-          console.log('[AgentMode] onRunInitialized');
-        },
-        onRunFailed: ({ error }) => {
-          console.error('[AgentMode] onRunFailed:', error);
-        },
-        onRunFinalized: () => {
-          console.log('[AgentMode] onRunFinalized');
-        },
-        onRunStartedEvent: () => {
-          console.log('[AgentMode] onRunStartedEvent');
-          setLoading(true);
-          // Create the placeholder assistant message with thinking steps
-          const placeholderId = `agent-response-${Date.now()}`;
-          agentMessageIdRef.current = placeholderId;
-          setPromptHistory(prev => [
-            ...prev,
-            {
-              role: 'assistant',
-              content: '',
-              agentThinkingSteps: [],
-              agentThinkingDone: false,
-            },
-          ]);
-        },
-        onRunFinishedEvent: () => {
-          console.log('[AgentMode] onRunFinishedEvent');
-          setLoading(false);
-          // Mark thinking as done and sanitize the final displayed content
-          setPromptHistory(prev => {
-            const updated = [...prev];
-            for (let i = updated.length - 1; i >= 0; i--) {
-              if (
-                updated[i].role === 'assistant' &&
-                updated[i].agentThinkingSteps !== undefined &&
-                !updated[i].agentThinkingDone
-              ) {
-                const cleanContent = sanitizeAgentContent(updated[i].content || '');
-                updated[i] = {
-                  ...updated[i],
-                  content: cleanContent,
-                  agentThinkingDone: true,
-                };
-                break;
-              }
-            }
-            return updated;
-          });
-          agentMessageIdRef.current = null;
-          agentTextBufferRef.current = '';
-          agentCurrentMsgIdRef.current = '';
-        },
-        onRunErrorEvent: ({ event }) => {
-          console.error('[AgentMode] onRunErrorEvent:', event);
-          setLoading(false);
-          setPromptHistory(prev => [
-            ...prev,
-            {
-              role: 'assistant',
-              content: `Agent error: ${event.message}`,
-              error: true,
-            },
-          ]);
-          agentMessageIdRef.current = null;
-        },
-        onTextMessageStartEvent: ({ event }) => {
-          console.log('[AgentMode] onTextMessageStartEvent:', event.messageId);
-          agentTextBufferRef.current = '';
-          agentCurrentMsgIdRef.current = event.messageId;
-        },
-        onTextMessageContentEvent: ({ event }) => {
-          console.log('[AgentMode] onTextMessageContentEvent:', { delta: event.delta });
-          agentTextBufferRef.current += event.delta || '';
-        },
-        onTextMessageEndEvent: () => {
-          console.log('[AgentMode] onTextMessageEndEvent');
-          const fullText = agentTextBufferRef.current;
-          const msgId = agentCurrentMsgIdRef.current;
-          const stepType = classifyAgentText(fullText);
-          const isToolMessage = stepType === 'tool-result' || stepType === 'tool-start';
-
-          // Update the placeholder assistant message:
-          // - Tool-result / tool-start messages go ONLY into agentThinkingSteps
-          //   (they must never overwrite the displayed content).
-          // - Other messages replace content (final answer is the last non-tool one).
-          setPromptHistory(prev => {
-            const updated = [...prev];
-            for (let i = updated.length - 1; i >= 0; i--) {
-              if (
-                updated[i].role === 'assistant' &&
-                updated[i].agentThinkingSteps !== undefined &&
-                !updated[i].agentThinkingDone
-              ) {
-                const existingSteps = updated[i].agentThinkingSteps || [];
-                const prevContent = updated[i].content || '';
-                const newSteps = [...existingSteps];
-
-                // For non-tool messages, move previous content into thinking
-                // steps (if it hasn't already been added).
-                if (!isToolMessage && prevContent.trim()) {
-                  const prevType = classifyAgentText(prevContent);
-                  const alreadyInSteps = newSteps.some(step => step.content === prevContent);
-                  if (!alreadyInSteps) {
-                    newSteps.push({
-                      id: `step-prev-${i}-${newSteps.length}`,
-                      content: prevContent,
-                      type: prevType,
-                      timestamp: Date.now(),
-                    });
-                  }
+        // Create the HolmesAgent routing through K8s service proxy
+        const cluster = getCluster();
+        if (!cluster) {
+          console.error('[AgentMode] No cluster available');
+          return;
+        }
+        const agent = new HolmesAgent(getHolmesProxyBaseUrl(cluster, pluginSettings));
+        agent.subscribe({
+          onEvent: ({ event }) => {
+            console.log('[AgentMode] onEvent:', event.type, event);
+          },
+          onRunInitialized: () => {
+            console.log('[AgentMode] onRunInitialized');
+          },
+          onRunFailed: ({ error }) => {
+            console.error('[AgentMode] onRunFailed:', error);
+          },
+          onRunFinalized: () => {
+            console.log('[AgentMode] onRunFinalized');
+          },
+          onRunStartedEvent: () => {
+            console.log('[AgentMode] onRunStartedEvent');
+            setLoading(true);
+            // Create the placeholder assistant message with thinking steps
+            const placeholderId = `agent-response-${Date.now()}`;
+            agentMessageIdRef.current = placeholderId;
+            setPromptHistory(prev => [
+              ...prev,
+              {
+                role: 'assistant',
+                content: '',
+                agentThinkingSteps: [],
+                agentThinkingDone: false,
+              },
+            ]);
+          },
+          onRunFinishedEvent: () => {
+            console.log('[AgentMode] onRunFinishedEvent');
+            setLoading(false);
+            // Mark thinking as done and sanitize the final displayed content
+            setPromptHistory(prev => {
+              const updated = [...prev];
+              for (let i = updated.length - 1; i >= 0; i--) {
+                if (
+                  updated[i].role === 'assistant' &&
+                  updated[i].agentThinkingSteps !== undefined &&
+                  !updated[i].agentThinkingDone
+                ) {
+                  const cleanContent = sanitizeAgentContent(updated[i].content || '');
+                  updated[i] = {
+                    ...updated[i],
+                    content: cleanContent,
+                    agentThinkingDone: true,
+                  };
+                  break;
                 }
-
-                // Always record the message as a thinking step
-                newSteps.push({
-                  id: `step-${msgId}`,
-                  content: fullText,
-                  type: stepType,
-                  timestamp: Date.now(),
-                });
-
-                // Only update displayed content for non-tool messages
-                const newContent = isToolMessage ? updated[i].content : fullText;
-
-                updated[i] = {
-                  ...updated[i],
-                  content: newContent,
-                  agentThinkingSteps: newSteps,
-                };
-                break;
               }
-            }
-            return updated;
-          });
+              return updated;
+            });
+            agentMessageIdRef.current = null;
+            agentTextBufferRef.current = '';
+            agentCurrentMsgIdRef.current = '';
+          },
+          onRunErrorEvent: ({ event }) => {
+            console.error('[AgentMode] onRunErrorEvent:', event);
+            setLoading(false);
+            setPromptHistory(prev => [
+              ...prev,
+              {
+                role: 'assistant',
+                content: `Agent error: ${event.message}`,
+                error: true,
+              },
+            ]);
+            agentMessageIdRef.current = null;
+          },
+          onTextMessageStartEvent: ({ event }) => {
+            console.log('[AgentMode] onTextMessageStartEvent:', event.messageId);
+            agentTextBufferRef.current = '';
+            agentCurrentMsgIdRef.current = event.messageId;
+          },
+          onTextMessageContentEvent: ({ event }) => {
+            console.log('[AgentMode] onTextMessageContentEvent:', { delta: event.delta });
+            agentTextBufferRef.current += event.delta || '';
+          },
+          onTextMessageEndEvent: () => {
+            console.log('[AgentMode] onTextMessageEndEvent');
+            const fullText = agentTextBufferRef.current;
+            const msgId = agentCurrentMsgIdRef.current;
+            const stepType = classifyAgentText(fullText);
+            const isToolMessage = stepType === 'tool-result' || stepType === 'tool-start';
 
-          agentTextBufferRef.current = '';
-          agentCurrentMsgIdRef.current = '';
-        },
-        onToolCallStartEvent: ({ event }) => {
-          console.log('[AgentMode] onToolCallStartEvent:', event.toolCallName);
-          // Add tool call as a thinking step
-          setPromptHistory(prev => {
-            const updated = [...prev];
-            for (let i = updated.length - 1; i >= 0; i--) {
-              if (
-                updated[i].role === 'assistant' &&
-                updated[i].agentThinkingSteps !== undefined &&
-                !updated[i].agentThinkingDone
-              ) {
-                const steps = [...(updated[i].agentThinkingSteps || [])];
-                steps.push({
-                  id: `tool-${event.toolCallId || event.toolCallName}-${Date.now()}`,
-                  content: `Calling tool: ${event.toolCallName}`,
-                  type: 'tool-start',
-                  timestamp: Date.now(),
-                });
-                updated[i] = { ...updated[i], agentThinkingSteps: steps };
-                break;
-              }
-            }
-            return updated;
-          });
-        },
-        onToolCallEndEvent: ({ toolCallName }) => {
-          console.log('[AgentMode] onToolCallEndEvent:', toolCallName);
-          // Add tool result as a thinking step
-          setPromptHistory(prev => {
-            const updated = [...prev];
-            for (let i = updated.length - 1; i >= 0; i--) {
-              if (
-                updated[i].role === 'assistant' &&
-                updated[i].agentThinkingSteps !== undefined &&
-                !updated[i].agentThinkingDone
-              ) {
-                const steps = [...(updated[i].agentThinkingSteps || [])];
-                steps.push({
-                  id: `tool-end-${toolCallName}-${Date.now()}`,
-                  content: `Tool ${toolCallName} completed`,
-                  type: 'tool-result',
-                  timestamp: Date.now(),
-                });
-                updated[i] = { ...updated[i], agentThinkingSteps: steps };
-                break;
-              }
-            }
-            return updated;
-          });
-        },
-      });
-      holmesAgentRef.current = agent;
+            // Update the placeholder assistant message:
+            // - Tool-result / tool-start messages go ONLY into agentThinkingSteps
+            //   (they must never overwrite the displayed content).
+            // - Other messages replace content (final answer is the last non-tool one).
+            setPromptHistory(prev => {
+              const updated = [...prev];
+              for (let i = updated.length - 1; i >= 0; i--) {
+                if (
+                  updated[i].role === 'assistant' &&
+                  updated[i].agentThinkingSteps !== undefined &&
+                  !updated[i].agentThinkingDone
+                ) {
+                  const existingSteps = updated[i].agentThinkingSteps || [];
+                  const prevContent = updated[i].content || '';
+                  const newSteps = [...existingSteps];
 
-      // [PROACTIVE_DIAGNOSIS_DISABLED] — agent diagnosis setup
-      /*
+                  // For non-tool messages, move previous content into thinking
+                  // steps (if it hasn't already been added).
+                  if (!isToolMessage && prevContent.trim()) {
+                    const prevType = classifyAgentText(prevContent);
+                    const alreadyInSteps = newSteps.some(step => step.content === prevContent);
+                    if (!alreadyInSteps) {
+                      newSteps.push({
+                        id: `step-prev-${i}-${newSteps.length}`,
+                        content: prevContent,
+                        type: prevType,
+                        timestamp: Date.now(),
+                      });
+                    }
+                  }
+
+                  // Always record the message as a thinking step
+                  newSteps.push({
+                    id: `step-${msgId}`,
+                    content: fullText,
+                    type: stepType,
+                    timestamp: Date.now(),
+                  });
+
+                  // Only update displayed content for non-tool messages
+                  const newContent = isToolMessage ? updated[i].content : fullText;
+
+                  updated[i] = {
+                    ...updated[i],
+                    content: newContent,
+                    agentThinkingSteps: newSteps,
+                  };
+                  break;
+                }
+              }
+              return updated;
+            });
+
+            agentTextBufferRef.current = '';
+            agentCurrentMsgIdRef.current = '';
+          },
+          onToolCallStartEvent: ({ event }) => {
+            console.log('[AgentMode] onToolCallStartEvent:', event.toolCallName);
+            // Add tool call as a thinking step
+            setPromptHistory(prev => {
+              const updated = [...prev];
+              for (let i = updated.length - 1; i >= 0; i--) {
+                if (
+                  updated[i].role === 'assistant' &&
+                  updated[i].agentThinkingSteps !== undefined &&
+                  !updated[i].agentThinkingDone
+                ) {
+                  const steps = [...(updated[i].agentThinkingSteps || [])];
+                  steps.push({
+                    id: `tool-${event.toolCallId || event.toolCallName}-${Date.now()}`,
+                    content: `Calling tool: ${event.toolCallName}`,
+                    type: 'tool-start',
+                    timestamp: Date.now(),
+                  });
+                  updated[i] = { ...updated[i], agentThinkingSteps: steps };
+                  break;
+                }
+              }
+              return updated;
+            });
+          },
+          onToolCallEndEvent: ({ toolCallName }) => {
+            console.log('[AgentMode] onToolCallEndEvent:', toolCallName);
+            // Add tool result as a thinking step
+            setPromptHistory(prev => {
+              const updated = [...prev];
+              for (let i = updated.length - 1; i >= 0; i--) {
+                if (
+                  updated[i].role === 'assistant' &&
+                  updated[i].agentThinkingSteps !== undefined &&
+                  !updated[i].agentThinkingDone
+                ) {
+                  const steps = [...(updated[i].agentThinkingSteps || [])];
+                  steps.push({
+                    id: `tool-end-${toolCallName}-${Date.now()}`,
+                    content: `Tool ${toolCallName} completed`,
+                    type: 'tool-result',
+                    timestamp: Date.now(),
+                  });
+                  updated[i] = { ...updated[i], agentThinkingSteps: steps };
+                  break;
+                }
+              }
+              return updated;
+            });
+          },
+        });
+        holmesAgentRef.current = agent;
+
+        // [PROACTIVE_DIAGNOSIS_DISABLED] — agent diagnosis setup
+        /*
         // ─── Set up proactive diagnosis via dedicated HolmesAgent ──────
         // One HolmesAgent instance, reused sequentially for all diagnoses.
         // Between each diagnosis we resetThread() to get a fresh conversation.
         // Chat is blocked (loading=true) while diagnosis runs.
-        const diagAgent = new HolmesAgent(getHolmesProxyBaseUrl(cluster));
+        const diagAgent = new HolmesAgent(getHolmesProxyBaseUrl(cluster, pluginSettings));
         diagnosisAgentRef.current = diagAgent;
 
         const agentDiagnoseFn = async (prompt: string, onStep?: DiagnosisStepCallback): Promise<string> => {
@@ -1106,28 +1107,30 @@ export default function AIPrompt(props: {
         // ─── End proactive diagnosis agent setup ────────────────────
         */
 
-      setPromptHistory(prev => [
-        ...prev,
-        {
-          role: 'system',
-          content: `Agent mode active. Connected to Holmes ag-ui server at ${agent.connectionLabel}.`,
-        },
-      ]);
-    } else {
-      setIsAgentMode(false);
-      setAgentModeStatus('idle');
-      holmesAgentRef.current = null;
-      // [PROACTIVE_DIAGNOSIS_DISABLED] — Clean up proactive diagnosis
-      // diagnoseFnRef.current = null;
-      // diagnosisAgentRef.current = null;
-      // proactiveDiagnosisManager.setDiagnoseFn(null);
-      // setDiagnoseFnReady(false);
-      setPromptHistory(prev => [
-        ...prev,
-        { role: 'system', content: 'Switched back to AI Chat mode.' },
-      ]);
-    }
-  }, []);
+        setPromptHistory(prev => [
+          ...prev,
+          {
+            role: 'system',
+            content: `Agent mode active. Connected to Holmes ag-ui server at ${agent.connectionLabel}.`,
+          },
+        ]);
+      } else {
+        setIsAgentMode(false);
+        setAgentModeStatus('idle');
+        holmesAgentRef.current = null;
+        // [PROACTIVE_DIAGNOSIS_DISABLED] — Clean up proactive diagnosis
+        // diagnoseFnRef.current = null;
+        // diagnosisAgentRef.current = null;
+        // proactiveDiagnosisManager.setDiagnoseFn(null);
+        // setDiagnoseFnReady(false);
+        setPromptHistory(prev => [
+          ...prev,
+          { role: 'system', content: 'Switched back to AI Chat mode.' },
+        ]);
+      }
+    },
+    [pluginSettings]
+  );
 
   // Auto-initialize agent mode on first mount (agent is default mode)
   React.useEffect(() => {

--- a/ai-assistant/src/utils.tsx
+++ b/ai-assistant/src/utils.tsx
@@ -126,7 +126,7 @@ export type HeadlampEventPayload =
       objectEvent?: ResourceListViewLoadedEvent['data'];
     };
 
-interface PluginConfig extends SavedConfigurations {
+export interface PluginConfig extends SavedConfigurations {
   /** Is the AI Assistant UI panel open? */
   isUIPanelOpen?: boolean;
   /** Is the config popover shown? */
@@ -143,6 +143,11 @@ interface PluginConfig extends SavedConfigurations {
   enabledTools?: string[] | Record<string, boolean>;
   /** MCP configuration */
   mcpConfig?: MCPConfig;
+
+  /** HolmesGPT Kubernetes Service settings (used by the Holmes agent mode) */
+  holmesNamespace?: string; // default: "default"
+  holmesServiceName?: string; // default: "holmesgpt-holmes"
+  holmesPort?: number; // default: 80
 }
 
 export const pluginStore = new ConfigStore<PluginConfig>(PLUGIN_NAME);


### PR DESCRIPTION
## Problem
HolmesGPT service targeting (namespace/service/port) was hardcoded to `default/holmesgpt-holmes:80`, which forced deployments into the `default` namespace or required a proxy workaround.

## Changes
- Add Holmes service settings to plugin config (ConfigStore): `holmesNamespace`, `holmesServiceName`, `holmesPort`
- Use those settings to build the Kubernetes service proxy path and base URL for the Holmes agent
- Add **Settings → Holmes Agent** section to configure these values in the UI

## How to configure
In Headlamp: **Settings → Plugins → AI Assistant → Holmes Agent**
- Namespace (e.g. `observability`)
- Service name (e.g. `holmesgpt-holmes`)
- Port (e.g. `80`)

## How to test
```bash
cd ai-assistant
npm ci
npm run tsc
npm run lint
```
