### PR TITLE
knative: Align list columns with kubectl output

### DIFF
--- a/knative/src/components/domainmappings/List.tsx
+++ b/knative/src/components/domainmappings/List.tsx
@@ -82,6 +82,28 @@ export function useDomainMappingColumns(
         },
       },
       {
+        id: 'reason',
+        label: 'Reason',
+        gridTemplate: 'auto',
+        disableFiltering: true,
+        getValue: item => {
+          const dm = item as KnativeDomainMapping;
+          return getReadyCondition(dm).reason?.toLowerCase() || '';
+        },
+        render: item => {
+          const dm = item as KnativeDomainMapping;
+          const reason = getReadyCondition(dm).reason;
+          if (!reason) {
+            return (
+              <Typography variant="body2" color="text.secondary">
+                -
+              </Typography>
+            );
+          }
+          return <Typography variant="body2">{reason}</Typography>;
+        },
+      },
+      {
         id: 'clusterdomainclaim',
         label: 'ClusterDomainClaim',
         gridTemplate: 'auto',

--- a/knative/src/components/revisions/List.tsx
+++ b/knative/src/components/revisions/List.tsx
@@ -207,6 +207,17 @@ export function RevisionsList() {
           ),
       },
       {
+        id: 'image',
+        label: 'Image',
+        gridTemplate: 'auto',
+        getValue: rev => rev.primaryImage ?? '',
+        render: rev => (
+          <Typography variant="body2" color="text.secondary" noWrap title={rev.primaryImage}>
+            {rev.primaryImage?.split('@')[0] || '-'}
+          </Typography>
+        ),
+      },
+      {
         id: 'ready',
         label: 'Ready',
         gridTemplate: 'auto',
@@ -220,15 +231,21 @@ export function RevisionsList() {
         ),
       },
       {
-        id: 'image',
-        label: 'Image',
+        id: 'reason',
+        label: 'Reason',
         gridTemplate: 'auto',
-        getValue: rev => rev.primaryImage ?? '',
-        render: rev => (
-          <Typography variant="body2" color="text.secondary" noWrap title={rev.primaryImage}>
-            {rev.primaryImage?.split('@')[0] || '-'}
-          </Typography>
-        ),
+        getValue: rev => rev.readyCondition?.reason?.toLowerCase() || '',
+        render: rev => {
+          const reason = rev.readyCondition?.reason;
+          if (!reason) {
+            return (
+              <Typography variant="body2" color="text.secondary">
+                -
+              </Typography>
+            );
+          }
+          return <Typography variant="body2">{reason}</Typography>;
+        },
       },
       {
         id: 'traffic',


### PR DESCRIPTION
Fixes #479

## Problem

The Revisions and DomainMappings list views were not consistent with
`kubectl get` column output.

`kubectl get revisions`:
- Shows IMAGE before READY, and has a separate REASON column
- Plugin had READY before IMAGE, and no REASON column

`kubectl get domainmapping`:
- Has a separate REASON column after READY
- Plugin had no REASON column

## Changes

**revisions/List.tsx:**
- Moved `image` column before `ready` to match kubectl order
- Added `reason` column after `ready`

**domainmappings/List.tsx:**
- Added `reason` column after `ready`

## Testing

`npm run tsc`, `npm run lint`, and `npm run format` all pass clean.