### PR TITLE
Volcano: Add logs viewer for jobs

### DIFF
--- a/volcano/src/components/jobs/Detail.tsx
+++ b/volcano/src/components/jobs/Detail.tsx
@@ -15,6 +15,7 @@ import { VolcanoPodGroup } from '../../resources/podgroup';
 import { getJobStatusColor } from '../../utils/status';
 import { formatStringList, getPolicyRows, getTaskContainerRows, getTaskRows } from './detailRows';
 import JobCommandActionButton from './JobCommandActionButton';
+import { JobLogsHeaderButton } from './JobLogsViewer';
 import { getJobPodIssues, groupJobPodIssues, PodResource } from './pods';
 
 /**
@@ -493,7 +494,17 @@ export default function JobDetail() {
           },
         ];
       }}
-      actions={(job: VolcanoJob) => (job ? getJobActionButtons(job) : [])}
+      actions={(job: VolcanoJob) =>
+        job
+          ? [
+              {
+                id: 'volcano-job-logs',
+                action: <JobLogsHeaderButton job={job} />,
+              },
+              ...getJobActionButtons(job),
+            ]
+          : []
+      }
       extraSections={(job: VolcanoJob) =>
         job &&
         [

--- a/volcano/src/components/jobs/JobLogsViewer.stories.tsx
+++ b/volcano/src/components/jobs/JobLogsViewer.stories.tsx
@@ -1,0 +1,186 @@
+import { LogViewer } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import Box from '@mui/material/Box';
+import FormControl from '@mui/material/FormControl';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import InputLabel from '@mui/material/InputLabel';
+import MenuItem from '@mui/material/MenuItem';
+import Select from '@mui/material/Select';
+import Switch from '@mui/material/Switch';
+import Typography from '@mui/material/Typography';
+import type { Meta, StoryFn } from '@storybook/react';
+import React from 'react';
+
+type JobLogsViewerStoryProps = {
+  helperMessage: string | null;
+  logs: string[];
+  showReconnectButton: boolean;
+};
+
+function JobLogsViewerStoryHarness({
+  helperMessage,
+  logs,
+  showReconnectButton,
+}: JobLogsViewerStoryProps) {
+  const [selectedPodName, setSelectedPodName] = React.useState<'all' | string>('all');
+  const [selectedContainer, setSelectedContainer] = React.useState('main');
+  const [lines, setLines] = React.useState(100);
+  const [showPrevious, setShowPrevious] = React.useState(false);
+  const [showTimestamps, setShowTimestamps] = React.useState(true);
+  const [follow, setFollow] = React.useState(true);
+
+  const topActions = [
+    <Box
+      key="job-log-controls"
+      sx={{ display: 'flex', flexDirection: 'column', gap: 1, width: '100%' }}
+    >
+      <Box
+        sx={{
+          minHeight: theme => theme.spacing(3),
+          display: 'flex',
+          alignItems: 'center',
+        }}
+      >
+        <Typography
+          variant="body2"
+          sx={{
+            color: 'text.secondary',
+            fontFamily:
+              'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+          }}
+        >
+          {helperMessage || ' '}
+        </Typography>
+      </Box>
+
+      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2, width: '100%' }}>
+        <FormControl sx={{ minWidth: 220 }}>
+          <InputLabel id="story-job-logs-pod-label">Select Pod</InputLabel>
+          <Select
+            id="story-job-logs-pod-select"
+            labelId="story-job-logs-pod-label"
+            value={selectedPodName}
+            label="Select Pod"
+            onChange={event => setSelectedPodName(event.target.value as 'all' | string)}
+          >
+            <MenuItem value="all">All Pods</MenuItem>
+            <MenuItem value="job-worker-0">job-worker-0</MenuItem>
+          </Select>
+        </FormControl>
+
+        <FormControl sx={{ minWidth: 220 }}>
+          <InputLabel id="story-job-logs-container-label">Container</InputLabel>
+          <Select
+            id="story-job-logs-container-select"
+            labelId="story-job-logs-container-label"
+            value={selectedContainer}
+            label="Container"
+            onChange={event => setSelectedContainer(event.target.value)}
+          >
+            <MenuItem value="main">main</MenuItem>
+            <MenuItem value="sidecar">sidecar</MenuItem>
+          </Select>
+        </FormControl>
+
+        <FormControl sx={{ minWidth: 120 }}>
+          <InputLabel id="story-job-logs-lines-label">Lines</InputLabel>
+          <Select
+            id="story-job-logs-lines-select"
+            labelId="story-job-logs-lines-label"
+            value={lines}
+            label="Lines"
+            onChange={event => setLines(Number(event.target.value))}
+          >
+            {[100, 1000, 2500].map(option => (
+              <MenuItem key={option} value={option}>
+                {option}
+              </MenuItem>
+            ))}
+            <MenuItem value={-1}>All</MenuItem>
+          </Select>
+        </FormControl>
+
+        <FormControlLabel
+          label="Show previous"
+          control={
+            <Switch checked={showPrevious} onChange={() => setShowPrevious(value => !value)} />
+          }
+        />
+        <FormControlLabel
+          label="Timestamps"
+          control={
+            <Switch checked={showTimestamps} onChange={() => setShowTimestamps(value => !value)} />
+          }
+        />
+        <FormControlLabel
+          label="Follow"
+          control={<Switch checked={follow} onChange={() => setFollow(value => !value)} />}
+        />
+      </Box>
+    </Box>,
+  ];
+
+  return (
+    <LogViewer
+      noDialog
+      open
+      title="example-job"
+      downloadName="example-job"
+      logs={logs}
+      topActions={topActions}
+      onClose={() => {}}
+      handleReconnect={() => {}}
+      showReconnectButton={showReconnectButton}
+    />
+  );
+}
+
+const meta = {
+  title: 'Jobs/JobLogsViewer',
+  component: JobLogsViewerStoryHarness,
+} satisfies Meta<typeof JobLogsViewerStoryHarness>;
+
+export default meta;
+
+const Template: StoryFn<typeof JobLogsViewerStoryHarness> = args => (
+  <JobLogsViewerStoryHarness {...args} />
+);
+
+export const SinglePod = Template.bind({});
+SinglePod.args = {
+  helperMessage: null,
+  logs: ['2026-04-18T13:16:58.715082657Z hello from template\n'],
+  showReconnectButton: false,
+};
+
+export const AllPods = Template.bind({});
+AllPods.args = {
+  helperMessage: null,
+  logs: [
+    '[job-worker-0/main] 2026-04-18T13:16:58.715082657Z hello from template\n',
+    '[job-worker-1/main] 2026-04-18T13:16:59.715082657Z processing batch\n',
+  ],
+  showReconnectButton: false,
+};
+
+export const NoPods = Template.bind({});
+NoPods.args = {
+  helperMessage:
+    'No pods have been created for this Job yet. It may still be pending or unschedulable. Check Pod Issues and Events.',
+  logs: [],
+  showReconnectButton: false,
+};
+
+export const NoLogsYet = Template.bind({});
+NoLogsYet.args = {
+  helperMessage:
+    'No logs available yet. The selected container may not have started or may not have emitted output. Check Pod Issues and Events.',
+  logs: [],
+  showReconnectButton: false,
+};
+
+export const ReconnectVisible = Template.bind({});
+ReconnectVisible.args = {
+  helperMessage: null,
+  logs: ['2026-04-18T13:16:58.715082657Z hello from template\n'],
+  showReconnectButton: true,
+};

--- a/volcano/src/components/jobs/JobLogsViewer.tsx
+++ b/volcano/src/components/jobs/JobLogsViewer.tsx
@@ -1,0 +1,426 @@
+import { Icon } from '@iconify/react';
+import { Activity } from '@kinvolk/headlamp-plugin/lib';
+import {
+  ActionButton,
+  AuthVisible,
+  LogViewer,
+} from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import Pod from '@kinvolk/headlamp-plugin/lib/k8s/pod';
+import Box from '@mui/material/Box';
+import FormControl from '@mui/material/FormControl';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import InputLabel from '@mui/material/InputLabel';
+import MenuItem from '@mui/material/MenuItem';
+import Select from '@mui/material/Select';
+import Switch from '@mui/material/Switch';
+import Typography from '@mui/material/Typography';
+import { useSnackbar } from 'notistack';
+import React from 'react';
+import { VolcanoJob } from '../../resources/job';
+import {
+  getContainerNames,
+  getDefaultContainerName,
+  getLogsHelperMessage,
+  getSelectedPods,
+  hasRestartedContainer,
+  isTerminalPod,
+  JOB_NAME_LABEL,
+} from './jobLogs';
+import { useJobLogsStream } from './useJobLogsStream';
+
+/**
+ * Props for the Job logs activity viewer.
+ */
+type JobLogsViewerProps = {
+  /** Activity id used to close the full-screen logs viewer. */
+  activityId: string;
+  /** Volcano Job whose related pod logs are shown. */
+  job: VolcanoJob;
+};
+
+/**
+ * Props for the Job logs viewer control bar.
+ */
+type JobLogsControlsProps = {
+  /** Pods discovered for the selected Volcano Job. */
+  pods: Pod[] | null;
+  /** Whether the related pod list is still loading. */
+  podsLoading: boolean;
+  /** Currently selected pod name or `all` for aggregated logs. */
+  selectedPodName: 'all' | string;
+  /** Updates the selected pod name. */
+  setSelectedPodName: React.Dispatch<React.SetStateAction<'all' | string>>;
+  /** Container names available for the current pod selection. */
+  availableContainers: string[];
+  /** Currently selected container name. */
+  selectedContainer: string;
+  /** Updates the selected container name. */
+  setSelectedContainer: React.Dispatch<React.SetStateAction<string>>;
+  /** Number of log lines requested from the cluster. */
+  lines: number;
+  /** Updates the requested log line count. */
+  setLines: React.Dispatch<React.SetStateAction<number>>;
+  /** Whether previous container logs should be shown. */
+  showPrevious: boolean;
+  /** Updates the previous-logs toggle state. */
+  setShowPrevious: React.Dispatch<React.SetStateAction<boolean>>;
+  /** Whether the selected container has previous logs available. */
+  canShowPrevious: boolean;
+  /** Whether timestamps should be shown in the log output. */
+  showTimestamps: boolean;
+  /** Updates the timestamp toggle state. */
+  setShowTimestamps: React.Dispatch<React.SetStateAction<boolean>>;
+  /** Whether the log stream should continue following new output. */
+  follow: boolean;
+  /** Updates the follow toggle state. */
+  setFollow: React.Dispatch<React.SetStateAction<boolean>>;
+  /** Helper message shown above the log terminal when no log content is available yet. */
+  helperMessage: string | null;
+};
+
+/**
+ * Renders the Job logs viewer controls and helper message strip.
+ *
+ * @param props Control bar properties for selecting pods, containers, and log options.
+ * @returns Control bar shown above the logs terminal.
+ */
+function JobLogsControls({
+  pods,
+  podsLoading,
+  selectedPodName,
+  setSelectedPodName,
+  availableContainers,
+  selectedContainer,
+  setSelectedContainer,
+  lines,
+  setLines,
+  showPrevious,
+  setShowPrevious,
+  canShowPrevious,
+  showTimestamps,
+  setShowTimestamps,
+  follow,
+  setFollow,
+  helperMessage,
+}: JobLogsControlsProps) {
+  return (
+    <Box
+      key="job-log-controls"
+      sx={{ display: 'flex', flexDirection: 'column', gap: 1, width: '100%' }}
+    >
+      <Box
+        sx={{
+          minHeight: theme => theme.spacing(3),
+          display: 'flex',
+          alignItems: 'center',
+        }}
+      >
+        <Typography
+          variant="body2"
+          sx={{
+            color: 'text.secondary',
+            fontFamily:
+              'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+          }}
+        >
+          {helperMessage || ' '}
+        </Typography>
+      </Box>
+
+      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2, width: '100%' }}>
+        <FormControl sx={{ minWidth: 220 }}>
+          <InputLabel id="job-logs-pod-label">Select Pod</InputLabel>
+          <Select
+            id="job-logs-pod-select"
+            labelId="job-logs-pod-label"
+            value={selectedPodName}
+            label="Select Pod"
+            onChange={event => setSelectedPodName(event.target.value as 'all' | string)}
+            disabled={podsLoading || !pods?.length}
+          >
+            <MenuItem value="all">All Pods</MenuItem>
+            {(pods || []).map(pod => (
+              <MenuItem key={pod.getName()} value={pod.getName()}>
+                {pod.getName()}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+
+        <FormControl sx={{ minWidth: 220 }}>
+          <InputLabel id="job-logs-container-label">Container</InputLabel>
+          <Select
+            id="job-logs-container-select"
+            labelId="job-logs-container-label"
+            value={selectedContainer}
+            label="Container"
+            onChange={event => setSelectedContainer(event.target.value)}
+            disabled={!availableContainers.length}
+          >
+            {availableContainers.map(container => (
+              <MenuItem key={container} value={container}>
+                {container}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+
+        <FormControl sx={{ minWidth: 120 }}>
+          <InputLabel id="job-logs-lines-label">Lines</InputLabel>
+          <Select
+            id="job-logs-lines-select"
+            labelId="job-logs-lines-label"
+            value={lines}
+            label="Lines"
+            onChange={event => setLines(Number(event.target.value))}
+          >
+            {[100, 1000, 2500].map(option => (
+              <MenuItem key={option} value={option}>
+                {option}
+              </MenuItem>
+            ))}
+            <MenuItem value={-1}>All</MenuItem>
+          </Select>
+        </FormControl>
+
+        <FormControlLabel
+          label="Show previous"
+          control={
+            <Switch checked={showPrevious} onChange={() => setShowPrevious(value => !value)} />
+          }
+          disabled={!canShowPrevious}
+        />
+
+        <FormControlLabel
+          label="Timestamps"
+          control={
+            <Switch checked={showTimestamps} onChange={() => setShowTimestamps(value => !value)} />
+          }
+        />
+
+        <FormControlLabel
+          label="Follow"
+          control={<Switch checked={follow} onChange={() => setFollow(value => !value)} />}
+        />
+      </Box>
+    </Box>
+  );
+}
+
+/**
+ * Renders the full-screen logs viewer for a Volcano Job.
+ *
+ * @param props Viewer properties including the activity id and target Job.
+ * @returns Job logs viewer with controls, helper strip, and terminal output.
+ */
+function JobLogsViewer({ activityId, job }: JobLogsViewerProps) {
+  const namespace = job.metadata.namespace;
+  const cluster = job.cluster;
+  const jobName = job.metadata.name;
+  const { enqueueSnackbar } = useSnackbar();
+
+  const [selectedPodName, setSelectedPodName] = React.useState<'all' | string>('all');
+  const [selectedContainer, setSelectedContainer] = React.useState('');
+  const [lines, setLines] = React.useState(100);
+  const [showTimestamps, setShowTimestamps] = React.useState(true);
+  const [follow, setFollow] = React.useState(true);
+  const [showPrevious, setShowPrevious] = React.useState(false);
+
+  const {
+    items: pods,
+    error: podError,
+    isLoading: podsLoading,
+  } = Pod.useList({
+    namespace,
+    cluster,
+    labelSelector: jobName ? `${JOB_NAME_LABEL}=${jobName}` : undefined,
+  });
+
+  const selectedPods = React.useMemo(
+    () => getSelectedPods(pods || [], selectedPodName),
+    [pods, selectedPodName]
+  );
+
+  const availableContainers = React.useMemo(() => getContainerNames(selectedPods), [selectedPods]);
+
+  const canShowPrevious = React.useMemo(
+    () => hasRestartedContainer(selectedPods, selectedContainer),
+    [selectedContainer, selectedPods]
+  );
+
+  const isInitializingSelection = React.useMemo(
+    () => !!pods?.length && !!selectedPods.length && !selectedContainer,
+    [pods, selectedContainer, selectedPods]
+  );
+
+  const [shouldShowNoPodsMessage, setShouldShowNoPodsMessage] = React.useState(false);
+  const [shouldShowNoLogsMessage, setShouldShowNoLogsMessage] = React.useState(false);
+
+  const canRequestLogs = React.useMemo(
+    () => !!pods?.length && !!selectedPods.length && !!selectedContainer,
+    [pods, selectedContainer, selectedPods]
+  );
+
+  const allSelectedPodsAreTerminal = React.useMemo(
+    () => selectedPods.length > 0 && selectedPods.every(isTerminalPod),
+    [selectedPods]
+  );
+
+  React.useEffect(() => {
+    if (podsLoading || pods?.length) {
+      setShouldShowNoPodsMessage(false);
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setShouldShowNoPodsMessage(true);
+    }, 300);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [pods, podsLoading]);
+
+  React.useEffect(() => {
+    if (!pods?.length) {
+      return;
+    }
+
+    if (selectedPodName !== 'all' && !pods.some(pod => pod.getName() === selectedPodName)) {
+      setSelectedPodName('all');
+      return;
+    }
+
+    const nextDefaultContainer =
+      availableContainers.includes(selectedContainer) && selectedContainer
+        ? selectedContainer
+        : getDefaultContainerName(selectedPods);
+
+    if (nextDefaultContainer !== selectedContainer) {
+      setSelectedContainer(nextDefaultContainer);
+    }
+  }, [availableContainers, pods, selectedContainer, selectedPodName, selectedPods]);
+
+  const { logs, showReconnectButton, xtermRef, handleReconnect } = useJobLogsStream({
+    selectedPods,
+    selectedPodName,
+    selectedContainer,
+    lines,
+    showPrevious,
+    showTimestamps,
+    follow,
+    allSelectedPodsAreTerminal,
+  });
+
+  React.useEffect(() => {
+    if (!canRequestLogs || logs.length > 0) {
+      setShouldShowNoLogsMessage(false);
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setShouldShowNoLogsMessage(true);
+    }, 300);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [canRequestLogs, logs]);
+
+  React.useEffect(() => {
+    if (!podError) {
+      return;
+    }
+
+    const message = podError instanceof Error ? podError.message : String(podError);
+    enqueueSnackbar(`Failed to load Job pods: ${message}`, { variant: 'error' });
+  }, [enqueueSnackbar, podError]);
+
+  const helperMessage = React.useMemo(
+    () =>
+      getLogsHelperMessage({
+        logs,
+        podError,
+        pods,
+        podsLoading,
+        isInitializingSelection,
+        shouldShowNoLogsMessage,
+        shouldShowNoPodsMessage,
+        selectedContainer,
+        selectedPods,
+      }),
+    [
+      logs,
+      podError,
+      pods,
+      podsLoading,
+      isInitializingSelection,
+      shouldShowNoLogsMessage,
+      shouldShowNoPodsMessage,
+      selectedContainer,
+      selectedPods,
+    ]
+  );
+
+  const topActions = [
+    <JobLogsControls
+      key="job-log-controls"
+      pods={pods}
+      podsLoading={podsLoading}
+      selectedPodName={selectedPodName}
+      setSelectedPodName={setSelectedPodName}
+      availableContainers={availableContainers}
+      selectedContainer={selectedContainer}
+      setSelectedContainer={setSelectedContainer}
+      lines={lines}
+      setLines={setLines}
+      showPrevious={showPrevious}
+      setShowPrevious={setShowPrevious}
+      canShowPrevious={canShowPrevious}
+      showTimestamps={showTimestamps}
+      setShowTimestamps={setShowTimestamps}
+      follow={follow}
+      setFollow={setFollow}
+      helperMessage={helperMessage}
+    />,
+  ];
+
+  return (
+    <LogViewer
+      noDialog
+      open
+      title={jobName}
+      downloadName={`${jobName}_${selectedPodName === 'all' ? 'all_pods' : selectedPodName}`}
+      logs={logs}
+      topActions={topActions}
+      xtermRef={xtermRef}
+      onClose={() => Activity.close(activityId)}
+      handleReconnect={handleReconnect}
+      showReconnectButton={showReconnectButton}
+    />
+  );
+}
+
+/**
+ * Renders the Job logs action shown in the details header.
+ *
+ * @param props Action button properties.
+ * @returns Header action for opening the Job logs viewer.
+ */
+export function JobLogsHeaderButton({ job }: { job: VolcanoJob }) {
+  return (
+    <AuthVisible item={Pod} authVerb="get" subresource="log" namespace={job.metadata.namespace}>
+      <ActionButton
+        icon="mdi:file-document-box-outline"
+        description="Show Logs"
+        onClick={() => {
+          const activityId = `volcano-job-logs-${job.metadata.uid || job.metadata.name}`;
+          Activity.launch({
+            id: activityId,
+            title: `Logs: ${job.metadata.name}`,
+            icon: <Icon icon="mdi:file-document-box-outline" width="100%" height="100%" />,
+            cluster: job.cluster,
+            location: 'full',
+            content: <JobLogsViewer activityId={activityId} job={job} />,
+          });
+        }}
+      />
+    </AuthVisible>
+  );
+}

--- a/volcano/src/components/jobs/jobLogs.test.ts
+++ b/volcano/src/components/jobs/jobLogs.test.ts
@@ -1,0 +1,73 @@
+import { getLogsHelperMessage, sortLogsByTimestamp } from './jobLogs';
+
+describe('getLogsHelperMessage', () => {
+  it('returns no pods message once the no-pods guard is enabled', () => {
+    expect(
+      getLogsHelperMessage({
+        logs: [],
+        podError: null,
+        pods: [],
+        podsLoading: false,
+        isInitializingSelection: false,
+        shouldShowNoLogsMessage: false,
+        shouldShowNoPodsMessage: true,
+        selectedContainer: '',
+        selectedPods: [],
+      })
+    ).toBe(
+      'No pods have been created for this Job yet. It may still be pending or unschedulable. Check Pod Issues and Events.'
+    );
+  });
+
+  it('returns no logs message once a valid selection is settled', () => {
+    expect(
+      getLogsHelperMessage({
+        logs: [],
+        podError: null,
+        pods: [{ metadata: { name: 'job-0' } }],
+        podsLoading: false,
+        isInitializingSelection: false,
+        shouldShowNoLogsMessage: true,
+        shouldShowNoPodsMessage: false,
+        selectedContainer: 'main',
+        selectedPods: [{ metadata: { name: 'job-0' } }],
+      })
+    ).toBe(
+      'No logs available yet. The selected container may not have started or may not have emitted output. Check Pod Issues and Events.'
+    );
+  });
+
+  it('returns loading message while selection is still initializing', () => {
+    expect(
+      getLogsHelperMessage({
+        logs: [],
+        podError: null,
+        pods: [{ metadata: { name: 'job-0' } }],
+        podsLoading: false,
+        isInitializingSelection: true,
+        shouldShowNoLogsMessage: true,
+        shouldShowNoPodsMessage: false,
+        selectedContainer: '',
+        selectedPods: [{ metadata: { name: 'job-0' } }],
+      })
+    ).toBe('Loading logs...');
+  });
+});
+
+describe('sortLogsByTimestamp', () => {
+  it('sorts by full RFC3339 timestamp and falls back deterministically', () => {
+    const logs = [
+      '[pod-b/main] 2026-04-18T13:16:58.715082657Z hello from template',
+      '[pod-a/main] 2026-04-18T13:16:58.115082657Z starting up',
+      '[pod-c/main] no timestamp here',
+      '[pod-a/main] 2026-04-18T13:16:58.115082657Z another line',
+    ];
+
+    expect(sortLogsByTimestamp(logs)).toEqual([
+      '[pod-a/main] 2026-04-18T13:16:58.115082657Z another line',
+      '[pod-a/main] 2026-04-18T13:16:58.115082657Z starting up',
+      '[pod-b/main] 2026-04-18T13:16:58.715082657Z hello from template',
+      '[pod-c/main] no timestamp here',
+    ]);
+  });
+});

--- a/volcano/src/components/jobs/jobLogs.ts
+++ b/volcano/src/components/jobs/jobLogs.ts
@@ -1,0 +1,226 @@
+interface PodLike {
+  metadata?: {
+    name?: string;
+  };
+  spec?: {
+    containers?: Array<{
+      name: string;
+    }>;
+  };
+  status?: {
+    containerStatuses?: Array<{
+      name: string;
+      restartCount?: number;
+    }>;
+  };
+}
+
+interface PodWithPhase extends PodLike {
+  status?: PodLike['status'] & {
+    phase?: string;
+  };
+}
+
+export const JOB_NAME_LABEL = 'volcano.sh/job-name';
+
+const NO_PODS_MESSAGE =
+  'No pods have been created for this Job yet. It may still be pending or unschedulable. Check Pod Issues and Events.';
+const NO_LOGS_MESSAGE =
+  'No logs available yet. The selected container may not have started or may not have emitted output. Check Pod Issues and Events.';
+
+const timestampPattern = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?/;
+
+/**
+ * Returns containers that are available across the selected pod set.
+ *
+ * @param pods Pods currently selected in the logs viewer.
+ * @returns Container names in the first pod's order.
+ */
+export function getContainerNames(pods: PodLike[]): string[] {
+  const firstPodContainers = pods[0]?.spec?.containers?.map(container => container.name) || [];
+
+  if (pods.length <= 1) {
+    return firstPodContainers;
+  }
+
+  return firstPodContainers.filter(containerName =>
+    pods.every(pod =>
+      (pod.spec?.containers || []).some(container => container.name === containerName)
+    )
+  );
+}
+
+/**
+ * Picks the default container shown when logs are first opened.
+ *
+ * @param pods Pods currently selected in the logs viewer.
+ * @returns First compatible container name or an empty string.
+ */
+export function getDefaultContainerName(pods: PodLike[]): string {
+  return getContainerNames(pods)[0] || '';
+}
+
+/**
+ * Reports whether the selected container has previous logs available.
+ *
+ * @param pods Pods currently selected in the logs viewer.
+ * @param containerName Selected container name.
+ * @returns `true` when any selected pod restarted that container.
+ */
+export function hasRestartedContainer(pods: PodLike[], containerName: string): boolean {
+  return pods.some(pod =>
+    (pod.status?.containerStatuses || []).some(
+      status => status.name === containerName && (status.restartCount || 0) > 0
+    )
+  );
+}
+
+/**
+ * Prefixes log lines with pod and container identity for multi-pod views.
+ *
+ * @param podName Pod name shown in the log prefix.
+ * @param containerName Container name shown in the log prefix.
+ * @param fragment Raw log fragment returned by the Pod log stream.
+ * @returns Fragment with a prefix applied to each line.
+ */
+export function formatPrefixedLogFragment(
+  podName: string,
+  containerName: string,
+  fragment: string
+): string {
+  const prefix = `[${podName}/${containerName}] `;
+  const normalized = fragment.endsWith('\n') ? fragment : `${fragment}\n`;
+
+  return normalized
+    .split('\n')
+    .map((line, index, lines) => {
+      const isTrailingEmpty = index === lines.length - 1 && line === '';
+      if (isTrailingEmpty) {
+        return '';
+      }
+      return `${prefix}${line}`;
+    })
+    .join('\n');
+}
+
+/**
+ * Sorts aggregated log lines by RFC3339-like timestamp when one is present.
+ *
+ * @param logs Aggregated log lines across selected pods.
+ * @returns Sorted logs for deterministic rendering.
+ */
+export function sortLogsByTimestamp(logs: string[]): string[] {
+  return logs
+    .map((log, index) => ({ log, index }))
+    .sort((left, right) => {
+      const leftTimestamp = left.log.match(timestampPattern)?.[0] || '';
+      const rightTimestamp = right.log.match(timestampPattern)?.[0] || '';
+
+      if (!leftTimestamp && rightTimestamp) {
+        return 1;
+      }
+
+      if (leftTimestamp && !rightTimestamp) {
+        return -1;
+      }
+
+      const timestampComparison = leftTimestamp.localeCompare(rightTimestamp);
+
+      if (timestampComparison !== 0) {
+        return timestampComparison;
+      }
+
+      const logComparison = left.log.localeCompare(right.log);
+
+      if (logComparison !== 0) {
+        return logComparison;
+      }
+
+      return left.index - right.index;
+    })
+    .map(entry => entry.log);
+}
+
+/**
+ * Returns the selected pod subset for the current logs view.
+ *
+ * @param pods Pods discovered for the Volcano Job.
+ * @param selectedPodName Selected pod name or `all`.
+ * @returns Matching pod subset.
+ */
+export function getSelectedPods<T extends PodLike>(
+  pods: T[],
+  selectedPodName: 'all' | string
+): T[] {
+  if (selectedPodName === 'all') {
+    return pods;
+  }
+
+  return pods.filter(pod => pod.metadata?.name === selectedPodName);
+}
+
+/**
+ * Reports whether a pod is already in a terminal phase.
+ *
+ * @param pod Pod selected in the logs viewer.
+ * @returns `true` when the pod already succeeded or failed.
+ */
+export function isTerminalPod(pod: PodWithPhase): boolean {
+  return pod.status?.phase === 'Succeeded' || pod.status?.phase === 'Failed';
+}
+
+/**
+ * Resolves the helper text shown above the log viewer for loading and empty states.
+ *
+ * @param options Derived log viewer state.
+ * @returns User-facing helper text or `null` when no helper should be shown.
+ */
+export function getLogsHelperMessage({
+  logs,
+  podError,
+  pods,
+  podsLoading,
+  isInitializingSelection,
+  shouldShowNoLogsMessage,
+  shouldShowNoPodsMessage,
+  selectedContainer,
+  selectedPods,
+}: {
+  logs: string[];
+  podError: unknown;
+  pods: PodLike[] | null;
+  podsLoading: boolean;
+  isInitializingSelection: boolean;
+  shouldShowNoLogsMessage: boolean;
+  shouldShowNoPodsMessage: boolean;
+  selectedContainer: string;
+  selectedPods: PodLike[];
+}): string | null {
+  if (podError) {
+    return `Failed to load Job pods: ${
+      podError instanceof Error ? podError.message : String(podError)
+    }`;
+  }
+
+  if (logs.length > 0) {
+    return null;
+  }
+
+  if (podsLoading || isInitializingSelection) {
+    return 'Loading logs...';
+  }
+
+  if (!pods?.length) {
+    return shouldShowNoPodsMessage ? NO_PODS_MESSAGE : null;
+  }
+
+  if (!selectedContainer || !selectedPods.length) {
+    return null;
+  }
+
+  if (logs.length === 0) {
+    return shouldShowNoLogsMessage ? NO_LOGS_MESSAGE : null;
+  }
+
+  return null;
+}

--- a/volcano/src/components/jobs/useJobLogsStream.ts
+++ b/volcano/src/components/jobs/useJobLogsStream.ts
@@ -1,0 +1,227 @@
+import Pod from '@kinvolk/headlamp-plugin/lib/k8s/pod';
+import type { Terminal as XTerm } from '@xterm/xterm';
+import React from 'react';
+import { formatPrefixedLogFragment, sortLogsByTimestamp } from './jobLogs';
+
+/**
+ * Inputs that control the Job log streaming lifecycle.
+ */
+type UseJobLogsStreamOptions = {
+  /** Pods currently selected in the viewer. */
+  selectedPods: Pod[];
+  /** Selected pod name or `all` when aggregating logs across pods. */
+  selectedPodName: 'all' | string;
+  /** Selected container name. */
+  selectedContainer: string;
+  /** Number of log lines requested from the cluster. */
+  lines: number;
+  /** Whether previous container logs should be shown. */
+  showPrevious: boolean;
+  /** Whether timestamps should be shown in the log output. */
+  showTimestamps: boolean;
+  /** Whether the log stream should continue following new output. */
+  follow: boolean;
+  /** Whether all selected pods are already terminal and should suppress reconnect UI. */
+  allSelectedPodsAreTerminal: boolean;
+};
+
+/**
+ * Stream state and controls exposed to the Job logs viewer.
+ */
+type UseJobLogsStreamResult = {
+  /** Current real log content shown in the terminal and used for downloads. */
+  logs: string[];
+  /** Whether the reconnect button should be shown. */
+  showReconnectButton: boolean;
+  /** Terminal instance owned by the log stream hook. */
+  xtermRef: React.RefObject<XTerm | null>;
+  /** Clears current stream state and restarts log streaming. */
+  handleReconnect: () => void;
+};
+
+/**
+ * Manages pod log streaming state for the Volcano Job logs viewer.
+ *
+ * @param options Current log stream configuration.
+ * @returns Streamed logs, reconnect state, terminal ref, and reconnect handler.
+ */
+export function useJobLogsStream({
+  selectedPods,
+  selectedPodName,
+  selectedContainer,
+  lines,
+  showPrevious,
+  showTimestamps,
+  follow,
+  allSelectedPodsAreTerminal,
+}: UseJobLogsStreamOptions): UseJobLogsStreamResult {
+  const xtermRef = React.useRef<XTerm | null>(null);
+  const [logs, setLogs] = React.useState<string[]>([]);
+  const [showReconnectButton, setShowReconnectButton] = React.useState(false);
+  const [reconnectNonce, setReconnectNonce] = React.useState(0);
+  const allPodLogsByPodRef = React.useRef<Record<string, string[]>>({});
+  const lastProcessedLogCountByPodRef = React.useRef(new Map<string, number>());
+
+  const clearLogs = React.useCallback(() => {
+    xtermRef.current?.clear();
+    setLogs([]);
+    allPodLogsByPodRef.current = {};
+    lastProcessedLogCountByPodRef.current.clear();
+  }, []);
+
+  const writeEntireLogBuffer = React.useCallback((nextLogs: string[]) => {
+    xtermRef.current?.clear();
+    xtermRef.current?.write(nextLogs.join('').replace(/\n/g, '\r\n'));
+  }, []);
+
+  const rebuildAllPodsLogBuffer = React.useCallback(() => {
+    const aggregatedLogs = sortLogsByTimestamp(
+      Object.entries(allPodLogsByPodRef.current).flatMap(([podName, podLogs]) =>
+        podLogs.map(log => formatPrefixedLogFragment(podName, selectedContainer, log))
+      )
+    );
+
+    writeEntireLogBuffer(aggregatedLogs);
+    setLogs(aggregatedLogs);
+  }, [selectedContainer, writeEntireLogBuffer]);
+
+  const appendAllPodsLogFragments = React.useCallback(
+    (podName: string, nextLogs: string[]) => {
+      const previousCount = lastProcessedLogCountByPodRef.current.get(podName) ?? 0;
+      const nextCount = nextLogs.length;
+
+      allPodLogsByPodRef.current = {
+        ...allPodLogsByPodRef.current,
+        [podName]: nextLogs,
+      };
+
+      if (nextCount < previousCount) {
+        lastProcessedLogCountByPodRef.current.set(podName, nextCount);
+        rebuildAllPodsLogBuffer();
+        return;
+      }
+
+      if (nextCount === previousCount) {
+        return;
+      }
+
+      const newFragments = nextLogs
+        .slice(previousCount)
+        .map(log => formatPrefixedLogFragment(podName, selectedContainer, log));
+
+      xtermRef.current?.write(newFragments.join('').replace(/\n/g, '\r\n'));
+      setLogs(currentLogs => currentLogs.concat(newFragments));
+      lastProcessedLogCountByPodRef.current.set(podName, nextCount);
+    },
+    [rebuildAllPodsLogBuffer, selectedContainer]
+  );
+
+  const updateSinglePodLogBuffer = React.useCallback(
+    (nextLogs: string[], lastRenderedCount: number) => {
+      if (!xtermRef.current) {
+        setLogs(nextLogs);
+        return nextLogs.length;
+      }
+
+      if (nextLogs.length < lastRenderedCount) {
+        writeEntireLogBuffer(nextLogs);
+      } else if (nextLogs.length > lastRenderedCount) {
+        xtermRef.current.write(nextLogs.slice(lastRenderedCount).join('').replace(/\n/g, '\r\n'));
+      }
+
+      setLogs(nextLogs);
+      return nextLogs.length;
+    },
+    [writeEntireLogBuffer]
+  );
+
+  React.useEffect(() => {
+    if (!selectedContainer) {
+      clearLogs();
+      return;
+    }
+
+    if (!selectedPods.length) {
+      clearLogs();
+      return;
+    }
+
+    setShowReconnectButton(false);
+
+    if (selectedPodName === 'all') {
+      clearLogs();
+      const cleanups = selectedPods.map(pod =>
+        pod.getLogs(
+          selectedContainer,
+          ({ logs: nextLogs }: { logs: string[]; hasJsonLogs?: boolean }) => {
+            appendAllPodsLogFragments(pod.getName(), [...nextLogs]);
+          },
+          {
+            tailLines: lines,
+            showPrevious,
+            showTimestamps,
+            follow,
+            onReconnectStop: () => {
+              if (!allSelectedPodsAreTerminal) {
+                setShowReconnectButton(true);
+              }
+            },
+          }
+        )
+      );
+
+      return () => cleanups.forEach(cleanup => cleanup());
+    }
+
+    const pod = selectedPods[0];
+    if (!pod) {
+      clearLogs();
+      return;
+    }
+
+    let lastRenderedCount = 0;
+    clearLogs();
+
+    return pod.getLogs(
+      selectedContainer,
+      ({ logs: nextLogs }: { logs: string[]; hasJsonLogs?: boolean }) => {
+        lastRenderedCount = updateSinglePodLogBuffer([...nextLogs], lastRenderedCount);
+      },
+      {
+        tailLines: lines,
+        showPrevious,
+        showTimestamps,
+        follow,
+        onReconnectStop: () => {
+          if (!allSelectedPodsAreTerminal) {
+            setShowReconnectButton(true);
+          }
+        },
+      }
+    );
+  }, [
+    allSelectedPodsAreTerminal,
+    clearLogs,
+    follow,
+    lines,
+    reconnectNonce,
+    selectedContainer,
+    selectedPodName,
+    selectedPods,
+    showPrevious,
+    showTimestamps,
+  ]);
+
+  const handleReconnect = React.useCallback(() => {
+    clearLogs();
+    setShowReconnectButton(false);
+    setReconnectNonce(value => value + 1);
+  }, [clearLogs]);
+
+  return {
+    logs,
+    showReconnectButton,
+    xtermRef,
+    handleReconnect,
+  };
+}


### PR DESCRIPTION
## Summary
Add a logs viewer to Volcano Job details so users can inspect logs for pods created by a Job directly from the Headlamp plugin.

<img width="1625" height="594" alt="image" src="https://github.com/user-attachments/assets/81b87217-52b5-45bf-a341-36e5eb3cdc75" />

## Changes
- add a `Show Logs` header action to Volcano Job details
- discover related pods using `volcano.sh/job-name=<job-name>`
- support `All Pods` and single-pod log viewing
- support container selection and standard log controls:
  - lines
  - show previous
  - timestamps
  - follow
- add clearer empty states for:
  - pending or unschedulable Jobs with no pods yet
  - selected containers with no logs yet
- extract pure helpers and stream lifecycle logic into dedicated modules