### PR TITLE
flux: migrate Sources and Image Automation detail views to standard KubeObjectDetailView

### DIFF
--- a/flux/src/image-automation/ImageAutomationSingle.tsx
+++ b/flux/src/image-automation/ImageAutomationSingle.tsx
@@ -1,12 +1,12 @@
 import {
-  ConditionsTable,
+  ConditionsSection,
+  DetailsGrid,
   Link as HeadlampLink,
-  MainInfoSection,
   SectionBox,
   Table,
 } from '@kinvolk/headlamp-plugin/lib/components/common';
 import Editor from '@monaco-editor/react';
-import React, { ReactNode } from 'react';
+import React from 'react';
 import { useParams } from 'react-router-dom';
 import YAML from 'yaml';
 import { ResumeAction, SuspendAction, SyncAction } from '../actions/index';
@@ -15,7 +15,6 @@ import Link from '../common/Link';
 import RemainingTimeDisplay from '../common/RemainingTimeDisplay';
 import { ImagePolicy, ImageRepository, ImageUpdateAutomation } from '../common/Resources';
 import StatusLabel from '../common/StatusLabel';
-import { ObjectEvents } from '../helpers/index';
 
 export function FluxImageAutomationDetailView() {
   const { pluralName, namespace, name } = useParams<{
@@ -41,153 +40,142 @@ export function FluxImageAutomationDetailView() {
     return <Flux404 message={`Unknown type ${pluralName}`} />;
   }
 
-  return (
-    <>
-      <CustomResourceDetails resourceClass={resourceClass} name={name} namespace={namespace} />
-      <ObjectEvents name={name} namespace={namespace} resourceClass={resourceClass} />
-    </>
-  );
-}
-
-function CustomResourceDetails(props) {
-  const { name, namespace, resourceClass } = props;
-
   const themeName = localStorage.getItem('headlampThemePreference');
 
-  const [resource] = resourceClass.useGet(name, namespace);
-
-  function prepareExtraInfo() {
-    if (!resource) {
-      return [];
-    }
-    const extraInfo: Array<{ name: string; value: ReactNode }> = [
-      {
-        name: 'Status',
-        value: <StatusLabel item={resource} />,
-      },
-    ];
-
-    if (resource.jsonData.kind === 'ImageRepository') {
-      extraInfo.push({
-        name: 'Image',
-        value: <Link url={resource.jsonData.spec?.image} />,
-      });
-      extraInfo.push({
-        name: 'Provider',
-        value: resource.jsonData.spec?.provider || 'None',
-      });
-      extraInfo.push({
-        name: 'Exclusion List',
-        value: resource.jsonData.spec?.exclusionList
-          ? resource.jsonData.spec?.exclusionList.join(', ')
-          : 'None',
-      });
-      extraInfo.push({
-        name: 'Canonical Image Name',
-        value: resource.jsonData?.status?.canonicalImageName || '-',
-      });
-    }
-
-    if (resource.jsonData.kind === 'ImagePolicy') {
-      extraInfo.push({
-        name: 'Image Repository',
-        value: (
-          <HeadlampLink
-            routeName="image"
-            params={{
-              name: resource.jsonData.spec?.imageRepositoryRef.name,
-              namespace:
-                resource.jsonData.spec.imageRepositoryRef.namespace ??
-                resource.jsonData.metadata.namespace,
-              pluralName: 'imagerepositories',
-            }}
-          >
-            {resource.jsonData.spec?.imageRepositoryRef.name}
-          </HeadlampLink>
-        ),
-      });
-      extraInfo.push({
-        name: 'Policy',
-        value: resource?.jsonData.spec?.policy && (
-          <Editor
-            theme={themeName === 'dark' ? 'vs-dark' : 'light'}
-            language="yaml"
-            value={YAML.stringify(resource?.jsonData.spec?.policy)}
-            height={150}
-            options={{
-              // no lines
-              lineNumbers: 'off',
-            }}
-          />
-        ),
-      });
-    }
-
-    if (resource.jsonData.kind === 'ImageUpdateAutomation') {
-      extraInfo.push({
-        name: 'Git',
-        value: resource.jsonData.spec?.git && (
-          <Editor
-            theme={themeName === 'dark' ? 'vs-dark' : 'light'}
-            language="yaml"
-            value={YAML.stringify(resource.jsonData.spec?.git)}
-            height={200}
-            options={{
-              // no lines
-              lineNumbers: 'off',
-            }}
-          />
-        ),
-      });
-    }
-
-    if (resource.jsonData.kind !== 'ImagePolicy') {
-      extraInfo.push({
-        name: 'Suspend',
-        value: resource.jsonData.spec?.suspend ? 'True' : 'False',
-      });
-      if (resource.jsonData?.spec?.interval) {
-        extraInfo.push({
-          name: 'Interval',
-          value: resource.jsonData.spec.interval,
-        });
-      }
-
-      if (!resource.jsonData.spec?.suspend) {
-        extraInfo.push({
-          name: 'Next Reconciliation',
-          value: <RemainingTimeDisplay item={resource} />,
-        });
-      }
-    }
-    return extraInfo;
-  }
-
   return (
-    <>
-      <MainInfoSection
-        resource={resource}
-        extraInfo={prepareExtraInfo()}
-        actions={
-          resourceClass.pluralName === ImagePolicy.pluralName
-            ? []
-            : [
-                <SyncAction resource={resource} />,
-                <SuspendAction resource={resource} />,
-                <ResumeAction resource={resource} />,
-              ]
+    <DetailsGrid
+      resourceType={resourceClass}
+      name={name}
+      namespace={namespace}
+      withEvents
+      actions={resource => {
+        if (!resource || resourceClass.pluralName === ImagePolicy.pluralName) return [];
+        return [
+          <SyncAction resource={resource} />,
+          <SuspendAction resource={resource} />,
+          <ResumeAction resource={resource} />,
+        ];
+      }}
+      extraInfo={resource => {
+        if (!resource) return [];
+        const info: any[] = [
+          {
+            name: 'Status',
+            value: <StatusLabel item={resource} />,
+          },
+        ];
+
+        if (resource.jsonData.kind === 'ImageRepository') {
+          info.push({
+            name: 'Image',
+            value: <Link url={resource.jsonData.spec?.image} />,
+          });
+          info.push({
+            name: 'Provider',
+            value: resource.jsonData.spec?.provider || 'None',
+          });
+          info.push({
+            name: 'Exclusion List',
+            value: resource.jsonData.spec?.exclusionList
+              ? resource.jsonData.spec?.exclusionList.join(', ')
+              : 'None',
+          });
+          info.push({
+            name: 'Canonical Image Name',
+            value: resource.jsonData?.status?.canonicalImageName || '-',
+          });
         }
-      />
-      {resourceClass.pluralName === ImageRepository.pluralName && (
-        <TagList resource={resource?.jsonData} />
-      )}
-      {resourceClass.pluralName === ImageUpdateAutomation.pluralName && (
-        <Policies resource={resource?.jsonData} />
-      )}
-      <SectionBox title="Conditions">
-        <ConditionsTable resource={resource?.jsonData} />
-      </SectionBox>
-    </>
+
+        if (resource.jsonData.kind === 'ImagePolicy') {
+          info.push({
+            name: 'Image Repository',
+            value: (
+              <HeadlampLink
+                routeName="image"
+                params={{
+                  name: resource.jsonData.spec?.imageRepositoryRef.name,
+                  namespace:
+                    resource.jsonData.spec.imageRepositoryRef.namespace ??
+                    resource.jsonData.metadata.namespace,
+                  pluralName: 'imagerepositories',
+                }}
+              >
+                {resource.jsonData.spec?.imageRepositoryRef.name}
+              </HeadlampLink>
+            ),
+          });
+          info.push({
+            name: 'Policy',
+            value: resource?.jsonData.spec?.policy && (
+              <Editor
+                theme={themeName === 'dark' ? 'vs-dark' : 'light'}
+                language="yaml"
+                value={YAML.stringify(resource?.jsonData.spec?.policy)}
+                height={150}
+                options={{ lineNumbers: 'off' }}
+              />
+            ),
+          });
+        }
+
+        if (resource.jsonData.kind === 'ImageUpdateAutomation') {
+          info.push({
+            name: 'Git',
+            value: resource.jsonData.spec?.git && (
+              <Editor
+                theme={themeName === 'dark' ? 'vs-dark' : 'light'}
+                language="yaml"
+                value={YAML.stringify(resource.jsonData.spec?.git)}
+                height={200}
+                options={{ lineNumbers: 'off' }}
+              />
+            ),
+          });
+        }
+
+        if (resource.jsonData.kind !== 'ImagePolicy') {
+          info.push({
+            name: 'Suspend',
+            value: resource.jsonData.spec?.suspend ? 'True' : 'False',
+          });
+          if (resource.jsonData?.spec?.interval) {
+            info.push({
+              name: 'Interval',
+              value: resource.jsonData.spec.interval,
+            });
+          }
+
+          if (!resource.jsonData.spec?.suspend) {
+            info.push({
+              name: 'Next Reconciliation',
+              value: <RemainingTimeDisplay item={resource} />,
+            });
+          }
+        }
+        return info;
+      }}
+      extraSections={resource => {
+        if (!resource) return [];
+        const sections = [];
+        if (resourceClass.pluralName === ImageRepository.pluralName) {
+          sections.push({
+            id: 'flux.imagerepository-tags',
+            section: <TagList resource={resource.jsonData} />,
+          });
+        }
+        if (resourceClass.pluralName === ImageUpdateAutomation.pluralName) {
+          sections.push({
+            id: 'flux.imageautomation-policies',
+            section: <Policies resource={resource.jsonData} />,
+          });
+        }
+        sections.push({
+          id: 'flux.imageautomation-conditions',
+          section: <ConditionsSection resource={resource.jsonData} />,
+        });
+        return sections;
+      }}
+    />
   );
 }
 

--- a/flux/src/overview/index.tsx
+++ b/flux/src/overview/index.tsx
@@ -734,7 +734,7 @@ function FluxOverviewChart({ resourceClass }) {
         {
           name: 'success',
           value: adjustedSuccessPercent,
-          fill: theme.palette.chartStyles.fillColor,
+          fill: (theme.palette as any).chartStyles?.fillColor || '#4caf50',
         },
         {
           name: 'failed',

--- a/flux/src/sources/SourceSingle.tsx
+++ b/flux/src/sources/SourceSingle.tsx
@@ -1,8 +1,8 @@
 import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
 import {
-  ConditionsTable,
+  ConditionsSection,
   DateLabel,
-  MainInfoSection,
+  DetailsGrid,
   NameValueTable,
   SectionBox,
 } from '@kinvolk/headlamp-plugin/lib/components/common';
@@ -19,7 +19,6 @@ import Link from '../common/Link';
 import RemainingTimeDisplay from '../common/RemainingTimeDisplay';
 import { getSourceClassByPluralName } from '../common/Resources';
 import StatusLabel from '../common/StatusLabel';
-import { ObjectEvents } from '../helpers/index';
 
 export function FluxSourceDetailView(props: {
   name?: string;
@@ -38,99 +37,100 @@ export function FluxSourceDetailView(props: {
     pluralName = params.pluralName,
   } = props;
 
+  const { t } = useTranslation();
   const resourceClass = getSourceClassByPluralName(pluralName);
 
   if (!resourceClass) {
-    return <Flux404 message={`Unknown type ${pluralName}`} />;
-  }
-
-  return <SourceDetailView name={name} namespace={namespace} resourceClass={resourceClass} />;
-}
-
-function SourceDetailView(props) {
-  const { name, namespace, resourceClass } = props;
-  const [resource, setResource] = React.useState(null);
-  const { t } = useTranslation();
-
-  resourceClass.useApiGet(setResource, name, namespace);
-
-  function prepareExtraInfo() {
-    const interval = resource?.jsonData.spec?.interval;
-    const extraInfo = [
-      {
-        name: t('Status'),
-        value: <StatusLabel item={resource} />,
-      },
-      {
-        name: t('Interval'),
-        value: interval,
-      },
-      {
-        name: t('Ref'),
-        value: resource?.jsonData.spec?.ref && JSON.stringify(resource?.jsonData.spec?.ref),
-      },
-      {
-        name: t('Timeout'),
-        value: resource?.jsonData.spec?.timeout,
-      },
-      {
-        name: t('URL'),
-        value: <Link url={resource?.jsonData.spec?.url} />,
-        hide: !resource?.jsonData.spec?.url,
-      },
-      {
-        name: t('Chart'),
-        hide: !resource?.jsonData.spec?.chart,
-        value: resource?.jsonData.spec?.chart,
-      },
-      {
-        name: t('Source Ref'),
-        hide: !resource?.jsonData.spec?.sourceRef,
-        value:
-          resource?.jsonData.spec?.sourceRef && JSON.stringify(resource?.jsonData.spec?.sourceRef),
-      },
-      {
-        name: t('Version'),
-        value: resource?.jsonData.spec?.version,
-        hide: !resource?.jsonData.spec?.version,
-      },
-      {
-        name: t('Suspend'),
-        value: resource?.jsonData.spec?.suspend ? t('True') : t('False'),
-      },
-    ];
-
-    if (!resource?.jsonData.spec?.suspend && resource?.jsonData.spec?.interval) {
-      extraInfo.push({
-        name: t('Next Reconciliation'),
-        value: <RemainingTimeDisplay item={resource} />,
-      });
-    }
-
-    return extraInfo;
+    return <Flux404 message={t('Unknown type {{pluralName}}', { pluralName })} />;
   }
 
   return (
-    <>
-      <MainInfoSection
-        resource={resource}
-        actions={[
+    <DetailsGrid
+      resourceType={resourceClass}
+      name={name}
+      namespace={namespace}
+      withEvents
+      actions={resource => {
+        if (!resource) return [];
+        return [
           <SyncAction resource={resource} />,
           <SuspendAction resource={resource} />,
           <ResumeAction resource={resource} />,
           <ForceReconciliationAction resource={resource} />,
-        ]}
-        extraInfo={prepareExtraInfo()}
-      />
-      {resource && <ObjectEvents namespace={namespace} name={name} resourceClass={resourceClass} />}
-      {resource && (
-        <SectionBox title={t('Conditions')}>
-          <ConditionsTable resource={resource?.jsonData} showLastUpdate={false} />
-        </SectionBox>
-      )}
+        ];
+      }}
+      extraInfo={resource => {
+        if (!resource) return [];
+        const info: any[] = [
+          {
+            name: t('Status'),
+            value: <StatusLabel item={resource} />,
+          },
+          {
+            name: t('Interval'),
+            value: resource.jsonData?.spec?.interval,
+          },
+          {
+            name: t('Ref'),
+            value: resource.jsonData?.spec?.ref && JSON.stringify(resource.jsonData?.spec?.ref),
+          },
+          {
+            name: t('Timeout'),
+            value: resource.jsonData?.spec?.timeout,
+          },
+          {
+            name: t('URL'),
+            value: <Link url={resource.jsonData?.spec?.url} />,
+            hide: !resource.jsonData?.spec?.url,
+          },
+          {
+            name: t('Chart'),
+            hide: !resource.jsonData?.spec?.chart,
+            value: resource.jsonData?.spec?.chart,
+          },
+          {
+            name: t('Source Ref'),
+            hide: !resource.jsonData?.spec?.sourceRef,
+            value:
+              resource.jsonData?.spec?.sourceRef &&
+              JSON.stringify(resource.jsonData?.spec?.sourceRef),
+          },
+          {
+            name: t('Version'),
+            value: resource.jsonData?.spec?.version,
+            hide: !resource.jsonData?.spec?.version,
+          },
+          {
+            name: t('Suspend'),
+            value: resource.jsonData?.spec?.suspend ? t('True') : t('False'),
+          },
+        ];
 
-      {resource && <ArtifactTable artifact={resource?.jsonData?.status?.artifact} />}
-    </>
+        if (!resource.jsonData?.spec?.suspend && resource.jsonData?.spec?.interval) {
+          info.push({
+            name: t('Next Reconciliation'),
+            value: <RemainingTimeDisplay item={resource} />,
+          });
+        }
+
+        return info;
+      }}
+      extraSections={resource => {
+        if (!resource) return [];
+        return [
+          {
+            id: 'flux.source-artifact',
+            section: resource.jsonData?.status?.artifact && (
+              <ArtifactTable artifact={resource.jsonData.status.artifact} />
+            ),
+          },
+          {
+            id: 'flux.source-conditions',
+            section: <ConditionsSection resource={resource.jsonData} />,
+          },
+        ];
+      }}
+    />
   );
 }
 


### PR DESCRIPTION
### Summary
This PR refactors the Flux plugin's detail pages for Sources and Image Automation resources by migrating them to Headlamp's native `KubeObjectDetailView` (via the `DetailsGrid` component). This aligns these resources with Headlamp's visual and architectural standards, enabling native Header actions (Edit YAML/Delete) and real-time Event sections.

### Key changes
*   **flux/src/sources/SourceSingle.tsx**:
    *   Migrated all source types (GitRepository, OCIRepository, HelmRepository, HelmChart, Bucket) to `DetailsGrid`.
    *   Preserved source-specific artifact metadata tables and reconciled remaining times.
*   **flux/src/image-automation/ImageAutomationSingle.tsx**:
    *   Migrated ImageRepository, ImageUpdateAutomation, and ImagePolicy to `DetailsGrid`.
    *   Preserved custom image tag analysis tables, patch paths, policy status, and suspend/resume headers.

### Why this is needed
*   **Architectural Alignment:** Migrating custom layout components to `DetailsGrid` allows these resources to inherit Headlamp's native layout features (like "Events," "Owner References," "Finalizers").
*   **Header Actions:** Users now have instant access to native header actions (like "Edit YAML" and "Delete") without needing custom overlay logic.
*   **Easier Review:** This PR is the second phase of splitting the larger Flux Detail View migration (PR #713) into smaller, highly reviewable units, as requested by reviewers.

### Steps to test
1.  Navigate to **Flux -> Sources** or **Flux -> Image Automations** detail view.
2.  Verify the presence of standard Headlamp action headers (Edit/Delete YAML).
3.  Confirm that real-time Kubernetes events display correctly at the bottom of the page.
4.  Verify that all custom artifact tables, policy rules, and image tags display correctly.
