### PR TITLE
Volcano: show install guide when Volcano is not detected

### DIFF
--- a/volcano/src/components/common/CommonComponents.tsx
+++ b/volcano/src/components/common/CommonComponents.tsx
@@ -1,0 +1,58 @@
+import { Box, CircularProgress, Grid, Link as MuiLink, Typography } from '@mui/material';
+import { ReactNode } from 'react';
+import { useVolcanoInstalled } from '../../hooks/useVolcanoInstalled';
+
+interface NotInstalledBannerProps {
+  isLoading?: boolean;
+}
+
+export function NotInstalledBanner({ isLoading = false }: NotInstalledBannerProps) {
+  if (isLoading) {
+    return (
+      <Box display="flex" justifyContent="center" alignItems="center" p={2} minHeight="200px">
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  return (
+    <Box display="flex" justifyContent="center" alignItems="center" p={2} minHeight="200px">
+      <Grid container spacing={2} direction="column" justifyContent="center" alignItems="center">
+        <Grid item>
+          <Typography variant="h5">
+            Volcano was not detected on your cluster. If you haven&apos;t already, please install
+            it.
+          </Typography>
+        </Grid>
+        <Grid item>
+          <Typography>
+            Learn how to{' '}
+            <MuiLink
+              href="https://volcano.sh/en/docs/installation/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              install
+            </MuiLink>{' '}
+            Volcano
+          </Typography>
+        </Grid>
+      </Grid>
+    </Box>
+  );
+}
+
+interface VolcanoInstallCheckProps {
+  children: ReactNode;
+  fallback?: ReactNode;
+}
+
+export function VolcanoInstallCheck({ children, fallback }: VolcanoInstallCheckProps) {
+  const { isVolcanoInstalled, isVolcanoCheckLoading } = useVolcanoInstalled();
+
+  if (!isVolcanoInstalled) {
+    return fallback || <NotInstalledBanner isLoading={isVolcanoCheckLoading} />;
+  }
+
+  return <>{children}</>;
+}

--- a/volcano/src/components/jobs/List.tsx
+++ b/volcano/src/components/jobs/List.tsx
@@ -1,6 +1,7 @@
 import { Link, ResourceListView, StatusLabel } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 import { VolcanoJob } from '../../resources/job';
 import { getJobStatusColor } from '../../utils/status';
+import { VolcanoInstallCheck } from '../common/CommonComponents';
 
 /**
  * Renders the Volcano Jobs list page.
@@ -9,42 +10,44 @@ import { getJobStatusColor } from '../../utils/status';
  */
 export default function JobList() {
   return (
-    <ResourceListView
-      title="Volcano Jobs"
-      resourceClass={VolcanoJob}
-      columns={[
-        'name',
-        'namespace',
-        {
-          id: 'status',
-          label: 'Status',
-          getValue: (job: VolcanoJob) => job.phase,
-          render: (job: VolcanoJob) => (
-            <StatusLabel status={getJobStatusColor(job.phase)}>{job.phase}</StatusLabel>
-          ),
-        },
-        {
-          id: 'queue',
-          label: 'Queue',
-          getValue: (job: VolcanoJob) => job.queue,
-          render: (job: VolcanoJob) => (
-            <Link routeName="volcano-queue-detail" params={{ name: job.queue }}>
-              {job.queue}
-            </Link>
-          ),
-        },
-        {
-          id: 'running',
-          label: 'Running',
-          getValue: (job: VolcanoJob) => `${job.runningCount}/${job.minAvailable}`,
-        },
-        {
-          id: 'tasks',
-          label: 'Tasks',
-          getValue: (job: VolcanoJob) => job.taskCount,
-        },
-        'age',
-      ]}
-    />
+    <VolcanoInstallCheck>
+      <ResourceListView
+        title="Volcano Jobs"
+        resourceClass={VolcanoJob}
+        columns={[
+          'name',
+          'namespace',
+          {
+            id: 'status',
+            label: 'Status',
+            getValue: (job: VolcanoJob) => job.phase,
+            render: (job: VolcanoJob) => (
+              <StatusLabel status={getJobStatusColor(job.phase)}>{job.phase}</StatusLabel>
+            ),
+          },
+          {
+            id: 'queue',
+            label: 'Queue',
+            getValue: (job: VolcanoJob) => job.queue,
+            render: (job: VolcanoJob) => (
+              <Link routeName="volcano-queue-detail" params={{ name: job.queue }}>
+                {job.queue}
+              </Link>
+            ),
+          },
+          {
+            id: 'running',
+            label: 'Running',
+            getValue: (job: VolcanoJob) => `${job.runningCount}/${job.minAvailable}`,
+          },
+          {
+            id: 'tasks',
+            label: 'Tasks',
+            getValue: (job: VolcanoJob) => job.taskCount,
+          },
+          'age',
+        ]}
+      />
+    </VolcanoInstallCheck>
   );
 }

--- a/volcano/src/components/podgroups/List.tsx
+++ b/volcano/src/components/podgroups/List.tsx
@@ -1,6 +1,7 @@
 import { Link, ResourceListView, StatusLabel } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 import { VolcanoPodGroup } from '../../resources/podgroup';
 import { getPodGroupStatusColor } from '../../utils/status';
+import { VolcanoInstallCheck } from '../common/CommonComponents';
 
 /**
  * Renders the Volcano PodGroups list page.
@@ -9,44 +10,46 @@ import { getPodGroupStatusColor } from '../../utils/status';
  */
 export default function PodGroupList() {
   return (
-    <ResourceListView
-      title="Volcano PodGroups"
-      resourceClass={VolcanoPodGroup}
-      columns={[
-        'name',
-        'namespace',
-        {
-          id: 'status',
-          label: 'Status',
-          getValue: (podGroup: VolcanoPodGroup) => podGroup.phase,
-          render: (podGroup: VolcanoPodGroup) => (
-            <StatusLabel status={getPodGroupStatusColor(podGroup.phase)}>
-              {podGroup.phase}
-            </StatusLabel>
-          ),
-        },
-        {
-          id: 'min-member',
-          label: 'Min Member',
-          getValue: (podGroup: VolcanoPodGroup) => podGroup.minMember,
-        },
-        {
-          id: 'running',
-          label: 'Running',
-          getValue: (podGroup: VolcanoPodGroup) => podGroup.runningCount,
-        },
-        {
-          id: 'queue',
-          label: 'Queue',
-          getValue: (podGroup: VolcanoPodGroup) => podGroup.queue,
-          render: (podGroup: VolcanoPodGroup) => (
-            <Link routeName="volcano-queue-detail" params={{ name: podGroup.queue }}>
-              {podGroup.queue}
-            </Link>
-          ),
-        },
-        'age',
-      ]}
-    />
+    <VolcanoInstallCheck>
+      <ResourceListView
+        title="Volcano PodGroups"
+        resourceClass={VolcanoPodGroup}
+        columns={[
+          'name',
+          'namespace',
+          {
+            id: 'status',
+            label: 'Status',
+            getValue: (podGroup: VolcanoPodGroup) => podGroup.phase,
+            render: (podGroup: VolcanoPodGroup) => (
+              <StatusLabel status={getPodGroupStatusColor(podGroup.phase)}>
+                {podGroup.phase}
+              </StatusLabel>
+            ),
+          },
+          {
+            id: 'min-member',
+            label: 'Min Member',
+            getValue: (podGroup: VolcanoPodGroup) => podGroup.minMember,
+          },
+          {
+            id: 'running',
+            label: 'Running',
+            getValue: (podGroup: VolcanoPodGroup) => podGroup.runningCount,
+          },
+          {
+            id: 'queue',
+            label: 'Queue',
+            getValue: (podGroup: VolcanoPodGroup) => podGroup.queue,
+            render: (podGroup: VolcanoPodGroup) => (
+              <Link routeName="volcano-queue-detail" params={{ name: podGroup.queue }}>
+                {podGroup.queue}
+              </Link>
+            ),
+          },
+          'age',
+        ]}
+      />
+    </VolcanoInstallCheck>
   );
 }

--- a/volcano/src/components/queues/List.tsx
+++ b/volcano/src/components/queues/List.tsx
@@ -1,6 +1,7 @@
 import { Link, ResourceListView, StatusLabel } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 import { VolcanoQueue } from '../../resources/queue';
 import { getQueueStatusColor } from '../../utils/status';
+import { VolcanoInstallCheck } from '../common/CommonComponents';
 
 /**
  * Renders the Volcano Queues list page.
@@ -9,39 +10,41 @@ import { getQueueStatusColor } from '../../utils/status';
  */
 export default function QueueList() {
   return (
-    <ResourceListView
-      title="Volcano Queues"
-      resourceClass={VolcanoQueue}
-      columns={[
-        'name',
-        {
-          id: 'state',
-          label: 'State',
-          getValue: (queue: VolcanoQueue) => queue.state,
-          render: (queue: VolcanoQueue) => (
-            <StatusLabel status={getQueueStatusColor(queue.state)}>{queue.state}</StatusLabel>
-          ),
-        },
-        {
-          id: 'weight',
-          label: 'Weight',
-          getValue: (queue: VolcanoQueue) => queue.weight,
-        },
-        {
-          id: 'parent',
-          label: 'Parent',
-          getValue: (queue: VolcanoQueue) => queue.spec.parent || '-',
-          render: (queue: VolcanoQueue) =>
-            queue.spec.parent ? (
-              <Link routeName="volcano-queue-detail" params={{ name: queue.spec.parent }}>
-                {queue.spec.parent}
-              </Link>
-            ) : (
-              '-'
+    <VolcanoInstallCheck>
+      <ResourceListView
+        title="Volcano Queues"
+        resourceClass={VolcanoQueue}
+        columns={[
+          'name',
+          {
+            id: 'state',
+            label: 'State',
+            getValue: (queue: VolcanoQueue) => queue.state,
+            render: (queue: VolcanoQueue) => (
+              <StatusLabel status={getQueueStatusColor(queue.state)}>{queue.state}</StatusLabel>
             ),
-        },
-        'age',
-      ]}
-    />
+          },
+          {
+            id: 'weight',
+            label: 'Weight',
+            getValue: (queue: VolcanoQueue) => queue.weight,
+          },
+          {
+            id: 'parent',
+            label: 'Parent',
+            getValue: (queue: VolcanoQueue) => queue.spec.parent || '-',
+            render: (queue: VolcanoQueue) =>
+              queue.spec.parent ? (
+                <Link routeName="volcano-queue-detail" params={{ name: queue.spec.parent }}>
+                  {queue.spec.parent}
+                </Link>
+              ) : (
+                '-'
+              ),
+          },
+          'age',
+        ]}
+      />
+    </VolcanoInstallCheck>
   );
 }

--- a/volcano/src/hooks/useVolcanoInstalled.tsx
+++ b/volcano/src/hooks/useVolcanoInstalled.tsx
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+import { isVolcanoInstalled as checkVolcanoInstallation } from '../isVolcanoInstalled';
+
+export function useVolcanoInstalled() {
+  const [isVolcanoInstalled, setIsVolcanoInstalled] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    async function checkVolcanoInstalled() {
+      const isInstalled = await checkVolcanoInstallation();
+      setIsVolcanoInstalled(!!isInstalled);
+    }
+    checkVolcanoInstalled();
+  }, []);
+
+  return {
+    isVolcanoInstalled,
+    isVolcanoCheckLoading: isVolcanoInstalled === null,
+  };
+}

--- a/volcano/src/isVolcanoInstalled.ts
+++ b/volcano/src/isVolcanoInstalled.ts
@@ -1,0 +1,16 @@
+import { ApiProxy } from '@kinvolk/headlamp-plugin/lib';
+
+export async function isVolcanoInstalled(): Promise<boolean> {
+  try {
+    const schedulingResponse = await ApiProxy.request('/apis/scheduling.volcano.sh/v1beta1', {
+      method: 'GET',
+    });
+    const batchResponse = await ApiProxy.request('/apis/batch.volcano.sh/v1alpha1', {
+      method: 'GET',
+    });
+
+    return !!schedulingResponse && !!batchResponse;
+  } catch (error) {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
This PR fixes the empty-state UX when Volcano is not installed.
When Volcano CRDs are missing, the plugin currently shows "Resource not found".
Fixes #595
## Changes
- Added Volcano installation probe:
  - `src/isVolcanoInstalled.ts`
- Added hook for install-check state:
  - `src/hooks/useVolcanoInstalled.tsx`
- Added shared install gate and banner:
  - `src/components/common/CommonComponents.tsx`
- Wrapped list views with install gate:
  - `src/components/jobs/List.tsx`
  - `src/components/queues/List.tsx`
  - `src/components/podgroups/List.tsx`
## Before

<img width="3420" height="2120" alt="image" src="https://github.com/user-attachments/assets/ebd74bc9-38b7-4dbc-b5eb-0657dc319a46" />

## After

<img width="1880" height="1002" alt="image" src="https://github.com/user-attachments/assets/6e6f74cd-ae44-400e-8a61-12c050af0a43" />


