### PR TITLE
kyverno: ViolationsView: Fix missing pod names in table

### DIFF
--- a/kyverno/src/components/ViolationsView.tsx
+++ b/kyverno/src/components/ViolationsView.tsx
@@ -31,6 +31,7 @@ import { useMemo, useState } from 'react';
 import {
   ClusterPolicyReport,
   PolicyReport,
+  PolicyReportInterface,
   PolicyReportResult,
   PolicyResultStatus,
 } from '../resources/policyReport';
@@ -40,6 +41,7 @@ type GroupBy = 'none' | 'policy' | 'namespace' | 'kind';
 
 interface ViolationEntry extends PolicyReportResult {
   reportNamespace?: string;
+  scope?: PolicyReportInterface['scope'];
 }
 
 const VIOLATION_STATUSES: PolicyResultStatus[] = ['fail', 'warn', 'error'];
@@ -56,6 +58,7 @@ function collectViolations(
         violations.push({
           ...result,
           reportNamespace: report.jsonData.metadata.namespace,
+          scope: report.jsonData.scope,
         });
       }
     }
@@ -64,7 +67,10 @@ function collectViolations(
   for (const report of clusterPolicyReports || []) {
     for (const result of report.results) {
       if (VIOLATION_STATUSES.includes(result.result)) {
-        violations.push({ ...result });
+        violations.push({
+          ...result,
+          scope: report.jsonData.scope,
+        });
       }
     }
   }
@@ -77,9 +83,9 @@ function getGroupKey(entry: ViolationEntry, groupBy: GroupBy): string {
     case 'policy':
       return entry.policy || 'Unknown';
     case 'namespace':
-      return entry.resources?.[0]?.namespace || entry.reportNamespace || 'cluster-scoped';
+      return entry.resources?.[0]?.namespace || entry.scope?.namespace || entry.reportNamespace || 'cluster-scoped';
     case 'kind':
-      return entry.resources?.[0]?.kind || 'Unknown';
+      return entry.resources?.[0]?.kind || entry.scope?.kind || 'Unknown';
     default:
       return '';
   }
@@ -99,15 +105,15 @@ function groupViolations(violations: ViolationEntry[], groupBy: GroupBy): Map<st
 const violationColumns = [
   {
     header: 'Resource',
-    accessorFn: (v: ViolationEntry) => v.resources?.[0]?.name || '-',
+    accessorFn: (v: ViolationEntry) => v.resources?.[0]?.name || v.scope?.name || '-',
   },
   {
     header: 'Kind',
-    accessorFn: (v: ViolationEntry) => v.resources?.[0]?.kind || '-',
+    accessorFn: (v: ViolationEntry) => v.resources?.[0]?.kind || v.scope?.kind || '-',
   },
   {
     header: 'Namespace',
-    accessorFn: (v: ViolationEntry) => v.resources?.[0]?.namespace || v.reportNamespace || '-',
+    accessorFn: (v: ViolationEntry) => v.resources?.[0]?.namespace || v.scope?.namespace || v.reportNamespace || '-',
   },
   {
     header: 'Policy',


### PR DESCRIPTION
When Kyverno generates per-resource policy reports, the resource information is stored in the report's scope rather than the individual result's resources array. This updates the ViolationsView to fall back to the report scope so that pod names are displayed correctly instead of '-'.

Before-

<img width="1463" height="490" alt="image" src="https://github.com/user-attachments/assets/65140b89-79bf-46a7-bdb0-14e3af28b766" />


After-
<img width="1463" height="490" alt="image" src="https://github.com/user-attachments/assets/76b9b25e-f107-439a-b49b-6b3d266e2a38" />
