### PR TITLE
Volcano: add pod issues in job details

### DIFF
--- a/volcano/src/components/jobs/Detail.tsx
+++ b/volcano/src/components/jobs/Detail.tsx
@@ -15,6 +15,7 @@ import { VolcanoPodGroup } from '../../resources/podgroup';
 import { getJobStatusColor } from '../../utils/status';
 import { formatStringList, getPolicyRows, getTaskContainerRows, getTaskRows } from './detailRows';
 import JobCommandActionButton from './JobCommandActionButton';
+import { getJobPodIssues, groupJobPodIssues, PodResource } from './pods';
 
 /**
  * Resolves the PodGroup related to a Volcano Job.
@@ -143,6 +144,87 @@ function getTasksSection(job: VolcanoJob) {
               <NameValueTable rows={[{ name: 'Containers', value: 'No containers defined' }]} />
             )}
           </SectionBox>
+        ))}
+      </SectionBox>
+    ),
+  };
+}
+
+/**
+ * Builds a section describing actionable pod runtime issues for the Job.
+ *
+ * When the Job is pending and no Pods have been created yet, this may also return
+ * an informational section suggesting PodGroup conditions and Events as likely
+ * places to investigate scheduling blockers.
+ *
+ * @param job Volcano Job shown in the details page.
+ * @param pods Pods created for the Job.
+ * @returns Section descriptor or `null` when there are no pod issues to show.
+ */
+function getPodIssuesSection(job: VolcanoJob, pods: InstanceType<typeof PodResource>[] | null) {
+  if (!pods) {
+    return null;
+  }
+
+  const podIssues = getJobPodIssues(pods);
+  const groupedPodIssues = groupJobPodIssues(podIssues);
+
+  if (groupedPodIssues.length === 0) {
+    if (job.phase === 'Pending' && pods.length === 0) {
+      return {
+        id: 'pod-issues',
+        section: (
+          <SectionBox title="Pod Issues">
+            <NameValueTable
+              rows={[
+                {
+                  name: 'Info',
+                  value:
+                    'No pods have been created for this job yet. Check PodGroup conditions and Events for scheduling blockers.',
+                },
+              ]}
+            />
+          </SectionBox>
+        ),
+      };
+    }
+
+    return null;
+  }
+
+  return {
+    id: 'pod-issues',
+    section: (
+      <SectionBox title="Pod Issues">
+        {groupedPodIssues.map((issue, index) => (
+          <NameValueTable
+            key={`${issue.reason}-${issue.message || 'no-message'}-${index}`}
+            rows={[
+              ...(issue.pods.length > 1 ? [{ name: 'Count', value: issue.pods.length }] : []),
+              {
+                name: issue.pods.length === 1 ? 'Pod' : 'Pods',
+                value: (
+                  <>
+                    {issue.pods.map((pod, podIndex) => (
+                      <span key={pod.podName}>
+                        {podIndex > 0 ? ', ' : ''}
+                        <Link kubeObject={pod.pod}>{pod.podName}</Link>
+                      </span>
+                    ))}
+                  </>
+                ),
+              },
+              {
+                name: issue.pods.length === 1 ? 'Container' : 'Containers',
+                value: issue.containerNames.length > 0 ? issue.containerNames.join(', ') : '-',
+              },
+              {
+                name: 'Reason',
+                value: `${issue.reason} (For more details, click the Pod link above)`,
+              },
+              { name: 'Message', value: issue.message || '-' },
+            ]}
+          />
         ))}
       </SectionBox>
     ),
@@ -300,7 +382,6 @@ function getJobActionButtons(job: VolcanoJob) {
       : []),
   ];
 }
-
 /**
  * Renders the Volcano Job details page.
  *
@@ -309,6 +390,13 @@ function getJobActionButtons(job: VolcanoJob) {
 export default function JobDetail() {
   const { namespace, name } = useParams<{ namespace: string; name: string }>();
   const [podGroups] = VolcanoPodGroup.useList({ namespace });
+  const [pods] = PodResource.useList({
+    namespace,
+    labelSelector:
+      name && namespace
+        ? `volcano.sh/job-name=${name},volcano.sh/job-namespace=${namespace}`
+        : undefined,
+  });
 
   return (
     <DetailsGrid
@@ -409,6 +497,7 @@ export default function JobDetail() {
       extraSections={(job: VolcanoJob) =>
         job &&
         [
+          getPodIssuesSection(job, pods),
           getPodStatusSection(job),
           getPluginsSection(job),
           getPoliciesSection(job),

--- a/volcano/src/components/jobs/pods.test.ts
+++ b/volcano/src/components/jobs/pods.test.ts
@@ -1,0 +1,116 @@
+import { groupJobPodIssues, type JobPodIssue } from './pods';
+
+function makeIssue({
+  podName,
+  containerName,
+  reason,
+  message,
+}: {
+  podName: string;
+  containerName?: string;
+  reason: string;
+  message?: string;
+}): JobPodIssue {
+  return {
+    pod: { metadata: { name: podName } } as JobPodIssue['pod'],
+    podName,
+    containerName,
+    reason,
+    message,
+  };
+}
+
+describe('groupJobPodIssues', () => {
+  it('groups issues with the same reason and message', () => {
+    const groupedIssues = groupJobPodIssues([
+      makeIssue({
+        podName: 'job-worker-0',
+        containerName: 'main',
+        reason: 'ImagePullBackOff',
+        message: 'failed to pull image',
+      }),
+      makeIssue({
+        podName: 'job-worker-1',
+        containerName: 'main',
+        reason: 'ImagePullBackOff',
+        message: 'failed to pull image',
+      }),
+    ]);
+
+    expect(groupedIssues).toHaveLength(1);
+    expect(groupedIssues[0].pods.map(pod => pod.podName)).toEqual(['job-worker-0', 'job-worker-1']);
+    expect(groupedIssues[0].containerNames).toEqual(['main']);
+  });
+
+  it('keeps issues separate when messages differ', () => {
+    const groupedIssues = groupJobPodIssues([
+      makeIssue({
+        podName: 'job-worker-0',
+        containerName: 'main',
+        reason: 'ImagePullBackOff',
+        message: 'failed to pull image',
+      }),
+      makeIssue({
+        podName: 'job-worker-1',
+        containerName: 'main',
+        reason: 'ImagePullBackOff',
+        message: 'pull access denied',
+      }),
+    ]);
+
+    expect(groupedIssues).toHaveLength(2);
+  });
+
+  it('keeps issues separate when reasons differ', () => {
+    const groupedIssues = groupJobPodIssues([
+      makeIssue({
+        podName: 'job-worker-0',
+        containerName: 'main',
+        reason: 'ErrImagePull',
+        message: 'failed to pull image',
+      }),
+      makeIssue({
+        podName: 'job-worker-1',
+        containerName: 'main',
+        reason: 'ImagePullBackOff',
+        message: 'failed to pull image',
+      }),
+    ]);
+
+    expect(groupedIssues).toHaveLength(2);
+  });
+
+  it('deduplicates pod names and container names within a group', () => {
+    const repeatedIssue = makeIssue({
+      podName: 'job-worker-0',
+      containerName: 'main',
+      reason: 'CreateContainerConfigError',
+      message: 'secret not found',
+    });
+
+    const groupedIssues = groupJobPodIssues([repeatedIssue, repeatedIssue]);
+
+    expect(groupedIssues).toHaveLength(1);
+    expect(groupedIssues[0].pods.map(pod => pod.podName)).toEqual(['job-worker-0']);
+    expect(groupedIssues[0].containerNames).toEqual(['main']);
+  });
+
+  it('ignores missing container names when building grouped container lists', () => {
+    const groupedIssues = groupJobPodIssues([
+      makeIssue({
+        podName: 'job-worker-0',
+        reason: 'Unschedulable',
+        message: '0/1 nodes are available',
+      }),
+      makeIssue({
+        podName: 'job-worker-1',
+        reason: 'Unschedulable',
+        message: '0/1 nodes are available',
+      }),
+    ]);
+
+    expect(groupedIssues).toHaveLength(1);
+    expect(groupedIssues[0].containerNames).toEqual([]);
+    expect(groupedIssues[0].pods.map(pod => pod.podName)).toEqual(['job-worker-0', 'job-worker-1']);
+  });
+});

--- a/volcano/src/components/jobs/pods.ts
+++ b/volcano/src/components/jobs/pods.ts
@@ -1,0 +1,204 @@
+import { K8s } from '@kinvolk/headlamp-plugin/lib';
+
+export const PodResource = K8s.ResourceClasses.Pod;
+
+/**
+ * Runtime issue extracted from a single Pod created by a Volcano Job.
+ */
+export interface JobPodIssue {
+  /** Pod object that exposed the issue. */
+  pod: InstanceType<typeof PodResource>;
+  /** Pod name shown in the UI. */
+  podName: string;
+  /** Container name associated with the issue when one can be identified. */
+  containerName?: string;
+  /** User-visible reason associated with the Pod issue. */
+  reason: string;
+  /** Detailed message associated with the Pod issue. */
+  message?: string;
+}
+
+/**
+ * Repeated Pod issues grouped by reason and message.
+ */
+export interface GroupedJobPodIssue {
+  /** Pods that share the same grouped issue. */
+  pods: Array<{
+    /** Pod object that exposed the issue. */
+    pod: InstanceType<typeof PodResource>;
+    /** Pod name shown in the grouped UI. */
+    podName: string;
+  }>;
+  /** Unique container names affected by the grouped issue. */
+  containerNames: string[];
+  /** Shared user-visible reason for the grouped issue. */
+  reason: string;
+  /** Shared detailed message for the grouped issue. */
+  message?: string;
+}
+
+const nonActionablePodReasons = new Set([
+  'Pending',
+  'ContainerCreating',
+  'PodInitializing',
+  'Running',
+  'Completed',
+  'Succeeded',
+  'Terminating',
+  'NotReady',
+  'Unknown',
+  'ContainersNotReady',
+  'Init:ContainerCreating',
+  'Init:PodInitializing',
+]);
+
+/**
+ * Checks whether an init-container reason only reflects startup progress.
+ *
+ * @param reason Pod status reason.
+ * @returns `true` when the reason is an init progress marker like `Init:1/2`.
+ */
+function isInitProgressReason(reason: string) {
+  return /^Init:\d+\/\d+$/.test(reason);
+}
+
+/**
+ * Expands a reason into equivalent candidates that may appear on init container states.
+ *
+ * @param reason Pod status reason.
+ * @returns Reason candidates used when matching container waiting or terminated states.
+ */
+function getReasonCandidates(reason: string) {
+  if (reason.startsWith('Init:') && !isInitProgressReason(reason)) {
+    return [reason, reason.slice('Init:'.length)];
+  }
+
+  return [reason];
+}
+
+/**
+ * Reports whether a Pod reason should be surfaced as an actionable issue.
+ *
+ * @param reason Pod status reason.
+ * @returns `true` when the reason represents a user-actionable runtime problem.
+ */
+function isActionablePodReason(reason?: string) {
+  if (!reason) {
+    return false;
+  }
+
+  if (nonActionablePodReasons.has(reason) || isInitProgressReason(reason)) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Resolves the most specific container name and message for a Pod issue reason.
+ *
+ * @param pod Pod whose statuses are inspected.
+ * @param reason User-visible Pod reason.
+ * @param message Fallback Pod message from the detailed status helper.
+ * @returns Container-specific issue details when a matching container state is found.
+ */
+function getIssueReasonDetails(
+  pod: InstanceType<typeof PodResource>,
+  reason: string,
+  message?: string
+) {
+  const containerStatuses = [
+    ...(pod.status?.containerStatuses ?? []),
+    ...(pod.status?.initContainerStatuses ?? []),
+  ];
+
+  const reasonCandidates = getReasonCandidates(reason);
+
+  const matchingContainer = containerStatuses.find(status => {
+    return (
+      reasonCandidates.includes(status.state?.waiting?.reason || '') ||
+      reasonCandidates.includes(status.state?.terminated?.reason || '')
+    );
+  });
+
+  if (!matchingContainer) {
+    return {
+      containerName: undefined,
+      reason,
+      message,
+    };
+  }
+
+  return {
+    containerName: matchingContainer.name,
+    reason,
+    message:
+      matchingContainer.state?.waiting?.message ||
+      matchingContainer.state?.terminated?.message ||
+      message,
+  };
+}
+
+/**
+ * Extracts user-visible runtime issues from Pods created by a Volcano Job.
+ *
+ * @param pods Pods related to a Volcano Job.
+ * @returns Pod issues derived from waiting and failed container states.
+ */
+export function getJobPodIssues(pods: InstanceType<typeof PodResource>[]): JobPodIssue[] {
+  return pods.flatMap(pod => {
+    const { reason, message } = pod.getDetailedStatus();
+
+    if (!isActionablePodReason(reason)) {
+      return [];
+    }
+
+    const issueDetails = getIssueReasonDetails(pod, reason, message);
+
+    return [
+      {
+        pod,
+        podName: pod.getName(),
+        containerName: issueDetails.containerName,
+        reason: issueDetails.reason,
+        message: issueDetails.message,
+      },
+    ];
+  });
+}
+
+/**
+ * Groups repeated Pod issues by reason and message to reduce duplicate output.
+ *
+ * @param podIssues Pod issues derived from Job-owned Pods.
+ * @returns Grouped issues with Pod links and unique container names.
+ */
+export function groupJobPodIssues(podIssues: JobPodIssue[]): GroupedJobPodIssue[] {
+  const groupedIssues = new Map<string, GroupedJobPodIssue>();
+
+  podIssues.forEach(issue => {
+    const key = `${issue.reason} ${issue.message || ''}`;
+    const existingIssue = groupedIssues.get(key);
+
+    if (existingIssue) {
+      if (!existingIssue.pods.some(pod => pod.podName === issue.podName)) {
+        existingIssue.pods.push({ pod: issue.pod, podName: issue.podName });
+      }
+
+      if (issue.containerName && !existingIssue.containerNames.includes(issue.containerName)) {
+        existingIssue.containerNames.push(issue.containerName);
+      }
+
+      return;
+    }
+
+    groupedIssues.set(key, {
+      pods: [{ pod: issue.pod, podName: issue.podName }],
+      containerNames: issue.containerName ? [issue.containerName] : [],
+      reason: issue.reason,
+      message: issue.message,
+    });
+  });
+
+  return Array.from(groupedIssues.values());
+}


### PR DESCRIPTION
## Summary
This adds a `Pod Issues` section to the Volcano Job details view to help explain why a Job remains `Pending` when the blocker is at the Pod/runtime layer (not only PodGroup/scheduler constraints).

<img width="1385" height="803" alt="screenshot_20260412_170603" src="https://github.com/user-attachments/assets/26d52bb3-4916-4c94-a1dc-21c304643b39" />

<img width="1603" height="682" alt="screenshot_20260412_180238" src="https://github.com/user-attachments/assets/003ffca9-ce70-47cf-bb90-7af34cdd7a55" />

## Changes
- add a `Pod Issues` section to Volcano Job details
- show only actionable pod-side blockers
- suppress normal transitional states such as:
  - `Pending`
  - `ContainerCreating`
  - `PodInitializing`
  - init progress states
- show a scheduling fallback when the Job is `Pending` and no Pods have been created yet
- add direct Pod links in the `Pod Issues` section