### PR TITLE
fix(flux): show 100% health when no resources exist

### DIFF
--- a/flux/src/overview/index.tsx
+++ b/flux/src/overview/index.tsx
@@ -711,7 +711,7 @@ function FluxOverviewChart({ resourceClass }) {
       const [success, failed, suspended, processing] = getStatus(crds);
 
       // Calculate actual percentages
-      const successPercent = total > 0 ? Math.round((success / total) * 100) : 0;
+      const successPercent = total > 0 ? Math.round((success / total) * 100) : 100;
       const failedPercent = total > 0 ? Math.round((failed / total) * 100) : 0;
       const suspendedPercent = total > 0 ? Math.round((suspended / total) * 100) : 0;
       const processingPercent = total > 0 ? Math.round((processing / total) * 100) : 0;


### PR DESCRIPTION
### **Summary**
This PR improves the UX of the Flux plugin's Overview dashboard by ensuring that resource types with no configured items show 100% health instead of 0%. This aligns the dashboard with Headlamp's visual standards (following the pattern established in the Kyverno plugin).

### **Key changes**

1. `flux/src/overview/index.tsx`: Updated the successPercent calculation in FluxOverviewChart to return 100 when the total number of resources is zero. This prevents the charts from defaulting to an "unhealthy" state for empty resource lists.
2. Why this is needed
3. Misleading Metrics: Currently, a cluster with no Flux resources configured (common in new or staging environments) displays 0% health/success, which incorrectly implies a failure.
4. User Consistency: Ensures that an "empty" state is not treated as "unhealthy," providing a cleaner and more accurate first-time experience for users.

### **Steps to test**

1. Connect to a cluster where Flux is installed but no Kustomizations or HelmReleases have been created yet.
2. Navigate to the Flux -> Overview page.
3. Verify that the charts for empty resource types show 100% health (success) instead of 0%.
4. Create a failing Flux resource (e.g., a Kustomization with an invalid source) and verify that the percentage accurately drops to reflect the failure.

### **Notes**
The calculation logic ensures that even with total: 0, the internal percentage sum remains 100, which correctly triggers the "All reconcilers healthy" banner on fresh installations.