### PR TITLE
minikube: Use readFileSync instead of cat

### DIFF
--- a/minikube/manage-minikube.js
+++ b/minikube/manage-minikube.js
@@ -8,6 +8,7 @@
  * manage-minikube.js ask-restart-libvirt-ubuntu24
  */
 const { exec, execSync, spawn, spawnSync } = require('child_process');
+const { readFileSync } = require('fs');
 const { createServer } = require('net');
 const { platform } = process;
 
@@ -64,7 +65,7 @@ function askRestartLibvirtUbuntu24() {
   }
 
   try {
-    const osRelease = execSync('cat /etc/os-release').toString();
+    const osRelease = readFileSync('/etc/os-release', 'utf8');
     if (!osRelease.includes('Ubuntu') || !osRelease.includes('24.')) {
       console.error('This command is specific to Ubuntu 24.');
       return;


### PR DESCRIPTION
This change replaces the `execSync('cat /etc/os-release').toString()` call in `askRestartLibvirtUbuntu24()` with `fs.readFileSync('/etc/os-release', 'utf8')`.

Specifically in `minikube/manage-minikube.js`:
- Add `readFileSync` from Node’s built-in `fs` module near the top-level requires.
- Update line 67 region to use `readFileSync('/etc/os-release', 'utf8')`.
- Keep surrounding logic unchanged so behavior remains the same (string content check for Ubuntu 24).
