### PR TITLE
flux: Fix broken sorting functionality for Status column in Flux plugin tables

### DIFF
--- a/flux/src/common/StatusLabel.tsx
+++ b/flux/src/common/StatusLabel.tsx
@@ -6,26 +6,37 @@ interface StatusLabelProps {
   item: KubeCRD;
 }
 
+export function getStatusText(item: KubeCRD): string {
+  const ready = item?.jsonData?.status?.conditions?.find((c: any) => c.type === 'Ready');
+  if (!ready) return '-';
+  if (item?.jsonData?.spec?.suspend) return 'Suspended';
+  if (ready.status === 'Unknown') return 'Reconciling…';
+  if (ready.reason === 'DependencyNotReady') return 'Waiting';
+  return ready.status === 'True' ? 'Ready' : 'Failed';
+}
+
 export default function StatusLabel(props: StatusLabelProps) {
   const { item } = props;
-  const ready = item?.jsonData?.status?.conditions?.find(c => c.type === 'Ready');
+  const ready = item?.jsonData?.status?.conditions?.find((c: any) => c.type === 'Ready');
 
   if (!ready) {
     return <span>-</span>;
   }
 
+  const text = getStatusText(item);
+
   if (item?.jsonData?.spec?.suspend) {
-    return <HLStatusLabel status="warning">Suspended</HLStatusLabel>;
+    return <HLStatusLabel status="warning">{text}</HLStatusLabel>;
   }
   if (ready.status === 'Unknown') {
-    return <HLStatusLabel status="warning">Reconciling…</HLStatusLabel>;
+    return <HLStatusLabel status="warning">{text}</HLStatusLabel>;
   }
 
   if (ready.reason === 'DependencyNotReady') {
     return (
       <HLStatusLabel status={'warning'}>
         <Tooltip title={ready.message}>
-          <Typography component="span">Waiting</Typography>
+          <Typography component="span">{text}</Typography>
         </Tooltip>
       </HLStatusLabel>
     );
@@ -35,7 +46,7 @@ export default function StatusLabel(props: StatusLabelProps) {
   return (
     <HLStatusLabel status={isReady ? 'success' : 'error'}>
       <Tooltip title={ready.message}>
-        <Typography component="span">{isReady ? 'Ready' : 'Failed'}</Typography>
+        <Typography component="span">{text}</Typography>
       </Tooltip>
     </HLStatusLabel>
   );

--- a/flux/src/common/Table.tsx
+++ b/flux/src/common/Table.tsx
@@ -11,7 +11,7 @@ import { KubeCRD } from '@kinvolk/headlamp-plugin/lib/lib/k8s/crd';
 import React from 'react';
 import { getSourceNameAndPluralKind } from '../helpers';
 import { PluralName } from '../helpers/pluralName';
-import StatusLabel from './StatusLabel';
+import StatusLabel, { getStatusText } from './StatusLabel';
 
 type CommonColumnType =
   | 'namespace'
@@ -141,9 +141,8 @@ export function Table(props: TableProps) {
           case 'status':
             return {
               header: 'Status',
-              accessorFn: item => {
-                return <StatusLabel item={item} />;
-              },
+              accessorFn: item => getStatusText(item),
+              Cell: ({ row: { original: item } }: any) => <StatusLabel item={item} />,
             };
           case 'revision':
             return {


### PR DESCRIPTION
## Summary:
This PR enhances the maintainability and correctness of the status logic by introducing a shared helper function (getStatusText) to derive the Status column text in both rendering (StatusLabel) and sorting (Table.tsx).


## Changes:
1. src/common/StatusLabel.tsx:
   - Added getStatusText(item) as the single source of truth for status label derivation ('Ready', 'Suspended', etc.).
   - Refactored StatusLabel to use the shared getStatusText for consistent rendering.
2. src/common/Table.tsx:
   - Updated the Status column's accessorFn to call getStatusText, ensuring sorting aligns with rendered text.

## Benefits:
- Prevents sorting keys from falling out of sync with rendered labels (e.g., Reconciling… with ellipsis matches sort string now).
- Simplifies future updates to status logic by centralizing it in getStatusText.

## Validation:
- Built the plugin (npm run build) with zero TypeScript errors or runtime issues.
- Ran `npm run lint-fix` and `npm test`
- Verified that Status column sorting and rendering remain consistent across:
  - Kustomizations
  - Image Automation
  - Image Repositories
  
This PR closes #224 the gap between sorting behavior and rendered output while improving the maintainability of the codebase.