### PR TITLE
flux: migrate Flagger and Terraform detail views to standard KubeObjectDetailView

### DIFF
--- a/flux/src/flagger/canarydetails.tsx
+++ b/flux/src/flagger/canarydetails.tsx
@@ -1,10 +1,8 @@
 import {
-  ConditionsTable,
+  ConditionsSection,
+  DetailsGrid,
   Link,
-  MainInfoSection,
-  SectionBox,
 } from '@kinvolk/headlamp-plugin/lib/components/common';
-import Event from '@kinvolk/headlamp-plugin/lib/K8s/event';
 import {
   Box,
   Card,
@@ -21,7 +19,6 @@ import {
 import React from 'react';
 import { useParams } from 'react-router-dom';
 import { ResumeAction, SuspendAction } from '../actions';
-import { ObjectEventsRenderer } from '../helpers';
 import FlaggerAvailabilityCheck, { useCanary } from './availabilitycheck';
 import CanaryStatus from './canarystatus';
 
@@ -35,43 +32,40 @@ export default function CanaryDetails() {
   );
 }
 
-function CanaryDetailsRenderer({ resource }) {
+function CanaryDetailsRenderer({ resource }: { resource: any }) {
   const { namespace, name } = useParams<{ name: string; namespace: string }>();
-  const [cr, setCr] = React.useState(null);
 
   const resourceClass = React.useMemo(() => {
     return resource.makeCRClass();
   }, [resource]);
 
-  resourceClass.useApiGet(setCr, name, namespace);
-
-  const [events] = Event.useList({
-    namespace,
-    fieldSelector: `involvedObject.name=${name},involvedObject.kind=Canary`,
-  });
-
-  if (!cr) return null;
-
-  const targetRef = cr?.jsonData?.spec?.targetRef || {};
-  const analysis = cr?.jsonData?.spec?.analysis || {};
-  const service = cr?.jsonData?.spec?.service || {};
-
   return (
-    <>
-      <MainInfoSection
-        resource={cr}
-        extraInfo={[
+    <DetailsGrid
+      resourceType={resourceClass}
+      name={name}
+      namespace={namespace}
+      withEvents
+      actions={resource => {
+        if (!resource) return [];
+        return [<SuspendAction resource={resource} />, <ResumeAction resource={resource} />];
+      }}
+      extraInfo={item => {
+        if (!item) return [];
+        const targetRef = item.jsonData?.spec?.targetRef || {};
+        const analysis = item.jsonData?.spec?.analysis || {};
+
+        const info: any[] = [
           {
             name: 'Suspend',
-            value: cr?.jsonData?.spec?.suspend ? 'True' : 'False',
+            value: item.jsonData?.spec?.suspend ? 'True' : 'False',
           },
           {
             name: 'Status',
-            value: <CanaryStatus status={cr?.jsonData?.status?.phase || 'Unknown'} />,
+            value: <CanaryStatus status={item.jsonData?.status?.phase || 'Unknown'} />,
           },
           {
             name: 'Service',
-            value: service.name || '-',
+            value: item.jsonData?.spec?.service?.name || '-',
           },
           {
             name: 'Target',
@@ -85,7 +79,7 @@ function CanaryDetailsRenderer({ resource }) {
                     routeName={`${targetRef.kind.toLowerCase()}`}
                     params={{
                       name: targetRef.name,
-                      namespace: targetRef.namespace || cr?.jsonData?.metadata?.namespace,
+                      namespace: targetRef.namespace || item.jsonData?.metadata?.namespace,
                     }}
                   >
                     {targetRef.name}
@@ -115,16 +109,20 @@ function CanaryDetailsRenderer({ resource }) {
             name: 'Webhooks',
             value: analysis?.webhooks ? <WebhooksSection webhooks={analysis.webhooks} /> : '-',
           },
-        ]}
-        actions={[<SuspendAction resource={cr} />, <ResumeAction resource={cr} />]}
-      />
+        ];
 
-      <SectionBox title="Conditions">
-        <ConditionsTable resource={cr?.jsonData} />
-      </SectionBox>
-
-      <ObjectEventsRenderer events={events?.map(event => new Event(event)) || []} />
-    </>
+        return info;
+      }}
+      extraSections={item => {
+        if (!item) return [];
+        return [
+          {
+            id: 'flagger.canary-conditions',
+            section: <ConditionsSection resource={item.jsonData} />,
+          },
+        ];
+      }}
+    />
   );
 }
 

--- a/flux/src/terraforms/TerraformSingle.tsx
+++ b/flux/src/terraforms/TerraformSingle.tsx
@@ -1,8 +1,4 @@
-import {
-  ConditionsTable,
-  MainInfoSection,
-  SectionBox,
-} from '@kinvolk/headlamp-plugin/lib/components/common';
+import { ConditionsSection, DetailsGrid } from '@kinvolk/headlamp-plugin/lib/components/common';
 import React from 'react';
 import { useParams } from 'react-router-dom';
 import {
@@ -13,44 +9,46 @@ import {
 } from '../actions/index';
 import { Terraform } from '../common/Resources';
 import StatusLabel from '../common/StatusLabel';
-import { ObjectEvents } from '../helpers/index';
 
 export function TerraformDetailView(props: { name?: string; namespace?: string }) {
   const params = useParams<{ namespace: string; name: string }>();
   const { name = params.name, namespace = params.namespace } = props;
-  const [cr] = Terraform.useGet(name, namespace);
-
-  function prepareExtraInfo() {
-    if (!cr) return [];
-    return [
-      { name: 'Status', value: <StatusLabel item={cr} /> },
-      { name: 'Source', value: cr?.jsonData?.spec?.sourceRef?.name },
-      { name: 'Path', value: cr?.jsonData?.spec?.path },
-      { name: 'Workspace', value: cr?.jsonData?.spec?.workspace },
-      { name: 'Interval', value: cr?.jsonData?.spec?.interval },
-      { name: 'Suspend', value: cr?.jsonData?.spec?.suspend ? 'True' : 'False' },
-    ];
-  }
-
-  function prepareActions() {
-    if (!cr) return [];
-    return [
-      <SyncWithSourceAction key="sync" resource={cr} />,
-      <SyncWithoutSourceAction key="sync-without-source" resource={cr} />,
-      <SuspendAction key="suspend" resource={cr} />,
-      <ResumeAction key="resume" resource={cr} />,
-    ];
-  }
 
   return (
-    <>
-      {cr && (
-        <MainInfoSection resource={cr} extraInfo={prepareExtraInfo()} actions={prepareActions()} />
-      )}
-      <SectionBox title="Conditions">
-        <ConditionsTable resource={cr?.jsonData} />
-      </SectionBox>
-      <ObjectEvents name={name} namespace={namespace} resourceClass={Terraform} />
-    </>
+    <DetailsGrid
+      resourceType={Terraform}
+      name={name}
+      namespace={namespace}
+      withEvents
+      actions={resource => {
+        if (!resource) return [];
+        return [
+          <SyncWithSourceAction key="sync" resource={resource} />,
+          <SyncWithoutSourceAction key="sync-without-source" resource={resource} />,
+          <SuspendAction key="suspend" resource={resource} />,
+          <ResumeAction key="resume" resource={resource} />,
+        ];
+      }}
+      extraInfo={resource => {
+        if (!resource) return [];
+        return [
+          { name: 'Status', value: <StatusLabel item={resource} /> },
+          { name: 'Source', value: resource.jsonData?.spec?.sourceRef?.name },
+          { name: 'Path', value: resource.jsonData?.spec?.path },
+          { name: 'Workspace', value: resource.jsonData?.spec?.workspace },
+          { name: 'Interval', value: resource.jsonData?.spec?.interval },
+          { name: 'Suspend', value: resource.jsonData?.spec?.suspend ? 'True' : 'False' },
+        ];
+      }}
+      extraSections={resource => {
+        if (!resource) return [];
+        return [
+          {
+            id: 'flux.terraform-conditions',
+            section: <ConditionsSection resource={resource.jsonData} />,
+          },
+        ];
+      }}
+    />
   );
 }


### PR DESCRIPTION
### Summary
This PR refactors the Flux plugin's detail pages for Flagger Canaries and Terraform resources by migrating them to Headlamp's native `KubeObjectDetailView` (using the `DetailsGrid` component). This aligns these resources with Headlamp's visual and architectural standards, enabling native Header actions (Edit YAML/Delete) and real-time Event sections.

### Key changes
*   **flux/src/flagger/canarydetails.tsx**:
    *   Migrated the Flagger Canary view to `DetailsGrid`.
    *   Preserved flagger-specific webhooks analysis, metrics, and custom webhook sections under "Extra Information".
*   **flux/src/terraforms/TerraformSingle.tsx**:
    *   Migrated the Terraform view to `DetailsGrid`.
    *   Preserved suspend/resume action headers and status metrics.

### Why this is needed
*   **Architectural Consistency:** Migrating custom layout components to `DetailsGrid` allows these resources to inherit Headlamp's native layout features (like "Events," "Owner References," "Finalizers").
*   **Header Actions:** Users now have instant access to native header actions (like "Edit YAML" and "Delete") without needing custom overlay logic.
*   **Easier Review:** This PR is part of splitting the larger Flux Detail View migration (PR #713) into smaller, highly reviewable units, as requested by reviewers.

### Steps to test
1.  Navigate to **Flux -> Canaries** or **Flux -> Terraforms** detail view.
2.  Verify the presence of standard Headlamp action headers (Edit/Delete YAML).
3.  Confirm that real-time Kubernetes events display correctly at the bottom of the page.
4.  Verify that all custom status metrics and extra tables display correctly.
