### PR TITLE
Add Fortem IDP external plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Please see [headlamp plugins on Artifact Hub](https://artifacthub.io/packages/se
 | [KAITO](https://github.com/kaito-project/headlamp-kaito) | Enhances the KAITO AKS extension with a visual interface in Headlamp for model deployment and GPU provisioning. | |[@chloe608](https://github.com/chloe608), [@chewong](https://github.com/chewong)|
 | [KubeVirt](https://github.com/naval-group/headlamp-kubevirt) | A comprehensive plugin for managing KubeVirt virtual machines: full VM lifecycle, VNC/serial console, VM Doctor (diagnostics, forensics, disk inspector), templates, image catalog, metrics, and more. | [ArtifactHub](https://artifacthub.io/packages/headlamp/headlamp-kubevirt/headlamp_kubevirt) | [@naval-group](https://github.com/naval-group) |
 | [Strimzi](https://github.com/cesaroangelo/strimzi-headlamp) | A Headlamp plugin for managing Strimzi (Apache Kafka on Kubernetes) resources. | [Demo](https://www.youtube.com/watch?v=MNt28s6b5d8) | [@cesaroangelo](https://github.com/cesaroangelo) |
+| [Fortem IDP](https://github.com/cybrixcc/headlamp-fortem) | View and manage Fortem environments, clusters, and cost metrics directly in Headlamp. Fortem is a self-hosted AI-native Kubernetes Internal Developer Platform. | [ArtifactHub](https://artifacthub.io/packages/headlamp/fortem/fortem) | [@dspv](https://github.com/dspv) |
 
 
 


### PR DESCRIPTION
Adds [Fortem IDP](https://github.com/cybrixcc/headlamp-fortem) to the external plugins list.

Fortem is a self-hosted AI-native Kubernetes Internal Developer Platform that installs via a single Helm chart. This plugin surfaces Fortem Environments (phase, cost/day, cluster, team) and Clusters directly in the Headlamp sidebar.

- GitHub: https://github.com/cybrixcc/headlamp-fortem
- ArtifactHub: https://artifacthub.io/packages/headlamp/fortem/fortem
- Maintainer: [@dspv](https://github.com/dspv)