### PR TITLE
strimzi: Add resource Map integration for Kafka resources

### DIFF
--- a/strimzi/src/index.tsx
+++ b/strimzi/src/index.tsx
@@ -1,4 +1,10 @@
-import { registerRoute, registerSidebarEntry } from '@kinvolk/headlamp-plugin/lib';
+import {
+  registerKindIcon,
+  registerMapSource,
+  registerRoute,
+  registerSidebarEntry,
+} from '@kinvolk/headlamp-plugin/lib';
+import { Icon } from '@iconify/react';
 import React from 'react';
 import { KafkaDetail } from './components/kafkas/Detail';
 import { KafkaList } from './components/KafkaList';
@@ -11,6 +17,7 @@ import { KafkaConnectList } from './components/KafkaConnectList';
 import { KafkaConnectorDetail } from './components/connectors/Detail';
 import { KafkaConnectorList } from './components/KafkaConnectorList';
 import { StrimziErrorBoundary } from './components/StrimziErrorBoundary';
+import { strimziSource } from './mapView';
 
 /**
  * Wraps a component in StrimziErrorBoundary so that any uncaught render
@@ -149,4 +156,35 @@ registerSidebarEntry({
   name: 'connectors',
   label: 'Kafka Connectors',
   url: '/strimzi/connectors',
+});
+
+// Register Strimzi resources as nodes on Headlamp's Map view, with edges
+// connecting topics/users/connectors to the Kafka cluster they target.
+registerMapSource(strimziSource);
+
+const STRIMZI_BLUE = 'rgb(0, 132, 255)';
+
+registerKindIcon('Kafka', {
+  icon: <Icon icon="mdi:server-network" width="70%" height="70%" />,
+  color: STRIMZI_BLUE,
+});
+
+registerKindIcon('KafkaTopic', {
+  icon: <Icon icon="mdi:file-tree" width="70%" height="70%" />,
+  color: STRIMZI_BLUE,
+});
+
+registerKindIcon('KafkaUser', {
+  icon: <Icon icon="mdi:account-key" width="70%" height="70%" />,
+  color: STRIMZI_BLUE,
+});
+
+registerKindIcon('KafkaConnect', {
+  icon: <Icon icon="mdi:transit-connection-variant" width="70%" height="70%" />,
+  color: STRIMZI_BLUE,
+});
+
+registerKindIcon('KafkaConnector', {
+  icon: <Icon icon="mdi:swap-horizontal" width="70%" height="70%" />,
+  color: STRIMZI_BLUE,
 });

--- a/strimzi/src/mapView.tsx
+++ b/strimzi/src/mapView.tsx
@@ -6,11 +6,12 @@ import { KafkaConnectDetail } from './components/connects/Detail';
 import { KafkaConnectorDetail } from './components/connectors/Detail';
 import { KafkaTopicDetail } from './components/topics/Detail';
 import { KafkaUserDetail } from './components/users/Detail';
-import { Kafka } from './resources/kafka';
-import { KafkaConnect } from './resources/kafkaConnect';
-import { KafkaConnector } from './resources/kafkaConnector';
-import { KafkaTopic } from './resources/kafkaTopic';
-import { KafkaUser } from './resources/kafkaUser';
+import { useStrimziApiVersions } from './hooks/useStrimziApiVersions';
+import { Kafka, KafkaV1 } from './resources/kafka';
+import { KafkaConnect, KafkaConnectV1 } from './resources/kafkaConnect';
+import { KafkaConnector, KafkaConnectorV1 } from './resources/kafkaConnector';
+import { KafkaTopic, KafkaTopicV1 } from './resources/kafkaTopic';
+import { KafkaUser, KafkaUserV1 } from './resources/kafkaUser';
 
 const STRIMZI_BLUE = 'rgb(0, 132, 255)';
 const CLUSTER_LABEL = 'strimzi.io/cluster';
@@ -60,12 +61,21 @@ const userIcon = <Icon icon="mdi:account-key" width="100%" height="100%" color={
 const connectIcon = <Icon icon="mdi:transit-connection-variant" width="100%" height="100%" color={STRIMZI_BLUE} />;
 const connectorIcon = <Icon icon="mdi:swap-horizontal" width="100%" height="100%" color={STRIMZI_BLUE} />;
 
+/**
+ * Strimzi 1.0+ retires the v1beta2 API and serves the CRDs as v1. Each map
+ * source resolves the API version the current cluster actually serves (via
+ * the shared `useStrimziApiVersions` probe) and picks the matching KubeObject
+ * class, the same way the list and detail views do. Pinning v1beta2 here
+ * would leave the map empty on v1-only clusters.
+ */
 const kafkaSource = {
   id: 'strimzi-kafkas',
   label: 'Kafka clusters',
   icon: kafkaIcon,
   useData() {
-    const [kafkas] = Kafka.useList();
+    const { kafka: kafkaVersion } = useStrimziApiVersions();
+    const KafkaClass = kafkaVersion === 'v1' ? KafkaV1 : Kafka;
+    const [kafkas] = KafkaClass.useList();
     return useMemo(() => {
       if (!kafkas) return null;
       const KafkaNodeDetails = makeDetailsComponent(KafkaDetail);
@@ -85,8 +95,11 @@ const kafkaTopicSource = {
   label: 'Kafka topics',
   icon: topicIcon,
   useData() {
-    const [topics] = KafkaTopic.useList();
-    const [kafkas] = Kafka.useList();
+    const { kafka: kafkaVersion } = useStrimziApiVersions();
+    const KafkaTopicClass = kafkaVersion === 'v1' ? KafkaTopicV1 : KafkaTopic;
+    const KafkaClass = kafkaVersion === 'v1' ? KafkaV1 : Kafka;
+    const [topics] = KafkaTopicClass.useList();
+    const [kafkas] = KafkaClass.useList();
     return useMemo(() => {
       if (!topics) return null;
       const TopicNodeDetails = makeDetailsComponent(KafkaTopicDetail);
@@ -114,8 +127,11 @@ const kafkaUserSource = {
   label: 'Kafka users',
   icon: userIcon,
   useData() {
-    const [users] = KafkaUser.useList();
-    const [kafkas] = Kafka.useList();
+    const { kafka: kafkaVersion } = useStrimziApiVersions();
+    const KafkaUserClass = kafkaVersion === 'v1' ? KafkaUserV1 : KafkaUser;
+    const KafkaClass = kafkaVersion === 'v1' ? KafkaV1 : Kafka;
+    const [users] = KafkaUserClass.useList();
+    const [kafkas] = KafkaClass.useList();
     return useMemo(() => {
       if (!users) return null;
       const UserNodeDetails = makeDetailsComponent(KafkaUserDetail);
@@ -143,7 +159,9 @@ const kafkaConnectSource = {
   label: 'Kafka Connect clusters',
   icon: connectIcon,
   useData() {
-    const [connects] = KafkaConnect.useList();
+    const { kafka: kafkaVersion } = useStrimziApiVersions();
+    const KafkaConnectClass = kafkaVersion === 'v1' ? KafkaConnectV1 : KafkaConnect;
+    const [connects] = KafkaConnectClass.useList();
     return useMemo(() => {
       if (!connects) return null;
       const ConnectNodeDetails = makeDetailsComponent(KafkaConnectDetail);
@@ -163,8 +181,11 @@ const kafkaConnectorSource = {
   label: 'Kafka connectors',
   icon: connectorIcon,
   useData() {
-    const [connectors] = KafkaConnector.useList();
-    const [connects] = KafkaConnect.useList();
+    const { kafka: kafkaVersion } = useStrimziApiVersions();
+    const KafkaConnectorClass = kafkaVersion === 'v1' ? KafkaConnectorV1 : KafkaConnector;
+    const KafkaConnectClass = kafkaVersion === 'v1' ? KafkaConnectV1 : KafkaConnect;
+    const [connectors] = KafkaConnectorClass.useList();
+    const [connects] = KafkaConnectClass.useList();
     return useMemo(() => {
       if (!connectors) return null;
       const ConnectorNodeDetails = makeDetailsComponent(KafkaConnectorDetail);

--- a/strimzi/src/mapView.tsx
+++ b/strimzi/src/mapView.tsx
@@ -1,0 +1,201 @@
+import { Icon } from '@iconify/react';
+import React, { useMemo } from 'react';
+import { GraphNode } from '@kinvolk/headlamp-plugin/lib/components/resourceMap/graph/graphModel';
+import { KafkaDetail } from './components/kafkas/Detail';
+import { KafkaConnectDetail } from './components/connects/Detail';
+import { KafkaConnectorDetail } from './components/connectors/Detail';
+import { KafkaTopicDetail } from './components/topics/Detail';
+import { KafkaUserDetail } from './components/users/Detail';
+import { Kafka } from './resources/kafka';
+import { KafkaConnect } from './resources/kafkaConnect';
+import { KafkaConnector } from './resources/kafkaConnector';
+import { KafkaTopic } from './resources/kafkaTopic';
+import { KafkaUser } from './resources/kafkaUser';
+
+const STRIMZI_BLUE = 'rgb(0, 132, 255)';
+const CLUSTER_LABEL = 'strimzi.io/cluster';
+
+type KubeLike = { metadata: { uid: string; name: string; namespace?: string; labels?: Record<string, string> } };
+
+const makeEdge = (from: KubeLike, to: KubeLike) => ({
+  id: `${from.metadata.uid}-${to.metadata.uid}`,
+  source: from.metadata.uid,
+  target: to.metadata.uid,
+});
+
+type DetailComponent = React.ComponentType<{ node: GraphNode }>;
+
+/**
+ * Build a `detailsComponent` for a map node that renders the existing list/detail
+ * Detail page. `kubeObject` is optional on `GraphNode`, so we guard before
+ * forwarding to the underlying detail component.
+ */
+function makeDetailsComponent(
+  Detail: React.ComponentType<{ namespace?: string; name?: string }>
+): DetailComponent {
+  return function NodeDetails({ node }: { node: GraphNode }) {
+    const meta = node.kubeObject?.jsonData?.metadata;
+    if (!meta) return null;
+    return <Detail namespace={meta.namespace} name={meta.name} />;
+  };
+}
+
+/**
+ * Find the Kafka cluster that a Strimzi child resource belongs to. Strimzi
+ * stamps the `strimzi.io/cluster` label on KafkaTopic / KafkaUser / KafkaConnector
+ * to mark which cluster they target. We match on (label, namespace) because
+ * cluster names are only unique within a namespace.
+ */
+function findClusterByLabel<T extends KubeLike>(child: KubeLike, clusters: T[] | null): T | undefined {
+  const clusterName = child.metadata.labels?.[CLUSTER_LABEL];
+  if (!clusterName || !clusters) return undefined;
+  return clusters.find(
+    c => c.metadata.name === clusterName && c.metadata.namespace === child.metadata.namespace
+  );
+}
+
+const kafkaIcon = <Icon icon="mdi:server-network" width="100%" height="100%" color={STRIMZI_BLUE} />;
+const topicIcon = <Icon icon="mdi:file-tree" width="100%" height="100%" color={STRIMZI_BLUE} />;
+const userIcon = <Icon icon="mdi:account-key" width="100%" height="100%" color={STRIMZI_BLUE} />;
+const connectIcon = <Icon icon="mdi:transit-connection-variant" width="100%" height="100%" color={STRIMZI_BLUE} />;
+const connectorIcon = <Icon icon="mdi:swap-horizontal" width="100%" height="100%" color={STRIMZI_BLUE} />;
+
+const kafkaSource = {
+  id: 'strimzi-kafkas',
+  label: 'Kafka clusters',
+  icon: kafkaIcon,
+  useData() {
+    const [kafkas] = Kafka.useList();
+    return useMemo(() => {
+      if (!kafkas) return null;
+      const KafkaNodeDetails = makeDetailsComponent(KafkaDetail);
+      const nodes = kafkas.map(k => ({
+        id: k.metadata.uid,
+        kubeObject: k,
+        weight: 3000,
+        detailsComponent: KafkaNodeDetails,
+      }));
+      return { nodes };
+    }, [kafkas]);
+  },
+};
+
+const kafkaTopicSource = {
+  id: 'strimzi-kafka-topics',
+  label: 'Kafka topics',
+  icon: topicIcon,
+  useData() {
+    const [topics] = KafkaTopic.useList();
+    const [kafkas] = Kafka.useList();
+    return useMemo(() => {
+      if (!topics) return null;
+      const TopicNodeDetails = makeDetailsComponent(KafkaTopicDetail);
+      const nodes = topics.map(t => ({
+        id: t.metadata.uid,
+        kubeObject: t,
+        weight: 1000,
+        detailsComponent: TopicNodeDetails,
+      }));
+
+      const edges = topics
+        .map(t => {
+          const cluster = findClusterByLabel(t, kafkas);
+          return cluster ? makeEdge(t, cluster) : null;
+        })
+        .filter((e): e is NonNullable<typeof e> => e !== null);
+
+      return { nodes, edges };
+    }, [topics, kafkas]);
+  },
+};
+
+const kafkaUserSource = {
+  id: 'strimzi-kafka-users',
+  label: 'Kafka users',
+  icon: userIcon,
+  useData() {
+    const [users] = KafkaUser.useList();
+    const [kafkas] = Kafka.useList();
+    return useMemo(() => {
+      if (!users) return null;
+      const UserNodeDetails = makeDetailsComponent(KafkaUserDetail);
+      const nodes = users.map(u => ({
+        id: u.metadata.uid,
+        kubeObject: u,
+        weight: 1000,
+        detailsComponent: UserNodeDetails,
+      }));
+
+      const edges = users
+        .map(u => {
+          const cluster = findClusterByLabel(u, kafkas);
+          return cluster ? makeEdge(u, cluster) : null;
+        })
+        .filter((e): e is NonNullable<typeof e> => e !== null);
+
+      return { nodes, edges };
+    }, [users, kafkas]);
+  },
+};
+
+const kafkaConnectSource = {
+  id: 'strimzi-kafka-connects',
+  label: 'Kafka Connect clusters',
+  icon: connectIcon,
+  useData() {
+    const [connects] = KafkaConnect.useList();
+    return useMemo(() => {
+      if (!connects) return null;
+      const ConnectNodeDetails = makeDetailsComponent(KafkaConnectDetail);
+      const nodes = connects.map(c => ({
+        id: c.metadata.uid,
+        kubeObject: c,
+        weight: 2500,
+        detailsComponent: ConnectNodeDetails,
+      }));
+      return { nodes };
+    }, [connects]);
+  },
+};
+
+const kafkaConnectorSource = {
+  id: 'strimzi-kafka-connectors',
+  label: 'Kafka connectors',
+  icon: connectorIcon,
+  useData() {
+    const [connectors] = KafkaConnector.useList();
+    const [connects] = KafkaConnect.useList();
+    return useMemo(() => {
+      if (!connectors) return null;
+      const ConnectorNodeDetails = makeDetailsComponent(KafkaConnectorDetail);
+      const nodes = connectors.map(c => ({
+        id: c.metadata.uid,
+        kubeObject: c,
+        weight: 1000,
+        detailsComponent: ConnectorNodeDetails,
+      }));
+
+      const edges = connectors
+        .map(c => {
+          const connect = findClusterByLabel(c, connects);
+          return connect ? makeEdge(c, connect) : null;
+        })
+        .filter((e): e is NonNullable<typeof e> => e !== null);
+
+      return { nodes, edges };
+    }, [connectors, connects]);
+  },
+};
+
+export const strimziSource = {
+  id: 'strimzi',
+  label: 'Strimzi',
+  icon: kafkaIcon,
+  sources: [
+    kafkaSource,
+    kafkaTopicSource,
+    kafkaUserSource,
+    kafkaConnectSource,
+    kafkaConnectorSource,
+  ],
+};


### PR DESCRIPTION
Adds the resource Map integration for the Strimzi plugin, following the flow in Headlamp's plugin development tutorial.

This PR was originally scoped to also include a Prometheus metrics section. Per review feedback that has been split out: the metrics work is being reworked to follow the prometheus plugin's chart pattern (Karpenter/KEDA style) and will come as a separate PR. This PR is now Map-only.

## Map view

Registers Kafka, KafkaTopic, KafkaUser, KafkaConnect, and KafkaConnector as nodes under one "Strimzi" source group. Edges are derived from the standard `strimzi.io/cluster` label, so topics and users link to their Kafka cluster, and connectors link to their Connect cluster. Each node opens the existing Detail component, so the map and the list pages stay consistent. Custom MDI icons are registered for the five kinds.

A KafkaConnect to Kafka edge is intentionally not drawn. The only link is `bootstrapServers`, and parsing it reliably across listener configs is brittle. Happy to add it later if there is a clean signal.

## Test plan

- [ ] Open the Map view, enable the Strimzi sources, and confirm the five kinds appear with icons and edges
- [ ] Click a node and confirm the existing Detail page opens
- [ ] `npm run tsc`, `npm run lint`, `npm test`, and `npm run build` all pass
