### PR TITLE
fix(flux): resolve empty Helm inventory and speed up resource loading

### DIFF
--- a/flux/src/common/StatusLabel.tsx
+++ b/flux/src/common/StatusLabel.tsx
@@ -1,12 +1,13 @@
 import { StatusLabel as HLStatusLabel } from '@kinvolk/headlamp-plugin/lib/components/common';
-import { KubeObject } from '@kinvolk/headlamp-plugin/lib/lib/k8s/KubeObject';
+import { KubeCRD } from '@kinvolk/headlamp-plugin/lib/k8s/crd';
+import { KubeObject } from '@kinvolk/headlamp-plugin/lib/k8s/KubeObject';
 import { Tooltip, Typography } from '@mui/material';
 
 interface StatusLabelProps {
   item: KubeObject;
 }
 
-export function getStatusText(item: KubeCRD): string {
+export function getStatusText(item: KubeObject | KubeCRD): string {
   const ready = item?.jsonData?.status?.conditions?.find((c: any) => c.type === 'Ready');
   if (!ready) return '-';
   if (item?.jsonData?.spec?.suspend) return 'Suspended';

--- a/flux/src/helm-releases/Inventory.tsx
+++ b/flux/src/helm-releases/Inventory.tsx
@@ -227,15 +227,13 @@ async function fetchResources(
   chartName: string,
   namespace: string
 ): Promise<Array<HelmResourceKind>> {
-  const resources = [];
-
   const queryParams = new URLSearchParams();
   queryParams.append(
     'labelSelector',
     `helm.toolkit.fluxcd.io/name=${chartName},helm.toolkit.fluxcd.io/namespace=${namespace}`
   );
 
-  for (const resourceKind of resourceKinds) {
+  const resourcePromises = resourceKinds.map(async resourceKind => {
     const { kind, apiVersion, hasNamespace } = resourceKind;
 
     const groupName = apiVersion.includes('/') ? apiVersion.split('/')[0] : '';
@@ -245,22 +243,28 @@ async function fetchResources(
     const api = groupName ? `/apis/${groupName}` : '/api';
     const namespaceFilter = hasNamespace ? `namespaces/${namespace}/` : '';
 
-    request(`${api}/${version}/${namespaceFilter}${pluralName}?${queryParams.toString()}`)
-      .then(response => {
-        response.items.forEach(item => {
-          resources.push({ ...item, kind, apiVersion, groupName }); // add kind, apiVersion, groupName for link
-        });
-      })
-      .catch(error => {
-        if (error.status === 404) {
-          console.log(`No ${pluralName} found for chart ${chartName}`);
-        } else {
-          console.error(error);
-        }
-      });
-  }
+    try {
+      const response = await request(
+        `${api}/${version}/${namespaceFilter}${pluralName}?${queryParams.toString()}`
+      );
+      return response.items.map(item => ({
+        ...item,
+        kind,
+        apiVersion,
+        groupName,
+      }));
+    } catch (error) {
+      if (error.status === 404) {
+        console.log(`No ${pluralName} found for chart ${chartName}`);
+      } else {
+        console.error(error);
+      }
+      return [];
+    }
+  });
 
-  return resources;
+  const results = await Promise.all(resourcePromises);
+  return results.flat();
 }
 
 /**


### PR DESCRIPTION
### Description
I found that the `fetchResources` function was returning the data list immediately, without actually waiting for the API calls to finish. On top of that, it was firing these requests one-by-one in a loop, which was making the process quite slow.

<img width="657" height="371" alt="image" src="https://github.com/user-attachments/assets/d0c87115-e5da-4ecc-ac88-67face3957a6" />

### Changes
I have refactored the function to use `Promise.all` with a `.map()` logic. Now, the code correctly waits for all the data to arrive before showing it in the UI. Also, instead of making separate calls one by one, it now fetches everything at once in parallel, which makes it much more efficient.

<img width="645" height="429" alt="image" src="https://github.com/user-attachments/assets/c6d0ba8c-222b-4d88-8fc6-aac095dc863f" />



