### PR TITLE
fix(flux): resolve hardcoded URLs and maintain cluster context

### DIFF
--- a/flux/src/helpers/index.tsx
+++ b/flux/src/helpers/index.tsx
@@ -195,6 +195,7 @@ export function NameLink(resourceClass: KubeObjectClass) {
           namespace: row.original.jsonData.metadata.namespace,
           pluralName: pluralName,
         }}
+        activeCluster={row.original.cluster}
       >
         {cell.getValue()}
       </Link>

--- a/flux/src/index.tsx
+++ b/flux/src/index.tsx
@@ -244,6 +244,7 @@ registerRoute({
   sidebar: 'notifications',
   component: () => <Notifications />,
   exact: true,
+  name: 'notifications',
 });
 
 registerRoute({

--- a/flux/src/overview/index.tsx
+++ b/flux/src/overview/index.tsx
@@ -1,5 +1,5 @@
 import { Icon } from '@iconify/react';
-import { K8s } from '@kinvolk/headlamp-plugin/lib';
+import { K8s, Router, Utils } from '@kinvolk/headlamp-plugin/lib';
 import {
   ActionButton,
   Link,
@@ -22,6 +22,7 @@ import {
 } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import React, { useEffect, useState } from 'react';
+import { useHistory } from 'react-router-dom';
 import SourceLink from '../common/Link';
 import {
   AlertNotification,
@@ -205,6 +206,7 @@ function FluxHealthBanner({
 }
 
 export function FluxOverview() {
+  const history = useHistory();
   const [sortFilter, setSortFilter] = useState(() => store.get()?.overviewSortFilter ?? 'failed');
   const [showFilter, setShowFilter] = useState(
     () => store.get()?.overviewShowFilter ?? 'configured'
@@ -439,7 +441,10 @@ export function FluxOverview() {
               description="Flux Settings"
               icon="mdi:cog"
               onClick={() => {
-                window.location.href = '/settings/plugins/@headlamp-k8s%2Fflux';
+                const settingsUrl = Router.createRouteURL('pluginSettings', {
+                  pluginName: '@headlamp-k8s/flux',
+                });
+                history.push(settingsUrl);
               }}
             />,
           ],
@@ -597,33 +602,33 @@ function FluxOverviewChart({ resourceClass }) {
     switch (name) {
       case 'externalartifacts': // fallthrough
       case 'gitrepositories':
-        return '/flux/sources';
+        return 'sources';
       case 'ocirepositories':
-        return '/flux/sources';
+        return 'sources';
       case 'buckets':
-        return '/flux/sources';
+        return 'sources';
       case 'helmrepositories':
-        return '/flux/sources';
+        return 'sources';
       case 'helmcharts':
-        return '/flux/sources';
+        return 'sources';
       case 'kustomizations':
-        return '/flux/kustomizations';
+        return 'kustomizations';
       case 'helmreleases':
-        return '/flux/helmreleases';
+        return 'helmreleases';
       case 'alerts':
-        return '/flux/notifications';
+        return 'notifications';
       case 'providers':
-        return '/flux/notifications';
+        return 'notifications';
       case 'receivers':
-        return '/flux/notifications';
+        return 'notifications';
       case 'imagerepositories':
-        return '/flux/image-automations';
+        return 'image-automations';
       case 'imageupdateautomations':
-        return '/flux/image-automations';
+        return 'image-automations';
       case 'imagepolicies':
-        return '/flux/image-automations';
+        return 'image-automations';
       case 'terraforms':
-        return '/flux/terraforms';
+        return 'terraforms';
     }
 
     return '';
@@ -772,7 +777,7 @@ function FluxOverviewChart({ resourceClass }) {
       return (
         <Box>
           <Box>
-            <Link routeName={prepareLink(resourceClass.apiName)}>
+            <Link routeName={prepareLink(resourceClass.apiName)} activeCluster={Utils.getCluster()}>
               {prepareName(resourceClass.apiName)}
             </Link>
           </Box>


### PR DESCRIPTION
### **Summary**
This PR refactors the Flux plugin's navigation logic to eliminate hardcoded URL strings and direct window.location mutations. It migrates all internal links to use Headlamp's Routing API, ensuring compatibility with multi-cluster and sub-path deployments.

### **Key changes**
`flux/src/overview/index.tsx`:

1. Migrated the "Flux Settings" action to use Utils.Router.createRouteURL instead of a hardcoded path.
2. Updated the prepareLink helper to return internal route names (e.g., 'sources', 'kustomizations') which allows Headlamp to dynamically generate the correct URLs.
3. Ensured FluxOverviewChart links pass the activeCluster context to prevent accidental cluster switching.

`flux/src/helpers/index.tsx`:

1. Updated the NameLink helper to propagate row.original.cluster to the Link component, ensuring resource links maintain the correct cluster context in multi-cluster environments.
2. Why this is needed
3. Broken Navigation: Hardcoded paths starting with / fail when Headlamp is served behind a reverse proxy or has a base path (e.g., /headlamp/).
4. Cluster Context Loss: Without the activeCluster property, navigating through the Flux plugin can cause the UI to drop the user back into the default cluster, creating confusion and potential errors when managing multiple environments.

### **Steps to test**

1. In a multi-cluster Headlamp environment, navigate to the Flux -> Overview page of a non-default cluster.
2. Click on any resource category legend (e.g., "Kustomizations").
3. Verify that you are taken to the correct list view on the same cluster (check the URL prefix).
4. Click the "Settings" (cog) icon in the Flux Overview header and verify it correctly opens the plugin settings page without a 404 error.