### PR TITLE
cert-manager: link SecretKeySelector names to Secret detail pages

### DIFF
--- a/cert-manager/src/components/challenges/Detail.stories.tsx
+++ b/cert-manager/src/components/challenges/Detail.stories.tsx
@@ -96,7 +96,12 @@ export function PureChallengeDetail({
             },
             {
               name: 'Solver',
-              value: <ACMEChallengeSolverComponent solver={challenge.spec.solver} />,
+              value: (
+                <ACMEChallengeSolverComponent
+                  solver={challenge.spec.solver}
+                  namespace={challenge.metadata.namespace}
+                />
+              ),
             },
             { name: 'Token', value: challenge.spec.token },
             { name: 'URL', value: challenge.spec.url },

--- a/cert-manager/src/components/challenges/Detail.tsx
+++ b/cert-manager/src/components/challenges/Detail.tsx
@@ -51,7 +51,12 @@ export function ChallengeDetail() {
               },
               {
                 name: 'Solver',
-                value: <ACMEChallengeSolverComponent solver={item.spec.solver} />,
+                value: (
+                  <ACMEChallengeSolverComponent
+                    solver={item.spec.solver}
+                    namespace={item.metadata.namespace}
+                  />
+                ),
               },
               {
                 name: 'Token',

--- a/cert-manager/src/components/clusterIssuers/Detail.tsx
+++ b/cert-manager/src/components/clusterIssuers/Detail.tsx
@@ -19,7 +19,7 @@ export function ClusterIssuerDetail() {
       resourceType={ClusterIssuer}
       name={name}
       withEvents
-      extraInfo={item => item?.spec && processIssuerExtraInfo(item.spec)}
+      extraInfo={item => item?.spec && processIssuerExtraInfo(item.spec)} // TODO: Discover namespace for cluster issuer secrets and pass
       extraSections={item =>
         item && [
           {

--- a/cert-manager/src/components/common/CommonComponents.stories.tsx
+++ b/cert-manager/src/components/common/CommonComponents.stories.tsx
@@ -187,9 +187,10 @@ EmptyConditions.args = {
 // SecretKeySelectorComponent Stories
 // =============================================================================
 
-const SecretKeySelectorTemplate: StoryFn<{ selector: SecretKeySelector }> = args => (
-  <SecretKeySelectorComponent {...args} />
-);
+const SecretKeySelectorTemplate: StoryFn<{
+  selector: SecretKeySelector;
+  namespace: string;
+}> = args => <SecretKeySelectorComponent {...args} />;
 
 export const SecretKeySelectorDefault = SecretKeySelectorTemplate.bind({});
 SecretKeySelectorDefault.args = {
@@ -210,9 +211,10 @@ SecretKeySelectorWithoutKey.args = {
 // ACMEChallengeSolverComponent Stories
 // =============================================================================
 
-const ACMEChallengeSolverTemplate: StoryFn<{ solver: ACMEChallengeSolver }> = args => (
-  <ACMEChallengeSolverComponent {...args} />
-);
+const ACMEChallengeSolverTemplate: StoryFn<{
+  solver: ACMEChallengeSolver;
+  namespace?: string;
+}> = args => <ACMEChallengeSolverComponent {...args} />;
 
 export const HTTP01Solver = ACMEChallengeSolverTemplate.bind({});
 HTTP01Solver.args = {

--- a/cert-manager/src/components/common/CommonComponents.tsx
+++ b/cert-manager/src/components/common/CommonComponents.tsx
@@ -1,4 +1,5 @@
 import { Icon } from '@iconify/react';
+import { K8s } from '@kinvolk/headlamp-plugin/lib';
 import {
   DateLabel,
   LabelListItem,
@@ -141,15 +142,25 @@ export function ConditionsTable({ conditions }: ConditionsTableProps) {
 
 interface SecretKeySelectorProps {
   selector: SecretKeySelector;
+  namespace?: string;
 }
 
-export function SecretKeySelectorComponent({ selector }: SecretKeySelectorProps) {
+export function SecretKeySelectorComponent({ selector, namespace }: SecretKeySelectorProps) {
   return (
     <NameValueTable
       rows={[
         {
           name: 'Name',
-          value: selector.name,
+          value: namespace ? (
+            <Link
+              routeName={K8s.ResourceClasses.Secret.kind}
+              params={{ name: selector.name, namespace }}
+            >
+              {selector.name}
+            </Link>
+          ) : (
+            selector.name
+          ),
         },
         {
           name: 'Key',
@@ -162,45 +173,50 @@ export function SecretKeySelectorComponent({ selector }: SecretKeySelectorProps)
 
 interface ACMEChallengeSolverProps {
   solver: ACMEChallengeSolver;
+  namespace?: string;
 }
 
-const cloudflareGetter = (item: any) => {
-  const thisItem = item?.cloudflare;
+export function ACMEChallengeSolverComponent({ solver, namespace }: ACMEChallengeSolverProps) {
+  const cloudflareGetter = (item: any) => {
+    const thisItem = item?.cloudflare;
 
-  if (!thisItem) {
-    return '-';
-  }
+    if (!thisItem) {
+      return '-';
+    }
 
-  const rows: NameValueTableRow[] = [];
+    const rows: NameValueTableRow[] = [];
 
-  if (thisItem.email) {
-    rows.push({
-      name: 'Email',
-      value: thisItem.email,
-    });
-  }
+    if (thisItem.email) {
+      rows.push({
+        name: 'Email',
+        value: thisItem.email,
+      });
+    }
 
-  if (thisItem.apiKeySecretRef) {
-    rows.push({
-      name: 'API Key Secret',
-      value: <SecretKeySelectorComponent selector={thisItem.apiKeySecretRef} />,
-    });
-  }
+    if (thisItem.apiKeySecretRef) {
+      rows.push({
+        name: 'API Key Secret',
+        value: (
+          <SecretKeySelectorComponent selector={thisItem.apiKeySecretRef} namespace={namespace} />
+        ),
+      });
+    }
 
-  if (thisItem.apiTokenSecretRef) {
-    rows.push({
-      name: 'API Token Secret',
-      value: <SecretKeySelectorComponent selector={thisItem.apiTokenSecretRef} />,
-    });
-  }
+    if (thisItem.apiTokenSecretRef) {
+      rows.push({
+        name: 'API Token Secret',
+        value: (
+          <SecretKeySelectorComponent selector={thisItem.apiTokenSecretRef} namespace={namespace} />
+        ),
+      });
+    }
 
-  if (rows.length === 0) {
-    return '-';
-  }
-  return <NameValueTable rows={rows} />;
-};
+    if (rows.length === 0) {
+      return '-';
+    }
+    return <NameValueTable rows={rows} />;
+  };
 
-export function ACMEChallengeSolverComponent({ solver }: ACMEChallengeSolverProps) {
   const getItemGetter = (key: string) => {
     if (key === 'cloudflare') {
       return cloudflareGetter;

--- a/cert-manager/src/components/common/processIssuerExtraInfo.tsx
+++ b/cert-manager/src/components/common/processIssuerExtraInfo.tsx
@@ -6,7 +6,7 @@ import {
   StringArray,
 } from './CommonComponents';
 
-export function processIssuerExtraInfo(spec: IssuerSpec): NameValueTableRow[] {
+export function processIssuerExtraInfo(spec: IssuerSpec, namespace?: string): NameValueTableRow[] {
   const extraInfo: NameValueTableRow[] = [];
 
   if (spec.acme) {
@@ -22,7 +22,12 @@ export function processIssuerExtraInfo(spec: IssuerSpec): NameValueTableRow[] {
             { name: 'Skip TLS Verify', value: spec.acme.skipTLSVerify?.toString() },
             {
               name: 'Private Key Secret Ref',
-              value: <SecretKeySelectorComponent selector={spec.acme.privateKeySecretRef} />,
+              value: (
+                <SecretKeySelectorComponent
+                  selector={spec.acme.privateKeySecretRef}
+                  namespace={namespace}
+                />
+              ),
             },
             {
               name: 'External Account Binding',
@@ -36,6 +41,7 @@ export function processIssuerExtraInfo(spec: IssuerSpec): NameValueTableRow[] {
                       value: (
                         <SecretKeySelectorComponent
                           selector={spec.acme.externalAccountBinding.keySecretRef}
+                          namespace={namespace}
                         />
                       ),
                     },
@@ -55,7 +61,7 @@ export function processIssuerExtraInfo(spec: IssuerSpec): NameValueTableRow[] {
               name: 'Solvers',
               value: spec.acme.solvers?.map((solver, index) => (
                 <div key={index} style={{ marginBottom: '20px' }}>
-                  <ACMEChallengeSolverComponent solver={solver} />
+                  <ACMEChallengeSolverComponent solver={solver} namespace={namespace} />
                 </div>
               )),
             },
@@ -100,7 +106,10 @@ export function processIssuerExtraInfo(spec: IssuerSpec): NameValueTableRow[] {
                     {
                       name: 'Token Secret Ref',
                       value: spec.vault.auth.tokenSecretRef && (
-                        <SecretKeySelectorComponent selector={spec.vault.auth.tokenSecretRef} />
+                        <SecretKeySelectorComponent
+                          selector={spec.vault.auth.tokenSecretRef}
+                          namespace={namespace}
+                        />
                       ),
                     },
                     {
@@ -115,6 +124,7 @@ export function processIssuerExtraInfo(spec: IssuerSpec): NameValueTableRow[] {
                               value: (
                                 <SecretKeySelectorComponent
                                   selector={spec.vault.auth.appRole.secretRef}
+                                  namespace={namespace}
                                 />
                               ),
                             },
@@ -133,6 +143,7 @@ export function processIssuerExtraInfo(spec: IssuerSpec): NameValueTableRow[] {
                               value: (
                                 <SecretKeySelectorComponent
                                   selector={spec.vault.auth.kubernetes.secretRef}
+                                  namespace={namespace}
                                 />
                               ),
                             },
@@ -183,7 +194,10 @@ export function processIssuerExtraInfo(spec: IssuerSpec): NameValueTableRow[] {
                     {
                       name: 'Credentials Ref',
                       value: (
-                        <SecretKeySelectorComponent selector={spec.venafi.tpp.credentialsRef} />
+                        <SecretKeySelectorComponent
+                          selector={spec.venafi.tpp.credentialsRef}
+                          namespace={namespace}
+                        />
                       ),
                     },
                     { name: 'CA Bundle', value: spec.venafi.tpp.caBundle },
@@ -202,6 +216,7 @@ export function processIssuerExtraInfo(spec: IssuerSpec): NameValueTableRow[] {
                       value: (
                         <SecretKeySelectorComponent
                           selector={spec.venafi.cloud.apiTokenSecretRef}
+                          namespace={namespace}
                         />
                       ),
                     },

--- a/cert-manager/src/components/issuers/Detail.stories.tsx
+++ b/cert-manager/src/components/issuers/Detail.stories.tsx
@@ -41,7 +41,7 @@ interface PureIssuerDetailProps {
 }
 
 // Helper function to render issuer type specific info
-function renderIssuerTypeInfo(spec: IssuerSpec) {
+function renderIssuerTypeInfo(spec: IssuerSpec, namespace?: string) {
   if (spec.acme) {
     return (
       <SectionBox title="ACME Configuration">
@@ -54,7 +54,10 @@ function renderIssuerTypeInfo(spec: IssuerSpec) {
             {
               name: 'Private Key Secret Ref',
               value: spec.acme.privateKeySecretRef ? (
-                <SecretKeySelectorComponent selector={spec.acme.privateKeySecretRef} />
+                <SecretKeySelectorComponent
+                  selector={spec.acme.privateKeySecretRef}
+                  namespace={namespace}
+                />
               ) : (
                 '-'
               ),
@@ -64,7 +67,7 @@ function renderIssuerTypeInfo(spec: IssuerSpec) {
               value:
                 spec.acme.solvers?.map((solver, index) => (
                   <Box key={index} mb={2}>
-                    <ACMEChallengeSolverComponent solver={solver} />
+                    <ACMEChallengeSolverComponent solver={solver} namespace={namespace} />
                   </Box>
                 )) || '-',
             },
@@ -201,7 +204,7 @@ export function PureIssuerDetail({
       </SectionBox>
 
       {/* Issuer Type Configuration */}
-      {renderIssuerTypeInfo(issuer.spec)}
+      {renderIssuerTypeInfo(issuer.spec, issuer.metadata.namespace)}
 
       {/* ACME Status (if applicable) */}
       {issuer.status?.acme && (

--- a/cert-manager/src/components/issuers/Detail.tsx
+++ b/cert-manager/src/components/issuers/Detail.tsx
@@ -20,7 +20,7 @@ export function IssuerDetail() {
       name={name}
       namespace={namespace}
       withEvents
-      extraInfo={item => item?.spec && processIssuerExtraInfo(item.spec)}
+      extraInfo={item => item?.spec && processIssuerExtraInfo(item.spec, item.metadata.namespace)}
       extraSections={item =>
         item && [
           {


### PR DESCRIPTION
This pull request enhances the handling of Kubernetes `Secret` references throughout the cert-manager UI components by ensuring the `namespace` is consistently passed to components that render or link to these secrets. This enables correct linking and display of secret resources, especially in multi-namespace scenarios. The changes also update related storybook stories and utility functions to accept and forward the `namespace` prop.

**Namespace propagation and Secret linking improvements:**

* Updated `SecretKeySelectorComponent` and `ACMEChallengeSolverComponent` to accept an optional `namespace` prop, and use it to create links to the correct `Secret` resource within the appropriate namespace. (`cert-manager/src/components/common/CommonComponents.tsx`) [[1]](diffhunk://#diff-0333ec15b062ca9bc20037a2c3ae2c313d8b7dcc626f18ed700991a91262e27bR145-R163) [[2]](diffhunk://#diff-0333ec15b062ca9bc20037a2c3ae2c313d8b7dcc626f18ed700991a91262e27bR176-R179) [[3]](diffhunk://#diff-0333ec15b062ca9bc20037a2c3ae2c313d8b7dcc626f18ed700991a91262e27bL186-R210)
* Modified all usages of `SecretKeySelectorComponent` and `ACMEChallengeSolverComponent` in challenge, issuer, and cluster issuer detail components and their stories to pass the relevant `namespace` from the resource metadata. (`cert-manager/src/components/challenges/Detail.tsx`, `cert-manager/src/components/challenges/Detail.stories.tsx`, `cert-manager/src/components/issuers/Detail.tsx`, `cert-manager/src/components/issuers/Detail.stories.tsx`, `cert-manager/src/components/clusterIssuers/Detail.tsx`) [[1]](diffhunk://#diff-7336c4bf6d38390239b73b8f65e45a2f1203a397e4fc82ce9921175f0ec29027L54-R54) [[2]](diffhunk://#diff-ebfa773a0c1c2bd7be5656add1522021861b8f57ed54995459c6b4687bbdf859L99-R99) [[3]](diffhunk://#diff-7e45b724497f5045ad6ddeb5fc7abfefd3f11a6a04cb3b4bec575533a589dc1fL44-R44) [[4]](diffhunk://#diff-7e45b724497f5045ad6ddeb5fc7abfefd3f11a6a04cb3b4bec575533a589dc1fL57-R60) [[5]](diffhunk://#diff-7e45b724497f5045ad6ddeb5fc7abfefd3f11a6a04cb3b4bec575533a589dc1fL67-R70) [[6]](diffhunk://#diff-7e45b724497f5045ad6ddeb5fc7abfefd3f11a6a04cb3b4bec575533a589dc1fL204-R207) [[7]](diffhunk://#diff-ce8fd8e8d0d47299c64c797652e07d546e804006bc1de92192a9505908663228L23-R23) [[8]](diffhunk://#diff-00e013cfe727705d0bc143dac9b032d7b193c1c96eebc1e8be772c9cfc471c40L22-R22)

**Utility and story updates:**

* Updated `processIssuerExtraInfo` utility to accept and propagate `namespace`, ensuring all secret references in issuer details are correctly linked. (`cert-manager/src/components/common/processIssuerExtraInfo.tsx`) [[1]](diffhunk://#diff-56d5a8ad6f42b7953c1a096bd5996a3f978af102c1e3a71edfcddc2325890329L9-R9) [[2]](diffhunk://#diff-56d5a8ad6f42b7953c1a096bd5996a3f978af102c1e3a71edfcddc2325890329L25-R30) [[3]](diffhunk://#diff-56d5a8ad6f42b7953c1a096bd5996a3f978af102c1e3a71edfcddc2325890329R44) [[4]](diffhunk://#diff-56d5a8ad6f42b7953c1a096bd5996a3f978af102c1e3a71edfcddc2325890329L58-R64) [[5]](diffhunk://#diff-56d5a8ad6f42b7953c1a096bd5996a3f978af102c1e3a71edfcddc2325890329L103-R112) [[6]](diffhunk://#diff-56d5a8ad6f42b7953c1a096bd5996a3f978af102c1e3a71edfcddc2325890329R127) [[7]](diffhunk://#diff-56d5a8ad6f42b7953c1a096bd5996a3f978af102c1e3a71edfcddc2325890329R146) [[8]](diffhunk://#diff-56d5a8ad6f42b7953c1a096bd5996a3f978af102c1e3a71edfcddc2325890329L186-R200) [[9]](diffhunk://#diff-56d5a8ad6f42b7953c1a096bd5996a3f978af102c1e3a71edfcddc2325890329R219)
* Updated storybook templates and arguments for the affected components to support the new `namespace` prop, ensuring stories accurately reflect real-world usage. (`cert-manager/src/components/common/CommonComponents.stories.tsx`) [[1]](diffhunk://#diff-ade1da648f2b732b1ad0440479feb5ece4b5800efbfbd58b0f675c417ed3c2d9L190-R193) [[2]](diffhunk://#diff-ade1da648f2b732b1ad0440479feb5ece4b5800efbfbd58b0f675c417ed3c2d9L213-R214)

**Other:**

* Added a TODO comment in `ClusterIssuerDetail` noting the need to discover and pass the correct namespace for cluster issuer secrets in the future. (`cert-manager/src/components/clusterIssuers/Detail.tsx`)
* Works toward #609 

**Example**
<img width="1024" height="628" alt="image" src="https://github.com/user-attachments/assets/e80cb9f2-c7c3-44f9-b42a-32c8c5b3aa98" />
