### PR TITLE
strimzi: api: Add runtime v1/v1beta2 API version detection

### DIFF
--- a/strimzi/README.md
+++ b/strimzi/README.md
@@ -41,7 +41,7 @@ A Headlamp plugin for managing Strimzi (Apache Kafka on Kubernetes) resources di
 ## 📋 Prerequisites
 
 - [Headlamp](https://headlamp.dev/) installed
-- A Kubernetes cluster with [Strimzi operator](https://strimzi.io/) deployed
+- A Kubernetes cluster with [Strimzi operator](https://strimzi.io/) deployed (0.x with `v1beta2` APIs, or 1.0+ with `v1` APIs; the plugin detects and uses whichever version the cluster serves)
 
 ## 🚀 Quick Start
 

--- a/strimzi/src/components/KafkaClusterTopology.tsx
+++ b/strimzi/src/components/KafkaClusterTopology.tsx
@@ -14,6 +14,7 @@ import { Button, ButtonGroup, Box, useTheme, Chip } from '@mui/material';
 import type { KafkaInterface } from '../resources';
 import { KafkaNodePool, StrimziPodSet, isKRaftMode } from '../crds';
 import { ApiProxy } from '@kinvolk/headlamp-plugin/lib';
+import { useStrimziApiVersions } from '../hooks/useStrimziApiVersions';
 import { useTopologyTheme } from '../hooks/useTopologyTheme';
 import { hexToRgba } from '../utils/topologyColors';
 
@@ -582,6 +583,7 @@ function TopologyFlow({ kafka, onEditResource }: TopologyProps) {
   const [nodes, setNodes] = React.useState<Node[]>([]);
 
   const theme = useTopologyTheme();
+  const { kafka: kafkaVersion, core: coreVersion } = useStrimziApiVersions();
 
   const isKRaft = React.useMemo(() => isKRaftMode(kafka), [kafka]);
   const clusterReady = React.useMemo(
@@ -595,8 +597,8 @@ function TopologyFlow({ kafka, onEditResource }: TopologyProps) {
     const namespace = kafka.metadata.namespace;
 
     Promise.all([
-      ApiProxy.request('/apis/kafka.strimzi.io/v1beta2/kafkanodepools'),
-      ApiProxy.request('/apis/core.strimzi.io/v1beta2/strimzipodsets'),
+      ApiProxy.request(`/apis/kafka.strimzi.io/${kafkaVersion}/kafkanodepools`),
+      ApiProxy.request(`/apis/core.strimzi.io/${coreVersion}/strimzipodsets`),
       ApiProxy.request(
         `/api/v1/namespaces/${namespace}/pods?labelSelector=strimzi.io/cluster=${clusterName}`
       ),
@@ -966,7 +968,7 @@ function TopologyFlow({ kafka, onEditResource }: TopologyProps) {
           </div>
         ),
         editInfo: onEditResource ? {
-          resourceUrl: `/apis/kafka.strimzi.io/v1beta2/namespaces/${namespace}/kafkas/${clusterName}`,
+          resourceUrl: `/apis/kafka.strimzi.io/${kafkaVersion}/namespaces/${namespace}/kafkas/${clusterName}`,
           resourceName: clusterName,
           resourceKind: 'Kafka',
         } : undefined,
@@ -1059,7 +1061,7 @@ function TopologyFlow({ kafka, onEditResource }: TopologyProps) {
             resourceType: 'KafkaNodePool',
             replicaInfo: `Replicas: ${replicas}`,
             editInfo: onEditResource ? {
-              resourceUrl: `/apis/kafka.strimzi.io/v1beta2/namespaces/${namespace}/kafkanodepools/${poolName}`,
+              resourceUrl: `/apis/kafka.strimzi.io/${kafkaVersion}/namespaces/${namespace}/kafkanodepools/${poolName}`,
               resourceName: poolName,
               resourceKind: 'KafkaNodePool',
             } : undefined,
@@ -1101,7 +1103,7 @@ function TopologyFlow({ kafka, onEditResource }: TopologyProps) {
               resourceType: 'StrimziPodSet',
               replicaInfo: `Ready Pods: ${readyPodsCount}/${nodeIds.length}`,
               editInfo: onEditResource ? {
-                resourceUrl: `/apis/core.strimzi.io/v1beta2/namespaces/${namespace}/strimzipodsets/${podSet.metadata.name}`,
+                resourceUrl: `/apis/core.strimzi.io/${coreVersion}/namespaces/${namespace}/strimzipodsets/${podSet.metadata.name}`,
                 resourceName: podSet.metadata.name,
                 resourceKind: 'StrimziPodSet',
               } : undefined,
@@ -1184,7 +1186,7 @@ function TopologyFlow({ kafka, onEditResource }: TopologyProps) {
             resourceType: 'StrimziPodSet',
             replicaInfo: `Ready Pods: ${readyPodsCount}/${brokerCount}`,
             editInfo: onEditResource ? {
-              resourceUrl: `/apis/core.strimzi.io/v1beta2/namespaces/${namespace}/strimzipodsets/${kafkaPodSet.metadata.name}`,
+              resourceUrl: `/apis/core.strimzi.io/${coreVersion}/namespaces/${namespace}/strimzipodsets/${kafkaPodSet.metadata.name}`,
               resourceName: kafkaPodSet.metadata.name,
               resourceKind: 'StrimziPodSet',
             } : undefined,
@@ -1269,7 +1271,7 @@ function TopologyFlow({ kafka, onEditResource }: TopologyProps) {
             resourceType: 'StrimziPodSet',
             replicaInfo: `Ready Pods: ${zkReadyPodsCount}/${zkCount}`,
             editInfo: onEditResource ? {
-              resourceUrl: `/apis/core.strimzi.io/v1beta2/namespaces/${namespace}/strimzipodsets/${zkPodSet.metadata.name}`,
+              resourceUrl: `/apis/core.strimzi.io/${coreVersion}/namespaces/${namespace}/strimzipodsets/${zkPodSet.metadata.name}`,
               resourceName: zkPodSet.metadata.name,
               resourceKind: 'StrimziPodSet',
             } : undefined,
@@ -1346,7 +1348,7 @@ function TopologyFlow({ kafka, onEditResource }: TopologyProps) {
             resourceType: 'StrimziPodSet',
             replicaInfo: `Ready Pods: ${kafkaReadyPodsCount}/${brokerCount}`,
             editInfo: onEditResource ? {
-              resourceUrl: `/apis/core.strimzi.io/v1beta2/namespaces/${namespace}/strimzipodsets/${kafkaPodSet.metadata.name}`,
+              resourceUrl: `/apis/core.strimzi.io/${coreVersion}/namespaces/${namespace}/strimzipodsets/${kafkaPodSet.metadata.name}`,
               resourceName: kafkaPodSet.metadata.name,
               resourceKind: 'StrimziPodSet',
             } : undefined,

--- a/strimzi/src/components/KafkaConnectList.tsx
+++ b/strimzi/src/components/KafkaConnectList.tsx
@@ -6,8 +6,9 @@ import {
   type ColumnType,
   type ResourceTableColumn,
 } from '@kinvolk/headlamp-plugin/lib/components/common';
-import { KafkaConnect } from '../resources/kafkaConnect';
+import { KafkaConnect, KafkaConnectV1 } from '../resources/kafkaConnect';
 import { readyChipProps } from '../utils/readyChip';
+import { useStrimziApiVersions } from '../hooks/useStrimziApiVersions';
 
 /**
  * List view for Strimzi `KafkaConnect` resources (Kafka Connect clusters).
@@ -19,6 +20,8 @@ import { readyChipProps } from '../utils/readyChip';
  */
 export function KafkaConnectList() {
   const theme = useTheme();
+  const { kafka: kafkaVersion } = useStrimziApiVersions();
+  const KafkaConnectClass = kafkaVersion === 'v1' ? KafkaConnectV1 : KafkaConnect;
 
   const columns: (ColumnType | ResourceTableColumn<KafkaConnect>)[] = [
     'name',
@@ -64,6 +67,6 @@ export function KafkaConnectList() {
   ];
 
   return (
-    <ResourceListView title="Kafka Connect Clusters" resourceClass={KafkaConnect} columns={columns} />
+    <ResourceListView title="Kafka Connect Clusters" resourceClass={KafkaConnectClass} columns={columns} />
   );
 }

--- a/strimzi/src/components/KafkaConnectorList.tsx
+++ b/strimzi/src/components/KafkaConnectorList.tsx
@@ -15,9 +15,10 @@ import {
   type ColumnType,
   type ResourceTableColumn,
 } from '@kinvolk/headlamp-plugin/lib/components/common';
-import { KafkaConnector } from '../resources/kafkaConnector';
+import { KafkaConnector, KafkaConnectorV1 } from '../resources/kafkaConnector';
 import type { KafkaConnectorInterface, KafkaConnectorState } from '../resources/kafkaConnector';
 import { getErrorMessage } from '../utils/errors';
+import { useStrimziApiVersions } from '../hooks/useStrimziApiVersions';
 import { readyChipProps } from '../utils/readyChip';
 import { Toast, ToastMessage } from './Toast';
 
@@ -38,6 +39,9 @@ const STATE_CHIP_COLORS: Record<KafkaConnectorState, 'success' | 'warning' | 'de
  */
 export function KafkaConnectorList() {
   const theme = useTheme();
+  const { kafka: kafkaVersion } = useStrimziApiVersions();
+  const KafkaConnectorClass = kafkaVersion === 'v1' ? KafkaConnectorV1 : KafkaConnector;
+
   const [toast, setToast] = React.useState<ToastMessage | null>(null);
   const [pendingState, setPendingState] = React.useState<{
     connector: KafkaConnectorInterface;
@@ -48,7 +52,7 @@ export function KafkaConnectorList() {
     connector: KafkaConnectorInterface,
     targetState: KafkaConnectorState
   ) => {
-    const path = `/apis/kafka.strimzi.io/v1beta2/namespaces/${connector.metadata.namespace}/kafkaconnectors/${connector.metadata.name}`;
+    const path = `/apis/kafka.strimzi.io/${kafkaVersion}/namespaces/${connector.metadata.namespace}/kafkaconnectors/${connector.metadata.name}`;
     try {
       await ApiProxy.request(path, {
         method: 'PATCH',
@@ -183,7 +187,7 @@ export function KafkaConnectorList() {
 
   return (
     <>
-      <ResourceListView title="Kafka Connectors" resourceClass={KafkaConnector} columns={columns} />
+      <ResourceListView title="Kafka Connectors" resourceClass={KafkaConnectorClass} columns={columns} />
       <Dialog
         open={pendingState !== null}
         onClose={() => setPendingState(null)}

--- a/strimzi/src/components/KafkaList.tsx
+++ b/strimzi/src/components/KafkaList.tsx
@@ -5,11 +5,15 @@ import {
   type ColumnType,
   type ResourceTableColumn,
 } from '@kinvolk/headlamp-plugin/lib/components/common';
-import { Kafka } from '../resources/kafka';
+import { Kafka, KafkaV1 } from '../resources/kafka';
 import { KafkaTopologyModal } from './KafkaTopologyModal';
 import type { KafkaInterface } from '../resources/kafka';
+import { useStrimziApiVersions } from '../hooks/useStrimziApiVersions';
 
 export function KafkaList() {
+  const { kafka: kafkaVersion } = useStrimziApiVersions();
+  const KafkaClass = kafkaVersion === 'v1' ? KafkaV1 : Kafka;
+
   const [selectedKafka, setSelectedKafka] = React.useState<KafkaInterface | null>(null);
   const [isTopologyModalOpen, setIsTopologyModalOpen] = React.useState(false);
 
@@ -60,7 +64,7 @@ export function KafkaList() {
     <>
       <ResourceListView
         title="Kafka Clusters"
-        resourceClass={Kafka}
+        resourceClass={KafkaClass}
         columns={columns}
       />
       <KafkaTopologyModal

--- a/strimzi/src/components/KafkaTopicList.tsx
+++ b/strimzi/src/components/KafkaTopicList.tsx
@@ -7,14 +7,18 @@ import {
   type ColumnType,
   type ResourceTableColumn,
 } from '@kinvolk/headlamp-plugin/lib/components/common';
-import { Kafka, KafkaTopic } from '../resources';
+import { Kafka, KafkaTopic, KafkaTopicV1 } from '../resources';
 import type { KafkaTopicInterface } from '../resources';
 import { getErrorMessage } from '../utils/errors';
+import { useStrimziApiVersions } from '../hooks/useStrimziApiVersions';
 import { Toast, ToastMessage } from './Toast';
 import { TopicFormModal, type TopicFormData } from './TopicFormModal';
 
 export function KafkaTopicList() {
   const theme = useTheme();
+  const { kafka: kafkaVersion } = useStrimziApiVersions();
+  const KafkaTopicClass = kafkaVersion === 'v1' ? KafkaTopicV1 : KafkaTopic;
+  const kafkaApiPath = `/apis/kafka.strimzi.io/${kafkaVersion}`;
   const { items: kafkaClusters } = Kafka.useList({});
   const [toast, setToast] = React.useState<ToastMessage | null>(null);
   const [showCreateDialog, setShowCreateDialog] = React.useState(false);
@@ -47,7 +51,7 @@ export function KafkaTopicList() {
     setLoading(true);
     try {
       const topicResource = {
-        apiVersion: 'kafka.strimzi.io/v1beta2',
+        apiVersion: 'kafka.strimzi.io/' + kafkaVersion,
         kind: 'KafkaTopic',
         metadata: {
           name: formData.name,
@@ -68,7 +72,7 @@ export function KafkaTopicList() {
       };
 
       await ApiProxy.request(
-        `/apis/kafka.strimzi.io/v1beta2/namespaces/${formData.namespace}/kafkatopics`,
+        `${kafkaApiPath}/namespaces/${formData.namespace}/kafkatopics`,
         {
           method: 'POST',
           body: JSON.stringify(topicResource),
@@ -112,7 +116,7 @@ export function KafkaTopicList() {
       };
 
       await ApiProxy.request(
-        `/apis/kafka.strimzi.io/v1beta2/namespaces/${editingTopic.metadata.namespace}/kafkatopics/${editingTopic.metadata.name}`,
+        `${kafkaApiPath}/namespaces/${editingTopic.metadata.namespace}/kafkatopics/${editingTopic.metadata.name}`,
         {
           method: 'PUT',
           body: JSON.stringify(updatedTopic),
@@ -142,7 +146,7 @@ export function KafkaTopicList() {
 
     try {
       await ApiProxy.request(
-        `/apis/kafka.strimzi.io/v1beta2/namespaces/${deletingTopic.metadata.namespace}/kafkatopics/${deletingTopic.metadata.name}`,
+        `${kafkaApiPath}/namespaces/${deletingTopic.metadata.namespace}/kafkatopics/${deletingTopic.metadata.name}`,
         { method: 'DELETE' }
       );
       setToast({ message: `Topic "${deletingTopic.metadata.name}" deleted successfully`, type: 'success' });
@@ -252,7 +256,7 @@ export function KafkaTopicList() {
     <>
       <ResourceListView
         title="Kafka Topics"
-        resourceClass={KafkaTopic}
+        resourceClass={KafkaTopicClass}
         columns={columns}
         headerProps={{
           titleSideActions: [

--- a/strimzi/src/components/KafkaUserList.tsx
+++ b/strimzi/src/components/KafkaUserList.tsx
@@ -7,15 +7,19 @@ import {
   type ColumnType,
   type ResourceTableColumn,
 } from '@kinvolk/headlamp-plugin/lib/components/common';
-import { Kafka, KafkaUser } from '../resources';
+import { Kafka, KafkaUser, KafkaUserV1 } from '../resources';
 import type { CreateKafkaUserPayload, KafkaUserInterface } from '../resources';
 import { getErrorMessage } from '../utils/errors';
+import { useStrimziApiVersions } from '../hooks/useStrimziApiVersions';
 import { SecureSecretDisplay } from './SecureSecretDisplay';
 import { Toast, ToastMessage } from './Toast';
 import { KafkaUserCreateFormModal, type UserFormData } from './KafkaUserCreateFormModal';
 
 export function KafkaUserList() {
   const theme = useTheme();
+  const { kafka: kafkaVersion } = useStrimziApiVersions();
+  const KafkaUserClass = kafkaVersion === 'v1' ? KafkaUserV1 : KafkaUser;
+  const kafkaApiPath = `/apis/kafka.strimzi.io/${kafkaVersion}`;
   const { items: kafkaClusters } = Kafka.useList({});
   const [toast, setToast] = React.useState<ToastMessage | null>(null);
   const [showCreateDialog, setShowCreateDialog] = React.useState(false);
@@ -80,7 +84,7 @@ export function KafkaUserList() {
     setLoading(true);
     try {
       const userResource: CreateKafkaUserPayload = {
-        apiVersion: 'kafka.strimzi.io/v1beta2',
+        apiVersion: `kafka.strimzi.io/${kafkaVersion}`,
         kind: 'KafkaUser',
         metadata: {
           name: formData.name,
@@ -104,7 +108,7 @@ export function KafkaUserList() {
       }
 
       await ApiProxy.request(
-        `/apis/kafka.strimzi.io/v1beta2/namespaces/${formData.namespace}/kafkausers`,
+        `${kafkaApiPath}/namespaces/${formData.namespace}/kafkausers`,
         {
           method: 'POST',
           body: JSON.stringify(userResource),
@@ -142,7 +146,7 @@ export function KafkaUserList() {
 
     try {
       await ApiProxy.request(
-        `/apis/kafka.strimzi.io/v1beta2/namespaces/${deletingUser.metadata.namespace}/kafkausers/${deletingUser.metadata.name}`,
+        `${kafkaApiPath}/namespaces/${deletingUser.metadata.namespace}/kafkausers/${deletingUser.metadata.name}`,
         { method: 'DELETE' }
       );
       setToast({ message: `User "${deletingUser.metadata.name}" deleted successfully`, type: 'success' });
@@ -268,7 +272,7 @@ export function KafkaUserList() {
     <>
       <ResourceListView
         title="Kafka Users"
-        resourceClass={KafkaUser}
+        resourceClass={KafkaUserClass}
         columns={columns}
         headerProps={{
           titleSideActions: [

--- a/strimzi/src/crds.ts
+++ b/strimzi/src/crds.ts
@@ -19,10 +19,15 @@ export interface K8sListResponse<T> {
 // Re-export resource classes and their interfaces
 export {
   Kafka,
+  KafkaV1,
   KafkaConnect,
+  KafkaConnectV1,
   KafkaConnector,
+  KafkaConnectorV1,
   KafkaTopic,
+  KafkaTopicV1,
   KafkaUser,
+  KafkaUserV1,
   type ConnectorPlugin,
   type KafkaConnectInterface,
   type KafkaConnectSpec,

--- a/strimzi/src/hooks/useStrimziApiVersions.ts
+++ b/strimzi/src/hooks/useStrimziApiVersions.ts
@@ -1,0 +1,39 @@
+/**
+ * React hook that returns the Strimzi API versions available on the
+ * current cluster, triggering a re-render once the probe completes.
+ *
+ * Components use the returned `kafka` and `core` version strings to
+ * select the right KubeObject class and to build API paths for direct
+ * `ApiProxy.request` calls.
+ *
+ * @example
+ * ```tsx
+ * const { kafka: kafkaVersion } = useStrimziApiVersions();
+ * const KafkaClass = kafkaVersion === 'v1' ? KafkaV1 : Kafka;
+ * return <ResourceListView resourceClass={KafkaClass} ... />;
+ * ```
+ */
+import React from 'react';
+import {
+  getStrimziApiVersions,
+  resolveStrimziApiVersions,
+  type StrimziApiVersions,
+} from '../utils/strimziApiVersion';
+
+export function useStrimziApiVersions(): StrimziApiVersions {
+  const [versions, setVersions] = React.useState<StrimziApiVersions>(
+    getStrimziApiVersions
+  );
+
+  React.useEffect(() => {
+    let cancelled = false;
+    resolveStrimziApiVersions().then(resolved => {
+      if (!cancelled) setVersions(resolved);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return versions;
+}

--- a/strimzi/src/resources/index.ts
+++ b/strimzi/src/resources/index.ts
@@ -3,12 +3,14 @@ export * from './kafka';
 export * from './kafkaTopic';
 export {
   KafkaUser,
+  KafkaUserV1,
   type CreateKafkaUserPayload,
   type KafkaUserInterface,
   type KafkaUserSpec,
 } from './kafkaUser';
 export {
   KafkaConnect,
+  KafkaConnectV1,
   type ConnectorPlugin,
   type KafkaConnectInterface,
   type KafkaConnectSpec,
@@ -16,6 +18,7 @@ export {
 } from './kafkaConnect';
 export {
   KafkaConnector,
+  KafkaConnectorV1,
   type KafkaConnectorInterface,
   type KafkaConnectorSpec,
   type KafkaConnectorState,

--- a/strimzi/src/resources/kafka.ts
+++ b/strimzi/src/resources/kafka.ts
@@ -96,3 +96,8 @@ export class Kafka extends KubeObject<KafkaInterface> {
     return 'N/A';
   }
 }
+
+/** Kafka resource class targeting the `kafka.strimzi.io/v1` API (Strimzi 1.0.0+). */
+export class KafkaV1 extends Kafka {
+  static apiVersion = 'kafka.strimzi.io/v1';
+}

--- a/strimzi/src/resources/kafkaConnect.ts
+++ b/strimzi/src/resources/kafkaConnect.ts
@@ -121,3 +121,8 @@ export class KafkaConnect extends KubeObject<KafkaConnectInterface> {
     return this.status?.connectorPlugins ?? [];
   }
 }
+
+/** KafkaConnect resource class targeting the `kafka.strimzi.io/v1` API (Strimzi 1.0.0+). */
+export class KafkaConnectV1 extends KafkaConnect {
+  static apiVersion = 'kafka.strimzi.io/v1';
+}

--- a/strimzi/src/resources/kafkaConnector.ts
+++ b/strimzi/src/resources/kafkaConnector.ts
@@ -125,3 +125,16 @@ export class KafkaConnector extends KubeObject<KafkaConnectorInterface> {
     return this.status?.tasksMax ?? this.spec?.tasksMax;
   }
 }
+
+/**
+ * KafkaConnector resource class targeting the `kafka.strimzi.io/v1` API
+ * (Strimzi 1.0.0+). In v1, `spec.pause` is removed; `spec.state` is the
+ * only supported lifecycle field.
+ */
+export class KafkaConnectorV1 extends KafkaConnector {
+  static apiVersion = 'kafka.strimzi.io/v1';
+
+  get desiredState(): KafkaConnectorState {
+    return this.spec?.state ?? 'running';
+  }
+}

--- a/strimzi/src/resources/kafkaTopic.ts
+++ b/strimzi/src/resources/kafkaTopic.ts
@@ -52,3 +52,8 @@ export class KafkaTopic extends KubeObject<KafkaTopicInterface> {
     return this.spec?.replicas ?? 0;
   }
 }
+
+/** KafkaTopic resource class targeting the `kafka.strimzi.io/v1` API (Strimzi 1.0.0+). */
+export class KafkaTopicV1 extends KafkaTopic {
+  static apiVersion = 'kafka.strimzi.io/v1';
+}

--- a/strimzi/src/resources/kafkaUser.ts
+++ b/strimzi/src/resources/kafkaUser.ts
@@ -85,3 +85,8 @@ export class KafkaUser extends KubeObject<KafkaUserInterface> {
     return this.spec?.authorization?.type ?? 'None';
   }
 }
+
+/** KafkaUser resource class targeting the `kafka.strimzi.io/v1` API (Strimzi 1.0.0+). */
+export class KafkaUserV1 extends KafkaUser {
+  static apiVersion = 'kafka.strimzi.io/v1';
+}

--- a/strimzi/src/utils/strimziApiVersion.ts
+++ b/strimzi/src/utils/strimziApiVersion.ts
@@ -1,0 +1,68 @@
+/**
+ * Strimzi API version detection.
+ *
+ * Strimzi 1.0.0 promoted all CRDs to `v1` and removed `v1beta2`.
+ * This module probes the API group discovery endpoint once per page load
+ * and returns whichever version the connected cluster actually serves.
+ * Components use this to build correct API paths without a hard cutover.
+ */
+import { ApiProxy } from '@kinvolk/headlamp-plugin/lib';
+
+export interface StrimziApiVersions {
+  /** Version served by `kafka.strimzi.io` (Kafka, KafkaTopic, KafkaUser, KafkaNodePool, …). */
+  kafka: string;
+  /** Version served by `core.strimzi.io` (StrimziPodSet). */
+  core: string;
+}
+
+/** Safe default used before the probe completes (or if discovery is unreachable). */
+const DEFAULT_VERSIONS: StrimziApiVersions = { kafka: 'v1beta2', core: 'v1beta2' };
+
+let _cache: StrimziApiVersions | null = null;
+/** Single shared probe promise — ensures discovery is only attempted once. */
+let _probePromise: Promise<StrimziApiVersions> | null = null;
+
+async function probeGroup(group: string): Promise<string> {
+  try {
+    const data = await ApiProxy.request(`/apis/${group}`);
+    const served: string[] = (data?.versions ?? []).map(
+      (v: { version: string }) => v.version
+    );
+    return served.includes('v1') ? 'v1' : 'v1beta2';
+  } catch {
+    return 'v1beta2';
+  }
+}
+
+/**
+ * Resolves the Strimzi API versions available on the current cluster.
+ * The result is cached after the first successful probe; subsequent calls
+ * return the cached value immediately.
+ */
+export function resolveStrimziApiVersions(): Promise<StrimziApiVersions> {
+  if (_cache) return Promise.resolve(_cache);
+  if (!_probePromise) {
+    _probePromise = Promise.all([
+      probeGroup('kafka.strimzi.io'),
+      probeGroup('core.strimzi.io'),
+    ]).then(([kafka, core]) => {
+      _cache = { kafka, core };
+      return _cache;
+    });
+  }
+  return _probePromise;
+}
+
+/**
+ * Returns the cached versions synchronously.
+ * Returns the default (`v1beta2`) before the probe completes.
+ */
+export function getStrimziApiVersions(): StrimziApiVersions {
+  return _cache ?? DEFAULT_VERSIONS;
+}
+
+/** Clears the cache (useful in tests). */
+export function _resetStrimziApiVersionCache(): void {
+  _cache = null;
+  _probePromise = null;
+}


### PR DESCRIPTION
## Summary

Strimzi 1.0.0 graduated all CRDs to `kafka.strimzi.io/v1` and
`core.strimzi.io/v1`, retiring the `v1beta2` API. Rather than a hard
cutover that would break clusters still running Strimzi 0.x, this PR
makes the plugin work with **both** generations by detecting which
version the connected cluster serves.

Key changes:

- **`src/utils/strimziApiVersion.ts`** — probes the API group discovery
  endpoints (`/apis/kafka.strimzi.io` and `/apis/core.strimzi.io`) once
  on plugin load and caches the result. A single shared promise prevents
  duplicate requests when multiple components mount simultaneously.
- **`src/hooks/useStrimziApiVersions.ts`** — React hook that returns the
  cached `{ kafka, core }` version strings and triggers a re-render when
  the probe resolves.
- **V1 subclasses** (`KafkaV1`, `KafkaTopicV1`, `KafkaUserV1`,
  `KafkaConnectV1`, `KafkaConnectorV1`) extend the existing v1beta2
  classes with a single `static apiVersion` override. No logic is
  duplicated.
- **`KafkaConnectorV1`** also overrides `desiredState()` to drop the
  deprecated `spec.pause` fallback that was removed from the v1 API.
- All six list / topology components call `useStrimziApiVersions()`,
  select the right class for `ResourceListView`, and build API paths
  from the resolved version string.

## Why this is needed

- Clusters running Strimzi 0.x only serve `v1beta2`; pointing them at
  `v1` returns 404s.
- Clusters running Strimzi 1.0+ only serve `v1`; pointing them at
  `v1beta2` returns 404s.
- A single release should cover both, with no user configuration
  required.

## Steps to test

1. Apply Strimzi 0.x on a cluster (serves v1beta2). Install the plugin.
   Verify all list views load and CRUD operations work.
2. Apply Strimzi 1.0+ on a cluster (serves v1 only). Install the plugin.
   Verify all list views load and CRUD operations work.
3. In both cases, check the browser console. There should be no 404
   errors on `/apis/kafka.strimzi.io/...` or `/apis/core.strimzi.io/...`.

## Notes

- The probe defaults to `v1beta2` before it resolves (safe fallback).
  On a Strimzi 1.0 cluster there is a brief initial flash before the
  correct v1 class is used; this resolves in one re-render cycle.
- PRs #666 and #667 (hard v1-only migration) can be superseded by this
  approach and closed.