### PR TITLE
fix(chart): guard against undefined data point in multi-series merge

### DIFF
--- a/prometheus/src/components/Chart/Chart/Chart.tsx
+++ b/prometheus/src/components/Chart/Chart/Chart.tsx
@@ -149,7 +149,7 @@ export default function Chart(props: ChartProps) {
         (element, index) => {
           const mergedElement = { timestamp: element.timestamp };
           for (const plotName of Object.keys(fetchedMetrics)) {
-            mergedElement[plotName] = fetchedMetrics[plotName].data[index].y;
+            mergedElement[plotName] = fetchedMetrics[plotName].data[index]?.y ?? null;
           }
           return mergedElement;
         }


### PR DESCRIPTION

When two Prometheus `query_range` responses return different sample counts, which happens routinely on fresh or restarted pods  the merge loop in `Chart.tsx` throws `TypeError: Cannot read properties of undefined (reading 'y')` and kills the chart panel via ErrorBoundary.

The fix is one line: optional-chain `data[index]` and fall back to `null`. Recharts already handles null dataKey values gracefully, so the shorter series just shows a gap instead of crashing.

Tested against NetworkChart (rx + tx) on a freshly scheduled pod , both series render cleanly now.
