### PR TITLE
strimzi: Add Error Boundary to prevent plugin crashes breaking Headlamp

### DIFF
--- a/strimzi/src/components/StrimziErrorBoundary.tsx
+++ b/strimzi/src/components/StrimziErrorBoundary.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { Box, Typography } from '@mui/material';
+import { SectionBox } from '@kinvolk/headlamp-plugin/lib/components/common';
+
+interface State {
+  hasError: boolean;
+  message: string;
+}
+
+/**
+ * React Error Boundary for the Strimzi plugin.
+ *
+ * Wrapping every plugin route in this boundary ensures that uncaught
+ * render errors inside any Strimzi component are contained here and
+ * never propagate up to Headlamp's root React tree. Without this, a
+ * render crash inside the plugin can blank the entire Headlamp UI,
+ * including the home-page cluster connection indicators.
+ */
+export class StrimziErrorBoundary extends React.Component<
+  React.PropsWithChildren<unknown>,
+  State
+> {
+  constructor(props: React.PropsWithChildren<unknown>) {
+    super(props);
+    this.state = { hasError: false, message: '' };
+  }
+
+  static getDerivedStateFromError(error: unknown): State {
+    const message =
+      error instanceof Error ? error.message : 'An unexpected error occurred.';
+    return { hasError: true, message };
+  }
+
+  componentDidCatch(error: unknown, info: React.ErrorInfo) {
+    console.error('[Strimzi plugin] Render error:', error, info.componentStack);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <SectionBox title="Strimzi plugin error">
+          <Box sx={{ p: 2 }}>
+            <Typography variant="body1" gutterBottom>
+              Something went wrong while rendering this view.
+            </Typography>
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              component="pre"
+              sx={{ whiteSpace: 'pre-wrap' }}
+            >
+              {this.state.message}
+            </Typography>
+          </Box>
+        </SectionBox>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/strimzi/src/index.tsx
+++ b/strimzi/src/index.tsx
@@ -1,5 +1,6 @@
 import { registerRoute, registerSidebarEntry } from '@kinvolk/headlamp-plugin/lib';
 import React from 'react';
+import { StrimziErrorBoundary } from './components/StrimziErrorBoundary';
 import { KafkaDetail } from './components/kafkas/Detail';
 import { KafkaList } from './components/KafkaList';
 import { KafkaTopicDetail } from './components/topics/Detail';
@@ -11,13 +12,30 @@ import { KafkaConnectList } from './components/KafkaConnectList';
 import { KafkaConnectorDetail } from './components/connectors/Detail';
 import { KafkaConnectorList } from './components/KafkaConnectorList';
 
+/**
+ * Wraps a component in StrimziErrorBoundary so that any uncaught render
+ * error inside the plugin is contained and never propagates to Headlamp's
+ * root React tree (which would break the home page cluster indicators).
+ */
+function safe(Component: React.ComponentType): () => React.ReactElement {
+  function SafeWrapper(): React.ReactElement {
+    return React.createElement(
+      StrimziErrorBoundary,
+      null,
+      React.createElement(Component)
+    );
+  }
+  SafeWrapper.displayName = `Safe(${Component.displayName ?? Component.name})`;
+  return SafeWrapper;
+}
+
 // List routes
 registerRoute({
   path: '/strimzi/kafkas',
   sidebar: 'kafkas',
   name: 'Kafka Clusters',
   exact: true,
-  component: () => React.createElement(KafkaList),
+  component: safe(KafkaList),
 });
 
 registerRoute({
@@ -25,7 +43,7 @@ registerRoute({
   sidebar: 'topics',
   name: 'Kafka Topics',
   exact: true,
-  component: () => React.createElement(KafkaTopicList),
+  component: safe(KafkaTopicList),
 });
 
 registerRoute({
@@ -33,7 +51,7 @@ registerRoute({
   sidebar: 'users',
   name: 'Kafka Users',
   exact: true,
-  component: () => React.createElement(KafkaUserList),
+  component: safe(KafkaUserList),
 });
 
 registerRoute({
@@ -41,7 +59,7 @@ registerRoute({
   sidebar: 'connects',
   name: 'Kafka Connect Clusters',
   exact: true,
-  component: () => React.createElement(KafkaConnectList),
+  component: safe(KafkaConnectList),
 });
 
 registerRoute({
@@ -49,7 +67,7 @@ registerRoute({
   sidebar: 'connectors',
   name: 'Kafka Connectors',
   exact: true,
-  component: () => React.createElement(KafkaConnectorList),
+  component: safe(KafkaConnectorList),
 });
 
 // Detail routes (used by ResourceListView name link and direct navigation)
@@ -58,7 +76,7 @@ registerRoute({
   sidebar: 'kafkas',
   name: 'Kafka Cluster',
   exact: true,
-  component: () => React.createElement(KafkaDetail),
+  component: safe(KafkaDetail),
 });
 
 registerRoute({
@@ -66,7 +84,7 @@ registerRoute({
   sidebar: 'topics',
   name: 'Kafka Topic',
   exact: true,
-  component: () => React.createElement(KafkaTopicDetail),
+  component: safe(KafkaTopicDetail),
 });
 
 registerRoute({
@@ -74,7 +92,7 @@ registerRoute({
   sidebar: 'users',
   name: 'Kafka User',
   exact: true,
-  component: () => React.createElement(KafkaUserDetail),
+  component: safe(KafkaUserDetail),
 });
 
 registerRoute({
@@ -82,7 +100,7 @@ registerRoute({
   sidebar: 'connects',
   name: 'Kafka Connect Cluster',
   exact: true,
-  component: () => React.createElement(KafkaConnectDetail),
+  component: safe(KafkaConnectDetail),
 });
 
 registerRoute({
@@ -90,7 +108,7 @@ registerRoute({
   sidebar: 'connectors',
   name: 'Kafka Connector',
   exact: true,
-  component: () => React.createElement(KafkaConnectorDetail),
+  component: safe(KafkaConnectorDetail),
 });
 
 // Register sidebar entries


### PR DESCRIPTION
## Summary

When the Strimzi plugin is installed on a cluster that does not have
the Strimzi operator deployed, any navigation to a Strimzi view causes
API calls that return 404. In some cases this leads to a React render
error that propagates all the way up to Headlamp's root React tree,
blanking the entire UI and making cluster connections appear broken on
the home page. This was reported by Jakub.

**Root cause:** The plugin had no React Error Boundary. An uncaught
error inside any plugin component escapes the plugin and crashes
Headlamp's own rendering.

**Fix:** Two changes, zero new dependencies:

1. `StrimziErrorBoundary` — a React class component (Error Boundaries
   must be class components per the React spec). Catches any render
   error in its subtree and shows a scoped error message inside the
   Strimzi view, leaving the rest of Headlamp completely unaffected.

2. `safe()` helper in `index.tsx` — wraps every registered route
   component with the boundary. The wrapper is a named function
   component so React DevTools shows a useful display name.

## Steps to test

1. Install the plugin in Headlamp.
2. Connect to a cluster that does **not** have Strimzi installed.
3. Navigate to **Strimzi > Kafka Clusters** in the sidebar.
4. **Before this fix:** Headlamp home page shows clusters as
   disconnected / the entire UI may go blank.
5. **After this fix:** Only the Strimzi view shows an error message;
   the rest of Headlamp continues to work normally.