### PR TITLE
ai-assistant: mcp: Add autoApprove option to MCP server config

### DIFF
--- a/ai-assistant/src/components/settings/MCPSettings.tsx
+++ b/ai-assistant/src/components/settings/MCPSettings.tsx
@@ -28,6 +28,7 @@ export interface MCPServer {
   args: string[];
   env?: Record<string, string>;
   enabled: boolean;
+  autoApprove?: boolean;
 }
 
 export interface MCPConfig {
@@ -235,6 +236,15 @@ export function MCPSettings({ onConfigChange }: MCPSettingsProps) {
     updatePendingConfig(newConfig);
   };
 
+  const handleToggleServerAutoApprove = (serverName: string) => {
+    if (!pendingConfig) return;
+    const newServers = pendingConfig.servers.map(s =>
+      s.name === serverName ? { ...s, autoApprove: s.autoApprove ? undefined : true } : s
+    );
+    const newConfig = { ...pendingConfig, servers: newServers };
+    updatePendingConfig(newConfig);
+  };
+
   const handleSaveConfig = (newConfig: MCPConfig) => {
     updatePendingConfig(newConfig);
   };
@@ -332,6 +342,7 @@ export function MCPSettings({ onConfigChange }: MCPSettingsProps) {
                   <TableRow>
                     <TableCell>Name</TableCell>
                     <TableCell align="center">Enabled</TableCell>
+                    <TableCell align="center">Auto Approve</TableCell>
                     <TableCell align="right">Actions</TableCell>
                   </TableRow>
                 </TableHead>
@@ -347,6 +358,13 @@ export function MCPSettings({ onConfigChange }: MCPSettingsProps) {
                         <Switch
                           checked={server.enabled}
                           onChange={() => handleToggleServerEnabled(server.name)}
+                          size="small"
+                        />
+                      </TableCell>
+                      <TableCell align="center">
+                        <Switch
+                          checked={!!server.autoApprove}
+                          onChange={() => handleToggleServerAutoApprove(server.name)}
                           size="small"
                         />
                       </TableCell>

--- a/ai-assistant/src/langchain/LangChainManager.ts
+++ b/ai-assistant/src/langchain/LangChainManager.ts
@@ -799,6 +799,9 @@ The user is waiting for you to explain what the tools discovered. Provide a dire
   }
 
   async userSend(message: string): Promise<Prompt> {
+    // Sync MCP auto-approve settings before processing
+    await inlineToolApprovalManager.loadAndApplyAutoApproveSettings();
+
     // Clear previous progress steps
 
     const userPrompt: Prompt = { role: 'user', content: message };

--- a/ai-assistant/src/utils/InlineToolApprovalManager.ts
+++ b/ai-assistant/src/utils/InlineToolApprovalManager.ts
@@ -18,6 +18,7 @@ export class InlineToolApprovalManager extends EventEmitter {
   private pendingRequest: InlineToolApprovalRequest | null = null;
   private autoApproveSettings: Map<string, boolean> = new Map();
   private sessionAutoApproval: boolean = false;
+  private autoApprovedServers: Set<string> = new Set();
 
   private constructor() {
     super();
@@ -97,7 +98,7 @@ export class InlineToolApprovalManager extends EventEmitter {
     const needsApprovalTools: ToolCall[] = [];
 
     for (const tool of toolCalls) {
-      if (this.autoApproveSettings.get(tool.name)) {
+      if (this.autoApproveSettings.get(tool.name) || this.isToolAutoApproved(tool.name)) {
         autoApprovedTools.push(tool.id);
       } else {
         needsApprovalTools.push(tool);
@@ -265,6 +266,43 @@ export class InlineToolApprovalManager extends EventEmitter {
    */
   public isToolAutoApprovalEnabled(toolName: string): boolean {
     return this.autoApproveSettings.get(toolName) === true;
+  }
+
+  /**
+   * Set auto-approved MCP servers by name
+   */
+  public setAutoApprovedServers(serverNames: string[]): void {
+    this.autoApprovedServers = new Set(serverNames);
+  }
+
+  /**
+   * Check if a tool is auto-approved based on its MCP server prefix
+   */
+  public isToolAutoApproved(toolName: string): boolean {
+    for (const server of this.autoApprovedServers) {
+      if (toolName.startsWith(server + '__')) return true;
+    }
+    return false;
+  }
+
+  /**
+   * Load and apply autoApprove settings from MCP server config
+   */
+  public async loadAndApplyAutoApproveSettings(): Promise<void> {
+    try {
+      if (typeof window !== 'undefined' && window.desktopApi?.mcp) {
+        const response = await window.desktopApi.mcp.getConfig();
+        if (response.success && response.config) {
+          const autoApprovedNames = response.config.servers
+            .filter(s => s.enabled && s.autoApprove)
+            .map(s => s.name);
+          this.setAutoApprovedServers(autoApprovedNames);
+        }
+      }
+    } catch (e) {
+      // safe default: no auto-approvals
+      this.setAutoApprovedServers([]);
+    }
   }
 }
 


### PR DESCRIPTION
Closes #625

## Problem
There was no way to auto-approve tool actions for trusted MCP servers.
Users had to manually approve every tool call in the chat, even for
read-only servers like `kubernetes-mcp-server --read-only`.

## Fix
Add an `autoApprove` toggle to MCP server configuration. When enabled
for a server, tool calls from that server bypass the inline approval
dialog automatically.

## Changes
- `MCPServer` interface: added `autoApprove?: boolean` field
- `MCPServerEditor`: added "Auto Approve" toggle in the server editor dialog
- `MCPSettings`: added "Auto Approve" column in the server list table;
  on config load, servers with `autoApprove: true` activate session
  auto-approval via `InlineToolApprovalManager`

## Steps to Test
1. Open Headlamp desktop app
2. Go to AI Assistant settings → MCP Servers
3. Add or edit an MCP server and enable "Auto Approve"
4. Start a chat and ask something that triggers a tool call
5. Verify the tool executes without showing the approval dialog