### PR TITLE
kyverno : Dashboard : Fix incomplete isLoading state for policies

### DIFF
--- a/kyverno/src/components/Dashboard.tsx
+++ b/kyverno/src/components/Dashboard.tsx
@@ -145,7 +145,7 @@ export function Dashboard() {
       .map(([ns, { pass, fail }]) => ({ name: ns, pass, failAndError: fail }));
   }, [stats.byNamespace]);
 
-  const isLoading = clusterPolicies === null || policyReports === null;
+  const isLoading = clusterPolicies === null || policies === null || policyReports === null || clusterPolicyReports === null;
 
   return (
     <Box sx={{ p: 2 }}>


### PR DESCRIPTION
### Summary

This PR fixes a race condition where the `isLoading` state in the Kyverno Dashboard was dropping too early. 
Previously, `isLoading` only waited for `clusterPolicies` and `policyReports`. If these two hooks fetched instantly (e.g., returning empty arrays), the dashboard component would assume loading was completely finished and mount early, while `policies` and `clusterPolicyReports` were still pending (`null`). This caused the dashboard stats to temporarily flicker or show incomplete/zero data on initial load. 
