### PR TITLE
prometheus: Add support for external Prometheus URL

### DIFF
--- a/prometheus/src/components/Settings/Settings.tsx
+++ b/prometheus/src/components/Settings/Settings.tsx
@@ -21,6 +21,14 @@ import { useEffect, useState } from 'react';
  * @returns {boolean} True if the address is valid, false otherwise.
  */
 function isValidAddress(address: string): boolean {
+  if (address.startsWith('http://') || address.startsWith('https://')) {
+    try {
+      new URL(address);
+      return true;
+    } catch {
+      return false;
+    }
+  }
   const regex = /^[a-z0-9-]+\/[a-z0-9-]+:[0-9]+$/;
   return regex.test(address);
 }
@@ -39,6 +47,7 @@ interface SettingsProps {
       autoDetect?: boolean;
       address?: string;
       subPath?: string;
+      externalUrl?: string;
       defaultTimespan?: string;
       defaultResolution?: string;
     }
@@ -170,6 +179,28 @@ export function Settings(props: SettingsProps) {
       ),
     },
     {
+      name: t('External Prometheus URL'),
+      value: (
+        <TextField
+          disabled={!isAddressFieldEnabled}
+          placeholder="https://prometheus.example.com"
+          helperText={t(
+            'Optional: Use an external Prometheus URL instead of an in-cluster service. Example: https://prometheus.example.com'
+          )}
+          value={selectedClusterData.externalUrl || ''}
+          onChange={e => {
+            onDataChange({
+              ...(data || {}),
+              [selectedCluster]: {
+                ...((data || {})[selectedCluster] || {}),
+                externalUrl: e.target.value || undefined,
+              },
+            });
+          }}
+        />
+      ),
+    },
+    {
       name: t('Prometheus Service Address'),
       value: (
         <Box display="flex" flexDirection="column" width="100%">
@@ -180,7 +211,7 @@ export function Settings(props: SettingsProps) {
                 addressError
                   ? t('Invalid format. Use: namespace/service-name:port')
                   : t(
-                      'Address of the Prometheus Service, only used when auto-detection is disabled. Format: namespace/service-name:port'
+                      'In-cluster address (namespace/service-name:port). Leave empty if using an External Prometheus URL above.'
                     )
               }
               error={addressError}

--- a/prometheus/src/request.tsx
+++ b/prometheus/src/request.tsx
@@ -309,23 +309,32 @@ export async function fetchMetrics(data: {
   if (data.query) {
     params.append('query', data.query);
   }
-  var url = `/api/v1/namespaces/${data.prefix}/proxy/api/v1/query_range?${params.toString()}`;
-  if (data.subPath && data.subPath !== '') {
-    if (data.subPath.startsWith('/')) {
-      data.subPath = data.subPath.slice(1);
+  let url: string;
+  const isExternalUrl = data.prefix.startsWith('http://') || data.prefix.startsWith('https://');
+  if (isExternalUrl) {
+    let base = data.prefix.replace(/\/$/, '');
+    if (data.subPath && data.subPath !== '') {
+      const subPath = data.subPath.replace(/^\//, '').replace(/\/$/, '');
+      base = `${base}/${subPath}`;
     }
-    if (data.subPath.endsWith('/')) {
-      data.subPath = data.subPath.slice(0, -1);
+    url = `${base}/api/v1/query_range?${params.toString()}`;
+  } else {
+    url = `/api/v1/namespaces/${data.prefix}/proxy/api/v1/query_range?${params.toString()}`;
+    if (data.subPath && data.subPath !== '') {
+      const subPath = data.subPath.replace(/^\//, '').replace(/\/$/, '');
+      url = `/api/v1/namespaces/${
+        data.prefix
+      }/proxy/${subPath}/api/v1/query_range?${params.toString()}`;
     }
-    url = `/api/v1/namespaces/${data.prefix}/proxy/${
-      data.subPath
-    }/api/v1/query_range?${params.toString()}`;
   }
 
-  const response = await request(url, {
-    method: 'GET',
-    isJSON: false,
-  });
+  const response = isExternalUrl
+    ? await fetch(url)
+    : await request(url, {
+        method: 'GET',
+        isJSON: false,
+      });
+
   if (response.status === 200) {
     return response.json();
   } else {

--- a/prometheus/src/util.ts
+++ b/prometheus/src/util.ts
@@ -21,6 +21,7 @@ type ClusterData = {
   isMetricsEnabled?: boolean;
   address?: string;
   subPath?: string;
+  externalUrl?: string;
   defaultTimespan?: string;
   defaultResolution?: string;
 };
@@ -110,6 +111,9 @@ export async function getPrometheusPrefix(cluster: string): Promise<string | nul
   if (clusterData?.address) {
     const [namespace, service] = clusterData?.address.split('/');
     return `${namespace}/services/${service}`;
+  }
+  if (clusterData?.externalUrl) {
+    return clusterData.externalUrl;
   }
   return null;
 }


### PR DESCRIPTION
Fixes #539

## Problem

When using Grafana Alloy or other collectors configured to `remote_write`
to an external Prometheus-compatible endpoint, there is no in-cluster
Prometheus service to proxy through. The plugin showed a generic
"Couldn't detect Prometheus in your cluster" error with no actionable
way to configure an external endpoint.

## Fix

Add an **External Prometheus URL** field to the plugin settings that
accepts a plain HTTP/HTTPS URL (e.g. `https://prometheus.example.com`).
When set, `fetchMetrics()` fetches directly from the external URL using
native `fetch()` instead of routing through the Kubernetes API proxy.

## Changes

- `util.ts`: added `externalUrl` field to `ClusterData` type; `getPrometheusPrefix()` returns it when configured
- `request.tsx`: detects external URLs in `fetchMetrics()` and uses native `fetch()` instead of the Kubernetes proxy path; subPath is correctly appended for external URLs too
- `Settings.tsx`: added External Prometheus URL text field; updated `isValidAddress()` to accept valid HTTP/HTTPS URLs; updated helper text on in-cluster address field to clarify when each is used

## Testing

`npm run tsc`, `npm run lint`, and `npm run format` all pass clean.