### PR TITLE
fix(kyverno): fix silent matching failure for namespaced Policy Reports

### DIFF
--- a/kyverno/src/components/PolicyViewer.tsx
+++ b/kyverno/src/components/PolicyViewer.tsx
@@ -159,15 +159,18 @@ function RulesTable({ rules }: { rules: PolicyRule[] }) {
   );
 }
 
-function AssociatedReportsSection({ policyName }: { policyName: string }) {
+function AssociatedReportsSection({ policyName, namespace }: { policyName: string; namespace?: string }) {
   const { items: policyReports } = PolicyReport.useList();
   const { items: clusterPolicyReports } = ClusterPolicyReport.useList();
 
   const matchingResults: (PolicyReportResult & { reportName: string; reportNamespace?: string })[] = [];
 
+  const qualifiedName = namespace ? `${namespace}/${policyName}` : policyName;
+  const matchesPolicy = (resultPolicy: string) => resultPolicy === policyName || resultPolicy === qualifiedName;
+
   for (const report of policyReports || []) {
     for (const result of report.results) {
-      if (result.policy === policyName) {
+      if (matchesPolicy(result.policy || '')) {
         matchingResults.push({
           ...result,
           reportName: report.jsonData.metadata.name,
@@ -179,7 +182,7 @@ function AssociatedReportsSection({ policyName }: { policyName: string }) {
 
   for (const report of clusterPolicyReports || []) {
     for (const result of report.results) {
-      if (result.policy === policyName) {
+      if (matchesPolicy(result.policy || '')) {
         matchingResults.push({
           ...result,
           reportName: report.jsonData.metadata.name,
@@ -298,7 +301,7 @@ function PolicyContent({
       <SectionBox title={`Rules (${policy.rules.length})`}>
         <RulesTable rules={policy.rules} />
       </SectionBox>
-      <AssociatedReportsSection policyName={policy.jsonData.metadata.name} />
+      <AssociatedReportsSection policyName={policy.jsonData.metadata.name} namespace={policy.jsonData.metadata.namespace} />
     </Box>
   );
 }


### PR DESCRIPTION
### Summary
This PR fixes a critical bug where Headlamp's Kyverno plugin failed to display report results for Namespaced Policies (e.g. `Policy` kind). Kyverno prefixes namespaced policy results with the namespace string internally (e.g., `default/require-labels`), causing the strict string comparison in the frontend to silently fail and mistakenly render `Associated Report Results (0)`.

### Changes
- Updated `AssociatedReportsSection` in `src/components/PolicyViewer.tsx` to conditionally accept a `namespace` prop.
- Added a smart-match helper (`matchesPolicy`) that checks both the raw `policyName` strings and `"namespace/policyName"` strings to appropriately capture the varying reporting formats from Kyverno's backend.
- Result payload in UI now accurately represents all validation scans rather than improperly skipping namespaced targets.

### Steps to Test
1. Make sure to have Kyverno deployed with at least one violated `Policy` resource tied to a specific namespace (e.g. `default`).
2. Generate a failed/passed state using a test pod so that a `PolicyReport` gets propagated.
3. Observe that navigating via `Headlamp -> Kyverno -> Policies -> Your Namespaced Policy` correctly lists `Associated Report Results (X)` rather than an incorrect string mismatch of `(0)`.

### Screenshots (Before)

<img width="1462" height="781" alt="image" src="https://github.com/user-attachments/assets/89a0b9e9-897f-447a-b17c-f1bd1ed7805b" />

### After

<img width="1462" height="781" alt="image" src="https://github.com/user-attachments/assets/d50fc45b-ca0d-46aa-9514-4cbbe1706bcb" />

