### PR TITLE
feat(ai-assistant): add vLLM provider for OpenAI-compatible endpoints

### DIFF
--- a/ai-assistant/README.md
+++ b/ai-assistant/README.md
@@ -25,6 +25,7 @@ The plugin supports multiple AI providers, allowing you to choose the one that b
 - **Mistral AI**
 - **Google** (Gemini models)
 - **DeepSeek** (DeepSeek-Chat, DeepSeek-Reasoner)
+- **OpenAI-Compatible** (vLLM, llama.cpp, and other OpenAI-compatible servers)
 - **Local Models** (via Ollama)
 
 You will need to provide your own API keys and endpoint information for the provider you choose to use. Please note that using AI providers may incur costs, so check the pricing details of your chosen provider.

--- a/ai-assistant/src/config/modelConfig.ts
+++ b/ai-assistant/src/config/modelConfig.ts
@@ -234,6 +234,37 @@ export const modelProviders: ModelProvider[] = [
     ],
   },
   {
+    id: 'vllm',
+    name: 'vLLM (OpenAI-compatible)',
+    icon: 'ai-providers:local',
+    description: 'Integration with vLLM or any OpenAI-compatible endpoint',
+    fields: [
+      {
+        name: 'apiKey',
+        label: 'API Key',
+        type: 'text',
+        required: false,
+        placeholder: 'sk-noop (leave blank if vLLM has no auth)',
+      },
+      {
+        name: 'baseUrl',
+        label: 'Base URL',
+        type: 'text',
+        required: true,
+        placeholder: 'http://vllm-server:8000/v1',
+        description: 'Full URL including /v1 — e.g. http://host:8000/v1',
+      },
+      {
+        name: 'model',
+        label: 'Model',
+        type: 'text',
+        required: true,
+        placeholder: 'meta-llama/Llama-3.1-8B-Instruct',
+        description: 'Must match --served-model-name passed to vLLM',
+      },
+    ],
+  },
+  {
     id: 'local',
     name: 'Local Models',
     icon: 'ai-providers:local',

--- a/ai-assistant/src/langchain/LangChainManager.ts
+++ b/ai-assistant/src/langchain/LangChainManager.ts
@@ -335,6 +335,24 @@ export default class LangChainManager extends AIManager {
             verbose: true,
           });
         }
+        case 'vllm': {
+          if (!sanitizedConfig.baseUrl) {
+            throw new Error('Base URL is required for vLLM');
+          }
+          if (!sanitizedConfig.model) {
+            throw new Error('Model is required for vLLM');
+          }
+          return new ChatOpenAI({
+            apiKey: sanitizedConfig.apiKey || 'sk-noop',
+            model: sanitizedConfig.model,
+            verbose: true,
+            configuration: {
+              baseURL: (url => (url.endsWith('/v1') ? url : `${url}/v1`))(
+                sanitizedConfig.baseUrl.replace(/\/+$/, '')
+              ),
+            },
+          });
+        }
         case 'local': {
           if (!sanitizedConfig.baseUrl) {
             throw new Error('Base URL is required for local models');
@@ -383,7 +401,7 @@ export default class LangChainManager extends AIManager {
    */
   private canUseDirectToolCalling(): boolean {
     // All major providers support direct tool calling
-    return ['openai', 'azure', 'anthropic', 'mistral', 'gemini'].includes(this.providerId);
+    return ['openai', 'azure', 'anthropic', 'mistral', 'gemini', 'vllm'].includes(this.providerId);
   }
 
   /**


### PR DESCRIPTION
Adds a `vLLM (OpenAI-compatible)` provider entry to the ai-assistant plugin, enabling users to connect to any OpenAI-compatible inference server (vLLM, llama.cpp, Ollama, etc.) running inside or outside the cluster.

Fields: Base URL (required), Model (required), API Key (optional — defaults to `sk-noop` for auth-free deployments). `LangChainManager` wires it via `ChatOpenAI` with a custom `configuration.baseURL`, reusing the existing client without adding a new dependency.

Closes #386
Related to #445