### PR TITLE
docs: add headlamp-kubevirt to external plugins list

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Please see [headlamp plugins on Artifact Hub](https://artifacthub.io/packages/se
 | [KubeVirt](https://github.com/buttahtoast/headlamp-plugins/tree/main/kubevirt) | A plugin for managing KubeVirt virtual machines within a Kubernetes cluster. |   | [@buttahtoast](https://github.com/buttahtoast) |
 | [Gatekeeper](https://github.com/sozercan/gatekeeper-headlamp-plugin) | A Headlamp plugin for managing [Gatekeeper](https://open-policy-agent.github.io/gatekeeper/) policies, violations, and a library of community-sourced policies. | | [@sozercan](https://github.com/sozercan) |
 | [KAITO](https://github.com/kaito-project/headlamp-kaito) | Enhances the KAITO AKS extension with a visual interface in Headlamp for model deployment and GPU provisioning. | |[@chloe608](https://github.com/chloe608), [@chewong](https://github.com/chewong)|
+| [KubeVirt](https://github.com/naval-group/headlamp-kubevirt) | A comprehensive plugin for managing KubeVirt virtual machines: full VM lifecycle, VNC/serial console, VM Doctor (diagnostics, forensics, disk inspector), templates, image catalog, metrics, and more. | [ArtifactHub](https://artifacthub.io/packages/headlamp/headlamp-kubevirt/headlamp_kubevirt) | [@naval-group](https://github.com/naval-group) |
 | [Strimzi](https://github.com/cesaroangelo/strimzi-headlamp) | A Headlamp plugin for managing Strimzi (Apache Kafka on Kubernetes) resources. | [Demo](https://www.youtube.com/watch?v=MNt28s6b5d8) | [@cesaroangelo](https://github.com/cesaroangelo) |
 
 


### PR DESCRIPTION
Add naval-group/headlamp-kubevirt to the external plugins table. A comprehensive KubeVirt management plugin with VM lifecycle, VNC/serial console, VM Doctor, templates, image catalog, metrics, and more.

Originally inspired by buttahtoast/headlamp-plugins.