### PR TITLE
volcano: Add resource map integration

### DIFF
--- a/volcano/package-lock.json
+++ b/volcano/package-lock.json
@@ -11,7 +11,7 @@
         "notistack": "^3.0.1"
       },
       "devDependencies": {
-        "@kinvolk/headlamp-plugin": "^0.13.1"
+        "@kinvolk/headlamp-plugin": "^0.14.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -1794,9 +1794,9 @@
       }
     },
     "node_modules/@kinvolk/headlamp-plugin": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@kinvolk/headlamp-plugin/-/headlamp-plugin-0.13.1.tgz",
-      "integrity": "sha512-aoAGs5w8HIS43p3YBcjzkIWZZlh18b/e02d+r/rr6+99vc48vOd9tKAIBZMVg4j+cVzbPtL1+t1tDE/UdeHcWQ==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@kinvolk/headlamp-plugin/-/headlamp-plugin-0.14.0.tgz",
+      "integrity": "sha512-oVIqpSzf2zZfZG44gwrGI8xTLImCIKupUJ26k7ZhVrFSUBY9Ga+R66tfCdN4Q/ShYha/8J+qlpy5ac9PjRq2KA==",
       "dev": true,
       "license": "Apache 2.0",
       "dependencies": {
@@ -1815,11 +1815,11 @@
         "@mui/x-date-pickers": "^7.15.0",
         "@mui/x-tree-view": "^6.17.0",
         "@reduxjs/toolkit": "^2.2.7",
-        "@storybook/addon-docs": "^9.1.17",
-        "@storybook/addon-links": "^9.1.17",
+        "@storybook/addon-docs": "^9.1.19",
+        "@storybook/addon-links": "^9.1.19",
         "@storybook/addon-webpack5-compiler-swc": "^3.0.0",
-        "@storybook/react-vite": "^9.1.17",
-        "@storybook/react-webpack5": "^9.1.17",
+        "@storybook/react-vite": "^9.1.19",
+        "@storybook/react-webpack5": "^9.1.19",
         "@tanstack/react-query": "^5.51.24",
         "@testing-library/dom": "^10.1.0",
         "@testing-library/jest-dom": "^6.4.8",
@@ -1890,9 +1890,9 @@
         "shx": "^0.4.0",
         "simple-eval": "^2.0.0",
         "spacetime": "^7.4.0",
-        "storybook": "^9.1.17",
+        "storybook": "^9.1.19",
         "table": "^6.8.2",
-        "tar": "^7.5.7",
+        "tar": "^7.5.11",
         "ts-loader": "^9.5.2",
         "typescript": "5.6.2",
         "validate-npm-package-name": "^3.0.0",

--- a/volcano/package.json
+++ b/volcano/package.json
@@ -38,6 +38,6 @@
     "notistack": "^3.0.1"
   },
   "devDependencies": {
-    "@kinvolk/headlamp-plugin": "^0.13.1"
+    "@kinvolk/headlamp-plugin": "^0.14.0"
   }
 }

--- a/volcano/src/components/jobs/Detail.tsx
+++ b/volcano/src/components/jobs/Detail.tsx
@@ -388,11 +388,13 @@ function getJobActionButtons(job: VolcanoJob) {
  *
  * @returns Job details view with extra sections and events.
  */
-export default function JobDetail() {
-  const { namespace, name } = useParams<{ namespace: string; name: string }>();
-  const [podGroups] = VolcanoPodGroup.useList({ namespace });
+export default function JobDetail(props: { namespace?: string; name?: string; cluster?: string }) {
+  const params = useParams<{ namespace: string; name: string }>();
+  const { namespace = params.namespace, name = params.name, cluster } = props;
+  const [podGroups] = VolcanoPodGroup.useList({ namespace, cluster });
   const [pods] = PodResource.useList({
     namespace,
+    cluster,
     labelSelector:
       name && namespace
         ? `volcano.sh/job-name=${name},volcano.sh/job-namespace=${namespace}`
@@ -404,6 +406,7 @@ export default function JobDetail() {
       resourceType={VolcanoJob}
       name={name}
       namespace={namespace}
+      cluster={cluster}
       withEvents
       extraInfo={(job: VolcanoJob) => {
         if (!job) {

--- a/volcano/src/components/map/QueueGlance.tsx
+++ b/volcano/src/components/map/QueueGlance.tsx
@@ -1,0 +1,65 @@
+import { Activity } from '@kinvolk/headlamp-plugin/lib';
+import { StatusLabel } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import type { GraphNode } from '@kinvolk/headlamp-plugin/lib/components/resourceMap/graph/graphModel';
+import MuiLink from '@mui/material/Link';
+import { Box } from '@mui/system';
+import type { MouseEvent } from 'react';
+import { isVolcanoJobApiVersion, isVolcanoPodGroupApiVersion } from '../../utils/volcanoApi';
+import QueueDetail from '../queues/Detail';
+
+function getQueueName(node: GraphNode) {
+  const apiVersion = node.kubeObject?.jsonData?.apiVersion;
+  const kind = node.kubeObject?.jsonData?.kind;
+  const queue = (node.kubeObject as any)?.queue;
+
+  const isVolcanoJob = kind === 'Job' && isVolcanoJobApiVersion(apiVersion);
+  const isVolcanoPodGroup = kind === 'PodGroup' && isVolcanoPodGroupApiVersion(apiVersion);
+
+  if (!isVolcanoJob && !isVolcanoPodGroup) {
+    return null;
+  }
+
+  return queue || null;
+}
+
+export function QueueGlance({ node }: { node: GraphNode }) {
+  const queueName = getQueueName(node);
+
+  if (!queueName) {
+    return null;
+  }
+
+  const openQueueDetails = (event: MouseEvent<HTMLAnchorElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    Activity.launch({
+      id: `volcano-queue-${node.kubeObject?.cluster || 'default'}-${queueName}`,
+      location: 'split-right',
+      temporary: true,
+      cluster: node.kubeObject?.cluster,
+      hideTitleInHeader: true,
+      title: queueName,
+      content: <QueueDetail name={queueName} cluster={node.kubeObject?.cluster} />,
+    });
+  };
+
+  return (
+    <Box
+      display="flex"
+      gap={1}
+      alignItems="center"
+      mt={2}
+      flexWrap="wrap"
+      onClick={event => event.stopPropagation()}
+      onPointerDown={event => event.stopPropagation()}
+    >
+      <StatusLabel status="">
+        Queue:{' '}
+        <MuiLink href="#" onClick={openQueueDetails} title={queueName} underline="hover">
+          {queueName}
+        </MuiLink>
+      </StatusLabel>
+    </Box>
+  );
+}

--- a/volcano/src/components/podgroups/Detail.tsx
+++ b/volcano/src/components/podgroups/Detail.tsx
@@ -133,14 +133,20 @@ function getMinTaskMemberSection(podGroup: VolcanoPodGroup) {
  *
  * @returns PodGroup details view with extra sections and events.
  */
-export default function PodGroupDetail() {
-  const { namespace, name } = useParams<{ namespace: string; name: string }>();
+export default function PodGroupDetail(props: {
+  namespace?: string;
+  name?: string;
+  cluster?: string;
+}) {
+  const params = useParams<{ namespace: string; name: string }>();
+  const { namespace = params.namespace, name = params.name, cluster } = props;
 
   return (
     <DetailsGrid
       resourceType={VolcanoPodGroup}
       name={name}
       namespace={namespace}
+      cluster={cluster}
       withEvents
       extraInfo={(podGroup: VolcanoPodGroup) =>
         podGroup && [

--- a/volcano/src/components/queues/Detail.tsx
+++ b/volcano/src/components/queues/Detail.tsx
@@ -455,16 +455,18 @@ function getChildQueuesSection(queue: VolcanoQueue, queues: VolcanoQueue[] | nul
  *
  * @returns Queue details view with extra sections and events.
  */
-export default function QueueDetail() {
-  const { name } = useParams<{ name: string }>();
-  const [queues] = VolcanoQueue.useList();
-  const [podGroups] = VolcanoPodGroup.useList();
+export default function QueueDetail(props: { name?: string; cluster?: string }) {
+  const params = useParams<{ name: string }>();
+  const { name = params.name, cluster } = props;
+  const [queues] = VolcanoQueue.useList({ cluster });
+  const [podGroups] = VolcanoPodGroup.useList({ cluster });
   const queuePodGroupStats = useMemo(() => getQueuePodGroupStats(podGroups), [podGroups]);
 
   return (
     <DetailsGrid
       resourceType={VolcanoQueue}
       name={name}
+      cluster={cluster}
       withEvents
       actions={(queue: VolcanoQueue) => (queue ? getQueueActionButtons(queue) : [])}
       extraInfo={(queue: VolcanoQueue) =>

--- a/volcano/src/index.tsx
+++ b/volcano/src/index.tsx
@@ -10,9 +10,11 @@ import PodGroupDetail from './components/podgroups/Detail';
 import PodGroupList from './components/podgroups/List';
 import QueueDetail from './components/queues/Detail';
 import QueueList from './components/queues/List';
+import { registerVolcanoMapExtensions } from './mapRegistration';
 import { registerVolcanoIcon } from './volcanoIcon';
 
 registerVolcanoIcon();
+registerVolcanoMapExtensions();
 
 /**
  * Route and sidebar registration settings for a Volcano resource section.

--- a/volcano/src/mapRegistration.tsx
+++ b/volcano/src/mapRegistration.tsx
@@ -1,0 +1,23 @@
+import { Icon } from '@iconify/react';
+import {
+  registerKindIcon,
+  registerKubeObjectGlance,
+  registerMapSource,
+} from '@kinvolk/headlamp-plugin/lib';
+import { QueueGlance } from './components/map/QueueGlance';
+import { volcanoSource } from './mapView';
+import { volcanoJobApiGroup, volcanoSchedulingApiGroup } from './utils/volcanoApi';
+
+const volcanoKindIcon = {
+  icon: <Icon icon="custom:volcano" width="70%" height="70%" />,
+  color: 'rgb(229, 39, 25)',
+};
+
+export function registerVolcanoMapExtensions() {
+  registerMapSource(volcanoSource);
+  registerKubeObjectGlance({ id: 'volcano-queue-glance', component: QueueGlance });
+
+  registerKindIcon('Job', volcanoKindIcon, volcanoJobApiGroup);
+  registerKindIcon('Queue', volcanoKindIcon, volcanoSchedulingApiGroup);
+  registerKindIcon('PodGroup', volcanoKindIcon, volcanoSchedulingApiGroup);
+}

--- a/volcano/src/mapView.tsx
+++ b/volcano/src/mapView.tsx
@@ -1,0 +1,352 @@
+import { Icon } from '@iconify/react';
+import { K8s } from '@kinvolk/headlamp-plugin/lib';
+import type {
+  GraphEdge,
+  GraphNode,
+} from '@kinvolk/headlamp-plugin/lib/components/resourceMap/graph/graphModel';
+import type { KubeObject } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import type { ComponentType } from 'react';
+import { useMemo } from 'react';
+import JobDetail from './components/jobs/Detail';
+import PodGroupDetail from './components/podgroups/Detail';
+import QueueDetail from './components/queues/Detail';
+import { VolcanoJob } from './resources/job';
+import { VolcanoPodGroup } from './resources/podgroup';
+import { VolcanoQueue } from './resources/queue';
+import { getJobStatusColor, getPodGroupStatusColor, getQueueStatusColor } from './utils/status';
+import { isVolcanoJobApiVersion } from './utils/volcanoApi';
+
+const volcanoMapIcon = (
+  <Icon icon="custom:volcano" width="100%" height="100%" color="rgb(229, 39, 25)" />
+);
+
+const PodResource = K8s.ResourceClasses.Pod;
+const volcanoJobNameLabel = 'volcano.sh/job-name';
+const volcanoJobNamespaceLabel = 'volcano.sh/job-namespace';
+
+type GraphNodeStatus = 'error' | 'success' | 'warning';
+type GraphDetailsComponentProps = { node: GraphNode };
+type VolcanoOwnerReference = {
+  apiVersion?: string;
+  kind?: string;
+  uid?: string;
+};
+type VolcanoMapKubeObject = KubeObject & {
+  metadata: {
+    uid: string;
+    ownerReferences?: VolcanoOwnerReference[];
+  };
+};
+
+function isVolcanoJobOwnerReference(ownerReference: VolcanoOwnerReference) {
+  return ownerReference.kind === 'Job' && isVolcanoJobApiVersion(ownerReference.apiVersion);
+}
+
+function referencesVolcanoJob(ownerReference: VolcanoOwnerReference, job: VolcanoJob) {
+  return isVolcanoJobOwnerReference(ownerReference) && ownerReference.uid === job.metadata.uid;
+}
+
+function hasVolcanoJobOwnerReference(kubeObject: VolcanoMapKubeObject) {
+  return (
+    kubeObject.metadata.ownerReferences?.some(ownerReference =>
+      isVolcanoJobOwnerReference(ownerReference)
+    ) || false
+  );
+}
+
+function makeVolcanoNode(
+  kubeObject: VolcanoMapKubeObject,
+  weight: number,
+  subtitle: string,
+  status: GraphNodeStatus | undefined,
+  detailsComponent: ComponentType<GraphDetailsComponentProps>
+) {
+  return {
+    id: kubeObject.metadata.uid,
+    kubeObject,
+    subtitle,
+    status,
+    weight,
+    detailsComponent,
+  };
+}
+
+function makeQueueNode(queue: VolcanoQueue) {
+  return makeVolcanoNode(
+    queue,
+    5000,
+    'Volcano Queue',
+    getQueueStatusColor(queue.state),
+    ({ node }: GraphDetailsComponentProps) => (
+      <QueueDetail
+        name={node.kubeObject.jsonData.metadata.name}
+        cluster={node.kubeObject.cluster}
+      />
+    )
+  );
+}
+
+function makeJobNode(job: VolcanoJob) {
+  return makeVolcanoNode(
+    job,
+    4000,
+    'Volcano Job',
+    getJobStatusColor(job.phase),
+    ({ node }: GraphDetailsComponentProps) => (
+      <JobDetail
+        namespace={node.kubeObject.jsonData.metadata.namespace}
+        name={node.kubeObject.jsonData.metadata.name}
+        cluster={node.kubeObject.cluster}
+      />
+    )
+  );
+}
+
+function makePodGroupNode(podGroup: VolcanoPodGroup) {
+  return makeVolcanoNode(
+    podGroup,
+    3000,
+    'Volcano PodGroup',
+    getPodGroupStatusColor(podGroup.phase),
+    ({ node }: GraphDetailsComponentProps) => (
+      <PodGroupDetail
+        namespace={node.kubeObject.jsonData.metadata.namespace}
+        name={node.kubeObject.jsonData.metadata.name}
+        cluster={node.kubeObject.cluster}
+      />
+    )
+  );
+}
+
+function makePodNode(pod: InstanceType<typeof PodResource>) {
+  return {
+    id: pod.metadata.uid,
+    kubeObject: pod,
+  };
+}
+
+function makeKubeToKubeEdge(from: VolcanoMapKubeObject, to: VolcanoMapKubeObject): GraphEdge {
+  return {
+    id: `${from.metadata.uid}-${to.metadata.uid}`,
+    source: from.metadata.uid,
+    target: to.metadata.uid,
+  };
+}
+
+function makePodToJobEdge(pod: InstanceType<typeof PodResource>, job: VolcanoJob): GraphEdge {
+  return {
+    id: `${pod.metadata.uid}-${job.metadata.uid}`,
+    source: pod.metadata.uid,
+    target: job.metadata.uid,
+  };
+}
+
+function getQueueHierarchyEdges(queues: VolcanoQueue[]) {
+  const edges: GraphEdge[] = [];
+
+  queues.forEach(queue => {
+    const parentQueueName = queue.spec.parent;
+    if (!parentQueueName) {
+      return;
+    }
+
+    const parentQueue = queues.find(candidate => candidate.metadata.name === parentQueueName);
+    if (parentQueue) {
+      edges.push(makeKubeToKubeEdge(parentQueue, queue));
+    }
+  });
+
+  return edges;
+}
+
+function getRelatedPodGroup(job: VolcanoJob, podGroups: VolcanoPodGroup[]) {
+  const byOwnerReference = podGroups.find(podGroup =>
+    podGroup.metadata.ownerReferences?.some(ownerReference =>
+      referencesVolcanoJob(ownerReference, job)
+    )
+  );
+
+  if (byOwnerReference) {
+    return byOwnerReference;
+  }
+
+  // Owner refs are authoritative, name fallback keeps older objects connected when refs are absent.
+  const canonicalName = `${job.metadata.name}-${job.metadata.uid}`;
+  const byCanonicalName = podGroups.find(podGroup => podGroup.metadata.name === canonicalName);
+
+  if (byCanonicalName) {
+    return byCanonicalName;
+  }
+
+  return podGroups.find(podGroup => podGroup.metadata.name === job.metadata.name) || null;
+}
+
+function getJobToPodGroupEdges(jobs: VolcanoJob[], podGroups: VolcanoPodGroup[]) {
+  const edges: GraphEdge[] = [];
+
+  jobs.forEach(job => {
+    const podGroup = getRelatedPodGroup(job, podGroups);
+    if (podGroup) {
+      edges.push(makeKubeToKubeEdge(job, podGroup));
+    }
+  });
+
+  return edges;
+}
+
+function getVolcanoPods(pods: InstanceType<typeof PodResource>[]) {
+  return pods.filter(pod => {
+    const labels = pod.metadata.labels || {};
+    const jobName = labels[volcanoJobNameLabel];
+    const jobNamespace = labels[volcanoJobNamespaceLabel];
+    const hasVolcanoJobLabels = Boolean(jobName && jobNamespace);
+
+    return hasVolcanoJobOwnerReference(pod) || hasVolcanoJobLabels;
+  });
+}
+
+function getPodJob(pod: InstanceType<typeof PodResource>, jobs: VolcanoJob[]) {
+  const byOwnerReference = jobs.find(job =>
+    pod.metadata.ownerReferences?.some(ownerReference => referencesVolcanoJob(ownerReference, job))
+  );
+
+  if (byOwnerReference) {
+    return byOwnerReference;
+  }
+
+  const labels = pod.metadata.labels || {};
+  const jobName = labels[volcanoJobNameLabel];
+  const jobNamespace = labels[volcanoJobNamespaceLabel];
+
+  if (!jobName || !jobNamespace) {
+    return null;
+  }
+
+  return (
+    jobs.find(
+      candidate =>
+        candidate.metadata.name === jobName && candidate.metadata.namespace === jobNamespace
+    ) || null
+  );
+}
+
+function getPodToJobEdges(jobs: VolcanoJob[], pods: InstanceType<typeof PodResource>[]) {
+  const edges: GraphEdge[] = [];
+
+  pods.forEach(pod => {
+    const job = getPodJob(pod, jobs);
+    if (job) {
+      edges.push(makePodToJobEdge(pod, job));
+    }
+  });
+
+  return edges;
+}
+
+const queueSource = {
+  id: 'volcano-queues',
+  label: 'queues',
+  icon: volcanoMapIcon,
+  useData() {
+    const [queues] = VolcanoQueue.useList();
+
+    return useMemo(() => {
+      if (!queues) {
+        return null;
+      }
+
+      return {
+        nodes: queues.map(queue => makeQueueNode(queue)),
+      };
+    }, [queues]);
+  },
+};
+
+const queueHierarchySource = {
+  id: 'volcano-queue-hierarchy',
+  label: 'queue hierarchy',
+  icon: volcanoMapIcon,
+  useData() {
+    const [queues] = VolcanoQueue.useList();
+
+    return useMemo(() => {
+      if (!queues) {
+        return null;
+      }
+
+      return {
+        edges: getQueueHierarchyEdges(queues),
+      };
+    }, [queues]);
+  },
+};
+
+const jobSource = {
+  id: 'volcano-jobs',
+  label: 'jobs',
+  icon: volcanoMapIcon,
+  useData() {
+    const [jobs] = VolcanoJob.useList();
+
+    return useMemo(() => {
+      if (!jobs) {
+        return null;
+      }
+
+      return {
+        nodes: jobs.map(job => makeJobNode(job)),
+      };
+    }, [jobs]);
+  },
+};
+
+const podGroupSource = {
+  id: 'volcano-podgroups',
+  label: 'podgroups',
+  icon: volcanoMapIcon,
+  useData() {
+    const [podGroups] = VolcanoPodGroup.useList();
+    const [jobs] = VolcanoJob.useList();
+
+    return useMemo(() => {
+      if (!podGroups || !jobs) {
+        return null;
+      }
+
+      return {
+        nodes: podGroups.map(podGroup => makePodGroupNode(podGroup)),
+        edges: getJobToPodGroupEdges(jobs, podGroups),
+      };
+    }, [podGroups, jobs]);
+  },
+};
+
+const podSource = {
+  id: 'volcano-pods',
+  label: 'pods',
+  icon: volcanoMapIcon,
+  useData() {
+    const [pods] = PodResource.useList();
+    const [jobs] = VolcanoJob.useList();
+
+    return useMemo(() => {
+      if (!pods || !jobs) {
+        return null;
+      }
+
+      const volcanoPods = getVolcanoPods(pods).filter(pod => getPodJob(pod, jobs));
+
+      return {
+        nodes: volcanoPods.map(pod => makePodNode(pod)),
+        edges: getPodToJobEdges(jobs, volcanoPods),
+      };
+    }, [pods, jobs]);
+  },
+};
+
+export const volcanoSource = {
+  id: 'volcano',
+  label: 'Volcano',
+  icon: volcanoMapIcon,
+  sources: [queueSource, jobSource, podGroupSource, podSource, queueHierarchySource],
+};

--- a/volcano/src/utils/volcanoApi.ts
+++ b/volcano/src/utils/volcanoApi.ts
@@ -1,0 +1,14 @@
+export const volcanoJobApiGroup = 'batch.volcano.sh';
+export const volcanoSchedulingApiGroup = 'scheduling.volcano.sh';
+
+export function isApiVersionInGroup(apiVersion: string | undefined, apiGroup: string) {
+  return apiVersion?.startsWith(`${apiGroup}/`) || false;
+}
+
+export function isVolcanoJobApiVersion(apiVersion: string | undefined) {
+  return isApiVersionInGroup(apiVersion, volcanoJobApiGroup);
+}
+
+export function isVolcanoPodGroupApiVersion(apiVersion: string | undefined) {
+  return isApiVersionInGroup(apiVersion, volcanoSchedulingApiGroup);
+}


### PR DESCRIPTION
## Summary
This PR adds Volcano resources to Headlamp’s resource map so users can inspect Queue, Job, PodGroup, Pod, and Queue hierarchy relationships visually.
## Changes
- register a Volcano map source
- add map nodes for:
  - Queues
  - Jobs
  - PodGroups
  - Volcano-managed Pods
- add map edges for:
  - parent Queue → child Queue
  - Volcano Job → PodGroup
  - Volcano Job → Pod 
- add API-group-aware matching for Volcano Jobs to avoid conflicts with Kubernetes `batch/v1` Jobs
- add Queue glance metadata for Volcano Jobs and PodGroups
- reuse existing Volcano detail pages in the map side panel
- register API-group aware Volcano icons for Job, Queue, and PodGroup map nodes
## Steps to Test
1. Install Volcano in a connected cluster.
2. Build/start the Volcano plugin.
3. Open the Headlamp resource map.
4. Enable the Volcano source.
5. Confirm Queues, Jobs, PodGroups, and Volcano Pods appear.
6. Confirm Queue hierarchy edges are shown.
7. Click Volcano Job, Queue, and PodGroup nodes and confirm the side panel shows the correct Volcano details.
8. Hover/click Queue glance information from Volcano Job or PodGroup nodes.

## Demo

https://github.com/user-attachments/assets/2a8a4936-bd62-4fb7-9faf-e7d26b49b394


## Notes for the Reviewers
I'm aware of the CI/CD Failure on `npm run tsc`, The reason for this block is the current `@kinvolk/headlamp-plugin@0.13.1` types missing the 3-argument `registerKindIcon(kind, icon, apiGroup)` signature, it is fixed in the headlamp repo already and it should pass the `tsc` test after the new release of `@kinvolk/headlamp-plugin`

