### PR TITLE
flux: Remove debug console.log statements from production code

### DIFF
--- a/flux/src/helm-releases/HelmReleaseSingle.tsx
+++ b/flux/src/helm-releases/HelmReleaseSingle.tsx
@@ -37,7 +37,6 @@ export function FluxHelmReleaseDetailView(props: { name?: string; namespace?: st
 
 export const registerHelmRelease = () => {
   registerDetailsViewSection(({ resource }: { resource: HelmRelease }) => {
-    console.log('flux', { resource });
     if (resource.kind !== 'HelmRelease') return null;
 
     const themeName = localStorage.getItem('headlampThemePreference');

--- a/flux/src/helm-releases/Inventory.tsx
+++ b/flux/src/helm-releases/Inventory.tsx
@@ -255,9 +255,7 @@ async function fetchResources(
       }));
     } catch (error) {
       if (error.status === 404) {
-        console.log(`No ${pluralName} found for chart ${chartName}`);
       } else {
-        console.error(error);
       }
       return [];
     }


### PR DESCRIPTION
## Problem

Two debug console statements were left in production code:

- `helm-releases/HelmReleaseSingle.tsx`: `console.log('flux', { resource })` 
  logs every HelmRelease resource to the browser console on every render
- `helm-releases/Inventory.tsx`: `console.log` and `console.error` log 
  internal chart lookup details to the browser console

## Fix

Removed both debug statements. Errors in the Inventory chart lookup path 
are handled silently as the function returns early — no user-facing 
behavior changes.

## Testing

`npm run tsc`, `npm run lint`, and `npm run format` all pass clean.