### PR TITLE
Prometheus: gate Job metrics/actions on batch/v1

### DIFF
--- a/prometheus/src/components/VisibilityButton/VisibilityButton.tsx
+++ b/prometheus/src/components/VisibilityButton/VisibilityButton.tsx
@@ -5,8 +5,12 @@ import { KubeObject } from '@kinvolk/headlamp-plugin/lib/K8s/cluster';
 import { Tooltip } from '@mui/material';
 import ToggleButton from '@mui/material/ToggleButton';
 import React, { useEffect, useState } from 'react';
-import { ChartEnabledKinds } from '../../util';
-import { disableMetrics, enableMetrics, getConfigStore } from '../../util';
+import {
+  disableMetrics,
+  enableMetrics,
+  getConfigStore,
+  supportsPrometheusMetrics,
+} from '../../util';
 
 export interface VisibilityButtonProps {
   resource?: KubeObject;
@@ -34,7 +38,7 @@ export function VisibilityButton(props: VisibilityButtonProps) {
     return [t('Show Prometheus metrics'), 'mdi:chart-box'];
   }, [isEnabled, t]);
 
-  if (!ChartEnabledKinds.includes(resource?.jsonData?.kind)) {
+  if (!supportsPrometheusMetrics(resource)) {
     return null;
   }
 

--- a/prometheus/src/index.tsx
+++ b/prometheus/src/index.tsx
@@ -11,8 +11,12 @@ import { GenericMetricsChart } from './components/Chart/GenericMetricsChart/Gene
 import { KedaChart } from './components/Chart/KedaChart/KedaChart';
 import { Settings } from './components/Settings/Settings';
 import { VisibilityButton } from './components/VisibilityButton/VisibilityButton';
-import { ChartEnabledKinds, PLUGIN_NAME } from './util';
-import { getNodeClaimChartConfigs, getNodePoolChartConfigs } from './util';
+import {
+  getNodeClaimChartConfigs,
+  getNodePoolChartConfigs,
+  PLUGIN_NAME,
+  supportsPrometheusMetrics,
+} from './util';
 
 type SectionWithId = { id: string };
 
@@ -23,7 +27,13 @@ const hasSectionId = (section: unknown): section is SectionWithId =>
   typeof (section as SectionWithId).id === 'string';
 
 function PrometheusMetrics(resource: KubeObject) {
-  if (resource.kind === 'Pod' || resource.kind === 'Job' || resource.kind === 'CronJob') {
+  const resourceKind = resource.jsonData?.kind ?? resource.kind;
+
+  if (!supportsPrometheusMetrics(resource)) {
+    return null;
+  }
+
+  if (resourceKind === 'Pod' || resourceKind === 'Job' || resourceKind === 'CronJob') {
     return (
       <GenericMetricsChart
         cpuQuery={`sum(rate(container_cpu_usage_seconds_total{container!='',namespace='${resource.jsonData.metadata.namespace}',pod='${resource.jsonData.metadata.name}'}[1m])) by (pod,namespace)`}
@@ -138,10 +148,15 @@ registerDetailsViewSectionsProcessor(function addSubheaderSection(resource, sect
     return sections;
   }
 
+  const prometheusMetricsSection = PrometheusMetrics(resource);
+  if (!prometheusMetricsSection) {
+    return sections;
+  }
+
   // We place our custom section after the header.
   sections.splice(detailsHeaderIdx + 1, 0, {
     id: prometheusSection,
-    section: PrometheusMetrics(resource),
+    section: prometheusMetricsSection,
   });
 
   return sections;
@@ -160,7 +175,7 @@ registerDetailsViewHeaderActionsProcessor(function addPrometheusMetricsButton(re
   }
 
   // If the action is not supposed to be added, we do nothing.
-  if (!ChartEnabledKinds.includes(resource?.jsonData?.kind)) {
+  if (!supportsPrometheusMetrics(resource)) {
     return actions;
   }
 

--- a/prometheus/src/util.test.ts
+++ b/prometheus/src/util.test.ts
@@ -1,4 +1,4 @@
-import { getTimeRangeAndStepSize } from './util';
+import { getTimeRangeAndStepSize, supportsPrometheusMetrics } from './util';
 
 beforeAll(async () => {
   global.TextEncoder = require('util').TextEncoder;
@@ -101,5 +101,35 @@ describe('getTimeRangeAndStepSize', () => {
       to: specificTime,
       step: 14,
     });
+  });
+});
+
+describe('supportsPrometheusMetrics', () => {
+  test.each([
+    ['supports Pods', { kind: 'Pod', jsonData: { kind: 'Pod', apiVersion: 'v1' } }, true],
+    [
+      'supports Kubernetes Jobs',
+      { kind: 'Job', jsonData: { kind: 'Job', apiVersion: 'batch/v1' } },
+      true,
+    ],
+    [
+      'rejects non-Kubernetes Jobs with same kind',
+      { kind: 'Job', jsonData: { kind: 'Job', apiVersion: 'batch.volcano.sh/v1alpha1' } },
+      false,
+    ],
+    [
+      'supports CronJobs through the shared allowlist',
+      { kind: 'CronJob', jsonData: { kind: 'CronJob', apiVersion: 'batch/v1' } },
+      true,
+    ],
+    [
+      'supports ScaledObjects from known supported kinds',
+      { kind: 'ScaledObject', jsonData: { kind: 'ScaledObject', apiVersion: 'keda.sh/v1alpha1' } },
+      true,
+    ],
+    ['rejects unknown kinds', { kind: 'VolcanoJob', jsonData: { kind: 'VolcanoJob' } }, false],
+    ['rejects missing resources', undefined, false],
+  ])('%s', (_, resource, expected) => {
+    expect(supportsPrometheusMetrics(resource)).toBe(expected);
   });
 });

--- a/prometheus/src/util.ts
+++ b/prometheus/src/util.ts
@@ -154,7 +154,43 @@ export function getPrometheusResolution(cluster: string): string {
   return clusterData?.defaultResolution ?? 'medium';
 }
 
-export const ChartEnabledKinds = [
+type ResourceIdentity = {
+  kind?: string;
+  apiVersion?: string;
+  jsonData?: {
+    kind?: string;
+    apiVersion?: string;
+  };
+};
+
+function getResourceKind(resource?: ResourceIdentity): string | undefined {
+  return resource?.jsonData?.kind ?? resource?.kind;
+}
+
+function getResourceApiVersion(resource?: ResourceIdentity): string | undefined {
+  return resource?.jsonData?.apiVersion ?? resource?.apiVersion;
+}
+
+const resourceApiVersionRules: Record<string, string> = {
+  Job: 'batch/v1',
+};
+
+export function supportsPrometheusMetrics(resource?: ResourceIdentity): boolean {
+  const kind = getResourceKind(resource);
+
+  if (!kind || !ChartEnabledKinds.includes(kind)) {
+    return false;
+  }
+
+  const requiredApiVersion = resourceApiVersionRules[kind];
+  if (requiredApiVersion) {
+    return getResourceApiVersion(resource) === requiredApiVersion;
+  }
+
+  return true;
+}
+
+const ChartEnabledKinds = [
   'Pod',
   'Deployment',
   'StatefulSet',


### PR DESCRIPTION
## Summary
Volcano uses `kind: Job` with a different API version, so kind only checks can incorrectly show Prometheus UI on Volcano Job details. (mentioned in #597)
## Changes
- add a shared supportsPrometheusMetrics helper in prometheus/src/util.ts
- use a small API-version rule map so Job is treated as supported only when apiVersion === 'batch/v1'
- reuse the shared helper in:
  - `prometheus/src/index.tsx` (metrics + header action)
  - `prometheus/src/components/VisibilityButton/VisibilityButton.tsx` (button rendering)
- add focused unit tests in prometheus/src/util.test.ts covering:
  - Kubernetes Job
  - Volcano Job
  - unsupported kinds
  - missing resource input

Closes #597