### PR TITLE
Volcano: Complete queue details view and add action buttons

### DIFF
--- a/volcano/src/components/queues/Detail.tsx
+++ b/volcano/src/components/queues/Detail.tsx
@@ -1,32 +1,275 @@
 import {
+  ActionButton,
+  AuthVisible,
   DetailsGrid,
+  Dialog,
   Link,
   NameValueTable,
   SectionBox,
+  SimpleTable,
   StatusLabel,
 } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import Button from '@mui/material/Button';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import TextField from '@mui/material/TextField';
+import { useSnackbar } from 'notistack';
+import { useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import {
+  createQueueCommand,
+  QUEUE_COMMAND_NAMESPACE,
+  VolcanoCommand,
+  VolcanoQueueCommandAction,
+} from '../../resources/command';
+import { VolcanoPodGroup } from '../../resources/podgroup';
 import { VolcanoQueue } from '../../resources/queue';
 import { getQueueStatusColor } from '../../utils/status';
+import { getQueuePodGroupStats, type QueuePodGroupStats } from './stats';
+
+interface QueueCommandActionButtonProps {
+  queue: VolcanoQueue;
+  label: string;
+  icon: string;
+  action: VolcanoQueueCommandAction;
+  successMessage: string;
+  longDescription?: string;
+}
 
 /**
- * Builds the Capacity Limits section for a Queue.
+ * Renders a queue action button that issues an open or close command.
+ *
+ * @param props Queue command button properties.
+ * @returns Queue command action button.
+ */
+function QueueCommandActionButton({
+  queue,
+  label,
+  icon,
+  action,
+  successMessage,
+  longDescription,
+}: QueueCommandActionButtonProps) {
+  const { enqueueSnackbar } = useSnackbar();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const onClick = async () => {
+    if (isSubmitting) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await createQueueCommand(queue, action);
+      enqueueSnackbar(successMessage, { variant: 'success' });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      enqueueSnackbar(`Failed to ${label.toLowerCase()} queue ${queue.metadata.name}: ${message}`, {
+        variant: 'error',
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <ActionButton
+      description={label}
+      longDescription={longDescription}
+      icon={icon}
+      onClick={onClick}
+      iconButtonProps={{ disabled: isSubmitting }}
+    />
+  );
+}
+
+/**
+ * Renders the action button and dialog used to update queue weight.
+ *
+ * @param props Queue weight action button properties.
+ * @returns Queue weight update action button and dialog.
+ */
+function UpdateQueueWeightActionButton({ queue }: { queue: VolcanoQueue }) {
+  const { enqueueSnackbar } = useSnackbar();
+  const [open, setOpen] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [weightValue, setWeightValue] = useState(String(queue.weight));
+
+  const parsedWeight = Number(weightValue);
+  const isWeightValid = Number.isInteger(parsedWeight) && parsedWeight > 0;
+
+  const submit = async () => {
+    if (!isWeightValid || isSubmitting) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await queue.patch({
+        spec: {
+          weight: parsedWeight,
+        },
+      });
+      enqueueSnackbar(`Updated queue weight for ${queue.metadata.name}.`, { variant: 'success' });
+      setOpen(false);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      enqueueSnackbar(`Failed to update queue weight for ${queue.metadata.name}: ${message}`, {
+        variant: 'error',
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      <ActionButton
+        description="Update Weight"
+        longDescription="Update queue weight (vcctl queue operate -a update -w <weight>)."
+        icon="mdi:tune"
+        onClick={() => {
+          setWeightValue(String(queue.weight));
+          setOpen(true);
+        }}
+      />
+      <Dialog open={open} onClose={() => setOpen(false)} title="Update Queue Weight">
+        <DialogContent>
+          <TextField
+            fullWidth
+            margin="normal"
+            label="Weight"
+            type="number"
+            value={weightValue}
+            onChange={event => setWeightValue(event.target.value)}
+            inputProps={{ min: 1, step: 1 }}
+            error={weightValue.length > 0 && !isWeightValid}
+            helperText={
+              weightValue.length > 0 && !isWeightValid
+                ? 'Weight must be an integer greater than 0.'
+                : ' '
+            }
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setOpen(false)} disabled={isSubmitting}>
+            Cancel
+          </Button>
+          <Button onClick={submit} disabled={isSubmitting || !isWeightValid}>
+            Update
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+}
+
+/**
+ * Builds the queue header action buttons shown in the details view.
  *
  * @param queue Queue shown in the details page.
- * @returns Section descriptor or `null` when no capability is defined.
+ * @returns Queue actions for open, close, and weight update.
  */
-function getCapacitySection(queue: VolcanoQueue) {
-  if (!queue.spec.capability) return null;
+function getQueueActionButtons(queue: VolcanoQueue) {
+  const canOpen = queue.state !== 'Open';
+  const canClose = queue.state === 'Open' && queue.getName() !== 'root';
+
+  return [
+    ...(canOpen
+      ? [
+          {
+            id: 'volcano-queue-open',
+            action: (
+              <AuthVisible
+                item={VolcanoCommand}
+                authVerb="create"
+                namespace={QUEUE_COMMAND_NAMESPACE}
+              >
+                <QueueCommandActionButton
+                  queue={queue}
+                  label="Open"
+                  longDescription="Open this queue (vcctl queue operate -a open)."
+                  icon="mdi:lock-open-variant-outline"
+                  action="OpenQueue"
+                  successMessage={`Open command created for ${queue.metadata.name}`}
+                />
+              </AuthVisible>
+            ),
+          },
+        ]
+      : []),
+    ...(canClose
+      ? [
+          {
+            id: 'volcano-queue-close',
+            action: (
+              <AuthVisible
+                item={VolcanoCommand}
+                authVerb="create"
+                namespace={QUEUE_COMMAND_NAMESPACE}
+              >
+                <QueueCommandActionButton
+                  queue={queue}
+                  label="Close"
+                  longDescription="Close this queue (vcctl queue operate -a close)."
+                  icon="mdi:lock-outline"
+                  action="CloseQueue"
+                  successMessage={`Close command created for ${queue.metadata.name}`}
+                />
+              </AuthVisible>
+            ),
+          },
+        ]
+      : []),
+    {
+      id: 'volcano-queue-update-weight',
+      action: (
+        <AuthVisible item={queue} authVerb="update">
+          <UpdateQueueWeightActionButton queue={queue} />
+        </AuthVisible>
+      ),
+    },
+  ];
+}
+
+/**
+ * Builds the capacity and allocated resources section for a Queue.
+ *
+ * @param queue Queue shown in the details page.
+ * @returns Section descriptor or `null` when no resource data is available.
+ */
+function getCapacityAllocatedSection(queue: VolcanoQueue) {
+  const capacity = queue.spec.capability || {};
+  const allocated = queue.status?.allocated || {};
+  const resourceKeys = Array.from(new Set([...Object.keys(capacity), ...Object.keys(allocated)]));
+  const resourceRows = resourceKeys.map(resource => ({ resource }));
+
+  if (!resourceKeys.length) {
+    return null;
+  }
 
   return {
-    id: 'capacity',
+    id: 'capacity-allocated',
     section: (
-      <SectionBox title="Capacity Limits">
-        <NameValueTable
-          rows={Object.entries(queue.spec.capability).map(([key, value]) => ({
-            name: key,
-            value: value,
-          }))}
+      <SectionBox title="Capacity and Allocated Resources">
+        <SimpleTable
+          data={resourceRows}
+          columns={[
+            {
+              label: 'Resource',
+              getter: (row: { resource: string }) => row.resource,
+              sort: true,
+            },
+            {
+              label: 'Capacity',
+              getter: (row: { resource: string }) => capacity[row.resource] ?? '-',
+            },
+            {
+              label: 'Allocated',
+              getter: (row: { resource: string }) => allocated[row.resource] ?? '-',
+            },
+          ]}
+          showPagination={false}
         />
       </SectionBox>
     ),
@@ -34,23 +277,173 @@ function getCapacitySection(queue: VolcanoQueue) {
 }
 
 /**
- * Builds the Allocated Resources section for a Queue.
+ * Builds the queue status section from PodGroup-derived counters.
  *
- * @param queue Queue shown in the details page.
- * @returns Section descriptor or `null` when no allocated resources are reported.
+ * @param queueName Queue name used to look up counters.
+ * @param queuePodGroupStats Queue counters keyed by queue name.
+ * @returns Queue status section descriptor.
  */
-function getAllocatedSection(queue: VolcanoQueue) {
-  if (!queue.status?.allocated) return null;
+function getQueueStatusSection(
+  queueName: string,
+  queuePodGroupStats: Record<string, QueuePodGroupStats>
+) {
+  const stats = queuePodGroupStats[queueName] || {
+    inqueue: 0,
+    pending: 0,
+    running: 0,
+    unknown: 0,
+    completed: 0,
+  };
 
   return {
-    id: 'allocated',
+    id: 'queue-status',
     section: (
-      <SectionBox title="Allocated Resources">
+      <SectionBox title="Queue Status">
         <NameValueTable
-          rows={Object.entries(queue.status.allocated).map(([key, value]) => ({
-            name: key,
-            value: value,
-          }))}
+          rows={[
+            { name: 'Inqueue', value: stats.inqueue },
+            { name: 'Pending', value: stats.pending },
+            { name: 'Running', value: stats.running },
+            { name: 'Unknown', value: stats.unknown },
+            { name: 'Completed', value: stats.completed },
+          ]}
+        />
+      </SectionBox>
+    ),
+  };
+}
+
+/**
+ * Builds the deserved and guarantee resources section for a Queue.
+ *
+ * @param queue Queue shown in the details page.
+ * @returns Section descriptor for deserved and guarantee resources.
+ */
+function getDeservedGuaranteeSection(queue: VolcanoQueue) {
+  const deservedResources = queue.deservedResources || {};
+  const configuredResources = queue.guaranteedResources || {};
+  const resourceKeys = Array.from(
+    new Set([...Object.keys(deservedResources), ...Object.keys(configuredResources)])
+  );
+  const resourceRows = resourceKeys.length ? resourceKeys.map(resource => ({ resource })) : [];
+
+  return {
+    id: 'deserved-guarantee',
+    section: (
+      <SectionBox title="Deserved and Guaranteed Resources">
+        <SimpleTable
+          data={resourceRows.length ? resourceRows : [{ resource: 'Resources' }]}
+          columns={[
+            {
+              label: 'Resource',
+              getter: (row: { resource: string }) => row.resource,
+              sort: true,
+            },
+            {
+              label: 'Deserved',
+              getter: (row: { resource: string }) => deservedResources[row.resource] ?? '-',
+            },
+            {
+              label: 'Guarantee',
+              getter: (row: { resource: string }) => configuredResources[row.resource] ?? '-',
+            },
+          ]}
+          showPagination={false}
+        />
+      </SectionBox>
+    ),
+  };
+}
+
+/**
+ * Builds the reservation section for a Queue.
+ *
+ * @param queue Queue shown in the details page.
+ * @returns Reservation section descriptor.
+ */
+function getReservationSection(queue: VolcanoQueue) {
+  const runtimeResources = queue.reservedResources || {};
+  const reservedNodes = queue.reservedNodes;
+  const resourceKeys = Object.keys(runtimeResources);
+
+  return {
+    id: 'reservation',
+    section: (
+      <SectionBox title="Reservation">
+        <NameValueTable
+          rows={[
+            ...(resourceKeys.length
+              ? resourceKeys.map(resource => ({
+                  name: resource,
+                  value: runtimeResources[resource],
+                }))
+              : [{ name: 'Resources', value: '-' }]),
+            {
+              name: 'Reserved Nodes',
+              value: reservedNodes.length ? reservedNodes.join(', ') : '-',
+            },
+          ]}
+        />
+      </SectionBox>
+    ),
+  };
+}
+
+/**
+ * Builds the child queues section for a Queue.
+ *
+ * @param queue Queue shown in the details page.
+ * @param queues All known queues.
+ * @returns Child queues section descriptor or `null` when there are no children.
+ */
+function getChildQueuesSection(queue: VolcanoQueue, queues: VolcanoQueue[] | null) {
+  if (!queues?.length) {
+    return null;
+  }
+
+  const childQueues = queues.filter(candidate => candidate.spec.parent === queue.getName());
+
+  if (!childQueues.length) {
+    return null;
+  }
+
+  return {
+    id: 'child-queues',
+    section: (
+      <SectionBox title="Child Queues">
+        <SimpleTable
+          data={childQueues}
+          columns={[
+            {
+              label: 'Name',
+              getter: (childQueue: VolcanoQueue) => (
+                <Link routeName="volcano-queue-detail" params={{ name: childQueue.getName() }}>
+                  {childQueue.getName()}
+                </Link>
+              ),
+              sort: (childQueue: VolcanoQueue) => childQueue.getName(),
+            },
+            {
+              label: 'State',
+              getter: (childQueue: VolcanoQueue) => (
+                <StatusLabel status={getQueueStatusColor(childQueue.state)}>
+                  {childQueue.state}
+                </StatusLabel>
+              ),
+              sort: (childQueue: VolcanoQueue) => childQueue.state,
+            },
+            {
+              label: 'Weight',
+              getter: (childQueue: VolcanoQueue) => childQueue.weight,
+              sort: (childQueue: VolcanoQueue) => childQueue.weight,
+            },
+            {
+              label: 'Priority',
+              getter: (childQueue: VolcanoQueue) => childQueue.priority,
+              sort: (childQueue: VolcanoQueue) => childQueue.priority,
+            },
+          ]}
+          showPagination={false}
         />
       </SectionBox>
     ),
@@ -64,12 +457,16 @@ function getAllocatedSection(queue: VolcanoQueue) {
  */
 export default function QueueDetail() {
   const { name } = useParams<{ name: string }>();
+  const [queues] = VolcanoQueue.useList();
+  const [podGroups] = VolcanoPodGroup.useList();
+  const queuePodGroupStats = useMemo(() => getQueuePodGroupStats(podGroups), [podGroups]);
 
   return (
     <DetailsGrid
       resourceType={VolcanoQueue}
       name={name}
       withEvents
+      actions={(queue: VolcanoQueue) => (queue ? getQueueActionButtons(queue) : [])}
       extraInfo={(queue: VolcanoQueue) =>
         queue && [
           {
@@ -79,7 +476,8 @@ export default function QueueDetail() {
             ),
           },
           { name: 'Weight', value: queue.weight },
-          { name: 'Priority', value: queue.spec.priority || 0 },
+          { name: 'Priority', value: queue.priority },
+          { name: 'Dequeue Strategy', value: queue.dequeueStrategy },
           { name: 'Reclaimable', value: queue.spec.reclaimable !== false ? 'Yes' : 'No' },
           {
             name: 'Parent Queue',
@@ -94,7 +492,14 @@ export default function QueueDetail() {
         ]
       }
       extraSections={(queue: VolcanoQueue) =>
-        queue && [getCapacitySection(queue), getAllocatedSection(queue)].filter(Boolean)
+        queue &&
+        [
+          getQueueStatusSection(queue.metadata.name, queuePodGroupStats),
+          getCapacityAllocatedSection(queue),
+          getDeservedGuaranteeSection(queue),
+          getReservationSection(queue),
+          getChildQueuesSection(queue, queues),
+        ].filter(Boolean)
       }
     />
   );

--- a/volcano/src/components/queues/List.tsx
+++ b/volcano/src/components/queues/List.tsx
@@ -4,53 +4,7 @@ import { VolcanoPodGroup } from '../../resources/podgroup';
 import { VolcanoQueue } from '../../resources/queue';
 import { getQueueStatusColor } from '../../utils/status';
 import { VolcanoInstallCheck } from '../common/CommonComponents';
-
-interface QueuePodGroupStats {
-  inqueue: number;
-  pending: number;
-  running: number;
-  unknown: number;
-  completed: number;
-}
-
-function getQueuePodGroupStats(
-  podGroups: VolcanoPodGroup[] | null | undefined
-): Record<string, QueuePodGroupStats> {
-  const stats: Record<string, QueuePodGroupStats> = {};
-
-  for (const podGroup of podGroups ?? []) {
-    const queueName = podGroup.queue;
-    if (!stats[queueName]) {
-      stats[queueName] = {
-        inqueue: 0,
-        pending: 0,
-        running: 0,
-        unknown: 0,
-        completed: 0,
-      };
-    }
-
-    switch (podGroup.phase) {
-      case 'Inqueue':
-        stats[queueName].inqueue += 1;
-        break;
-      case 'Pending':
-        stats[queueName].pending += 1;
-        break;
-      case 'Running':
-        stats[queueName].running += 1;
-        break;
-      case 'Unknown':
-        stats[queueName].unknown += 1;
-        break;
-      case 'Completed':
-        stats[queueName].completed += 1;
-        break;
-    }
-  }
-
-  return stats;
-}
+import { getQueuePodGroupStats } from './stats';
 
 /**
  * Renders the Volcano Queues list page.

--- a/volcano/src/components/queues/stats.ts
+++ b/volcano/src/components/queues/stats.ts
@@ -1,0 +1,61 @@
+import { VolcanoPodGroup } from '../../resources/podgroup';
+
+/**
+ * Queue-level counters derived from PodGroup phases.
+ * @see https://github.com/volcano-sh/volcano/blob/master/pkg/cli/podgroup/podgroup.go
+ */
+export interface QueuePodGroupStats {
+  inqueue: number;
+  pending: number;
+  running: number;
+  unknown: number;
+  completed: number;
+}
+
+/**
+ * Builds queue counters from PodGroups using the same phase bucketing as `vcctl queue get/list`.
+ *
+ * @param podGroups PodGroups to aggregate by queue.
+ * @returns Queue counters keyed by queue name.
+ * @see https://github.com/volcano-sh/volcano/blob/master/pkg/cli/queue/get.go
+ * @see https://github.com/volcano-sh/volcano/blob/master/pkg/cli/queue/list.go
+ * @see https://github.com/volcano-sh/volcano/blob/master/pkg/cli/podgroup/podgroup.go
+ */
+export function getQueuePodGroupStats(
+  podGroups: VolcanoPodGroup[] | null | undefined
+): Record<string, QueuePodGroupStats> {
+  const stats: Record<string, QueuePodGroupStats> = {};
+
+  for (const podGroup of podGroups ?? []) {
+    const queueName = podGroup.queue;
+    if (!stats[queueName]) {
+      stats[queueName] = {
+        inqueue: 0,
+        pending: 0,
+        running: 0,
+        unknown: 0,
+        completed: 0,
+      };
+    }
+
+    switch (podGroup.phase) {
+      case 'Inqueue':
+        stats[queueName].inqueue += 1;
+        break;
+      case 'Pending':
+        stats[queueName].pending += 1;
+        break;
+      case 'Running':
+        stats[queueName].running += 1;
+        break;
+      case 'Unknown':
+        stats[queueName].unknown += 1;
+        break;
+      case 'Completed':
+        stats[queueName].completed += 1;
+        break;
+    }
+  }
+
+  return stats;
+}

--- a/volcano/src/resources/command.ts
+++ b/volcano/src/resources/command.ts
@@ -1,0 +1,89 @@
+import { KubeObject, KubeObjectInterface } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import { VolcanoQueue } from './queue';
+
+/**
+ * Volcano bus actions used by queue open/close operations.
+ * @see https://github.com/volcano-sh/volcano/blob/master/staging/src/volcano.sh/apis/pkg/apis/bus/v1alpha1/actions.go
+ * @see https://github.com/volcano-sh/volcano/blob/master/pkg/cli/queue/operate.go
+ */
+export type VolcanoQueueCommandAction = 'OpenQueue' | 'CloseQueue';
+
+/**
+ * Namespace used by `vcctl queue operate` when creating queue Command objects.
+ * @see https://github.com/volcano-sh/volcano/blob/master/pkg/cli/queue/util.go
+ */
+export const QUEUE_COMMAND_NAMESPACE = 'default';
+
+/**
+ * Volcano bus Command resource payload used to target a queue action.
+ * @see https://github.com/volcano-sh/volcano/blob/master/staging/src/volcano.sh/apis/pkg/apis/bus/v1alpha1/commands.go
+ */
+export interface KubeVolcanoCommand extends KubeObjectInterface {
+  /** Action to execute for the target object. */
+  action?: string;
+  /** Target object reference for this command. */
+  target?: {
+    apiVersion?: string;
+    kind?: string;
+    name?: string;
+    uid?: string;
+    controller?: boolean;
+    blockOwnerDeletion?: boolean;
+  };
+}
+
+/**
+ * Kubernetes wrapper for the Volcano bus Command CRD.
+ * @see https://github.com/volcano-sh/volcano/blob/master/staging/src/volcano.sh/apis/pkg/apis/bus/v1alpha1/commands.go
+ * @see https://github.com/volcano-sh/volcano/blob/master/config/crd/volcano/bases/bus.volcano.sh_commands.yaml
+ */
+export class VolcanoCommand extends KubeObject<KubeVolcanoCommand> {
+  static kind = 'Command';
+  static apiName = 'commands';
+  static apiVersion = 'bus.volcano.sh/v1alpha1';
+  static isNamespaced = true;
+}
+
+/**
+ * Creates a Volcano bus command for queue open/close actions.
+ * Mirrors the upstream CLI helper used by `vcctl queue operate`.
+ *
+ * @param queue Queue targeted by the command.
+ * @param action Queue command action to create.
+ * @see https://github.com/volcano-sh/volcano/blob/master/pkg/cli/queue/util.go
+ * @see https://github.com/volcano-sh/volcano/blob/master/pkg/cli/queue/operate.go
+ * @see https://github.com/volcano-sh/volcano/blob/master/staging/src/volcano.sh/apis/pkg/apis/bus/v1alpha1/commands.go
+ */
+export async function createQueueCommand(queue: VolcanoQueue, action: VolcanoQueueCommandAction) {
+  const name = queue.metadata.name;
+  const uid = queue.metadata.uid;
+
+  if (!name || !uid) {
+    throw new Error('Queue metadata is incomplete for issuing this command');
+  }
+
+  const targetReference = {
+    apiVersion: queue.jsonData.apiVersion || VolcanoQueue.apiVersion,
+    kind: queue.jsonData.kind || 'Queue',
+    name,
+    uid,
+    controller: true,
+    blockOwnerDeletion: true,
+  };
+
+  await VolcanoCommand.apiEndpoint.post(
+    {
+      apiVersion: VolcanoCommand.apiVersion,
+      kind: VolcanoCommand.kind,
+      metadata: {
+        generateName: `${name}-${action.toLowerCase()}-`,
+        namespace: QUEUE_COMMAND_NAMESPACE,
+        ownerReferences: [targetReference],
+      },
+      action,
+      target: targetReference,
+    },
+    {},
+    queue.cluster
+  );
+}

--- a/volcano/src/resources/queue.ts
+++ b/volcano/src/resources/queue.ts
@@ -146,4 +146,48 @@ export class VolcanoQueue extends KubeObject<KubeVolcanoQueue> {
   get weight(): number {
     return this.spec.weight ?? 1;
   }
+
+  get priority(): number {
+    return this.spec.priority ?? 0;
+  }
+
+  get dequeueStrategy(): NonNullable<QueueSpec['dequeueStrategy']> {
+    return this.spec.dequeueStrategy ?? 'traverse';
+  }
+
+  get inqueue(): number {
+    return this.status?.inqueue ?? 0;
+  }
+
+  get pending(): number {
+    return this.status?.pending ?? 0;
+  }
+
+  get running(): number {
+    return this.status?.running ?? 0;
+  }
+
+  get unknown(): number {
+    return this.status?.unknown ?? 0;
+  }
+
+  get completed(): number {
+    return this.status?.completed ?? 0;
+  }
+
+  get guaranteedResources() {
+    return this.spec.guarantee?.resource;
+  }
+
+  get deservedResources() {
+    return this.spec.deserved;
+  }
+
+  get reservedResources() {
+    return this.status?.reservation?.resource;
+  }
+
+  get reservedNodes() {
+    return this.status?.reservation?.nodes ?? [];
+  }
 }


### PR DESCRIPTION
## Summary
This updates the Volcano Queue details view to better match the information and workflows users get from `vcctl queue` and `kubectl describe queue`.
It adds queue lifecycle actions, fills in missing queue fields and resource sections, and shows child queues directly from the details page.
## Changes
- add queue action buttons in the details view:
  - `Open`
  - `Close`
  - `Update Weight`
  
<img width="1593" height="198" alt="image" src="https://github.com/user-attachments/assets/6abdde7c-e59c-4c27-b729-933540d8e113" />
  
- align queue actions with `vcctl queue operate`
  - open/close create a Volcano `Command`
  - update weight patches `spec.weight`
- hide queue actions when the current user does not have the required permissions
- add missing queue fields:
  - `Dequeue Strategy`
  - `Priority`
  - `Reclaimable`
- add queue status section with:
  - `Inqueue`
  - `Pending`
  - `Running`
  - `Unknown`
  - `Completed`
- add `Reservation` section
- add `Capacity and Allocated Resources` and `Deserved and Guaranteed Resources` comparison sections
- add child queues section
- shared queue stats logic for reuse between queue list and queue detail
- add queue command resource helper for open/close actions

Closes #600