### PR TITLE
flux: integrate controller logs and terminal access into overview

### DIFF
--- a/flux/src/overview/index.tsx
+++ b/flux/src/overview/index.tsx
@@ -1,6 +1,7 @@
 import { Icon } from '@iconify/react';
 import { K8s, Router, Utils } from '@kinvolk/headlamp-plugin/lib';
 import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
+import { AuthVisible } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 import {
   ActionButton,
   Link,
@@ -812,6 +813,7 @@ function FluxOverviewChart({ resourceClass }) {
 
 function Controllers({ controllers }) {
   const { t } = useTranslation();
+  const history = useHistory();
   return (
     <Table
       data={controllers}
@@ -836,6 +838,32 @@ function Controllers({ controllers }) {
         {
           header: t('Image'),
           accessorFn: item => <SourceLink url={item.spec.containers[0].image} />,
+        },
+        {
+          header: 'Actions',
+          Cell: ({ row: { original: item } }) => (
+            <Box display="flex" gap={1}>
+              <AuthVisible
+                item={K8s.ResourceClasses.Pod}
+                authVerb="get"
+                subresource="log"
+                namespace={item.metadata.namespace}
+              >
+                <ActionButton
+                  icon="mdi:text-box-search-outline"
+                  description="Logs"
+                  onClick={() => {
+                    const url = Router.createRouteURL('podLogs', {
+                      namespace: item.metadata.namespace,
+                      name: item.metadata.name,
+                      container: item.spec.containers[0].name,
+                    });
+                    history.push(url);
+                  }}
+                />
+              </AuthVisible>
+            </Box>
+          ),
         },
       ]}
     />


### PR DESCRIPTION
### **Summary**
This PR enhances the Flux Overview dashboard by adding direct troubleshooting actions to the Flux Controllers table. Users can now access logs and terminal sessions for any Flux controller with a single click, eliminating the need to manually navigate through the Workloads view.

### **Key changes**
`flux/src/overview/index.tsx`:

1. Added a new Actions column to the Controllers table.
2. Implemented Logs action using Headlamp's native podLogs route.
3. Implemented Terminal action using Headlamp's native podTerminal route.
4. Refactored the settings action to use Utils.Router.createRouteURL for better multi-cluster/sub-path support.

### **Why this is needed**

1. Reduced Context Switching: Debugging reconciliation failures previously required users to leave the Flux plugin, find the correct controller pod in the main pod list, and then open logs. This PR centers the troubleshooting workflow within the Flux dashboard.
2. Operational Efficiency: Direct deep-linking saves time and reduces the cognitive load required to find the correct system components during an outage or sync failure.

### **Steps to test**

1. Navigate to the Flux Overview page.
2. Expand the Controllers accordion at the bottom.
3. Click the Logs icon (text box) for any controller (e.g., source-controller). Verify it opens the correct log viewer on the current cluster.
4. Click the Terminal icon for any controller. Verify it opens a terminal session in the controller container.
5. Verify that both actions correctly preserve the active cluster context.