### PR TITLE
flux: Inventory: Fix memory leak in API subscriptions

### DIFF
--- a/flux/src/kustomizations/Inventory.tsx
+++ b/flux/src/kustomizations/Inventory.tsx
@@ -36,6 +36,9 @@ export function GetResourcesFromInventory(
   const [resources, setResources] = React.useState<KubeObject[]>([]);
 
   React.useEffect(() => {
+    setResources([]);
+    const unsubscribes: Promise<() => void>[] = [];
+
     props.inventory?.forEach(item => {
       const parsedID = parseID(item.id);
       const { name, namespace, group, kind } = parsedID;
@@ -51,7 +54,7 @@ export function GetResourcesFromInventory(
         customResourceDefinition: undefined as any,
       });
 
-      resourceClass.apiGet(
+      const unsubscribe = resourceClass.apiGet(
         data => {
           // add the resource if it does not exist yet, compare with uid.
           setResources(prevResources => {
@@ -70,8 +73,24 @@ export function GetResourcesFromInventory(
           });
         }
       )();
+
+      unsubscribes.push(unsubscribe);
     });
-  }, []);
+
+    return () => {
+      unsubscribes.forEach(unsubscribePromise => {
+        unsubscribePromise
+          .then(cancelFn => {
+            if (typeof cancelFn === 'function') {
+              cancelFn();
+            }
+          })
+          .catch(() => {
+            /* ignore */
+          });
+      });
+    };
+  }, [props.inventory]);
 
   return (
     <Table


### PR DESCRIPTION


### Description
I noticed a small bug in the `GetResourcesFromInventory` component (inside `src/kustomizations/Inventory.tsx`) where it was causing a memory leak and showing outdated data.

Basically, the `useEffect` hook was looping over `props.inventory` and making background API calls for each item using `resourceClass.apiGet(...)()`. But there were two main issues:
1. **Memory Leak:** The `apiGet` method actually gives us an `unsubscribe` function back to stop the API call, but we were not using it. Because we didn't add a cleanup function in the `useEffect`, these API calls kept running endlessly in the background even after the component was closed/unmounted. This could casue React warnings like `Can't perform a React state update on an unmounted component`.
2. **Stale Data:** The dependency array for the `useEffect` was left empty (`[]`). So, the code only ran once when the component loaded. If the `props.inventory` got updated later on (like if new resources were added or removed), the UI wouldn't update and just kept showing the old data.

### Changes Made
* **Added Cleanup Logic:** I have captured the `unsubscribe` functions returned by the API calls into an array and executed them in the `useEffect` return statement. This properly stops all the background API watchers when the component unmounts.
* **Updated Dependencies:** I added `props.inventory` to the `useEffect` dependency array. Now, whenever the inventory updates, the component correctly refreshes and clears out the old subscriptions.



