### PR TITLE
kyverno: fix policy ready status logic

### DIFF
--- a/kyverno/src/resources/kyvernoPolicy.ts
+++ b/kyverno/src/resources/kyvernoPolicy.ts
@@ -109,7 +109,9 @@ abstract class KyvernoPolicyBase extends KubeObject<KyvernoPolicyInterface> {
   }
 
   get ready(): boolean {
-    return this.status?.ready ?? false;
+    const conditions = this.status?.conditions || [];
+    const readyCond = conditions.find(c => c.type === 'Ready');
+    return readyCond?.status === 'True';
   }
 
   get rules(): PolicyRule[] {


### PR DESCRIPTION
## Changes
- Fixed the `ready` getter in `KyvernoPolicyBase` to correctly identify the policy status.
- Updated the logic to scan the `status.conditions` array for a `Ready` type with status `True`, instead of looking for a non-existent top-level `status.ready` boolean.

<img width="1487" height="162" alt="image" src="https://github.com/user-attachments/assets/238c2cb1-5e0b-4956-932d-0a8c1cca4752" />
