### PR TITLE
volcano: show min task member in podgroup details

### DIFF
--- a/volcano/src/components/podgroups/Detail.tsx
+++ b/volcano/src/components/podgroups/Detail.tsx
@@ -103,6 +103,32 @@ function getMinResourcesSection(podGroup: VolcanoPodGroup) {
 }
 
 /**
+ * Builds the Min Task Member section for a PodGroup when available.
+ *
+ * @param podGroup PodGroup shown in the details page.
+ * @returns Section descriptor or `null` when no min task members are defined.
+ */
+function getMinTaskMemberSection(podGroup: VolcanoPodGroup) {
+  if (!podGroup.minTaskMember || !Object.keys(podGroup.minTaskMember).length) {
+    return null;
+  }
+
+  return {
+    id: 'min-task-member',
+    section: (
+      <SectionBox title="Min Task Member">
+        <NameValueTable
+          rows={Object.entries(podGroup.minTaskMember).map(([key, value]) => ({
+            name: key,
+            value,
+          }))}
+        />
+      </SectionBox>
+    ),
+  };
+}
+
+/**
  * Renders the Volcano PodGroup details page.
  *
  * @returns PodGroup details view with extra sections and events.
@@ -149,6 +175,7 @@ export default function PodGroupDetail() {
         [
           getProgressSection(podGroup),
           getConditionsSection(podGroup),
+          getMinTaskMemberSection(podGroup),
           getMinResourcesSection(podGroup),
         ].filter(Boolean)
       }

--- a/volcano/src/resources/podgroup.ts
+++ b/volcano/src/resources/podgroup.ts
@@ -111,6 +111,10 @@ export class VolcanoPodGroup extends KubeObject<KubeVolcanoPodGroup> {
     return this.spec.minMember || 0;
   }
 
+  get minTaskMember(): PodGroupSpec['minTaskMember'] {
+    return this.spec.minTaskMember;
+  }
+
   get runningCount(): number {
     return this.status?.running || 0;
   }


### PR DESCRIPTION
## Summary
This updates the Volcano PodGroup details view to show `Min Task Member` when it is present in the PodGroup spec.

<img width="800" height="253" alt="image" src="https://github.com/user-attachments/assets/545f0b72-e776-4530-91bb-2e2e5cef5b48" />

## Changes
- add `minTaskMember` getter to `src/resources/podgroup.ts`
- add a `Min Task Member` section to `src/components/podgroups/Detail.tsx`
- render one row per task entry from `spec.minTaskMember`

Related to #600
