### PR TITLE
fix: compute ready status from policy conditions

### DIFF
--- a/kyverno/src/resources/kyvernoPolicy.ts
+++ b/kyverno/src/resources/kyvernoPolicy.ts
@@ -70,7 +70,6 @@ export interface KyvernoPolicySpec {
 }
 
 export interface KyvernoPolicyStatus {
-  ready?: boolean;
   conditions?: PolicyCondition[];
   autogen?: {
     rules?: PolicyRule[];
@@ -114,7 +113,7 @@ export class KyvernoPolicy extends KubeObject<KyvernoPolicyInterface> {
   }
 
   get ready(): boolean {
-    return this.status?.ready ?? false;
+    return this.status?.conditions?.some(c => c.type === 'Ready' && c.status === 'True') ?? false;
   }
 
   get rules(): PolicyRule[] {
@@ -149,7 +148,7 @@ export class KyvernoClusterPolicy extends KubeObject<KyvernoPolicyInterface> {
   }
 
   get ready(): boolean {
-    return this.status?.ready ?? false;
+    return this.status?.conditions?.some(c => c.type === 'Ready' && c.status === 'True') ?? false;
   }
 
   get rules(): PolicyRule[] {


### PR DESCRIPTION
**Summary:** 

Fixes the `ready` status detection for both Cluster and Namespaced Kyverno policies, adapting to Kyverno's removal of the deprecated `status.ready` field.

**Changes:**

- Removed `ready?: boolean;` from the `KyvernoPolicyStatus` interface.
- Updated the `get ready()` accessors in both `KyvernoPolicy` and `KyvernoClusterPolicy` classes to compute the status dynamically by checking if the `.some()` condition in the `conditions` array has `type === 'Ready'` and `status === 'True'`.