### PR TITLE
fix(flux): return undefined from useNamespaces when no namespace selected

### DIFF
--- a/flux/src/helpers/index.tsx
+++ b/flux/src/helpers/index.tsx
@@ -258,5 +258,8 @@ export const useNamespaces = () => {
   }
 
   const namespacesSet = useSelector(({ filter }: { filter: FilterState }) => filter.namespaces);
-  return useMemo(() => [...namespacesSet], [namespacesSet]);
+  return useMemo(
+    () => (namespacesSet.size === 0 ? undefined : [...namespacesSet]),
+    [namespacesSet]
+  );
 };


### PR DESCRIPTION
## Problem
Fixes #626

When no namespace filter is selected in Headlamp, `useNamespaces()` was 
returning an empty array `[]`. Passing `namespace: []` to `useList()` 
causes `KubeObject.js` to enter the array branch and set `namespaces = []`, 
which skips the `getAllowedNamespaces()` fallback — resulting in zero API 
calls and nothing displayed in the Sources view (and any other Flux view 
using `useNamespaces`).

## Fix
Return `undefined` instead of `[]` when `namespacesSet` is empty. This 
causes `useList()` to skip the namespace block entirely and fall through 
to `getAllowedNamespaces()`, correctly showing all resources.

## Changes
- `src/helpers/index.tsx`: one-line fix in `useNamespaces()`