### PR TITLE
ai-assistant: Fix TopBar icon color to be theme-responsive

### DIFF
--- a/ai-assistant/src/index.tsx
+++ b/ai-assistant/src/index.tsx
@@ -265,7 +265,7 @@ function HeadlampAIPrompt() {
           size="small"
           value="ai-assistant"
         >
-          <Icon icon="ai-assistant:logo" width="24px" />
+          <Icon icon="ai-assistant:logo" width="24px" color={theme.palette.text.primary} />
         </ToggleButton>
       </Tooltip>
 


### PR DESCRIPTION
Closes #535

## Problem
The AI assistant TopBar icon had no explicit color set, causing it to
be obscured on certain themes (e.g. aksd) where the AppBar background
color clashes with the default icon color.

## Fix
Use `theme.palette.text.primary` so the icon always uses the theme's
primary text color, which is guaranteed to be readable against any
AppBar background.

## Changes
- `src/index.tsx`: add `color={theme.palette.text.primary}` to the
  TopBar Icon component

## Steps to Test
1. Open Headlamp desktop app
2. Switch to a theme with a colored TopBar (e.g. aksd theme)
3. Verify the AI assistant icon in the TopBar is clearly visible