### PR TITLE
Volcano: improve Job details view and add lifecycle actions

### DIFF
--- a/volcano/package-lock.json
+++ b/volcano/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "@headlamp-k8s/volcano",
       "version": "0.1.0-alpha",
+      "dependencies": {
+        "notistack": "^3.0.1"
+      },
       "devDependencies": {
         "@kinvolk/headlamp-plugin": "^0.13.1"
       }
@@ -7009,7 +7012,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -9707,7 +9709,6 @@
       "version": "2.1.18",
       "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.18.tgz",
       "integrity": "sha512-2vFqsaDVIT9Gz7N6kAL++pLpp41l3PfDuusHcjnGLfR6+huZkl6ziX+zgVC3ZxpqWhzH6pyDdGrCeDhMIvwaxw==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "csstype": "^3.0.10"
@@ -11282,7 +11283,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -11591,7 +11591,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -12985,7 +12984,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/notistack/-/notistack-3.0.2.tgz",
       "integrity": "sha512-0R+/arLYbK5Hh7mEfR2adt0tyXJcCC9KkA2hc56FeWik2QN6Bm/S4uW+BjzDARsJth5u06nTjelSw/VSnB1YEA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "clsx": "^1.1.0",
@@ -13008,7 +13006,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
       "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -14242,7 +14239,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -14287,7 +14283,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -15319,7 +15314,6 @@
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"

--- a/volcano/package.json
+++ b/volcano/package.json
@@ -34,6 +34,9 @@
   "overrides": {
     "typescript": "5.6.2"
   },
+  "dependencies": {
+    "notistack": "^3.0.1"
+  },
   "devDependencies": {
     "@kinvolk/headlamp-plugin": "^0.13.1"
   }

--- a/volcano/src/components/jobs/Detail.tsx
+++ b/volcano/src/components/jobs/Detail.tsx
@@ -1,14 +1,20 @@
 import {
+  AuthVisible,
+  DateLabel,
   DetailsGrid,
   Link,
   NameValueTable,
   SectionBox,
+  SimpleTable,
   StatusLabel,
 } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 import { useParams } from 'react-router-dom';
+import { VolcanoCommand } from '../../resources/command';
 import { VolcanoJob } from '../../resources/job';
 import { VolcanoPodGroup } from '../../resources/podgroup';
 import { getJobStatusColor } from '../../utils/status';
+import { formatStringList, getPolicyRows, getTaskContainerRows, getTaskRows } from './detailRows';
+import JobCommandActionButton from './JobCommandActionButton';
 
 /**
  * Resolves the PodGroup related to a Volcano Job.
@@ -124,19 +130,175 @@ function getTasksSection(job: VolcanoJob) {
     section: (
       <SectionBox title="Tasks">
         {job.spec.tasks.map((task, index) => (
-          <NameValueTable
-            key={task.name || index}
-            rows={[
-              { name: 'Name', value: task.name || `Task ${index + 1}` },
-              { name: 'Replicas', value: task.replicas },
-              { name: 'Min Available', value: task.minAvailable ?? task.replicas },
-              { name: 'Image', value: task.template?.spec?.containers?.[0]?.image || '-' },
-            ]}
-          />
+          <SectionBox title={task.name || `Task ${index + 1}`} key={task.name || index}>
+            <NameValueTable rows={getTaskRows(task, index)} />
+            {(task.template?.spec?.containers || []).length > 0 ? (
+              task.template?.spec?.containers?.map((container, containerIndex) => (
+                <NameValueTable
+                  key={`${task.name || index}-${container.name || containerIndex}`}
+                  rows={getTaskContainerRows(container)}
+                />
+              ))
+            ) : (
+              <NameValueTable rows={[{ name: 'Containers', value: 'No containers defined' }]} />
+            )}
+          </SectionBox>
         ))}
       </SectionBox>
     ),
   };
+}
+
+/**
+ * Builds the Plugins section for the Job details page.
+ *
+ * @param job Volcano Job shown in the details page.
+ * @returns Section descriptor for configured plugins or `null` if none exist.
+ */
+function getPluginsSection(job: VolcanoJob) {
+  const plugins = job.spec.plugins || {};
+  const pluginNames = Object.keys(plugins);
+
+  if (pluginNames.length === 0) {
+    return null;
+  }
+
+  return {
+    id: 'plugins',
+    section: (
+      <SectionBox title="Plugins">
+        <NameValueTable
+          rows={pluginNames.map(pluginName => ({
+            name:
+              pluginName.toLowerCase() === 'ssh'
+                ? 'SSH'
+                : pluginName[0].toUpperCase() + pluginName.slice(1),
+            value: formatStringList(plugins[pluginName]),
+          }))}
+        />
+      </SectionBox>
+    ),
+  };
+}
+
+/**
+ * Builds the Policies section for the Job details page.
+ *
+ * @param job Volcano Job shown in the details page.
+ * @returns Section descriptor for lifecycle policies or `null` if none exist.
+ */
+function getPoliciesSection(job: VolcanoJob) {
+  if (!job.spec.policies?.length) {
+    return null;
+  }
+
+  return {
+    id: 'policies',
+    section: (
+      <SectionBox title="Policies">
+        {job.spec.policies.map((policy, index) => (
+          <NameValueTable key={`policy-${index}`} rows={getPolicyRows(policy)} />
+        ))}
+      </SectionBox>
+    ),
+  };
+}
+
+/**
+ * Builds the Conditions section for the Job details page.
+ *
+ * @param job Volcano Job shown in the details page.
+ * @returns Section descriptor for job conditions or `null` if none exist.
+ */
+function getConditionsSection(job: VolcanoJob) {
+  if (!job.status?.conditions?.length) {
+    return null;
+  }
+
+  return {
+    id: 'conditions',
+    section: (
+      <SectionBox title="Conditions">
+        <SimpleTable
+          data={job.status.conditions}
+          columns={[
+            {
+              label: 'Status',
+              getter: condition => condition.status || '-',
+            },
+            {
+              label: 'Last Transition',
+              getter: condition =>
+                condition.lastTransitionTime ? (
+                  <DateLabel date={condition.lastTransitionTime} />
+                ) : (
+                  '-'
+                ),
+            },
+          ]}
+        />
+      </SectionBox>
+    ),
+  };
+}
+
+/**
+ * Returns only the Job lifecycle actions that map to valid existing-job CLI operations.
+ * @see https://github.com/volcano-sh/volcano/blob/master/pkg/cli/vsuspend/suspend.go
+ * @see https://github.com/volcano-sh/volcano/blob/master/pkg/cli/vresume/resume.go
+ */
+function getJobActionButtons(job: VolcanoJob) {
+  const canSuspend = ![
+    'Aborting',
+    'Aborted',
+    'Terminating',
+    'Terminated',
+    'Completing',
+    'Completed',
+    'Failed',
+  ].includes(job.phase);
+  const canResume = job.phase === 'Aborted';
+
+  return [
+    ...(canSuspend
+      ? [
+          {
+            id: 'volcano-job-suspend',
+            action: (
+              <AuthVisible item={VolcanoCommand} authVerb="create" namespace={job.getNamespace()}>
+                <JobCommandActionButton
+                  job={job}
+                  label="Suspend"
+                  longDescription="Suspend this job (vcctl job suspend)."
+                  icon="mdi:pause"
+                  action="AbortJob"
+                  successMessage={`Suspend command created for ${job.metadata.name}`}
+                />
+              </AuthVisible>
+            ),
+          },
+        ]
+      : []),
+    ...(canResume
+      ? [
+          {
+            id: 'volcano-job-resume',
+            action: (
+              <AuthVisible item={VolcanoCommand} authVerb="create" namespace={job.getNamespace()}>
+                <JobCommandActionButton
+                  job={job}
+                  label="Resume"
+                  longDescription="Resume this job (vcctl job resume)."
+                  icon="mdi:play-circle"
+                  action="ResumeJob"
+                  successMessage={`Resume command created for ${job.metadata.name}`}
+                />
+              </AuthVisible>
+            ),
+          },
+        ]
+      : []),
+  ];
 }
 
 /**
@@ -166,6 +328,14 @@ export default function JobDetail() {
           {
             name: 'Status',
             value: <StatusLabel status={getJobStatusColor(job.phase)}>{job.phase}</StatusLabel>,
+          },
+          {
+            name: 'API Version',
+            value: job.jsonData.apiVersion || VolcanoJob.apiVersion,
+          },
+          {
+            name: 'Kind',
+            value: job.jsonData.kind || 'Job',
           },
           {
             name: 'Queue',
@@ -201,10 +371,50 @@ export default function JobDetail() {
             name: 'Max Retry',
             value: job.spec.maxRetry ?? 3,
           },
+          {
+            name: 'Generate Name',
+            value: job.metadata.generateName || '-',
+          },
+          {
+            name: 'Generation',
+            value: job.metadata.generation ?? '-',
+          },
+          {
+            name: 'Resource Version',
+            value: job.metadata.resourceVersion || '-',
+          },
+          {
+            name: 'UID',
+            value: job.metadata.uid || '-',
+          },
+          {
+            name: 'Retry Count',
+            value: job.status?.retryCount ?? 0,
+          },
+          {
+            name: 'Running Duration',
+            value: job.status?.runningDuration || '-',
+          },
+          {
+            name: 'State Last Transition Time',
+            value: job.status?.state?.lastTransitionTime || '-',
+          },
+          {
+            name: 'Version',
+            value: job.status?.version ?? '-',
+          },
         ];
       }}
+      actions={(job: VolcanoJob) => (job ? getJobActionButtons(job) : [])}
       extraSections={(job: VolcanoJob) =>
-        job && [getPodStatusSection(job), getTasksSection(job)].filter(Boolean)
+        job &&
+        [
+          getPodStatusSection(job),
+          getPluginsSection(job),
+          getPoliciesSection(job),
+          getTasksSection(job),
+          getConditionsSection(job),
+        ].filter(Boolean)
       }
     />
   );

--- a/volcano/src/components/jobs/JobCommandActionButton.stories.tsx
+++ b/volcano/src/components/jobs/JobCommandActionButton.stories.tsx
@@ -1,0 +1,68 @@
+import pauseIcon from '@iconify/icons-mdi/pause';
+import playCircleIcon from '@iconify/icons-mdi/play-circle';
+import type { Meta, StoryFn } from '@storybook/react';
+import { SnackbarProvider } from 'notistack';
+import { MemoryRouter } from 'react-router-dom';
+import type { VolcanoJob } from '../../resources/job';
+import JobCommandActionButton from './JobCommandActionButton';
+
+const baseJob = {
+  metadata: {
+    name: 'example-job',
+    namespace: 'default',
+    uid: 'example-job-uid',
+  },
+  getNamespace() {
+    return 'default';
+  },
+} as unknown as VolcanoJob;
+
+const meta = {
+  title: 'Jobs/JobCommandActionButton',
+  component: JobCommandActionButton,
+  decorators: [
+    Story => (
+      <SnackbarProvider>
+        <MemoryRouter>
+          <div
+            style={{
+              minHeight: 120,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              padding: 24,
+            }}
+          >
+            <Story />
+          </div>
+        </MemoryRouter>
+      </SnackbarProvider>
+    ),
+  ],
+} satisfies Meta<typeof JobCommandActionButton>;
+
+export default meta;
+
+const Template: StoryFn<typeof JobCommandActionButton> = args => (
+  <JobCommandActionButton {...args} />
+);
+
+export const Suspend = Template.bind({});
+Suspend.args = {
+  job: baseJob,
+  label: 'Suspend',
+  icon: pauseIcon,
+  action: 'AbortJob',
+  successMessage: 'Suspend command created for example-job',
+  longDescription: 'Suspend this job (vcctl job suspend).',
+};
+
+export const Resume = Template.bind({});
+Resume.args = {
+  job: baseJob,
+  label: 'Resume',
+  icon: playCircleIcon,
+  action: 'ResumeJob',
+  successMessage: 'Resume command created for example-job',
+  longDescription: 'Resume this job (vcctl job resume).',
+};

--- a/volcano/src/components/jobs/JobCommandActionButton.tsx
+++ b/volcano/src/components/jobs/JobCommandActionButton.tsx
@@ -1,0 +1,69 @@
+import { ActionButton } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { useSnackbar } from 'notistack';
+import { useState } from 'react';
+import { createJobCommand, VolcanoJobCommandAction } from '../../resources/command';
+import { VolcanoJob } from '../../resources/job';
+
+/**
+ * Props for the Job lifecycle action button component.
+ */
+interface JobCommandActionButtonProps {
+  /** Job targeted by the lifecycle action. */
+  job: VolcanoJob;
+  /** Short button label shown in the details header. */
+  label: string;
+  /** Icon name shown in the action button. */
+  icon: string;
+  /** Volcano command action issued for the Job. */
+  action: VolcanoJobCommandAction;
+  /** Success notification shown after command creation. */
+  successMessage: string;
+  /** Optional longer description for the action. */
+  longDescription?: string;
+}
+
+/**
+ * Renders a lifecycle action button and sends the corresponding Volcano bus command.
+ * @see https://github.com/volcano-sh/volcano/blob/master/pkg/cli/vsuspend/suspend.go
+ * @see https://github.com/volcano-sh/volcano/blob/master/pkg/cli/vresume/resume.go
+ */
+export default function JobCommandActionButton({
+  job,
+  label,
+  icon,
+  action,
+  successMessage,
+  longDescription,
+}: JobCommandActionButtonProps) {
+  const { enqueueSnackbar } = useSnackbar();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const onClick = async () => {
+    if (isSubmitting) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await createJobCommand(job, action);
+      enqueueSnackbar(successMessage, { variant: 'success' });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      enqueueSnackbar(`Failed to ${label.toLowerCase()} job ${job.metadata.name}: ${message}`, {
+        variant: 'error',
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <ActionButton
+      description={label}
+      longDescription={longDescription}
+      icon={icon}
+      onClick={onClick}
+      iconButtonProps={{ disabled: isSubmitting }}
+    />
+  );
+}

--- a/volcano/src/components/jobs/detailRows.ts
+++ b/volcano/src/components/jobs/detailRows.ts
@@ -1,0 +1,162 @@
+import { ContainerSpec, LifecyclePolicy, TaskSpec } from '../../resources/job';
+
+type DetailRow = {
+  name: string;
+  value: string | number;
+};
+
+/**
+ * Formats a list of strings for display in Job details rows.
+ *
+ * @param values String values to display.
+ * @returns Comma-separated string or `-` when empty.
+ */
+export function formatStringList(values?: string[]) {
+  return values && values.length > 0 ? values.join(', ') : '-';
+}
+
+/**
+ * Formats a string/number map for display in Job details rows.
+ *
+ * @param values Key-value map to display.
+ * @returns Comma-separated string or `-` when empty.
+ */
+export function formatKeyValueMap(values?: Record<string, string | number>) {
+  if (!values || Object.keys(values).length === 0) {
+    return '-';
+  }
+
+  return Object.entries(values)
+    .map(([key, value]) => `${key}: ${value}`)
+    .join(', ');
+}
+
+/**
+ * Formats container ports for display in Job details rows.
+ *
+ * @param ports Container ports to display.
+ * @returns Comma-separated port definitions or `-` when empty.
+ */
+export function formatContainerPorts(ports?: ContainerSpec['ports']) {
+  if (!ports || ports.length === 0) {
+    return '-';
+  }
+
+  return ports
+    .map(port => {
+      const name = port?.name ? `${port.name}: ` : '';
+      const number = port?.containerPort ?? '-';
+      const protocol = port?.protocol ?? 'TCP';
+      return `${name}${number}/${protocol}`;
+    })
+    .join(', ');
+}
+
+function formatEnvVars(env?: ContainerSpec['env']) {
+  if (!env || env.length === 0) {
+    return '-';
+  }
+
+  return env
+    .map(variable => {
+      if (variable.value !== undefined) {
+        return `${variable.name}=${variable.value}`;
+      }
+
+      if (variable.valueFrom) {
+        return `${variable.name}=<valueFrom>`;
+      }
+
+      return variable.name;
+    })
+    .join(', ');
+}
+
+/**
+ * Builds detail rows for a Volcano Job lifecycle policy.
+ *
+ * @param policy Job lifecycle policy.
+ * @returns Detail rows describing the policy.
+ */
+export function getPolicyRows(policy: LifecyclePolicy): DetailRow[] {
+  const rows: DetailRow[] = [];
+
+  if (policy.action !== undefined) {
+    rows.push({ name: 'Action', value: policy.action || '-' });
+  }
+
+  if (policy.event !== undefined) {
+    rows.push({ name: 'Event', value: policy.event || '-' });
+  }
+
+  if (policy.events !== undefined) {
+    rows.push({
+      name: 'Events',
+      value: policy.events.length ? policy.events.join(', ') : '-',
+    });
+  }
+
+  if (policy.exitCode !== undefined) {
+    rows.push({ name: 'Exit Code', value: policy.exitCode });
+  }
+
+  if (policy.timeout !== undefined) {
+    rows.push({ name: 'Timeout', value: policy.timeout || '-' });
+  }
+
+  return rows;
+}
+
+/**
+ * Builds detail rows for a task container.
+ *
+ * @param container Task container definition.
+ * @returns Detail rows describing the container.
+ */
+export function getTaskContainerRows(container: ContainerSpec): DetailRow[] {
+  return [
+    { name: 'Name', value: container.name || '-' },
+    { name: 'Image', value: container.image || '-' },
+    { name: 'Image Pull Policy', value: container.imagePullPolicy || '-' },
+    { name: 'Command', value: formatStringList(container.command) },
+    { name: 'Args', value: formatStringList(container.args) },
+    { name: 'Environment', value: formatEnvVars(container.env) },
+    { name: 'Ports', value: formatContainerPorts(container.ports) },
+    { name: 'Resource Requests', value: formatKeyValueMap(container.resources?.requests) },
+    { name: 'Resource Limits', value: formatKeyValueMap(container.resources?.limits) },
+    { name: 'Working Dir', value: container.workingDir || '-' },
+  ];
+}
+
+/**
+ * Builds detail rows for a Volcano Job task.
+ *
+ * @param task Task definition shown in the details page.
+ * @param index Task index used as a fallback label.
+ * @returns Detail rows describing the task.
+ */
+export function getTaskRows(task: TaskSpec, index: number): DetailRow[] {
+  return [
+    { name: 'Name', value: task.name || `Task ${index + 1}` },
+    { name: 'Replicas', value: task.replicas },
+    { name: 'Min Available', value: task.minAvailable ?? task.replicas },
+    { name: 'Max Retry', value: task.maxRetry ?? '-' },
+    { name: 'Restart Policy', value: task.template?.spec?.restartPolicy || '-' },
+    {
+      name: 'Image Pull Secrets',
+      value: formatStringList(
+        task.template?.spec?.imagePullSecrets
+          ?.map(secret => secret.name || '')
+          .filter(secretName => secretName)
+      ),
+    },
+    {
+      name: 'Template Annotations',
+      value: formatKeyValueMap(task.template?.metadata?.annotations),
+    },
+    {
+      name: 'Template Creation Timestamp',
+      value: task.template?.metadata?.creationTimestamp || '-',
+    },
+  ];
+}

--- a/volcano/src/resources/command.ts
+++ b/volcano/src/resources/command.ts
@@ -1,4 +1,5 @@
 import { KubeObject, KubeObjectInterface } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import { VolcanoJob } from './job';
 import { VolcanoQueue } from './queue';
 
 /**
@@ -9,18 +10,26 @@ import { VolcanoQueue } from './queue';
 export type VolcanoQueueCommandAction = 'OpenQueue' | 'CloseQueue';
 
 /**
+ * Volcano bus actions supported by the Job lifecycle commands used in the UI.
+ * @see https://github.com/volcano-sh/volcano/blob/master/staging/src/volcano.sh/apis/pkg/apis/bus/v1alpha1/actions.go
+ * @see https://github.com/volcano-sh/volcano/blob/master/pkg/cli/vsuspend/suspend.go
+ * @see https://github.com/volcano-sh/volcano/blob/master/pkg/cli/vresume/resume.go
+ */
+export type VolcanoJobCommandAction = 'AbortJob' | 'ResumeJob';
+
+/**
  * Namespace used by `vcctl queue operate` when creating queue Command objects.
  * @see https://github.com/volcano-sh/volcano/blob/master/pkg/cli/queue/util.go
  */
 export const QUEUE_COMMAND_NAMESPACE = 'default';
 
 /**
- * Volcano bus Command resource payload used to target a queue action.
+ * Volcano bus Command resource payload used to target a queue or job action.
  * @see https://github.com/volcano-sh/volcano/blob/master/staging/src/volcano.sh/apis/pkg/apis/bus/v1alpha1/commands.go
  */
 export interface KubeVolcanoCommand extends KubeObjectInterface {
   /** Action to execute for the target object. */
-  action?: string;
+  action?: VolcanoJobCommandAction;
   /** Target object reference for this command. */
   target?: {
     apiVersion?: string;
@@ -85,5 +94,67 @@ export async function createQueueCommand(queue: VolcanoQueue, action: VolcanoQue
     },
     {},
     queue.cluster
+  );
+}
+
+const maxGenerateNameLength = 63;
+
+function buildCommandGenerateName(name: string, action: VolcanoJobCommandAction) {
+  const suffix = `-${action.toLowerCase()}-`;
+  const maxPrefixLength = maxGenerateNameLength - suffix.length;
+  const prefix = name.slice(0, Math.max(maxPrefixLength, 1));
+
+  return `${prefix}${suffix}`;
+}
+
+/**
+ * Creates a Volcano bus command for an existing Job lifecycle action.
+ * Mirrors the upstream CLI helper used by `vcctl` suspend/resume flows.
+ * @see https://github.com/volcano-sh/volcano/blob/master/pkg/cli/util/util.go
+ * @see https://github.com/volcano-sh/volcano/blob/master/staging/src/volcano.sh/apis/pkg/apis/bus/v1alpha1/commands.go
+ * @see https://github.com/volcano-sh/volcano/blob/master/staging/src/volcano.sh/apis/pkg/apis/bus/v1alpha1/actions.go
+ */
+export async function createJobCommand(job: VolcanoJob, action: VolcanoJobCommandAction) {
+  const namespace = job.metadata.namespace;
+  const name = job.metadata.name;
+  const uid = job.metadata.uid;
+
+  if (!namespace || !name || !uid) {
+    const missingFields = [
+      !namespace ? 'namespace' : null,
+      !name ? 'name' : null,
+      !uid ? 'uid' : null,
+    ].filter((field): field is string => field !== null);
+
+    throw new Error(
+      `Job metadata is incomplete for issuing this command. Missing required field(s): ${missingFields.join(
+        ', '
+      )}`
+    );
+  }
+
+  const targetReference = {
+    apiVersion: job.jsonData.apiVersion || VolcanoJob.apiVersion,
+    kind: job.jsonData.kind || 'Job',
+    name,
+    uid,
+    controller: true,
+    blockOwnerDeletion: true,
+  };
+
+  await VolcanoCommand.apiEndpoint.post(
+    {
+      apiVersion: VolcanoCommand.apiVersion,
+      kind: VolcanoCommand.kind,
+      metadata: {
+        generateName: buildCommandGenerateName(name, action),
+        namespace,
+        ownerReferences: [targetReference],
+      },
+      action,
+      target: targetReference,
+    },
+    {},
+    job.cluster
   );
 }

--- a/volcano/src/resources/job.ts
+++ b/volcano/src/resources/job.ts
@@ -21,26 +21,112 @@ export interface TaskSpec {
     iteration?: 'any' | 'all';
   };
   /** Pod template used to create task replicas. */
-  template: {
-    /** Pod spec for the task template. */
-    spec: {
-      /** Container templates for task pods. */
-      containers: {
-        /** Container name. */
-        name: string;
-        /** Container image reference. */
-        image: string;
-        /** Optional command override. */
-        command?: string[];
-        /** Optional resource requests and limits. */
-        resources?: Record<string, unknown>;
-      }[];
-      /** Pod restart policy for this task template. */
-      restartPolicy?: string;
-    };
-  };
+  template: PodTemplateSpec;
   /** Lifecycle policies scoped to this task. */
   policies?: LifecyclePolicy[];
+  /** Topology policy for NUMA-aware scheduling. */
+  topologyPolicy?: string;
+}
+
+/**
+ * Pod template metadata used by a Volcano task.
+ * @see https://github.com/volcano-sh/apis/blob/ae35b8b12bc5ccb6ff5a62fcd9dca06234197e63/pkg/apis/batch/v1alpha1/job.go#L239
+ * @see https://github.com/kubernetes/api/blob/2b6c3c950fc28eddbbb7b9f98633b3be3dba97b0/core/v1/types.go#L5548
+ */
+export interface PodTemplateMetadata {
+  /** Labels applied to task pods. */
+  labels?: Record<string, string>;
+  /** Annotations applied to task pods. */
+  annotations?: Record<string, string>;
+  /** Template creation timestamp when present in the resource payload. */
+  creationTimestamp?: string;
+}
+
+/**
+ * Environment variable specification for a container.
+ * @see https://github.com/volcano-sh/apis/blob/ae35b8b12bc5ccb6ff5a62fcd9dca06234197e63/pkg/apis/batch/v1alpha1/job.go#L239
+ * @see https://github.com/kubernetes/api/blob/2b6c3c950fc28eddbbb7b9f98633b3be3dba97b0/core/v1/types.go#L2473
+ */
+export interface EnvVarSpec {
+  /** Environment variable name. */
+  name: string;
+  /** Literal value for the variable. */
+  value?: string;
+  /** Value source reference when value is not literal. */
+  valueFrom?: Record<string, unknown>;
+}
+
+/**
+ * Exposed container port definition.
+ * @see https://github.com/volcano-sh/apis/blob/ae35b8b12bc5ccb6ff5a62fcd9dca06234197e63/pkg/apis/batch/v1alpha1/job.go#L239
+ * @see https://github.com/kubernetes/api/blob/2b6c3c950fc28eddbbb7b9f98633b3be3dba97b0/core/v1/types.go#L2352
+ */
+export interface ContainerPortSpec {
+  /** Container port number. */
+  containerPort?: number;
+  /** Optional port name. */
+  name?: string;
+  /** Port protocol (TCP/UDP/SCTP). */
+  protocol?: string;
+}
+
+/**
+ * Kubernetes resource requirements for a container.
+ * @see https://github.com/volcano-sh/apis/blob/ae35b8b12bc5ccb6ff5a62fcd9dca06234197e63/pkg/apis/batch/v1alpha1/job.go#L239
+ * @see https://github.com/kubernetes/api/blob/2b6c3c950fc28eddbbb7b9f98633b3be3dba97b0/core/v1/types.go#L2841
+ */
+export interface ContainerResourceRequirements {
+  /** Resource limits map. */
+  limits?: Record<string, string>;
+  /** Resource requests map. */
+  requests?: Record<string, string>;
+}
+
+/**
+ * Container specification used in a task pod template.
+ * @see https://github.com/volcano-sh/apis/blob/ae35b8b12bc5ccb6ff5a62fcd9dca06234197e63/pkg/apis/batch/v1alpha1/job.go#L239
+ * @see https://github.com/kubernetes/api/blob/2b6c3c950fc28eddbbb7b9f98633b3be3dba97b0/core/v1/types.go#L2909
+ */
+export interface ContainerSpec {
+  /** Container name. */
+  name: string;
+  /** Container image reference. */
+  image: string;
+  /** Optional image pull policy. */
+  imagePullPolicy?: string;
+  /** Optional command override. */
+  command?: string[];
+  /** Optional arguments passed to the container entrypoint. */
+  args?: string[];
+  /** Optional working directory in the container. */
+  workingDir?: string;
+  /** Optional container environment variables. */
+  env?: EnvVarSpec[];
+  /** Optional declared container ports. */
+  ports?: ContainerPortSpec[];
+  /** Optional resource requests and limits. */
+  resources?: ContainerResourceRequirements;
+}
+
+/**
+ * Pod template spec used by a Volcano task.
+ * @see https://github.com/volcano-sh/apis/blob/ae35b8b12bc5ccb6ff5a62fcd9dca06234197e63/pkg/apis/batch/v1alpha1/job.go#L239
+ * @see https://github.com/kubernetes/api/blob/2b6c3c950fc28eddbbb7b9f98633b3be3dba97b0/core/v1/types.go#L5548
+ */
+export interface PodTemplateSpec {
+  /** Optional pod template metadata. */
+  metadata?: PodTemplateMetadata;
+  /** Pod spec for the task template. */
+  spec?: {
+    /** Container templates for task pods. */
+    containers?: ContainerSpec[];
+    /** Secrets used for pulling images. */
+    imagePullSecrets?: Array<{ name?: string }>;
+    /** Pod restart policy for this task template. */
+    restartPolicy?: string;
+    /** Scheduler name for task pods. */
+    schedulerName?: string;
+  };
 }
 
 /**
@@ -138,16 +224,10 @@ export interface JobState {
  * @see https://github.com/volcano-sh/apis/blob/ae35b8b12bc5ccb6ff5a62fcd9dca06234197e63/pkg/apis/batch/v1alpha1/job.go#L442-L447
  */
 export interface JobCondition {
-  /** Condition type, when present. */
-  type?: string;
   /** Volcano job phase. */
   status: JobPhase;
   /** Timestamp for the last condition transition. */
   lastTransitionTime?: string;
-  /** Short machine-friendly reason for this condition. */
-  reason?: string;
-  /** Human-readable condition message. */
-  message?: string;
 }
 
 /**
@@ -180,7 +260,7 @@ export interface VolcanoJobStatus {
   /** Resources created and controlled by this job. */
   controlledResources?: Record<string, string>;
   /** Per-task pod phase counters. */
-  taskStatusCount?: Record<string, Record<string, number>>;
+  taskStatusCount?: Record<string, { phase?: Record<string, number> }>;
   /** Condition history for job transitions. */
   conditions?: JobCondition[];
 }


### PR DESCRIPTION
## Summary
- expand the Volcano Job details page to show the missing data surfaced by `vcctl job view` and `kubectl describe jobs.batch.volcano.sh`
- add job lifecycle actions in the details header via Volcano `Command` resources

## Changes
- add Job header actions for:


**Suspend**

<img width="1609" height="313" alt="image" src="https://github.com/user-attachments/assets/069b80ae-8f6e-4a0c-84ab-ed5c50335324" />

  **Resume**
  
<img width="1603" height="303" alt="image" src="https://github.com/user-attachments/assets/c1b8e869-8251-48d9-8376-0b75fe253dc8" />

- add missing Job details coverage for:
  - plugins
  - policies
  - conditions
  - more task/container template details
  - metadata/status fields such as API version, kind, generation, resource version, UID, version, retry count, running duration, and state transition time
- extract Job detail formatting helpers into `src/components/jobs/helper.ts`
- add a Volcano `Command` resource wrapper and add Job command creation logic into `src/resources/command.ts` to be able to use the volcano actions 

Closes #599