### PR TITLE
knative: Add yaml test files

### DIFF
--- a/knative/README.md
+++ b/knative/README.md
@@ -19,3 +19,26 @@ Go to the Plugin Catalog, search for the Knative plugin, and click the Install b
 </video>
 
 Watch: https://github.com/user-attachments/assets/a5c9cac3-f711-4306-84cd-83178fc876e0
+
+## Development
+
+To make contributions and UI testing easier, this repository includes a suite of test manifests. You can apply these to your local development cluster to instantly generate a robust set of Knative resources covering various states and edge cases (like traffic splits, rollbacks, scaled-to-zero services, and broken domain mappings).
+
+To deploy the test suite:
+```bash
+kubectl apply -f test-files/deploy/
+```
+
+### Test Suite Manifests
+
+* **`00-namespace.yaml`**: Creates the `knative-map-test` namespace to isolate the test suite resources.
+* **`01-service-healthy.yaml`**: Deploys a baseline, fully healthy Knative Service with 100% traffic routed to a single revision.
+* **`01-service-failed-revision.yaml`**: Deploys a Knative Service containing a revision designed to fail (invalid container command) to verify the map's error rendering (`Ready: False`).
+* **`01-service-traffic-split-v1.yaml`**: Step 1 for the traffic split scenario, deploying the initial `v1` revision.
+* **`02-service-traffic-split-v2.yaml`**: Step 2 for the traffic split scenario, deploying `v2` and configuring a 50/50 traffic split across targets to test edge percentages on the map.
+* **`01-service-scaled-to-zero.yaml`**: Deploys a Knative Service explicitly locked to `min-scale: 0` and `max-scale: 0` to verify idle/inactive rendering.
+* **`01-service-rollback-v1.yaml`**: Step 1 for the rollback scenario, deploying the initial `v1` revision.
+* **`02-service-rollback-v2.yaml`**: Step 2 for the rollback scenario, deploying `v2` but pinning 100% traffic to `v1` (`stable`) and 0% to `v2` (`canary`) to test tag visualization.
+* **`03-domainmapping-healthy.yaml`**: Creates a healthy `DomainMapping` and its requisite `ClusterDomainClaim` to test active mapping edges on the graph.
+* **`03-domainmapping-broken-ref.yaml`**: Creates a `DomainMapping` targeting a non-existent Knative Service to verify the map handles broken references gracefully.
+* **`03-domainmapping-core-svc.yaml`**: Creates a `DomainMapping` targeting a core Kubernetes `v1 Service` to ensure the map ignores non-Knative targets.

--- a/knative/src/components/clusterdomainclaims/Glance.tsx
+++ b/knative/src/components/clusterdomainclaims/Glance.tsx
@@ -37,9 +37,10 @@ interface GlanceProps {
 export function ClusterDomainClaimGlance({ node }: GlanceProps) {
   const kubeObject = node.kubeObject;
   const isKnativeClusterDomainClaim =
-    kubeObject?.kind === ClusterDomainClaim.kind &&
-    typeof kubeObject?.apiVersion === 'string' &&
-    kubeObject.apiVersion.startsWith('networking.internal.knative.dev/');
+    kubeObject instanceof ClusterDomainClaim ||
+    (kubeObject?.kind === ClusterDomainClaim.kind &&
+      typeof kubeObject?.apiVersion === 'string' &&
+      kubeObject.apiVersion.startsWith('networking.internal.knative.dev/'));
 
   if (isKnativeClusterDomainClaim) {
     const cdc = kubeObject as ClusterDomainClaim;

--- a/knative/src/components/domainmappings/Glance.tsx
+++ b/knative/src/components/domainmappings/Glance.tsx
@@ -37,9 +37,10 @@ interface GlanceProps {
 export function DomainMappingGlance({ node }: GlanceProps) {
   const kubeObject = node.kubeObject;
   const isKnativeDomainMapping =
-    kubeObject?.kind === KnativeDomainMapping.kind &&
-    typeof kubeObject?.apiVersion === 'string' &&
-    kubeObject.apiVersion.startsWith('serving.knative.dev/');
+    kubeObject instanceof KnativeDomainMapping ||
+    (kubeObject?.kind === KnativeDomainMapping.kind &&
+      typeof kubeObject?.apiVersion === 'string' &&
+      kubeObject.apiVersion.startsWith('serving.knative.dev/'));
 
   if (isKnativeDomainMapping) {
     const dm = kubeObject as KnativeDomainMapping;
@@ -53,7 +54,7 @@ export function DomainMappingGlance({ node }: GlanceProps) {
         >
           Ready: {readyStatus}
         </StatusLabel>
-        {dm.spec?.ref?.name && <StatusLabel status="">Target: {dm.spec.ref.name}</StatusLabel>}
+        {dm.spec?.ref?.name && <StatusLabel>Target: {dm.spec.ref.name}</StatusLabel>}
       </Box>
     );
   }

--- a/knative/src/components/kservices/Glance.tsx
+++ b/knative/src/components/kservices/Glance.tsx
@@ -37,9 +37,10 @@ interface GlanceProps {
 export function KServiceGlance({ node }: GlanceProps) {
   const kubeObject = node.kubeObject;
   const isKnativeService =
-    kubeObject?.kind === KService.kind &&
-    typeof kubeObject?.apiVersion === 'string' &&
-    kubeObject.apiVersion.startsWith('serving.knative.dev/');
+    kubeObject instanceof KService ||
+    (kubeObject?.kind === KService.kind &&
+      typeof kubeObject?.apiVersion === 'string' &&
+      kubeObject.apiVersion.startsWith('serving.knative.dev/'));
 
   if (isKnativeService) {
     const svc = kubeObject as KService;
@@ -54,7 +55,7 @@ export function KServiceGlance({ node }: GlanceProps) {
           Ready: {readyStatus}
         </StatusLabel>
         {svc.status?.latestReadyRevisionName && (
-          <StatusLabel status="">Latest: {svc.status.latestReadyRevisionName}</StatusLabel>
+          <StatusLabel>Latest: {svc.status.latestReadyRevisionName}</StatusLabel>
         )}
       </Box>
     );

--- a/knative/src/components/revisions/Glance.tsx
+++ b/knative/src/components/revisions/Glance.tsx
@@ -37,24 +37,37 @@ interface GlanceProps {
 export function RevisionGlance({ node }: GlanceProps) {
   const kubeObject = node.kubeObject;
   const isKnativeRevision =
-    kubeObject?.kind === KRevision.kind &&
-    typeof kubeObject?.apiVersion === 'string' &&
-    kubeObject.apiVersion.startsWith('serving.knative.dev/');
+    kubeObject instanceof KRevision ||
+    (kubeObject?.kind === KRevision.kind &&
+      typeof kubeObject?.apiVersion === 'string' &&
+      kubeObject.apiVersion.startsWith('serving.knative.dev/'));
 
   if (isKnativeRevision) {
     const rev = kubeObject as KRevision;
     const readyStatus = rev.isReady ? 'True' : 'False';
-    const trafficStr = node.traffic?.length
-      ? node.traffic.map((t: any) => `${t.percent || 0}%${t.tag ? ` (${t.tag})` : ''}`).join(', ')
-      : null;
+
+    let trafficStr: string | null = null;
+    let tagsStr: string | null = null;
+
+    if (node.traffic?.length) {
+      const percents: string[] = [];
+      const tags: string[] = [];
+      for (const t of node.traffic) {
+        percents.push(`${t.percent || 0}%`);
+        if (t.tag) tags.push(t.tag);
+      }
+      trafficStr = percents.join(', ');
+      tagsStr = tags.length ? tags.join(', ') : null;
+    }
 
     return (
       <Box display="flex" gap={1} alignItems="center" mt={2} flexWrap="wrap" key="revision-glance">
         <StatusLabel status={rev.isReady ? 'success' : 'error'}>Ready: {readyStatus}</StatusLabel>
-        {rev.parentService && <StatusLabel status="">Service: {rev.parentService}</StatusLabel>}
-        {trafficStr && <StatusLabel status="">Traffic: {trafficStr}</StatusLabel>}
+        {rev.parentService && <StatusLabel>Service: {rev.parentService}</StatusLabel>}
+        {trafficStr && <StatusLabel>Traffic: {trafficStr}</StatusLabel>}
+        {tagsStr && <StatusLabel>Tags: {tagsStr}</StatusLabel>}
         {rev.primaryImage && (
-          <StatusLabel status="">
+          <StatusLabel>
             Image: {rev.primaryImage.split('/').pop()?.split('@')[0] || rev.primaryImage}
           </StatusLabel>
         )}

--- a/knative/src/index.tsx
+++ b/knative/src/index.tsx
@@ -143,6 +143,11 @@ registerRoute({
 
 registerMapSource(knativePluginSource);
 
+registerKindIcon('serving.knative.dev/Service', {
+  icon: <Icon icon="custom:knative" width="70%" height="70%" />,
+  color: 'rgb(7, 102, 174)',
+});
+
 registerKindIcon('Revision', {
   icon: <Icon icon="custom:knative" width="70%" height="70%" />,
   color: 'rgb(7, 102, 174)',

--- a/knative/src/mapView.tsx
+++ b/knative/src/mapView.tsx
@@ -19,10 +19,11 @@ import { DetailsGrid } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 import { useMemo } from 'react';
 import { ClusterDomainClaim, KnativeDomainMapping, KRevision, KService } from './resources/knative';
 
-export const makeKubeToKubeEdge = (from: any, to: any): any => ({
+export const makeKubeToKubeEdge = (from: any, to: any, options: any = {}): any => ({
   id: `${from.metadata.uid}-${to.metadata.uid}`,
   source: from.metadata.uid,
   target: to.metadata.uid,
+  ...options,
 });
 
 const KServiceDetails = ({ node }: { node: any }) => (
@@ -158,12 +159,16 @@ const knativeServiceSource: any = {
     return useMemo(() => {
       if (!kservices) return null;
 
-      const nodes = kservices.map(kservice => ({
-        id: kservice.metadata.uid,
-        kubeObject: kservice,
-        detailsComponent: KServiceDetails,
-        weight: 1100,
-      }));
+      const nodes = kservices.map(kservice => {
+        const status = kservice.isReady ? 'success' : 'error';
+        return {
+          id: kservice.metadata.uid,
+          kubeObject: kservice,
+          detailsComponent: KServiceDetails,
+          weight: 1100,
+          status,
+        };
+      });
 
       const edges: any[] = [];
       return {
@@ -199,8 +204,14 @@ const knativeRevisionSource: any = {
 
         if (parentSvc) {
           traffic = rev.getTrafficInService(parentSvc);
-          edges.push(makeKubeToKubeEdge(parentSvc, rev));
+          const trafficStr = traffic?.length
+            ? traffic.map((t: any) => `${t.percent || 0}%`).join(', ')
+            : undefined;
+
+          edges.push(makeKubeToKubeEdge(parentSvc, rev, trafficStr ? { label: trafficStr } : {}));
         }
+
+        const status = rev.isReady ? 'success' : 'error';
 
         return {
           id: rev.metadata.uid,
@@ -208,6 +219,7 @@ const knativeRevisionSource: any = {
           detailsComponent: RevisionDetails,
           weight: 1100,
           traffic,
+          status,
         };
       });
 
@@ -254,11 +266,15 @@ const knativeDomainMappingSource: any = {
           }
         }
 
+        const isReady = dm.status?.conditions?.find(c => c.type === 'Ready')?.status === 'True';
+        const status = isReady ? 'success' : 'error';
+
         return {
           id: dm.metadata.uid,
           kubeObject: dm,
           detailsComponent: DomainMappingDetails,
           weight: 1100,
+          status,
         };
       });
 

--- a/knative/test-files/deploy/00-namespace.yaml
+++ b/knative/test-files/deploy/00-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: knative-map-test

--- a/knative/test-files/deploy/01-service-failed-revision.yaml
+++ b/knative/test-files/deploy/01-service-failed-revision.yaml
@@ -1,0 +1,11 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: failed-service
+  namespace: knative-map-test
+spec:
+  template:
+    spec:
+      containers:
+        - image: busybox
+          command: ["sh", "-c", "exit 1"]

--- a/knative/test-files/deploy/01-service-healthy.yaml
+++ b/knative/test-files/deploy/01-service-healthy.yaml
@@ -1,0 +1,13 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: healthy-service
+  namespace: knative-map-test
+spec:
+  template:
+    spec:
+      containers:
+        - image: gcr.io/knative-samples/helloworld-go
+          env:
+            - name: TARGET
+              value: "healthy"

--- a/knative/test-files/deploy/01-service-rollback-v1.yaml
+++ b/knative/test-files/deploy/01-service-rollback-v1.yaml
@@ -1,0 +1,16 @@
+# Step 1: Apply this first to create revision rollback-service-v1
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: rollback-service
+  namespace: knative-map-test
+spec:
+  template:
+    metadata:
+      name: rollback-service-v1
+    spec:
+      containers:
+        - image: gcr.io/knative-samples/helloworld-go
+          env:
+            - name: TARGET
+              value: "v1"

--- a/knative/test-files/deploy/01-service-scaled-to-zero.yaml
+++ b/knative/test-files/deploy/01-service-scaled-to-zero.yaml
@@ -1,0 +1,17 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: scaled-to-zero-service
+  namespace: knative-map-test
+spec:
+  template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/min-scale: "0"
+        autoscaling.knative.dev/max-scale: "0"
+    spec:
+      containers:
+        - image: gcr.io/knative-samples/helloworld-go
+          env:
+            - name: TARGET
+              value: "scaled-to-zero"

--- a/knative/test-files/deploy/01-service-traffic-split-v1.yaml
+++ b/knative/test-files/deploy/01-service-traffic-split-v1.yaml
@@ -1,0 +1,15 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: traffic-split-service
+  namespace: knative-map-test
+spec:
+  template:
+    metadata:
+      name: traffic-split-service-v1
+    spec:
+      containers:
+        - image: gcr.io/knative-samples/helloworld-go
+          env:
+            - name: TARGET
+              value: "v1"

--- a/knative/test-files/deploy/02-service-rollback-v2.yaml
+++ b/knative/test-files/deploy/02-service-rollback-v2.yaml
@@ -1,0 +1,24 @@
+# Step 2: Apply this AFTER v1 is ready. Creates revision v2 but pins
+#         100% traffic to v1 (stable) and 0% to v2 (canary).
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: rollback-service
+  namespace: knative-map-test
+spec:
+  template:
+    metadata:
+      name: rollback-service-v2
+    spec:
+      containers:
+        - image: gcr.io/knative-samples/helloworld-go
+          env:
+            - name: TARGET
+              value: "v2"
+  traffic:
+    - revisionName: rollback-service-v1
+      percent: 100
+      tag: stable
+    - revisionName: rollback-service-v2
+      percent: 0
+      tag: canary

--- a/knative/test-files/deploy/02-service-traffic-split-v2.yaml
+++ b/knative/test-files/deploy/02-service-traffic-split-v2.yaml
@@ -1,0 +1,20 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: traffic-split-service
+  namespace: knative-map-test
+spec:
+  template:
+    metadata:
+      name: traffic-split-service-v2
+    spec:
+      containers:
+        - image: gcr.io/knative-samples/helloworld-go
+          env:
+            - name: TARGET
+              value: "v2"
+  traffic:
+    - revisionName: traffic-split-service-v1
+      percent: 50
+    - revisionName: traffic-split-service-v2
+      percent: 50

--- a/knative/test-files/deploy/03-domainmapping-broken-ref.yaml
+++ b/knative/test-files/deploy/03-domainmapping-broken-ref.yaml
@@ -1,0 +1,10 @@
+apiVersion: serving.knative.dev/v1beta1
+kind: DomainMapping
+metadata:
+  name: my-unique-broken-mapping.local-test.dev
+  namespace: knative-map-test
+spec:
+  ref:
+    name: non-existent-service
+    kind: Service
+    apiVersion: serving.knative.dev/v1

--- a/knative/test-files/deploy/03-domainmapping-core-svc.yaml
+++ b/knative/test-files/deploy/03-domainmapping-core-svc.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: core-k8s-service
+  namespace: knative-map-test
+spec:
+  ports:
+    - port: 80
+      targetPort: 8080
+  selector:
+    app: not-knative
+---
+apiVersion: serving.knative.dev/v1beta1
+kind: DomainMapping
+metadata:
+  name: my-unique-core-mapping.local-test.dev
+  namespace: knative-map-test
+spec:
+  ref:
+    name: core-k8s-service
+    kind: Service
+    apiVersion: v1

--- a/knative/test-files/deploy/03-domainmapping-healthy.yaml
+++ b/knative/test-files/deploy/03-domainmapping-healthy.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.internal.knative.dev/v1alpha1
+kind: ClusterDomainClaim
+metadata:
+  name: healthy.knative-map-test.local
+spec:
+  namespace: knative-map-test
+---
+apiVersion: serving.knative.dev/v1beta1
+kind: DomainMapping
+metadata:
+  name: healthy.knative-map-test.local
+  namespace: knative-map-test
+spec:
+  ref:
+    name: healthy-service
+    kind: Service
+    apiVersion: serving.knative.dev/v1


### PR DESCRIPTION
## Description
This PR fixes Glance and adds test yaml files

## Related Issue
#486  (LFX)

## Changes
 - Fixed glance view (was somehow broken)
 - Fixed `mapView` to show status for nodes
 - `namespace.yaml`: Creates the `knative-map-test` namespace to isolate the test suite resources.
 - `service-healthy.yaml`: Deploys a baseline, fully healthy Knative Service with 100% traffic routed to a single revision.
 - `service-failed-revision.yaml`: Deploys a Knative Service containing a revision designed to fail (invalid container command) to verify the map's error rendering (`Ready: False`).
 - `service-traffic-split.yaml`: Configures a Knative Service splitting traffic 50/50 across targets to test edge percentages on the map.
 - `service-scaled-to-zero.yaml`: Deploys a Knative Service explicitly locked to `min-scale: 0` and `max-scale: 0` to verify idle/inactive rendering.
 - `service-scaled-to-zero.yaml`: Deploys a Knative Service explicitly locked to `min-scale: 0` and `max-scale: 0` to verify idle/inactive rendering.
 - `service-rollback-v1.yaml`: Step 1 for the rollback scenario, deploying the initial `v1` revision.
 - `service-rollback-v2.yaml`: Step 2 for the rollback scenario, deploying `v2` but pinning 100% traffic to `v1` (`stable`) and 0% to `v2` (`canary`) to test tag visualization.
 - `domainmapping-healthy.yaml`: Creates a healthy `DomainMapping` and its requisite `ClusterDomainClaim` to test active mapping edges on the graph.
 - `domainmapping-broken-ref.yaml`: Creates a `DomainMapping` targeting a non-existent Knative Service to verify the map handles broken references gracefully.
 - `domainmapping-core-svc.yaml`: Creates a `DomainMapping` targeting a core Kubernetes `v1 Service` to ensure the map ignores non-Knative targets.

## Screenshots

<img width="1120" height="484" alt="image" src="https://github.com/user-attachments/assets/d74c9245-dbda-4c03-bd85-43ac969ae336" />

<img width="456" height="202" alt="image" src="https://github.com/user-attachments/assets/aa507fd2-2031-4c71-8d09-22e31b3d46d9" />

**Note:** Also added tag for revision glance and registered icon for kservice.