### PR TITLE
radius: standardize empty-state health reporting and preserve cluster context

### DIFF
--- a/radius/src/models/radius.ts
+++ b/radius/src/models/radius.ts
@@ -504,6 +504,9 @@ export function useRadiusResources(): [UCPResource[] | null, Error | null, boole
         // Build promises for all resource types across all providers
         const promises: Promise<UCPResource[]>[] = [];
 
+        let successCount = 0;
+        let lastError: Error | null = null;
+
         // Helper function to fetch resources for a provider
         const fetchProviderResources = async (
           provider: string,
@@ -512,12 +515,14 @@ export function useRadiusResources(): [UCPResource[] | null, Error | null, boole
           try {
             const path = `/apis/api.ucp.dev/v1alpha3/planes/radius/local/providers/${provider}/${resourceType}?api-version=${apiVersion}`;
             const data: UCPListResponse<UCPResource> = await ApiProxy.request(path, {}, true, true);
+            successCount++;
             return data.value || [];
           } catch (err) {
             const message = `Failed to fetch ${provider}/${resourceType}: ${
               err instanceof Error ? err.message : String(err)
             }`;
             console.warn(message);
+            lastError = err instanceof Error ? err : new Error(String(err));
             return [];
           }
         };
@@ -545,9 +550,12 @@ export function useRadiusResources(): [UCPResource[] | null, Error | null, boole
         const results = await Promise.all(promises);
         const allResources = results.flat();
 
-        if (allResources.length === 0) {
-          throw new Error(
-            'Failed to fetch Radius resources from all configured providers and resource types.'
+        if (successCount === 0 && promises.length > 0) {
+          throw (
+            lastError ||
+            new Error(
+              'Failed to fetch Radius resources from all configured providers and resource types.'
+            )
           );
         }
 

--- a/radius/src/radius-overview/index.tsx
+++ b/radius/src/radius-overview/index.tsx
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { Icon } from '@iconify/react';
+import { Utils } from '@kinvolk/headlamp-plugin/lib';
 import { Link, SectionBox, Table } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 import { TileChart } from '@kinvolk/headlamp-plugin/lib/components/common';
 import { Box, CircularProgress, Grid, Typography, useTheme } from '@mui/material';
@@ -83,27 +85,14 @@ function ResourceStatusChart({ resources, title }: ResourceStatusChartProps) {
   const theme = useTheme();
   const total = resources.length;
 
-  if (total === 0) {
-    return (
-      <Box sx={{ textAlign: 'center', p: 3 }}>
-        <Typography variant="h4" gutterBottom>
-          0
-        </Typography>
-        <Typography variant="body2" color="text.secondary">
-          {title}
-        </Typography>
-      </Box>
-    );
-  }
-
   const status = getResourceStatus(resources);
 
   // Calculate percentages ensuring they sum to 100%
   const percentages = [
-    Math.round((status.success / total) * 100),
-    Math.round((status.failed / total) * 100),
-    Math.round((status.processing / total) * 100),
-    Math.round((status.suspended / total) * 100),
+    total > 0 ? Math.round((status.success / total) * 100) : 100,
+    total > 0 ? Math.round((status.failed / total) * 100) : 0,
+    total > 0 ? Math.round((status.processing / total) * 100) : 0,
+    total > 0 ? Math.round((status.suspended / total) * 100) : 0,
   ];
 
   // Adjust to ensure total is 100% by modifying the largest percentage
@@ -226,14 +215,22 @@ export default function Overview() {
 
   if (appError || envError || resError) {
     return (
-      <Box sx={{ p: 3 }}>
-        <Typography color="error" variant="h6">
-          Error loading Radius resources
-        </Typography>
-        {appError && <Typography color="error">{appError.message}</Typography>}
-        {envError && <Typography color="error">{envError.message}</Typography>}
-        {resError && <Typography color="error">{resError.message}</Typography>}
-      </Box>
+      <SectionBox title="Radius Overview">
+        <Box p={3} display="flex" flexDirection="column" alignItems="center" gap={2}>
+          <Icon icon="radius:logo" width={48} height={48} />
+          <Typography variant="h6">Radius is not installed</Typography>
+          <Typography variant="body2" color="text.secondary">
+            Radius is an open-source cloud-native application platform.{' '}
+            <a
+              href="https://docs.radapp.io/installation/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Learn how to install Radius
+            </a>
+          </Typography>
+        </Box>
+      </SectionBox>
     );
   }
 
@@ -319,7 +316,11 @@ export default function Overview() {
               Cell: ({ row }: { row: { original: ApplicationTableData } }) => {
                 const appName = row.original.name;
                 return (
-                  <Link routeName="application-detail" params={{ applicationName: appName }}>
+                  <Link
+                    routeName="application-detail"
+                    params={{ applicationName: appName }}
+                    activeCluster={Utils.getCluster()}
+                  >
                     {appName}
                   </Link>
                 );
@@ -334,7 +335,11 @@ export default function Overview() {
                   return <Typography variant="body2">{envName}</Typography>;
                 }
                 return (
-                  <Link routeName="environment-detail" params={{ environmentName: envName }}>
+                  <Link
+                    routeName="environment-detail"
+                    params={{ environmentName: envName }}
+                    activeCluster={Utils.getCluster()}
+                  >
                     {envName}
                   </Link>
                 );
@@ -365,7 +370,11 @@ export default function Overview() {
               Cell: ({ row }: { row: { original: EnvironmentTableData } }) => {
                 const envName = row.original.name;
                 return (
-                  <Link routeName="environment-detail" params={{ environmentName: envName }}>
+                  <Link
+                    routeName="environment-detail"
+                    params={{ environmentName: envName }}
+                    activeCluster={Utils.getCluster()}
+                  >
                     {envName}
                   </Link>
                 );


### PR DESCRIPTION
### **Summary:**
This PR standardizes the Radius plugin's Overview dashboard by ensuring that resource types with no configured items report 100% health instead of an empty state. It also implements a "Not Installed" empty state and ensures that multi-cluster context is preserved during navigation, aligning the plugin with Headlamp's core visual and architectural standards.

### **Key changes**

`radius/src/radius-overview/index.tsx`:

1. Updated ResourceStatusChart to render a healthy (100%) chart when no resources exist, instead of returning a plain text "0" indicator.
2. Implemented a professional "Radius is not installed" empty state banner with installation links, triggered when Radius API calls fail.
3. Refactored all table Link components to propagate activeCluster context using Utils.getCluster(), preventing accidental cluster switching during navigation.

### **Why this is needed**

1. Misleading Metrics: Currently, the Radius dashboard shows an "empty" state for zero resources, which doesn't clearly signify a healthy environment. Aligning this with the "100% Success" pattern used in Flux and Kyverno provides a more positive and accurate UX.
2. User Consistency: A standardized "Not Installed" screen helps new users understand why the dashboard is empty and provides clear next steps for installation.
3. Cluster Context Loss: Without passing activeCluster to resource links, navigating through the Radius plugin in a multi-cluster setup can cause the UI to drop the user back into the default cluster.

### **Steps to test**

1. Connect to a cluster where Radius is not installed. Navigate to the Radius -> Overview page and verify the "Radius is not installed" banner appears.
2. Connect to a cluster where Radius is installed but no Applications or Environments exist. Verify that the status charts show 100% health instead of just the number "0".
3. In a multi-cluster environment, navigate to the Radius Overview of a non-default cluster and click on an Application or Environment name. Verify that you remain on the same cluster (check the URL prefix).