### PR TITLE
knative: implement dynamic sidebar filtering based on CRD discovery

### DIFF
--- a/knative/src/index.tsx
+++ b/knative/src/index.tsx
@@ -16,11 +16,14 @@
 
 import { Icon } from '@iconify/react';
 import {
+  K8s,
   registerKindIcon,
   registerKubeObjectGlance,
   registerMapSource,
   registerRoute,
   registerSidebarEntry,
+  registerSidebarEntryFilter,
+  Utils,
 } from '@kinvolk/headlamp-plugin/lib';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
@@ -47,6 +50,79 @@ function withQueryClient(Component: React.ComponentType) {
     );
   });
 }
+
+// Track whether Knative CRDs exist per cluster to hide sidebar.
+const knativeInstalledByCluster: Record<string, boolean> = {};
+const lastCheckedAt: Record<string, number> = {};
+const inFlight: Record<string, boolean> = {};
+const CHECK_TTL_MS = 30 * 1000;
+
+/**
+ * Checks if Knative is installed on the given cluster by probing for the
+ * core Knative Serving CRD ('services.serving.knative.dev').
+ * Uses a TTL-based cache and cancels the underlying Kubernetes watch to
+ * prevent socket/memory leaks.
+ *
+ * @param cluster The name of the cluster to check.
+ */
+function checkKnativeInstalled(cluster: string) {
+  const now = Date.now();
+  const fresh = now - (lastCheckedAt[cluster] ?? 0) < CHECK_TTL_MS;
+  if (inFlight[cluster] || fresh) {
+    return;
+  }
+  inFlight[cluster] = true;
+
+  let cancelFn: (() => void) | null = null;
+  let settled = false;
+
+  function settle(installed: boolean) {
+    if (settled) {
+      return;
+    }
+    settled = true;
+    knativeInstalledByCluster[cluster] = installed;
+    lastCheckedAt[cluster] = Date.now();
+    inFlight[cluster] = false;
+
+    if (cancelFn) {
+      cancelFn();
+    }
+  }
+
+  const getFn = K8s.ResourceClasses.CustomResourceDefinition.apiGet(
+    () => settle(true),
+    'services.serving.knative.dev',
+    undefined,
+    () => settle(false),
+    { cluster }
+  );
+
+  getFn()
+    .then(cancel => {
+      cancelFn = cancel;
+      if (settled) {
+        cancelFn();
+      }
+    })
+    .catch(() => {
+      settle(false);
+    });
+}
+
+registerSidebarEntryFilter(entry => {
+  if (entry.name !== 'knative' && entry.parent !== 'knative') {
+    return entry;
+  }
+
+  const cluster = Utils.getCluster() ?? '';
+  checkKnativeInstalled(cluster);
+
+  if (knativeInstalledByCluster[cluster] === false) {
+    return null;
+  }
+  return entry;
+});
 
 // Sidebar entries for Knative
 registerSidebarEntry({


### PR DESCRIPTION
### Summary
This PR refactors the Knative plugin's menu registration in the sidebar to implement dynamic, cluster-aware visibility filtering. It hides the entire Knative menu group when connected to a cluster where Knative's Serving components are not installed, matching Headlamp's visual quality standards.

### Key changes
*   **knative/src/index.tsx**:
    *   Imported `K8s`, `Utils`, and `registerSidebarEntryFilter` from the plugin SDK.
    *   Implemented `checkKnativeInstalled(cluster)` with a lightweight caching and time-to-live (TTL) mechanism to search the cluster's Custom Resource Definitions (CRDs) for `'services.serving.knative.dev'`.
    *   Registered a sidebar entry filter to hide the `knative` parent and all child entries if Knative is not installed on the active cluster.

### Why this is needed
*   **UI Clutter:** Statically registering Knative sidebar entries makes the menus permanently visible even on environments without Knative. Clicking them triggers dead views, leading to a cluttered and unpolished experience.
*   **Active Context Sync:** It guarantees that the sidebar navigation dynamically adapts when switching between different Kubernetes clusters with different capabilities.

### Steps to test
1.  Switch to a Kubernetes cluster that **does not** have Knative installed.
2.  Verify that the **Knative** sidebar menu entry is completely hidden.
3.  Switch to a cluster **with** Knative installed.
4.  Verify that the **Knative** sidebar menu entry (and all its sub-pages: KServices, Revisions, Domain Mapping, Cluster Domain Claims, Networking) displays correctly.
