### PR TITLE
strimzi: api: Add runtime v1/v1beta2 API version detection

### DIFF
--- a/strimzi/README.md
+++ b/strimzi/README.md
@@ -41,7 +41,7 @@ A Headlamp plugin for managing Strimzi (Apache Kafka on Kubernetes) resources di
 ## 📋 Prerequisites
 
 - [Headlamp](https://headlamp.dev/) installed
-- A Kubernetes cluster with [Strimzi operator](https://strimzi.io/) deployed
+- A Kubernetes cluster with [Strimzi operator](https://strimzi.io/) deployed (0.x with `v1beta2` APIs, or 1.0+ with `v1` APIs; the plugin detects and uses whichever version the cluster serves)
 
 ## 🚀 Quick Start
 

--- a/strimzi/src/components/KafkaClusterTopology.tsx
+++ b/strimzi/src/components/KafkaClusterTopology.tsx
@@ -635,7 +635,7 @@ function TopologyFlow({ kafka, onEditResource }: TopologyProps) {
         console.error('Failed to fetch Kafka topology data:', err);
         setLoading(false);
       });
-  }, [kafka.metadata.name, kafka.metadata.namespace]);
+  }, [kafka.metadata.name, kafka.metadata.namespace, kafkaVersion, coreVersion]);
 
   // Generate topology nodes
   React.useEffect(() => {

--- a/strimzi/src/components/KafkaClusterTopology.tsx
+++ b/strimzi/src/components/KafkaClusterTopology.tsx
@@ -14,6 +14,7 @@ import { Button, ButtonGroup, Box, useTheme, Chip } from '@mui/material';
 import type { KafkaInterface } from '../resources';
 import { KafkaNodePool, StrimziPodSet, isKRaftMode } from '../crds';
 import { ApiProxy } from '@kinvolk/headlamp-plugin/lib';
+import { useStrimziApiVersions } from '../hooks/useStrimziApiVersions';
 import { useTopologyTheme } from '../hooks/useTopologyTheme';
 import { hexToRgba } from '../utils/topologyColors';
 
@@ -582,6 +583,7 @@ function TopologyFlow({ kafka, onEditResource }: TopologyProps) {
   const [nodes, setNodes] = React.useState<Node[]>([]);
 
   const theme = useTopologyTheme();
+  const { kafka: kafkaVersion, core: coreVersion } = useStrimziApiVersions();
 
   const isKRaft = React.useMemo(() => isKRaftMode(kafka), [kafka]);
   const clusterReady = React.useMemo(
@@ -595,8 +597,8 @@ function TopologyFlow({ kafka, onEditResource }: TopologyProps) {
     const namespace = kafka.metadata.namespace;
 
     Promise.all([
-      ApiProxy.request('/apis/kafka.strimzi.io/v1beta2/kafkanodepools'),
-      ApiProxy.request('/apis/core.strimzi.io/v1beta2/strimzipodsets'),
+      ApiProxy.request(`/apis/kafka.strimzi.io/${kafkaVersion}/kafkanodepools`),
+      ApiProxy.request(`/apis/core.strimzi.io/${coreVersion}/strimzipodsets`),
       ApiProxy.request(
         `/api/v1/namespaces/${namespace}/pods?labelSelector=strimzi.io/cluster=${clusterName}`
       ),
@@ -966,7 +968,7 @@ function TopologyFlow({ kafka, onEditResource }: TopologyProps) {
           </div>
         ),
         editInfo: onEditResource ? {
-          resourceUrl: `/apis/kafka.strimzi.io/v1beta2/namespaces/${namespace}/kafkas/${clusterName}`,
+          resourceUrl: `/apis/kafka.strimzi.io/${kafkaVersion}/namespaces/${namespace}/kafkas/${clusterName}`,
           resourceName: clusterName,
           resourceKind: 'Kafka',
         } : undefined,
@@ -1059,7 +1061,7 @@ function TopologyFlow({ kafka, onEditResource }: TopologyProps) {
             resourceType: 'KafkaNodePool',
             replicaInfo: `Replicas: ${replicas}`,
             editInfo: onEditResource ? {
-              resourceUrl: `/apis/kafka.strimzi.io/v1beta2/namespaces/${namespace}/kafkanodepools/${poolName}`,
+              resourceUrl: `/apis/kafka.strimzi.io/${kafkaVersion}/namespaces/${namespace}/kafkanodepools/${poolName}`,
               resourceName: poolName,
               resourceKind: 'KafkaNodePool',
             } : undefined,
@@ -1101,7 +1103,7 @@ function TopologyFlow({ kafka, onEditResource }: TopologyProps) {
               resourceType: 'StrimziPodSet',
               replicaInfo: `Ready Pods: ${readyPodsCount}/${nodeIds.length}`,
               editInfo: onEditResource ? {
-                resourceUrl: `/apis/core.strimzi.io/v1beta2/namespaces/${namespace}/strimzipodsets/${podSet.metadata.name}`,
+                resourceUrl: `/apis/core.strimzi.io/${coreVersion}/namespaces/${namespace}/strimzipodsets/${podSet.metadata.name}`,
                 resourceName: podSet.metadata.name,
                 resourceKind: 'StrimziPodSet',
               } : undefined,
@@ -1184,7 +1186,7 @@ function TopologyFlow({ kafka, onEditResource }: TopologyProps) {
             resourceType: 'StrimziPodSet',
             replicaInfo: `Ready Pods: ${readyPodsCount}/${brokerCount}`,
             editInfo: onEditResource ? {
-              resourceUrl: `/apis/core.strimzi.io/v1beta2/namespaces/${namespace}/strimzipodsets/${kafkaPodSet.metadata.name}`,
+              resourceUrl: `/apis/core.strimzi.io/${coreVersion}/namespaces/${namespace}/strimzipodsets/${kafkaPodSet.metadata.name}`,
               resourceName: kafkaPodSet.metadata.name,
               resourceKind: 'StrimziPodSet',
             } : undefined,
@@ -1269,7 +1271,7 @@ function TopologyFlow({ kafka, onEditResource }: TopologyProps) {
             resourceType: 'StrimziPodSet',
             replicaInfo: `Ready Pods: ${zkReadyPodsCount}/${zkCount}`,
             editInfo: onEditResource ? {
-              resourceUrl: `/apis/core.strimzi.io/v1beta2/namespaces/${namespace}/strimzipodsets/${zkPodSet.metadata.name}`,
+              resourceUrl: `/apis/core.strimzi.io/${coreVersion}/namespaces/${namespace}/strimzipodsets/${zkPodSet.metadata.name}`,
               resourceName: zkPodSet.metadata.name,
               resourceKind: 'StrimziPodSet',
             } : undefined,
@@ -1346,7 +1348,7 @@ function TopologyFlow({ kafka, onEditResource }: TopologyProps) {
             resourceType: 'StrimziPodSet',
             replicaInfo: `Ready Pods: ${kafkaReadyPodsCount}/${brokerCount}`,
             editInfo: onEditResource ? {
-              resourceUrl: `/apis/core.strimzi.io/v1beta2/namespaces/${namespace}/strimzipodsets/${kafkaPodSet.metadata.name}`,
+              resourceUrl: `/apis/core.strimzi.io/${coreVersion}/namespaces/${namespace}/strimzipodsets/${kafkaPodSet.metadata.name}`,
               resourceName: kafkaPodSet.metadata.name,
               resourceKind: 'StrimziPodSet',
             } : undefined,

--- a/strimzi/src/components/KafkaConnectList.tsx
+++ b/strimzi/src/components/KafkaConnectList.tsx
@@ -9,6 +9,7 @@ import {
 import { KafkaConnect, KafkaConnectV1 } from '../resources/kafkaConnect';
 import { readyChipProps } from '../utils/readyChip';
 import { useStrimziApiVersions } from '../hooks/useStrimziApiVersions';
+import { StrimziNotInstalledMessage } from './StrimziNotInstalledMessage';
 
 /**
  * List view for Strimzi `KafkaConnect` resources (Kafka Connect clusters).
@@ -20,8 +21,10 @@ import { useStrimziApiVersions } from '../hooks/useStrimziApiVersions';
  */
 export function KafkaConnectList() {
   const theme = useTheme();
-  const { kafka: kafkaVersion } = useStrimziApiVersions();
+  const { ready, installed, kafka: kafkaVersion } = useStrimziApiVersions();
   const KafkaConnectClass = kafkaVersion === 'v1' ? KafkaConnectV1 : KafkaConnect;
+
+  if (ready && !installed) return <StrimziNotInstalledMessage />;
 
   const columns: (ColumnType | ResourceTableColumn<KafkaConnect>)[] = [
     'name',

--- a/strimzi/src/components/KafkaConnectList.tsx
+++ b/strimzi/src/components/KafkaConnectList.tsx
@@ -6,8 +6,9 @@ import {
   type ColumnType,
   type ResourceTableColumn,
 } from '@kinvolk/headlamp-plugin/lib/components/common';
-import { KafkaConnect } from '../resources/kafkaConnect';
+import { KafkaConnect, KafkaConnectV1 } from '../resources/kafkaConnect';
 import { readyChipProps } from '../utils/readyChip';
+import { useStrimziApiVersions } from '../hooks/useStrimziApiVersions';
 
 /**
  * List view for Strimzi `KafkaConnect` resources (Kafka Connect clusters).
@@ -19,6 +20,8 @@ import { readyChipProps } from '../utils/readyChip';
  */
 export function KafkaConnectList() {
   const theme = useTheme();
+  const { kafka: kafkaVersion } = useStrimziApiVersions();
+  const KafkaConnectClass = kafkaVersion === 'v1' ? KafkaConnectV1 : KafkaConnect;
 
   const columns: (ColumnType | ResourceTableColumn<KafkaConnect>)[] = [
     'name',
@@ -64,6 +67,6 @@ export function KafkaConnectList() {
   ];
 
   return (
-    <ResourceListView title="Kafka Connect Clusters" resourceClass={KafkaConnect} columns={columns} />
+    <ResourceListView title="Kafka Connect Clusters" resourceClass={KafkaConnectClass} columns={columns} />
   );
 }

--- a/strimzi/src/components/KafkaConnectorList.tsx
+++ b/strimzi/src/components/KafkaConnectorList.tsx
@@ -15,9 +15,10 @@ import {
   type ColumnType,
   type ResourceTableColumn,
 } from '@kinvolk/headlamp-plugin/lib/components/common';
-import { KafkaConnector } from '../resources/kafkaConnector';
+import { KafkaConnector, KafkaConnectorV1 } from '../resources/kafkaConnector';
 import type { KafkaConnectorInterface, KafkaConnectorState } from '../resources/kafkaConnector';
 import { getErrorMessage } from '../utils/errors';
+import { useStrimziApiVersions } from '../hooks/useStrimziApiVersions';
 import { readyChipProps } from '../utils/readyChip';
 import { Toast, ToastMessage } from './Toast';
 
@@ -38,6 +39,9 @@ const STATE_CHIP_COLORS: Record<KafkaConnectorState, 'success' | 'warning' | 'de
  */
 export function KafkaConnectorList() {
   const theme = useTheme();
+  const { kafka: kafkaVersion } = useStrimziApiVersions();
+  const KafkaConnectorClass = kafkaVersion === 'v1' ? KafkaConnectorV1 : KafkaConnector;
+
   const [toast, setToast] = React.useState<ToastMessage | null>(null);
   const [pendingState, setPendingState] = React.useState<{
     connector: KafkaConnectorInterface;
@@ -48,7 +52,7 @@ export function KafkaConnectorList() {
     connector: KafkaConnectorInterface,
     targetState: KafkaConnectorState
   ) => {
-    const path = `/apis/kafka.strimzi.io/v1beta2/namespaces/${connector.metadata.namespace}/kafkaconnectors/${connector.metadata.name}`;
+    const path = `/apis/kafka.strimzi.io/${kafkaVersion}/namespaces/${connector.metadata.namespace}/kafkaconnectors/${connector.metadata.name}`;
     try {
       await ApiProxy.request(path, {
         method: 'PATCH',
@@ -183,7 +187,7 @@ export function KafkaConnectorList() {
 
   return (
     <>
-      <ResourceListView title="Kafka Connectors" resourceClass={KafkaConnector} columns={columns} />
+      <ResourceListView title="Kafka Connectors" resourceClass={KafkaConnectorClass} columns={columns} />
       <Dialog
         open={pendingState !== null}
         onClose={() => setPendingState(null)}

--- a/strimzi/src/components/KafkaConnectorList.tsx
+++ b/strimzi/src/components/KafkaConnectorList.tsx
@@ -19,6 +19,7 @@ import { KafkaConnector, KafkaConnectorV1 } from '../resources/kafkaConnector';
 import type { KafkaConnectorInterface, KafkaConnectorState } from '../resources/kafkaConnector';
 import { getErrorMessage } from '../utils/errors';
 import { useStrimziApiVersions } from '../hooks/useStrimziApiVersions';
+import { StrimziNotInstalledMessage } from './StrimziNotInstalledMessage';
 import { readyChipProps } from '../utils/readyChip';
 import { Toast, ToastMessage } from './Toast';
 
@@ -39,8 +40,10 @@ const STATE_CHIP_COLORS: Record<KafkaConnectorState, 'success' | 'warning' | 'de
  */
 export function KafkaConnectorList() {
   const theme = useTheme();
-  const { kafka: kafkaVersion } = useStrimziApiVersions();
+  const { ready, installed, kafka: kafkaVersion } = useStrimziApiVersions();
   const KafkaConnectorClass = kafkaVersion === 'v1' ? KafkaConnectorV1 : KafkaConnector;
+
+  if (ready && !installed) return <StrimziNotInstalledMessage />;
 
   const [toast, setToast] = React.useState<ToastMessage | null>(null);
   const [pendingState, setPendingState] = React.useState<{

--- a/strimzi/src/components/KafkaList.tsx
+++ b/strimzi/src/components/KafkaList.tsx
@@ -5,11 +5,15 @@ import {
   type ColumnType,
   type ResourceTableColumn,
 } from '@kinvolk/headlamp-plugin/lib/components/common';
-import { Kafka } from '../resources/kafka';
+import { Kafka, KafkaV1 } from '../resources/kafka';
 import { KafkaTopologyModal } from './KafkaTopologyModal';
 import type { KafkaInterface } from '../resources/kafka';
+import { useStrimziApiVersions } from '../hooks/useStrimziApiVersions';
 
 export function KafkaList() {
+  const { kafka: kafkaVersion } = useStrimziApiVersions();
+  const KafkaClass = kafkaVersion === 'v1' ? KafkaV1 : Kafka;
+
   const [selectedKafka, setSelectedKafka] = React.useState<KafkaInterface | null>(null);
   const [isTopologyModalOpen, setIsTopologyModalOpen] = React.useState(false);
 
@@ -60,7 +64,7 @@ export function KafkaList() {
     <>
       <ResourceListView
         title="Kafka Clusters"
-        resourceClass={Kafka}
+        resourceClass={KafkaClass}
         columns={columns}
       />
       <KafkaTopologyModal

--- a/strimzi/src/components/KafkaList.tsx
+++ b/strimzi/src/components/KafkaList.tsx
@@ -9,10 +9,13 @@ import { Kafka, KafkaV1 } from '../resources/kafka';
 import { KafkaTopologyModal } from './KafkaTopologyModal';
 import type { KafkaInterface } from '../resources/kafka';
 import { useStrimziApiVersions } from '../hooks/useStrimziApiVersions';
+import { StrimziNotInstalledMessage } from './StrimziNotInstalledMessage';
 
 export function KafkaList() {
-  const { kafka: kafkaVersion } = useStrimziApiVersions();
+  const { ready, installed, kafka: kafkaVersion } = useStrimziApiVersions();
   const KafkaClass = kafkaVersion === 'v1' ? KafkaV1 : Kafka;
+
+  if (ready && !installed) return <StrimziNotInstalledMessage />;
 
   const [selectedKafka, setSelectedKafka] = React.useState<KafkaInterface | null>(null);
   const [isTopologyModalOpen, setIsTopologyModalOpen] = React.useState(false);

--- a/strimzi/src/components/KafkaTopicList.tsx
+++ b/strimzi/src/components/KafkaTopicList.tsx
@@ -7,14 +7,18 @@ import {
   type ColumnType,
   type ResourceTableColumn,
 } from '@kinvolk/headlamp-plugin/lib/components/common';
-import { Kafka, KafkaTopic } from '../resources';
+import { Kafka, KafkaTopic, KafkaTopicV1 } from '../resources';
 import type { KafkaTopicInterface } from '../resources';
 import { getErrorMessage } from '../utils/errors';
+import { useStrimziApiVersions } from '../hooks/useStrimziApiVersions';
 import { Toast, ToastMessage } from './Toast';
 import { TopicFormModal, type TopicFormData } from './TopicFormModal';
 
 export function KafkaTopicList() {
   const theme = useTheme();
+  const { kafka: kafkaVersion } = useStrimziApiVersions();
+  const KafkaTopicClass = kafkaVersion === 'v1' ? KafkaTopicV1 : KafkaTopic;
+  const kafkaApiPath = `/apis/kafka.strimzi.io/${kafkaVersion}`;
   const { items: kafkaClusters } = Kafka.useList({});
   const [toast, setToast] = React.useState<ToastMessage | null>(null);
   const [showCreateDialog, setShowCreateDialog] = React.useState(false);
@@ -47,7 +51,7 @@ export function KafkaTopicList() {
     setLoading(true);
     try {
       const topicResource = {
-        apiVersion: 'kafka.strimzi.io/v1beta2',
+        apiVersion: 'kafka.strimzi.io/' + kafkaVersion,
         kind: 'KafkaTopic',
         metadata: {
           name: formData.name,
@@ -68,7 +72,7 @@ export function KafkaTopicList() {
       };
 
       await ApiProxy.request(
-        `/apis/kafka.strimzi.io/v1beta2/namespaces/${formData.namespace}/kafkatopics`,
+        `${kafkaApiPath}/namespaces/${formData.namespace}/kafkatopics`,
         {
           method: 'POST',
           body: JSON.stringify(topicResource),
@@ -112,7 +116,7 @@ export function KafkaTopicList() {
       };
 
       await ApiProxy.request(
-        `/apis/kafka.strimzi.io/v1beta2/namespaces/${editingTopic.metadata.namespace}/kafkatopics/${editingTopic.metadata.name}`,
+        `${kafkaApiPath}/namespaces/${editingTopic.metadata.namespace}/kafkatopics/${editingTopic.metadata.name}`,
         {
           method: 'PUT',
           body: JSON.stringify(updatedTopic),
@@ -142,7 +146,7 @@ export function KafkaTopicList() {
 
     try {
       await ApiProxy.request(
-        `/apis/kafka.strimzi.io/v1beta2/namespaces/${deletingTopic.metadata.namespace}/kafkatopics/${deletingTopic.metadata.name}`,
+        `${kafkaApiPath}/namespaces/${deletingTopic.metadata.namespace}/kafkatopics/${deletingTopic.metadata.name}`,
         { method: 'DELETE' }
       );
       setToast({ message: `Topic "${deletingTopic.metadata.name}" deleted successfully`, type: 'success' });
@@ -252,7 +256,7 @@ export function KafkaTopicList() {
     <>
       <ResourceListView
         title="Kafka Topics"
-        resourceClass={KafkaTopic}
+        resourceClass={KafkaTopicClass}
         columns={columns}
         headerProps={{
           titleSideActions: [

--- a/strimzi/src/components/KafkaTopicList.tsx
+++ b/strimzi/src/components/KafkaTopicList.tsx
@@ -7,19 +7,23 @@ import {
   type ColumnType,
   type ResourceTableColumn,
 } from '@kinvolk/headlamp-plugin/lib/components/common';
-import { Kafka, KafkaTopic, KafkaTopicV1 } from '../resources';
+import { Kafka, KafkaV1, KafkaTopic, KafkaTopicV1 } from '../resources';
 import type { KafkaTopicInterface } from '../resources';
 import { getErrorMessage } from '../utils/errors';
 import { useStrimziApiVersions } from '../hooks/useStrimziApiVersions';
+import { StrimziNotInstalledMessage } from './StrimziNotInstalledMessage';
 import { Toast, ToastMessage } from './Toast';
 import { TopicFormModal, type TopicFormData } from './TopicFormModal';
 
 export function KafkaTopicList() {
   const theme = useTheme();
-  const { kafka: kafkaVersion } = useStrimziApiVersions();
+  const { ready, installed, kafka: kafkaVersion } = useStrimziApiVersions();
+  const KafkaClass = kafkaVersion === 'v1' ? KafkaV1 : Kafka;
   const KafkaTopicClass = kafkaVersion === 'v1' ? KafkaTopicV1 : KafkaTopic;
   const kafkaApiPath = `/apis/kafka.strimzi.io/${kafkaVersion}`;
-  const { items: kafkaClusters } = Kafka.useList({});
+
+  // All hooks must be called before any early return (Rules of Hooks).
+  const { items: kafkaClusters } = KafkaClass.useList({});
   const [toast, setToast] = React.useState<ToastMessage | null>(null);
   const [showCreateDialog, setShowCreateDialog] = React.useState(false);
   const [showEditDialog, setShowEditDialog] = React.useState(false);
@@ -251,6 +255,8 @@ export function KafkaTopicList() {
     },
     'age',
   ];
+
+  if (ready && !installed) return <StrimziNotInstalledMessage />;
 
   return (
     <>

--- a/strimzi/src/components/KafkaUserList.tsx
+++ b/strimzi/src/components/KafkaUserList.tsx
@@ -7,20 +7,24 @@ import {
   type ColumnType,
   type ResourceTableColumn,
 } from '@kinvolk/headlamp-plugin/lib/components/common';
-import { Kafka, KafkaUser, KafkaUserV1 } from '../resources';
+import { Kafka, KafkaV1, KafkaUser, KafkaUserV1 } from '../resources';
 import type { CreateKafkaUserPayload, KafkaUserInterface } from '../resources';
 import { getErrorMessage } from '../utils/errors';
 import { useStrimziApiVersions } from '../hooks/useStrimziApiVersions';
+import { StrimziNotInstalledMessage } from './StrimziNotInstalledMessage';
 import { SecureSecretDisplay } from './SecureSecretDisplay';
 import { Toast, ToastMessage } from './Toast';
 import { KafkaUserCreateFormModal, type UserFormData } from './KafkaUserCreateFormModal';
 
 export function KafkaUserList() {
   const theme = useTheme();
-  const { kafka: kafkaVersion } = useStrimziApiVersions();
+  const { ready, installed, kafka: kafkaVersion } = useStrimziApiVersions();
+  const KafkaClass = kafkaVersion === 'v1' ? KafkaV1 : Kafka;
   const KafkaUserClass = kafkaVersion === 'v1' ? KafkaUserV1 : KafkaUser;
   const kafkaApiPath = `/apis/kafka.strimzi.io/${kafkaVersion}`;
-  const { items: kafkaClusters } = Kafka.useList({});
+
+  // All hooks must be called before any early return (Rules of Hooks).
+  const { items: kafkaClusters } = KafkaClass.useList({});
   const [toast, setToast] = React.useState<ToastMessage | null>(null);
   const [showCreateDialog, setShowCreateDialog] = React.useState(false);
   const [showDeleteDialog, setShowDeleteDialog] = React.useState(false);
@@ -267,6 +271,8 @@ export function KafkaUserList() {
     },
     'age',
   ];
+
+  if (ready && !installed) return <StrimziNotInstalledMessage />;
 
   return (
     <>

--- a/strimzi/src/components/KafkaUserList.tsx
+++ b/strimzi/src/components/KafkaUserList.tsx
@@ -7,15 +7,19 @@ import {
   type ColumnType,
   type ResourceTableColumn,
 } from '@kinvolk/headlamp-plugin/lib/components/common';
-import { Kafka, KafkaUser } from '../resources';
+import { Kafka, KafkaUser, KafkaUserV1 } from '../resources';
 import type { CreateKafkaUserPayload, KafkaUserInterface } from '../resources';
 import { getErrorMessage } from '../utils/errors';
+import { useStrimziApiVersions } from '../hooks/useStrimziApiVersions';
 import { SecureSecretDisplay } from './SecureSecretDisplay';
 import { Toast, ToastMessage } from './Toast';
 import { KafkaUserCreateFormModal, type UserFormData } from './KafkaUserCreateFormModal';
 
 export function KafkaUserList() {
   const theme = useTheme();
+  const { kafka: kafkaVersion } = useStrimziApiVersions();
+  const KafkaUserClass = kafkaVersion === 'v1' ? KafkaUserV1 : KafkaUser;
+  const kafkaApiPath = `/apis/kafka.strimzi.io/${kafkaVersion}`;
   const { items: kafkaClusters } = Kafka.useList({});
   const [toast, setToast] = React.useState<ToastMessage | null>(null);
   const [showCreateDialog, setShowCreateDialog] = React.useState(false);
@@ -80,7 +84,7 @@ export function KafkaUserList() {
     setLoading(true);
     try {
       const userResource: CreateKafkaUserPayload = {
-        apiVersion: 'kafka.strimzi.io/v1beta2',
+        apiVersion: `kafka.strimzi.io/${kafkaVersion}`,
         kind: 'KafkaUser',
         metadata: {
           name: formData.name,
@@ -104,7 +108,7 @@ export function KafkaUserList() {
       }
 
       await ApiProxy.request(
-        `/apis/kafka.strimzi.io/v1beta2/namespaces/${formData.namespace}/kafkausers`,
+        `${kafkaApiPath}/namespaces/${formData.namespace}/kafkausers`,
         {
           method: 'POST',
           body: JSON.stringify(userResource),
@@ -142,7 +146,7 @@ export function KafkaUserList() {
 
     try {
       await ApiProxy.request(
-        `/apis/kafka.strimzi.io/v1beta2/namespaces/${deletingUser.metadata.namespace}/kafkausers/${deletingUser.metadata.name}`,
+        `${kafkaApiPath}/namespaces/${deletingUser.metadata.namespace}/kafkausers/${deletingUser.metadata.name}`,
         { method: 'DELETE' }
       );
       setToast({ message: `User "${deletingUser.metadata.name}" deleted successfully`, type: 'success' });
@@ -268,7 +272,7 @@ export function KafkaUserList() {
     <>
       <ResourceListView
         title="Kafka Users"
-        resourceClass={KafkaUser}
+        resourceClass={KafkaUserClass}
         columns={columns}
         headerProps={{
           titleSideActions: [

--- a/strimzi/src/components/StrimziErrorBoundary.tsx
+++ b/strimzi/src/components/StrimziErrorBoundary.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { Box, Typography } from '@mui/material';
+import { SectionBox } from '@kinvolk/headlamp-plugin/lib/components/common';
+
+interface State {
+  hasError: boolean;
+  message: string;
+}
+
+/**
+ * React Error Boundary for the Strimzi plugin.
+ *
+ * Wrapping every plugin route in this boundary ensures that uncaught
+ * render errors inside any Strimzi component are contained here and
+ * never propagate up to Headlamp's root. Without this, a render crash
+ * inside the plugin can blank the entire Headlamp UI.
+ */
+export class StrimziErrorBoundary extends React.Component<
+  React.PropsWithChildren<unknown>,
+  State
+> {
+  constructor(props: React.PropsWithChildren<unknown>) {
+    super(props);
+    this.state = { hasError: false, message: '' };
+  }
+
+  static getDerivedStateFromError(error: unknown): State {
+    const message =
+      error instanceof Error ? error.message : 'An unexpected error occurred.';
+    return { hasError: true, message };
+  }
+
+  componentDidCatch(error: unknown, info: React.ErrorInfo) {
+    console.error('[Strimzi plugin] Render error:', error, info.componentStack);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <SectionBox title="Strimzi plugin error">
+          <Box sx={{ p: 2 }}>
+            <Typography variant="body1" gutterBottom>
+              Something went wrong while rendering this view.
+            </Typography>
+            <Typography variant="body2" color="text.secondary" component="pre" sx={{ whiteSpace: 'pre-wrap' }}>
+              {this.state.message}
+            </Typography>
+          </Box>
+        </SectionBox>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/strimzi/src/components/StrimziNotInstalledMessage.tsx
+++ b/strimzi/src/components/StrimziNotInstalledMessage.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Box, Typography, Link } from '@mui/material';
+import { SectionBox } from '@kinvolk/headlamp-plugin/lib/components/common';
+
+/**
+ * Shown in place of any Strimzi list view when the kafka.strimzi.io API
+ * group is not present on the cluster (i.e. the Strimzi operator is not
+ * installed).
+ */
+export function StrimziNotInstalledMessage() {
+  return (
+    <SectionBox title="Strimzi not detected">
+      <Box sx={{ p: 2 }}>
+        <Typography variant="body1" gutterBottom>
+          The Strimzi operator was not found on this cluster. Install Strimzi to
+          use this plugin.
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          See the{' '}
+          <Link
+            href="https://strimzi.io/quickstarts/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Strimzi quick-start guide
+          </Link>{' '}
+          for installation instructions.
+        </Typography>
+      </Box>
+    </SectionBox>
+  );
+}

--- a/strimzi/src/crds.ts
+++ b/strimzi/src/crds.ts
@@ -19,10 +19,15 @@ export interface K8sListResponse<T> {
 // Re-export resource classes and their interfaces
 export {
   Kafka,
+  KafkaV1,
   KafkaConnect,
+  KafkaConnectV1,
   KafkaConnector,
+  KafkaConnectorV1,
   KafkaTopic,
+  KafkaTopicV1,
   KafkaUser,
+  KafkaUserV1,
   type ConnectorPlugin,
   type KafkaConnectInterface,
   type KafkaConnectSpec,

--- a/strimzi/src/hooks/useStrimziApiVersions.ts
+++ b/strimzi/src/hooks/useStrimziApiVersions.ts
@@ -1,0 +1,39 @@
+/**
+ * React hook that returns the Strimzi API versions available on the
+ * current cluster, triggering a re-render once the probe completes.
+ *
+ * Components use the returned `kafka` and `core` version strings to
+ * select the right KubeObject class and to build API paths for direct
+ * `ApiProxy.request` calls.
+ *
+ * @example
+ * ```tsx
+ * const { kafka: kafkaVersion } = useStrimziApiVersions();
+ * const KafkaClass = kafkaVersion === 'v1' ? KafkaV1 : Kafka;
+ * return <ResourceListView resourceClass={KafkaClass} ... />;
+ * ```
+ */
+import React from 'react';
+import {
+  getStrimziApiVersions,
+  resolveStrimziApiVersions,
+  type StrimziApiVersions,
+} from '../utils/strimziApiVersion';
+
+export function useStrimziApiVersions(): StrimziApiVersions {
+  const [versions, setVersions] = React.useState<StrimziApiVersions>(
+    getStrimziApiVersions
+  );
+
+  React.useEffect(() => {
+    let cancelled = false;
+    resolveStrimziApiVersions().then(resolved => {
+      if (!cancelled) setVersions(resolved);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return versions;
+}

--- a/strimzi/src/index.tsx
+++ b/strimzi/src/index.tsx
@@ -10,6 +10,20 @@ import { KafkaConnectDetail } from './components/connects/Detail';
 import { KafkaConnectList } from './components/KafkaConnectList';
 import { KafkaConnectorDetail } from './components/connectors/Detail';
 import { KafkaConnectorList } from './components/KafkaConnectorList';
+import { StrimziErrorBoundary } from './components/StrimziErrorBoundary';
+
+/**
+ * Wraps a component in StrimziErrorBoundary so that any uncaught render
+ * error inside the plugin is contained here and never propagates up to
+ * Headlamp's root React tree.
+ */
+function safe(Component: React.ComponentType): () => React.ReactElement {
+  function SafeWrapper(): React.ReactElement {
+    return React.createElement(StrimziErrorBoundary, null, React.createElement(Component));
+  }
+  SafeWrapper.displayName = `Safe(${Component.displayName ?? Component.name})`;
+  return SafeWrapper;
+}
 
 // List routes
 registerRoute({
@@ -17,7 +31,7 @@ registerRoute({
   sidebar: 'kafkas',
   name: 'Kafka Clusters',
   exact: true,
-  component: () => React.createElement(KafkaList),
+  component: safe(KafkaList),
 });
 
 registerRoute({
@@ -25,7 +39,7 @@ registerRoute({
   sidebar: 'topics',
   name: 'Kafka Topics',
   exact: true,
-  component: () => React.createElement(KafkaTopicList),
+  component: safe(KafkaTopicList),
 });
 
 registerRoute({
@@ -33,7 +47,7 @@ registerRoute({
   sidebar: 'users',
   name: 'Kafka Users',
   exact: true,
-  component: () => React.createElement(KafkaUserList),
+  component: safe(KafkaUserList),
 });
 
 registerRoute({
@@ -41,7 +55,7 @@ registerRoute({
   sidebar: 'connects',
   name: 'Kafka Connect Clusters',
   exact: true,
-  component: () => React.createElement(KafkaConnectList),
+  component: safe(KafkaConnectList),
 });
 
 registerRoute({
@@ -49,7 +63,7 @@ registerRoute({
   sidebar: 'connectors',
   name: 'Kafka Connectors',
   exact: true,
-  component: () => React.createElement(KafkaConnectorList),
+  component: safe(KafkaConnectorList),
 });
 
 // Detail routes (used by ResourceListView name link and direct navigation)
@@ -58,7 +72,7 @@ registerRoute({
   sidebar: 'kafkas',
   name: 'Kafka Cluster',
   exact: true,
-  component: () => React.createElement(KafkaDetail),
+  component: safe(KafkaDetail),
 });
 
 registerRoute({
@@ -66,7 +80,7 @@ registerRoute({
   sidebar: 'topics',
   name: 'Kafka Topic',
   exact: true,
-  component: () => React.createElement(KafkaTopicDetail),
+  component: safe(KafkaTopicDetail),
 });
 
 registerRoute({
@@ -74,7 +88,7 @@ registerRoute({
   sidebar: 'users',
   name: 'Kafka User',
   exact: true,
-  component: () => React.createElement(KafkaUserDetail),
+  component: safe(KafkaUserDetail),
 });
 
 registerRoute({
@@ -82,7 +96,7 @@ registerRoute({
   sidebar: 'connects',
   name: 'Kafka Connect Cluster',
   exact: true,
-  component: () => React.createElement(KafkaConnectDetail),
+  component: safe(KafkaConnectDetail),
 });
 
 registerRoute({
@@ -90,7 +104,7 @@ registerRoute({
   sidebar: 'connectors',
   name: 'Kafka Connector',
   exact: true,
-  component: () => React.createElement(KafkaConnectorDetail),
+  component: safe(KafkaConnectorDetail),
 });
 
 // Register sidebar entries

--- a/strimzi/src/resources/index.ts
+++ b/strimzi/src/resources/index.ts
@@ -3,12 +3,14 @@ export * from './kafka';
 export * from './kafkaTopic';
 export {
   KafkaUser,
+  KafkaUserV1,
   type CreateKafkaUserPayload,
   type KafkaUserInterface,
   type KafkaUserSpec,
 } from './kafkaUser';
 export {
   KafkaConnect,
+  KafkaConnectV1,
   type ConnectorPlugin,
   type KafkaConnectInterface,
   type KafkaConnectSpec,
@@ -16,6 +18,7 @@ export {
 } from './kafkaConnect';
 export {
   KafkaConnector,
+  KafkaConnectorV1,
   type KafkaConnectorInterface,
   type KafkaConnectorSpec,
   type KafkaConnectorState,

--- a/strimzi/src/resources/kafka.ts
+++ b/strimzi/src/resources/kafka.ts
@@ -96,3 +96,8 @@ export class Kafka extends KubeObject<KafkaInterface> {
     return 'N/A';
   }
 }
+
+/** Kafka resource class targeting the `kafka.strimzi.io/v1` API (Strimzi 1.0.0+). */
+export class KafkaV1 extends Kafka {
+  static apiVersion = 'kafka.strimzi.io/v1';
+}

--- a/strimzi/src/resources/kafkaConnect.ts
+++ b/strimzi/src/resources/kafkaConnect.ts
@@ -121,3 +121,8 @@ export class KafkaConnect extends KubeObject<KafkaConnectInterface> {
     return this.status?.connectorPlugins ?? [];
   }
 }
+
+/** KafkaConnect resource class targeting the `kafka.strimzi.io/v1` API (Strimzi 1.0.0+). */
+export class KafkaConnectV1 extends KafkaConnect {
+  static apiVersion = 'kafka.strimzi.io/v1';
+}

--- a/strimzi/src/resources/kafkaConnector.ts
+++ b/strimzi/src/resources/kafkaConnector.ts
@@ -125,3 +125,16 @@ export class KafkaConnector extends KubeObject<KafkaConnectorInterface> {
     return this.status?.tasksMax ?? this.spec?.tasksMax;
   }
 }
+
+/**
+ * KafkaConnector resource class targeting the `kafka.strimzi.io/v1` API
+ * (Strimzi 1.0.0+). In v1, `spec.pause` is removed; `spec.state` is the
+ * only supported lifecycle field.
+ */
+export class KafkaConnectorV1 extends KafkaConnector {
+  static apiVersion = 'kafka.strimzi.io/v1';
+
+  get desiredState(): KafkaConnectorState {
+    return this.spec?.state ?? 'running';
+  }
+}

--- a/strimzi/src/resources/kafkaTopic.ts
+++ b/strimzi/src/resources/kafkaTopic.ts
@@ -52,3 +52,8 @@ export class KafkaTopic extends KubeObject<KafkaTopicInterface> {
     return this.spec?.replicas ?? 0;
   }
 }
+
+/** KafkaTopic resource class targeting the `kafka.strimzi.io/v1` API (Strimzi 1.0.0+). */
+export class KafkaTopicV1 extends KafkaTopic {
+  static apiVersion = 'kafka.strimzi.io/v1';
+}

--- a/strimzi/src/resources/kafkaUser.ts
+++ b/strimzi/src/resources/kafkaUser.ts
@@ -85,3 +85,8 @@ export class KafkaUser extends KubeObject<KafkaUserInterface> {
     return this.spec?.authorization?.type ?? 'None';
   }
 }
+
+/** KafkaUser resource class targeting the `kafka.strimzi.io/v1` API (Strimzi 1.0.0+). */
+export class KafkaUserV1 extends KafkaUser {
+  static apiVersion = 'kafka.strimzi.io/v1';
+}

--- a/strimzi/src/utils/strimziApiVersion.test.ts
+++ b/strimzi/src/utils/strimziApiVersion.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ApiProxy } from '@kinvolk/headlamp-plugin/lib';
+import {
+  resolveStrimziApiVersions,
+  getStrimziApiVersions,
+  _resetStrimziApiVersionCache,
+} from './strimziApiVersion';
+
+vi.mock('@kinvolk/headlamp-plugin/lib', () => ({
+  ApiProxy: {
+    request: vi.fn(),
+  },
+}));
+
+const mockRequest = ApiProxy.request as ReturnType<typeof vi.fn>;
+
+function makeGroupList(names: string[], versionMap: Record<string, string[]> = {}) {
+  return {
+    groups: names.map(name => ({
+      name,
+      versions: (versionMap[name] ?? ['v1beta2']).map(v => ({ version: v })),
+      preferredVersion: { version: (versionMap[name] ?? ['v1beta2']).at(-1) },
+    })),
+  };
+}
+
+beforeEach(() => {
+  _resetStrimziApiVersionCache();
+  vi.clearAllMocks();
+});
+
+describe('resolveStrimziApiVersions', () => {
+  it('returns v1 when kafka.strimzi.io exposes v1', async () => {
+    mockRequest.mockResolvedValue(
+      makeGroupList(['kafka.strimzi.io', 'core.strimzi.io'], {
+        'kafka.strimzi.io': ['v1beta2', 'v1'],
+        'core.strimzi.io': ['v1beta2', 'v1'],
+      })
+    );
+
+    const result = await resolveStrimziApiVersions();
+    expect(result.installed).toBe(true);
+    expect(result.kafka).toBe('v1');
+    expect(result.core).toBe('v1');
+    expect(result.ready).toBe(true);
+  });
+
+  it('falls back to v1beta2 when only v1beta2 is served', async () => {
+    mockRequest.mockResolvedValue(
+      makeGroupList(['kafka.strimzi.io', 'core.strimzi.io'])
+    );
+
+    const result = await resolveStrimziApiVersions();
+    expect(result.installed).toBe(true);
+    expect(result.kafka).toBe('v1beta2');
+    expect(result.core).toBe('v1beta2');
+  });
+
+  it('sets installed=false when kafka.strimzi.io is absent', async () => {
+    mockRequest.mockResolvedValue(makeGroupList(['apps', 'batch']));
+
+    const result = await resolveStrimziApiVersions();
+    expect(result.installed).toBe(false);
+    expect(result.ready).toBe(true);
+  });
+
+  it('returns safe default and does not cache on transient network error', async () => {
+    mockRequest.mockRejectedValueOnce(new Error('network error'));
+
+    const result = await resolveStrimziApiVersions();
+    // Returns usable default.
+    expect(result.kafka).toBe('v1beta2');
+    expect(result.installed).toBe(true);
+
+    // Cache must NOT be populated after an error.
+    expect(getStrimziApiVersions().ready).toBe(false);
+
+    // Second call should retry (mock now succeeds with v1).
+    mockRequest.mockResolvedValue(
+      makeGroupList(['kafka.strimzi.io'], { 'kafka.strimzi.io': ['v1'] })
+    );
+    const retry = await resolveStrimziApiVersions();
+    expect(retry.kafka).toBe('v1');
+    expect(retry.installed).toBe(true);
+  });
+
+  it('makes only one /apis request even when called concurrently', async () => {
+    mockRequest.mockResolvedValue(
+      makeGroupList(['kafka.strimzi.io'], { 'kafka.strimzi.io': ['v1'] })
+    );
+
+    const [r1, r2, r3] = await Promise.all([
+      resolveStrimziApiVersions(),
+      resolveStrimziApiVersions(),
+      resolveStrimziApiVersions(),
+    ]);
+
+    expect(mockRequest).toHaveBeenCalledTimes(1);
+    expect(r1.kafka).toBe('v1');
+    expect(r2.kafka).toBe('v1');
+    expect(r3.kafka).toBe('v1');
+  });
+
+  it('returns cached result on subsequent calls', async () => {
+    mockRequest.mockResolvedValue(
+      makeGroupList(['kafka.strimzi.io'], { 'kafka.strimzi.io': ['v1'] })
+    );
+
+    await resolveStrimziApiVersions();
+    await resolveStrimziApiVersions();
+
+    expect(mockRequest).toHaveBeenCalledTimes(1);
+    expect(getStrimziApiVersions().kafka).toBe('v1');
+  });
+});

--- a/strimzi/src/utils/strimziApiVersion.ts
+++ b/strimzi/src/utils/strimziApiVersion.ts
@@ -1,0 +1,68 @@
+/**
+ * Strimzi API version detection.
+ *
+ * Strimzi 1.0.0 promoted all CRDs to `v1` and removed `v1beta2`.
+ * This module probes the API group discovery endpoint once per page load
+ * and returns whichever version the connected cluster actually serves.
+ * Components use this to build correct API paths without a hard cutover.
+ */
+import { ApiProxy } from '@kinvolk/headlamp-plugin/lib';
+
+export interface StrimziApiVersions {
+  /** Version served by `kafka.strimzi.io` (Kafka, KafkaTopic, KafkaUser, KafkaNodePool, …). */
+  kafka: string;
+  /** Version served by `core.strimzi.io` (StrimziPodSet). */
+  core: string;
+}
+
+/** Safe default used before the probe completes (or if discovery is unreachable). */
+const DEFAULT_VERSIONS: StrimziApiVersions = { kafka: 'v1beta2', core: 'v1beta2' };
+
+let _cache: StrimziApiVersions | null = null;
+/** Single shared probe promise — ensures discovery is only attempted once. */
+let _probePromise: Promise<StrimziApiVersions> | null = null;
+
+async function probeGroup(group: string): Promise<string> {
+  try {
+    const data = await ApiProxy.request(`/apis/${group}`);
+    const served: string[] = (data?.versions ?? []).map(
+      (v: { version: string }) => v.version
+    );
+    return served.includes('v1') ? 'v1' : 'v1beta2';
+  } catch {
+    return 'v1beta2';
+  }
+}
+
+/**
+ * Resolves the Strimzi API versions available on the current cluster.
+ * The result is cached after the first successful probe; subsequent calls
+ * return the cached value immediately.
+ */
+export function resolveStrimziApiVersions(): Promise<StrimziApiVersions> {
+  if (_cache) return Promise.resolve(_cache);
+  if (!_probePromise) {
+    _probePromise = Promise.all([
+      probeGroup('kafka.strimzi.io'),
+      probeGroup('core.strimzi.io'),
+    ]).then(([kafka, core]) => {
+      _cache = { kafka, core };
+      return _cache;
+    });
+  }
+  return _probePromise;
+}
+
+/**
+ * Returns the cached versions synchronously.
+ * Returns the default (`v1beta2`) before the probe completes.
+ */
+export function getStrimziApiVersions(): StrimziApiVersions {
+  return _cache ?? DEFAULT_VERSIONS;
+}
+
+/** Clears the cache (useful in tests). */
+export function _resetStrimziApiVersionCache(): void {
+  _cache = null;
+  _probePromise = null;
+}

--- a/strimzi/src/utils/strimziApiVersion.ts
+++ b/strimzi/src/utils/strimziApiVersion.ts
@@ -1,67 +1,113 @@
 /**
  * Strimzi API version detection.
  *
- * Strimzi 1.0.0 promoted all CRDs to `v1` and removed `v1beta2`.
- * This module probes the API group discovery endpoint once per page load
- * and returns whichever version the connected cluster actually serves.
- * Components use this to build correct API paths without a hard cutover.
+ * Probes the standard Kubernetes API-groups discovery endpoint (/apis) once
+ * per page load to determine whether Strimzi is installed and which API
+ * version it serves.
+ *
+ * Strimzi 1.0.0 promoted all CRDs to v1 and retired v1beta2.
+ * Earlier releases only serve v1beta2.
+ * If kafka.strimzi.io is absent from the API groups list, Strimzi is not
+ * installed and the plugin should render a friendly empty state rather than
+ * making API calls that will all return 404.
  */
 import { ApiProxy } from '@kinvolk/headlamp-plugin/lib';
 
 export interface StrimziApiVersions {
-  /** Version served by `kafka.strimzi.io` (Kafka, KafkaTopic, KafkaUser, KafkaNodePool, …). */
+  /** False while the probe is still in flight. */
+  ready: boolean;
+  /** True if the kafka.strimzi.io API group was found on the cluster. */
+  installed: boolean;
+  /** Version served by kafka.strimzi.io (Kafka, KafkaTopic, KafkaUser, …). */
   kafka: string;
-  /** Version served by `core.strimzi.io` (StrimziPodSet). */
+  /** Version served by core.strimzi.io (StrimziPodSet). */
   core: string;
 }
 
-/** Safe default used before the probe completes (or if discovery is unreachable). */
-const DEFAULT_VERSIONS: StrimziApiVersions = { kafka: 'v1beta2', core: 'v1beta2' };
+/** Used before the probe resolves (optimistic: don't flash "not installed"). */
+const PENDING_VERSIONS: StrimziApiVersions = {
+  ready: false,
+  installed: true,
+  kafka: 'v1beta2',
+  core: 'v1beta2',
+};
 
 let _cache: StrimziApiVersions | null = null;
-/** Single shared probe promise — ensures discovery is only attempted once. */
+/** Single shared promise so we never fire more than one /apis request. */
 let _probePromise: Promise<StrimziApiVersions> | null = null;
 
-async function probeGroup(group: string): Promise<string> {
-  try {
-    const data = await ApiProxy.request(`/apis/${group}`);
-    const served: string[] = (data?.versions ?? []).map(
-      (v: { version: string }) => v.version
-    );
-    return served.includes('v1') ? 'v1' : 'v1beta2';
-  } catch {
-    return 'v1beta2';
+interface ApiGroup {
+  name: string;
+  versions: Array<{ version: string }>;
+  preferredVersion?: { version: string };
+}
+
+function pickVersion(group: ApiGroup): string {
+  // Prefer the server-advertised preferredVersion; fall back to checking the
+  // versions list for v1, then default to v1beta2.
+  if (group.preferredVersion?.version) return group.preferredVersion.version;
+  const versions = group.versions.map(v => v.version);
+  return versions.includes('v1') ? 'v1' : 'v1beta2';
+}
+
+/**
+ * Runs the probe. Throws on transient failures (network, auth) so that the
+ * caller can choose not to cache the result and retry on the next call.
+ */
+async function runProbe(): Promise<StrimziApiVersions> {
+  const data = await ApiProxy.request('/apis');
+  const groups: ApiGroup[] = data?.groups ?? [];
+
+  const kafkaGroup = groups.find(g => g.name === 'kafka.strimzi.io');
+  const coreGroup = groups.find(g => g.name === 'core.strimzi.io');
+
+  if (!kafkaGroup) {
+    // API discovery worked but kafka.strimzi.io is absent: Strimzi is not installed.
+    return { ready: true, installed: false, kafka: 'v1beta2', core: 'v1beta2' };
   }
+
+  return {
+    ready: true,
+    installed: true,
+    kafka: pickVersion(kafkaGroup),
+    core: coreGroup ? pickVersion(coreGroup) : 'v1beta2',
+  };
 }
 
 /**
  * Resolves the Strimzi API versions available on the current cluster.
- * The result is cached after the first successful probe; subsequent calls
- * return the cached value immediately.
+ *
+ * The result is cached after a successful probe. On transient failures
+ * (network errors, proxy not ready) the promise is cleared so the next
+ * caller will retry rather than permanently pinning to the v1beta2 default.
  */
 export function resolveStrimziApiVersions(): Promise<StrimziApiVersions> {
   if (_cache) return Promise.resolve(_cache);
   if (!_probePromise) {
-    _probePromise = Promise.all([
-      probeGroup('kafka.strimzi.io'),
-      probeGroup('core.strimzi.io'),
-    ]).then(([kafka, core]) => {
-      _cache = { kafka, core };
-      return _cache;
-    });
+    _probePromise = runProbe()
+      .then(result => {
+        _cache = result;
+        return result;
+      })
+      .catch((): StrimziApiVersions => {
+        // Clear the promise so the next call will retry the probe.
+        _probePromise = null;
+        // Return a safe default without caching so future retries are possible.
+        return { ready: true, installed: true, kafka: 'v1beta2', core: 'v1beta2' };
+      });
   }
   return _probePromise;
 }
 
 /**
  * Returns the cached versions synchronously.
- * Returns the default (`v1beta2`) before the probe completes.
+ * Returns PENDING_VERSIONS (ready: false) before the probe completes.
  */
 export function getStrimziApiVersions(): StrimziApiVersions {
-  return _cache ?? DEFAULT_VERSIONS;
+  return _cache ?? PENDING_VERSIONS;
 }
 
-/** Clears the cache (useful in tests). */
+/** Clears the cache. Useful in tests. */
 export function _resetStrimziApiVersionCache(): void {
   _cache = null;
   _probePromise = null;


### PR DESCRIPTION
## Summary

Strimzi 1.0.0 graduated all CRDs to `kafka.strimzi.io/v1` and
`core.strimzi.io/v1`, retiring the `v1beta2` API. Rather than a hard
cutover that would break clusters still running Strimzi 0.x, this PR
makes the plugin work with **both** generations by detecting which
version the connected cluster serves at runtime.

Key changes:

- **`src/utils/strimziApiVersion.ts`** — probes the API group discovery
  endpoints (`/apis/kafka.strimzi.io` and `/apis/core.strimzi.io`) once
  on plugin load and caches the result. A single shared promise prevents
  duplicate requests when multiple components mount simultaneously.
- **`src/hooks/useStrimziApiVersions.ts`** — React hook that returns the
  cached `{ kafka, core }` version strings and triggers a re-render when
  the probe resolves.
- **V1 subclasses** (`KafkaV1`, `KafkaTopicV1`, `KafkaUserV1`,
  `KafkaConnectV1`, `KafkaConnectorV1`) extend the existing v1beta2
  classes with a single `static apiVersion` override. No logic is
  duplicated.
- **`KafkaConnectorV1`** also overrides `desiredState()` to drop the
  deprecated `spec.pause` fallback that was removed from the v1 API.
- All six list / topology components call `useStrimziApiVersions()`,
  select the right class for `ResourceListView`, and build API paths
  from the resolved version string.

## Why this is needed

- Clusters running Strimzi 0.x only serve `v1beta2`; pointing them at
  `v1` returns 404s.
- Clusters running Strimzi 1.0+ only serve `v1`; pointing them at
  `v1beta2` returns 404s.
- A single release should cover both, with no user configuration
  required.

## Steps to test

1. Apply Strimzi 0.x on a cluster (serves v1beta2). Install the plugin.
   Verify all list views load and CRUD operations work.
2. Apply Strimzi 1.0+ on a cluster (serves v1 only). Install the plugin.
   Verify all list views load and CRUD operations work.
3. In both cases, check the browser console. There should be no 404
   errors on `/apis/kafka.strimzi.io/...` or `/apis/core.strimzi.io/...`.

## Notes

- The probe defaults to `v1beta2` before it resolves (safe fallback for
  existing users). On a Strimzi 1.0 cluster, components re-render once
  the probe completes with the correct v1 classes.