### PR TITLE
volcano: Refactor shared plugin constants and relationships

### DIFF
--- a/volcano/src/components/jobflows/Detail.tsx
+++ b/volcano/src/components/jobflows/Detail.tsx
@@ -18,6 +18,7 @@ import {
   VolcanoJobFlow,
 } from '../../resources/jobflow';
 import { getJobFlowStatusColor, getJobStatusColor } from '../../utils/status';
+import { volcanoRouteNames } from '../../utils/volcanoRoutes';
 import { VolcanoFlowInstallCheck } from '../common/CommonComponents';
 import {
   getFlowStepSummary,
@@ -109,7 +110,10 @@ function renderJobTemplateLinks(templateNames?: string[], namespace?: string) {
       {templateNames.map((templateName, index) => (
         <span key={templateName}>
           {index > 0 ? ', ' : ''}
-          <Link routeName="volcano-jobtemplate-detail" params={{ namespace, name: templateName }}>
+          <Link
+            routeName={volcanoRouteNames.jobTemplateDetail}
+            params={{ namespace, name: templateName }}
+          >
             {templateName}
           </Link>
         </span>
@@ -145,7 +149,7 @@ function getFlowsSection(jobFlow: VolcanoJobFlow) {
               label: 'JobTemplate',
               getter: summary => (
                 <Link
-                  routeName="volcano-jobtemplate-detail"
+                  routeName={volcanoRouteNames.jobTemplateDetail}
                   params={{ namespace: jobFlow.metadata.namespace, name: summary.flow.name }}
                 >
                   {summary.flow.name}
@@ -159,7 +163,7 @@ function getFlowsSection(jobFlow: VolcanoJobFlow) {
                   summary.generatedJobName
                 ) : (
                   <Link
-                    routeName="volcano-job-detail"
+                    routeName={volcanoRouteNames.jobDetail}
                     params={{
                       namespace: jobFlow.metadata.namespace,
                       name: summary.generatedJobName,
@@ -264,7 +268,7 @@ function getGeneratedJobsSection(jobFlow: VolcanoJobFlow) {
               getter: jobStatus =>
                 jobStatus.name ? (
                   <Link
-                    routeName="volcano-job-detail"
+                    routeName={volcanoRouteNames.jobDetail}
                     params={{ namespace: jobFlow.metadata.namespace, name: jobStatus.name }}
                   >
                     {jobStatus.name}
@@ -336,7 +340,7 @@ function getConditionsSection(jobFlow: VolcanoJobFlow) {
                 name: 'Job',
                 value: (
                   <Link
-                    routeName="volcano-job-detail"
+                    routeName={volcanoRouteNames.jobDetail}
                     params={{ namespace: jobFlow.metadata.namespace, name: jobName }}
                   >
                     {jobName}

--- a/volcano/src/components/jobs/Detail.tsx
+++ b/volcano/src/components/jobs/Detail.tsx
@@ -13,59 +13,13 @@ import { VolcanoCommand } from '../../resources/command';
 import { VolcanoJob } from '../../resources/job';
 import { VolcanoPodGroup } from '../../resources/podgroup';
 import { getJobStatusColor } from '../../utils/status';
+import { volcanoJobNameLabel, volcanoJobNamespaceLabel } from '../../utils/volcanoLabels';
+import { getRelatedPodGroup } from '../../utils/volcanoRelationships';
+import { volcanoRouteNames } from '../../utils/volcanoRoutes';
 import { formatStringList, getPolicyRows, getTaskContainerRows, getTaskRows } from './detailRows';
 import JobCommandActionButton from './JobCommandActionButton';
 import { JobLogsHeaderButton } from './JobLogsViewer';
 import { getJobPodIssues, groupJobPodIssues, PodResource } from './pods';
-
-/**
- * Resolves the PodGroup related to a Volcano Job.
- *
- * Matching order:
- * 1) ownerReference UID match
- * 2) canonical PodGroup name `<job-name>-<job-uid>`
- * 3) legacy PodGroup name `<job-name>`
- *
- * @param job Volcano Job shown in the details page.
- * @param podGroups PodGroups listed in the same namespace.
- * @returns Related PodGroup when found; otherwise `null`.
- */
-function getRelatedPodGroup(
-  job: VolcanoJob,
-  podGroups: VolcanoPodGroup[] | null
-): VolcanoPodGroup | null {
-  if (!podGroups?.length) {
-    return null;
-  }
-
-  const byOwnerReference = podGroups.find(podGroup =>
-    podGroup.metadata.ownerReferences?.some(
-      ownerReference => ownerReference.kind === 'Job' && ownerReference.uid === job.metadata.uid
-    )
-  );
-
-  if (byOwnerReference) {
-    return byOwnerReference;
-  }
-
-  const jobName = job.metadata.name;
-  const jobUid = job.metadata.uid;
-
-  if (jobName && jobUid) {
-    const canonicalName = `${jobName}-${jobUid}`;
-    const byCanonicalName = podGroups.find(podGroup => podGroup.metadata.name === canonicalName);
-
-    if (byCanonicalName) {
-      return byCanonicalName;
-    }
-  }
-
-  if (jobName) {
-    return podGroups.find(podGroup => podGroup.metadata.name === jobName) || null;
-  }
-
-  return null;
-}
 
 /**
  * Builds the Pod Status section for the Job details page.
@@ -397,7 +351,7 @@ export default function JobDetail(props: { namespace?: string; name?: string; cl
     cluster,
     labelSelector:
       name && namespace
-        ? `volcano.sh/job-name=${name},volcano.sh/job-namespace=${namespace}`
+        ? `${volcanoJobNameLabel}=${name},${volcanoJobNamespaceLabel}=${namespace}`
         : undefined,
   });
 
@@ -432,7 +386,7 @@ export default function JobDetail(props: { namespace?: string; name?: string; cl
           {
             name: 'Queue',
             value: (
-              <Link routeName="volcano-queue-detail" params={{ name: job.queue }}>
+              <Link routeName={volcanoRouteNames.queueDetail} params={{ name: job.queue }}>
                 {job.queue}
               </Link>
             ),
@@ -442,7 +396,7 @@ export default function JobDetail(props: { namespace?: string; name?: string; cl
             value:
               relatedPodGroup && podGroupNamespace ? (
                 <Link
-                  routeName="volcano-podgroup-detail"
+                  routeName={volcanoRouteNames.podGroupDetail}
                   params={{ namespace: podGroupNamespace, name: relatedPodGroup.metadata.name }}
                 >
                   {relatedPodGroup.metadata.name}

--- a/volcano/src/components/jobs/List.tsx
+++ b/volcano/src/components/jobs/List.tsx
@@ -1,6 +1,7 @@
 import { Link, ResourceListView, StatusLabel } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 import { VolcanoJob } from '../../resources/job';
 import { getJobStatusColor } from '../../utils/status';
+import { volcanoRouteNames } from '../../utils/volcanoRoutes';
 import { VolcanoCoreInstallCheck } from '../common/CommonComponents';
 
 /**
@@ -30,7 +31,7 @@ export default function JobList() {
             label: 'Queue',
             getValue: (job: VolcanoJob) => job.queue,
             render: (job: VolcanoJob) => (
-              <Link routeName="volcano-queue-detail" params={{ name: job.queue }}>
+              <Link routeName={volcanoRouteNames.queueDetail} params={{ name: job.queue }}>
                 {job.queue}
               </Link>
             ),

--- a/volcano/src/components/jobs/jobLogs.ts
+++ b/volcano/src/components/jobs/jobLogs.ts
@@ -1,3 +1,5 @@
+import { volcanoJobNameLabel } from '../../utils/volcanoLabels';
+
 interface PodLike {
   metadata?: {
     name?: string;
@@ -21,7 +23,7 @@ interface PodWithPhase extends PodLike {
   };
 }
 
-export const JOB_NAME_LABEL = 'volcano.sh/job-name';
+export const JOB_NAME_LABEL = volcanoJobNameLabel;
 
 const NO_PODS_MESSAGE =
   'No pods have been created for this Job yet. It may still be pending or unschedulable. Check Pod Issues and Events.';

--- a/volcano/src/components/jobtemplates/Detail.tsx
+++ b/volcano/src/components/jobtemplates/Detail.tsx
@@ -11,6 +11,11 @@ import { LifecyclePolicy, TaskSpec, VolcanoJob } from '../../resources/job';
 import { VolcanoJobFlow } from '../../resources/jobflow';
 import { VolcanoJobTemplate } from '../../resources/jobtemplate';
 import { getJobFlowStatusColor, getJobStatusColor } from '../../utils/status';
+import {
+  volcanoCreatedByJobFlowLabel,
+  volcanoCreatedByJobTemplateLabel,
+} from '../../utils/volcanoLabels';
+import { volcanoRouteNames } from '../../utils/volcanoRoutes';
 import { VolcanoFlowInstallCheck } from '../common/CommonComponents';
 import {
   formatStringList,
@@ -18,9 +23,6 @@ import {
   getTaskContainerRows,
   getTaskRows,
 } from '../jobs/detailRows';
-
-const createdByJobTemplateLabel = 'volcano.sh/createdByJobTemplate';
-const createdByJobFlowLabel = 'volcano.sh/createdByJobFlow';
 
 function renderEmptySection(title: string, message: string) {
   return {
@@ -195,7 +197,7 @@ function getReferencedBySection(
               label: 'JobFlow',
               getter: row => (
                 <Link
-                  routeName="volcano-jobflow-detail"
+                  routeName={volcanoRouteNames.jobFlowDetail}
                   params={{
                     namespace: row.jobFlow.metadata.namespace,
                     name: row.jobFlow.metadata.name,
@@ -271,14 +273,14 @@ function getGeneratedJobsSection(
             {
               label: 'JobFlow',
               getter: row => {
-                const label = row.job?.metadata.labels?.[createdByJobFlowLabel];
+                const label = row.job?.metadata.labels?.[volcanoCreatedByJobFlowLabel];
                 if (!label) {
                   return '-';
                 }
 
                 const [namespace, name] = label.split('.', 2);
                 return namespace && name ? (
-                  <Link routeName="volcano-jobflow-detail" params={{ namespace, name }}>
+                  <Link routeName={volcanoRouteNames.jobFlowDetail} params={{ namespace, name }}>
                     {name}
                   </Link>
                 ) : (
@@ -346,7 +348,7 @@ export default function JobTemplateDetail() {
   const [generatedJobs] = VolcanoJob.useList({
     namespace,
     labelSelector:
-      namespace && name ? `${createdByJobTemplateLabel}=${namespace}.${name}` : undefined,
+      namespace && name ? `${volcanoCreatedByJobTemplateLabel}=${namespace}.${name}` : undefined,
   });
 
   return (
@@ -362,7 +364,10 @@ export default function JobTemplateDetail() {
                 {
                   name: 'Queue',
                   value: (
-                    <Link routeName="volcano-queue-detail" params={{ name: jobTemplate.queue }}>
+                    <Link
+                      routeName={volcanoRouteNames.queueDetail}
+                      params={{ name: jobTemplate.queue }}
+                    >
                       {jobTemplate.queue}
                     </Link>
                   ),

--- a/volcano/src/components/jobtemplates/List.tsx
+++ b/volcano/src/components/jobtemplates/List.tsx
@@ -1,5 +1,6 @@
 import { Link, ResourceListView } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 import { VolcanoJobTemplate } from '../../resources/jobtemplate';
+import { volcanoRouteNames } from '../../utils/volcanoRoutes';
 import { VolcanoFlowInstallCheck } from '../common/CommonComponents';
 
 /**
@@ -21,7 +22,7 @@ export default function JobTemplateList() {
             label: 'Queue',
             getValue: (jobTemplate: VolcanoJobTemplate) => jobTemplate.queue,
             render: (jobTemplate: VolcanoJobTemplate) => (
-              <Link routeName="volcano-queue-detail" params={{ name: jobTemplate.queue }}>
+              <Link routeName={volcanoRouteNames.queueDetail} params={{ name: jobTemplate.queue }}>
                 {jobTemplate.queue}
               </Link>
             ),

--- a/volcano/src/components/podgroups/Detail.tsx
+++ b/volcano/src/components/podgroups/Detail.tsx
@@ -8,6 +8,7 @@ import {
 import { useParams } from 'react-router-dom';
 import { VolcanoPodGroup } from '../../resources/podgroup';
 import { getPodGroupStatusColor } from '../../utils/status';
+import { volcanoRouteNames } from '../../utils/volcanoRoutes';
 
 /**
  * Builds the Progress section for a PodGroup.
@@ -161,7 +162,7 @@ export default function PodGroupDetail(props: {
           {
             name: 'Queue',
             value: (
-              <Link routeName="volcano-queue-detail" params={{ name: podGroup.queue }}>
+              <Link routeName={volcanoRouteNames.queueDetail} params={{ name: podGroup.queue }}>
                 {podGroup.queue}
               </Link>
             ),

--- a/volcano/src/components/podgroups/List.tsx
+++ b/volcano/src/components/podgroups/List.tsx
@@ -1,6 +1,7 @@
 import { Link, ResourceListView, StatusLabel } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 import { VolcanoPodGroup } from '../../resources/podgroup';
 import { getPodGroupStatusColor } from '../../utils/status';
+import { volcanoRouteNames } from '../../utils/volcanoRoutes';
 import { VolcanoCoreInstallCheck } from '../common/CommonComponents';
 
 /**
@@ -42,7 +43,7 @@ export default function PodGroupList() {
             label: 'Queue',
             getValue: (podGroup: VolcanoPodGroup) => podGroup.queue,
             render: (podGroup: VolcanoPodGroup) => (
-              <Link routeName="volcano-queue-detail" params={{ name: podGroup.queue }}>
+              <Link routeName={volcanoRouteNames.queueDetail} params={{ name: podGroup.queue }}>
                 {podGroup.queue}
               </Link>
             ),

--- a/volcano/src/components/queues/Detail.tsx
+++ b/volcano/src/components/queues/Detail.tsx
@@ -25,6 +25,7 @@ import {
 import { VolcanoPodGroup } from '../../resources/podgroup';
 import { VolcanoQueue } from '../../resources/queue';
 import { getQueueStatusColor } from '../../utils/status';
+import { volcanoRouteNames } from '../../utils/volcanoRoutes';
 import { getQueuePodGroupStats, type QueuePodGroupStats } from './stats';
 
 interface QueueCommandActionButtonProps {
@@ -417,7 +418,10 @@ function getChildQueuesSection(queue: VolcanoQueue, queues: VolcanoQueue[] | nul
             {
               label: 'Name',
               getter: (childQueue: VolcanoQueue) => (
-                <Link routeName="volcano-queue-detail" params={{ name: childQueue.getName() }}>
+                <Link
+                  routeName={volcanoRouteNames.queueDetail}
+                  params={{ name: childQueue.getName() }}
+                >
                   {childQueue.getName()}
                 </Link>
               ),
@@ -484,7 +488,7 @@ export default function QueueDetail(props: { name?: string; cluster?: string }) 
           {
             name: 'Parent Queue',
             value: queue.spec.parent ? (
-              <Link routeName="volcano-queue-detail" params={{ name: queue.spec.parent }}>
+              <Link routeName={volcanoRouteNames.queueDetail} params={{ name: queue.spec.parent }}>
                 {queue.spec.parent}
               </Link>
             ) : (

--- a/volcano/src/components/queues/List.tsx
+++ b/volcano/src/components/queues/List.tsx
@@ -3,6 +3,7 @@ import { useMemo } from 'react';
 import { VolcanoPodGroup } from '../../resources/podgroup';
 import { VolcanoQueue } from '../../resources/queue';
 import { getQueueStatusColor } from '../../utils/status';
+import { volcanoRouteNames } from '../../utils/volcanoRoutes';
 import { VolcanoCoreInstallCheck } from '../common/CommonComponents';
 import { getQueuePodGroupStats } from './stats';
 
@@ -41,7 +42,10 @@ export default function QueueList() {
             getValue: (queue: VolcanoQueue) => queue.spec.parent || '-',
             render: (queue: VolcanoQueue) =>
               queue.spec.parent ? (
-                <Link routeName="volcano-queue-detail" params={{ name: queue.spec.parent }}>
+                <Link
+                  routeName={volcanoRouteNames.queueDetail}
+                  params={{ name: queue.spec.parent }}
+                >
                   {queue.spec.parent}
                 </Link>
               ) : (

--- a/volcano/src/index.tsx
+++ b/volcano/src/index.tsx
@@ -11,7 +11,8 @@ import PodGroupList from './components/podgroups/List';
 import QueueDetail from './components/queues/Detail';
 import QueueList from './components/queues/List';
 import { registerVolcanoMapExtensions } from './mapRegistration';
-import { registerVolcanoIcon } from './volcanoIcon';
+import { volcanoRouteNames, volcanoRoutePaths } from './utils/volcanoRoutes';
+import { registerVolcanoIcon, volcanoIconName } from './volcanoIcon';
 
 registerVolcanoIcon();
 registerVolcanoMapExtensions();
@@ -24,8 +25,10 @@ interface VolcanoResourceRegistration {
   sidebarName: string;
   /** Sidebar label shown in the UI. */
   label: string;
-  /** Resource path segment under `/volcano`. */
-  path: string;
+  /** List route path for this resource. */
+  listPath: string;
+  /** Detail route path for this resource. */
+  detailPath: string;
   /** Route name for the list page. */
   listRouteName: string;
   /** Route name for the detail page. */
@@ -34,8 +37,6 @@ interface VolcanoResourceRegistration {
   ListComponent: ComponentType<any>;
   /** Detail page component for the resource. */
   DetailComponent: ComponentType<any>;
-  /** Whether detail route includes `:namespace`. */
-  hasNamespace: boolean;
 }
 
 /**
@@ -47,23 +48,23 @@ function registerVolcanoResource(config: VolcanoResourceRegistration) {
   const {
     sidebarName,
     label,
-    path,
+    listPath,
+    detailPath,
     listRouteName,
     detailRouteName,
     ListComponent,
     DetailComponent,
-    hasNamespace,
   } = config;
 
   registerSidebarEntry({
     parent: 'volcano',
     name: sidebarName,
     label,
-    url: `/volcano/${path}`,
+    url: listPath,
   });
 
   registerRoute({
-    path: `/volcano/${path}`,
+    path: listPath,
     sidebar: sidebarName,
     name: listRouteName,
     exact: true,
@@ -71,7 +72,7 @@ function registerVolcanoResource(config: VolcanoResourceRegistration) {
   });
 
   registerRoute({
-    path: `/volcano/${path}/${hasNamespace ? ':namespace/:name' : ':name'}`,
+    path: detailPath,
     sidebar: sidebarName,
     name: detailRouteName,
     exact: true,
@@ -83,60 +84,60 @@ registerSidebarEntry({
   parent: null,
   name: 'volcano',
   label: 'Volcano',
-  icon: 'custom:volcano',
-  url: '/volcano/jobs',
+  icon: volcanoIconName,
+  url: volcanoRoutePaths.jobsList,
 });
 
 const volcanoResources: VolcanoResourceRegistration[] = [
   {
     sidebarName: 'volcano-jobs',
     label: 'Jobs',
-    path: 'jobs',
-    listRouteName: 'volcano-jobs-list',
-    detailRouteName: 'volcano-job-detail',
+    listPath: volcanoRoutePaths.jobsList,
+    detailPath: volcanoRoutePaths.jobDetail,
+    listRouteName: volcanoRouteNames.jobsList,
+    detailRouteName: volcanoRouteNames.jobDetail,
     ListComponent: JobList,
     DetailComponent: JobDetail,
-    hasNamespace: true,
   },
   {
     sidebarName: 'volcano-jobtemplates',
     label: 'JobTemplates',
-    path: 'jobtemplates',
-    listRouteName: 'volcano-jobtemplates-list',
-    detailRouteName: 'volcano-jobtemplate-detail',
+    listPath: volcanoRoutePaths.jobTemplatesList,
+    detailPath: volcanoRoutePaths.jobTemplateDetail,
+    listRouteName: volcanoRouteNames.jobTemplatesList,
+    detailRouteName: volcanoRouteNames.jobTemplateDetail,
     ListComponent: JobTemplateList,
     DetailComponent: JobTemplateDetail,
-    hasNamespace: true,
   },
   {
     sidebarName: 'volcano-jobflows',
     label: 'JobFlows',
-    path: 'jobflows',
-    listRouteName: 'volcano-jobflows-list',
-    detailRouteName: 'volcano-jobflow-detail',
+    listPath: volcanoRoutePaths.jobFlowsList,
+    detailPath: volcanoRoutePaths.jobFlowDetail,
+    listRouteName: volcanoRouteNames.jobFlowsList,
+    detailRouteName: volcanoRouteNames.jobFlowDetail,
     ListComponent: JobFlowList,
     DetailComponent: JobFlowDetail,
-    hasNamespace: true,
   },
   {
     sidebarName: 'volcano-queues',
     label: 'Queues',
-    path: 'queues',
-    listRouteName: 'volcano-queues-list',
-    detailRouteName: 'volcano-queue-detail',
+    listPath: volcanoRoutePaths.queuesList,
+    detailPath: volcanoRoutePaths.queueDetail,
+    listRouteName: volcanoRouteNames.queuesList,
+    detailRouteName: volcanoRouteNames.queueDetail,
     ListComponent: QueueList,
     DetailComponent: QueueDetail,
-    hasNamespace: false,
   },
   {
     sidebarName: 'volcano-podgroups',
     label: 'PodGroups',
-    path: 'podgroups',
-    listRouteName: 'volcano-podgroups-list',
-    detailRouteName: 'volcano-podgroup-detail',
+    listPath: volcanoRoutePaths.podGroupsList,
+    detailPath: volcanoRoutePaths.podGroupDetail,
+    listRouteName: volcanoRouteNames.podGroupsList,
+    detailRouteName: volcanoRouteNames.podGroupDetail,
     ListComponent: PodGroupList,
     DetailComponent: PodGroupDetail,
-    hasNamespace: true,
   },
 ];
 

--- a/volcano/src/mapRegistration.tsx
+++ b/volcano/src/mapRegistration.tsx
@@ -7,10 +7,11 @@ import {
 import { QueueGlance } from './components/map/QueueGlance';
 import { volcanoSource } from './mapView';
 import { volcanoJobApiGroup, volcanoSchedulingApiGroup } from './utils/volcanoApi';
+import { volcanoIconColor, volcanoIconName } from './volcanoIcon';
 
 const volcanoKindIcon = {
-  icon: <Icon icon="custom:volcano" width="70%" height="70%" />,
-  color: 'rgb(229, 39, 25)',
+  icon: <Icon icon={volcanoIconName} width="70%" height="70%" />,
+  color: volcanoIconColor,
 };
 
 export function registerVolcanoMapExtensions() {

--- a/volcano/src/mapView.tsx
+++ b/volcano/src/mapView.tsx
@@ -14,45 +14,28 @@ import { VolcanoJob } from './resources/job';
 import { VolcanoPodGroup } from './resources/podgroup';
 import { VolcanoQueue } from './resources/queue';
 import { getJobStatusColor, getPodGroupStatusColor, getQueueStatusColor } from './utils/status';
-import { isVolcanoJobApiVersion } from './utils/volcanoApi';
+import {
+  getPodJob,
+  getRelatedPodGroup,
+  getVolcanoPods,
+  type VolcanoOwnerReference,
+} from './utils/volcanoRelationships';
+import { volcanoIconColor, volcanoIconName } from './volcanoIcon';
 
 const volcanoMapIcon = (
-  <Icon icon="custom:volcano" width="100%" height="100%" color="rgb(229, 39, 25)" />
+  <Icon icon={volcanoIconName} width="100%" height="100%" color={volcanoIconColor} />
 );
 
 const PodResource = K8s.ResourceClasses.Pod;
-const volcanoJobNameLabel = 'volcano.sh/job-name';
-const volcanoJobNamespaceLabel = 'volcano.sh/job-namespace';
 
 type GraphNodeStatus = 'error' | 'success' | 'warning';
 type GraphDetailsComponentProps = { node: GraphNode };
-type VolcanoOwnerReference = {
-  apiVersion?: string;
-  kind?: string;
-  uid?: string;
-};
 type VolcanoMapKubeObject = KubeObject & {
   metadata: {
     uid: string;
     ownerReferences?: VolcanoOwnerReference[];
   };
 };
-
-function isVolcanoJobOwnerReference(ownerReference: VolcanoOwnerReference) {
-  return ownerReference.kind === 'Job' && isVolcanoJobApiVersion(ownerReference.apiVersion);
-}
-
-function referencesVolcanoJob(ownerReference: VolcanoOwnerReference, job: VolcanoJob) {
-  return isVolcanoJobOwnerReference(ownerReference) && ownerReference.uid === job.metadata.uid;
-}
-
-function hasVolcanoJobOwnerReference(kubeObject: VolcanoMapKubeObject) {
-  return (
-    kubeObject.metadata.ownerReferences?.some(ownerReference =>
-      isVolcanoJobOwnerReference(ownerReference)
-    ) || false
-  );
-}
 
 function makeVolcanoNode(
   kubeObject: VolcanoMapKubeObject,
@@ -159,28 +142,6 @@ function getQueueHierarchyEdges(queues: VolcanoQueue[]) {
   return edges;
 }
 
-function getRelatedPodGroup(job: VolcanoJob, podGroups: VolcanoPodGroup[]) {
-  const byOwnerReference = podGroups.find(podGroup =>
-    podGroup.metadata.ownerReferences?.some(ownerReference =>
-      referencesVolcanoJob(ownerReference, job)
-    )
-  );
-
-  if (byOwnerReference) {
-    return byOwnerReference;
-  }
-
-  // Owner refs are authoritative, name fallback keeps older objects connected when refs are absent.
-  const canonicalName = `${job.metadata.name}-${job.metadata.uid}`;
-  const byCanonicalName = podGroups.find(podGroup => podGroup.metadata.name === canonicalName);
-
-  if (byCanonicalName) {
-    return byCanonicalName;
-  }
-
-  return podGroups.find(podGroup => podGroup.metadata.name === job.metadata.name) || null;
-}
-
 function getJobToPodGroupEdges(jobs: VolcanoJob[], podGroups: VolcanoPodGroup[]) {
   const edges: GraphEdge[] = [];
 
@@ -192,42 +153,6 @@ function getJobToPodGroupEdges(jobs: VolcanoJob[], podGroups: VolcanoPodGroup[])
   });
 
   return edges;
-}
-
-function getVolcanoPods(pods: InstanceType<typeof PodResource>[]) {
-  return pods.filter(pod => {
-    const labels = pod.metadata.labels || {};
-    const jobName = labels[volcanoJobNameLabel];
-    const jobNamespace = labels[volcanoJobNamespaceLabel];
-    const hasVolcanoJobLabels = Boolean(jobName && jobNamespace);
-
-    return hasVolcanoJobOwnerReference(pod) || hasVolcanoJobLabels;
-  });
-}
-
-function getPodJob(pod: InstanceType<typeof PodResource>, jobs: VolcanoJob[]) {
-  const byOwnerReference = jobs.find(job =>
-    pod.metadata.ownerReferences?.some(ownerReference => referencesVolcanoJob(ownerReference, job))
-  );
-
-  if (byOwnerReference) {
-    return byOwnerReference;
-  }
-
-  const labels = pod.metadata.labels || {};
-  const jobName = labels[volcanoJobNameLabel];
-  const jobNamespace = labels[volcanoJobNamespaceLabel];
-
-  if (!jobName || !jobNamespace) {
-    return null;
-  }
-
-  return (
-    jobs.find(
-      candidate =>
-        candidate.metadata.name === jobName && candidate.metadata.namespace === jobNamespace
-    ) || null
-  );
 }
 
 function getPodToJobEdges(jobs: VolcanoJob[], pods: InstanceType<typeof PodResource>[]) {

--- a/volcano/src/resources/command.ts
+++ b/volcano/src/resources/command.ts
@@ -1,4 +1,5 @@
 import { KubeObject, KubeObjectInterface } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import { volcanoBusApiVersion } from '../utils/volcanoApi';
 import { VolcanoJob } from './job';
 import { VolcanoQueue } from './queue';
 
@@ -49,7 +50,7 @@ export interface KubeVolcanoCommand extends KubeObjectInterface {
 export class VolcanoCommand extends KubeObject<KubeVolcanoCommand> {
   static kind = 'Command';
   static apiName = 'commands';
-  static apiVersion = 'bus.volcano.sh/v1alpha1';
+  static apiVersion = volcanoBusApiVersion;
   static isNamespaced = true;
 }
 

--- a/volcano/src/resources/job.ts
+++ b/volcano/src/resources/job.ts
@@ -1,4 +1,7 @@
 import { KubeObject, KubeObjectInterface } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import { volcanoJobApiVersion } from '../utils/volcanoApi';
+import { volcanoJobTypeLabel } from '../utils/volcanoLabels';
+import { volcanoRoutePaths } from '../utils/volcanoRoutes';
 
 /**
  * Task definition inside a Volcano Job spec.
@@ -202,8 +205,6 @@ export type JobPhase =
   | 'Terminated'
   | 'Failed';
 
-const volcanoJobTypeLabel = 'volcano.sh/job-type';
-
 /**
  * Current state details for a Volcano Job.
  * @see https://github.com/volcano-sh/apis/blob/ae35b8b12bc5ccb6ff5a62fcd9dca06234197e63/pkg/apis/batch/v1alpha1/job.go#L333
@@ -279,16 +280,16 @@ export interface KubeVolcanoJob extends KubeObjectInterface {
 export class VolcanoJob extends KubeObject<KubeVolcanoJob> {
   static kind = 'VolcanoJob';
   static apiName = 'jobs';
-  static apiVersion = 'batch.volcano.sh/v1alpha1';
+  static apiVersion = volcanoJobApiVersion;
   static isNamespaced = true;
 
   static get detailsRoute() {
-    return '/volcano/jobs/:namespace/:name';
+    return volcanoRoutePaths.jobDetail;
   }
 
   static getBaseObject() {
     return {
-      apiVersion: 'batch.volcano.sh/v1alpha1',
+      apiVersion: volcanoJobApiVersion,
       kind: 'Job',
       metadata: {
         name: '',

--- a/volcano/src/resources/jobflow.ts
+++ b/volcano/src/resources/jobflow.ts
@@ -1,4 +1,6 @@
 import { KubeObject, KubeObjectInterface } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import { volcanoFlowApiVersion } from '../utils/volcanoApi';
+import { volcanoRoutePaths } from '../utils/volcanoRoutes';
 import { VolcanoJobSpec } from './job';
 
 export type JobFlowPhase = 'Pending' | 'Running' | 'Failed' | 'Terminating' | 'Succeed' | string;
@@ -206,16 +208,16 @@ export interface KubeVolcanoJobFlow extends KubeObjectInterface {
 export class VolcanoJobFlow extends KubeObject<KubeVolcanoJobFlow> {
   static kind = 'JobFlow';
   static apiName = 'jobflows';
-  static apiVersion = 'flow.volcano.sh/v1alpha1';
+  static apiVersion = volcanoFlowApiVersion;
   static isNamespaced = true;
 
   static get detailsRoute() {
-    return '/volcano/jobflows/:namespace/:name';
+    return volcanoRoutePaths.jobFlowDetail;
   }
 
   static getBaseObject() {
     return {
-      apiVersion: 'flow.volcano.sh/v1alpha1',
+      apiVersion: volcanoFlowApiVersion,
       kind: 'JobFlow',
       metadata: {
         name: '',

--- a/volcano/src/resources/jobtemplate.ts
+++ b/volcano/src/resources/jobtemplate.ts
@@ -1,4 +1,6 @@
 import { KubeObject, KubeObjectInterface } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import { volcanoFlowApiVersion } from '../utils/volcanoApi';
+import { volcanoRoutePaths } from '../utils/volcanoRoutes';
 import { LifecyclePolicy, TaskSpec } from './job';
 
 /**
@@ -64,16 +66,16 @@ export interface KubeVolcanoJobTemplate extends KubeObjectInterface {
 export class VolcanoJobTemplate extends KubeObject<KubeVolcanoJobTemplate> {
   static kind = 'JobTemplate';
   static apiName = 'jobtemplates';
-  static apiVersion = 'flow.volcano.sh/v1alpha1';
+  static apiVersion = volcanoFlowApiVersion;
   static isNamespaced = true;
 
   static get detailsRoute() {
-    return '/volcano/jobtemplates/:namespace/:name';
+    return volcanoRoutePaths.jobTemplateDetail;
   }
 
   static getBaseObject() {
     return {
-      apiVersion: 'flow.volcano.sh/v1alpha1',
+      apiVersion: volcanoFlowApiVersion,
       kind: 'JobTemplate',
       metadata: {
         name: '',

--- a/volcano/src/resources/podgroup.ts
+++ b/volcano/src/resources/podgroup.ts
@@ -1,4 +1,6 @@
 import { KubeObject, KubeObjectInterface } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import { volcanoSchedulingApiVersion } from '../utils/volcanoApi';
+import { volcanoRoutePaths } from '../utils/volcanoRoutes';
 
 export type PodGroupPhase = 'Pending' | 'Running' | 'Unknown' | 'Inqueue' | 'Completed';
 
@@ -69,16 +71,16 @@ export interface KubeVolcanoPodGroup extends KubeObjectInterface {
 export class VolcanoPodGroup extends KubeObject<KubeVolcanoPodGroup> {
   static kind = 'PodGroup';
   static apiName = 'podgroups';
-  static apiVersion = 'scheduling.volcano.sh/v1beta1';
+  static apiVersion = volcanoSchedulingApiVersion;
   static isNamespaced = true;
 
   static get detailsRoute() {
-    return '/volcano/podgroups/:namespace/:name';
+    return volcanoRoutePaths.podGroupDetail;
   }
 
   static getBaseObject() {
     return {
-      apiVersion: 'scheduling.volcano.sh/v1beta1',
+      apiVersion: volcanoSchedulingApiVersion,
       kind: 'PodGroup',
       metadata: {
         name: '',

--- a/volcano/src/resources/queue.ts
+++ b/volcano/src/resources/queue.ts
@@ -1,4 +1,6 @@
 import { KubeObject, KubeObjectInterface } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import { volcanoSchedulingApiVersion } from '../utils/volcanoApi';
+import { volcanoRoutePaths } from '../utils/volcanoRoutes';
 
 export type QueueState = 'Open' | 'Closed' | 'Closing' | 'Unknown';
 
@@ -100,16 +102,16 @@ export interface KubeVolcanoQueue extends KubeObjectInterface {
 export class VolcanoQueue extends KubeObject<KubeVolcanoQueue> {
   static kind = 'Queue';
   static apiName = 'queues';
-  static apiVersion = 'scheduling.volcano.sh/v1beta1';
+  static apiVersion = volcanoSchedulingApiVersion;
   static isNamespaced = false;
 
   static get detailsRoute() {
-    return '/volcano/queues/:name';
+    return volcanoRoutePaths.queueDetail;
   }
 
   static getBaseObject() {
     return {
-      apiVersion: 'scheduling.volcano.sh/v1beta1',
+      apiVersion: volcanoSchedulingApiVersion,
       kind: 'Queue',
       metadata: {
         name: '',

--- a/volcano/src/utils/volcanoApi.ts
+++ b/volcano/src/utils/volcanoApi.ts
@@ -1,5 +1,16 @@
 export const volcanoJobApiGroup = 'batch.volcano.sh';
 export const volcanoSchedulingApiGroup = 'scheduling.volcano.sh';
+export const volcanoFlowApiGroup = 'flow.volcano.sh';
+export const volcanoBusApiGroup = 'bus.volcano.sh';
+
+export const volcanoJobApiVersion = `${volcanoJobApiGroup}/v1alpha1`;
+export const volcanoSchedulingApiVersion = `${volcanoSchedulingApiGroup}/v1beta1`;
+export const volcanoFlowApiVersion = `${volcanoFlowApiGroup}/v1alpha1`;
+export const volcanoBusApiVersion = `${volcanoBusApiGroup}/v1alpha1`;
+
+export function getApiPath(apiVersion: string) {
+  return `/apis/${apiVersion}`;
+}
 
 export function isApiVersionInGroup(apiVersion: string | undefined, apiGroup: string) {
   return apiVersion?.startsWith(`${apiGroup}/`) || false;

--- a/volcano/src/utils/volcanoLabels.ts
+++ b/volcano/src/utils/volcanoLabels.ts
@@ -1,0 +1,5 @@
+export const volcanoJobNameLabel = 'volcano.sh/job-name';
+export const volcanoJobNamespaceLabel = 'volcano.sh/job-namespace';
+export const volcanoJobTypeLabel = 'volcano.sh/job-type';
+export const volcanoCreatedByJobTemplateLabel = 'volcano.sh/createdByJobTemplate';
+export const volcanoCreatedByJobFlowLabel = 'volcano.sh/createdByJobFlow';

--- a/volcano/src/utils/volcanoRelationships.ts
+++ b/volcano/src/utils/volcanoRelationships.ts
@@ -1,0 +1,168 @@
+import { VolcanoJob } from '../resources/job';
+import { VolcanoPodGroup } from '../resources/podgroup';
+import { isVolcanoJobApiVersion } from './volcanoApi';
+import { volcanoJobNameLabel, volcanoJobNamespaceLabel } from './volcanoLabels';
+
+/**
+ * Owner reference fields used to identify Volcano Job ownership.
+ */
+export type VolcanoOwnerReference = {
+  /** API version of the referenced owner. */
+  apiVersion?: string;
+  /** Kubernetes kind of the referenced owner. */
+  kind?: string;
+  /** UID of the referenced owner. */
+  uid?: string;
+};
+
+/**
+ * Minimal Pod-like shape needed to resolve Volcano Job relationships.
+ */
+export type VolcanoPodLike = {
+  metadata: {
+    /** Labels used as a fallback when owner references are unavailable. */
+    labels?: Record<string, string>;
+    /** Owner references used to identify Volcano-controlled pods. */
+    ownerReferences?: VolcanoOwnerReference[];
+    /** Pod namespace. */
+    namespace?: string;
+  };
+};
+
+/**
+ * Reports whether an owner reference points to a Volcano Job.
+ *
+ * @param ownerReference Owner reference to inspect.
+ * @returns `true` when the reference targets a Volcano Job API version and kind.
+ */
+export function isVolcanoJobOwnerReference(ownerReference: VolcanoOwnerReference) {
+  return ownerReference.kind === 'Job' && isVolcanoJobApiVersion(ownerReference.apiVersion);
+}
+
+/**
+ * Reports whether an owner reference points to the given Volcano Job.
+ *
+ * @param ownerReference Owner reference to inspect.
+ * @param job Volcano Job expected to own the object.
+ * @returns `true` when the owner reference targets the Job UID.
+ */
+export function referencesVolcanoJob(ownerReference: VolcanoOwnerReference, job: VolcanoJob) {
+  return isVolcanoJobOwnerReference(ownerReference) && ownerReference.uid === job.metadata.uid;
+}
+
+/**
+ * Reports whether an object has a Volcano Job owner reference.
+ *
+ * @param kubeObject Object whose owner references are inspected.
+ * @returns `true` when any owner reference points to a Volcano Job.
+ */
+export function hasVolcanoJobOwnerReference(kubeObject: VolcanoPodLike) {
+  return (
+    kubeObject.metadata.ownerReferences?.some(ownerReference =>
+      isVolcanoJobOwnerReference(ownerReference)
+    ) || false
+  );
+}
+
+/**
+ * Filters pods to those related to Volcano Jobs.
+ *
+ * Pods are matched by Volcano Job owner reference first, or by Volcano job
+ * labels when owner references are unavailable.
+ *
+ * @param pods Pods to filter.
+ * @returns Pods associated with Volcano Jobs.
+ */
+export function getVolcanoPods<T extends VolcanoPodLike>(pods: T[]) {
+  return pods.filter(pod => {
+    const labels = pod.metadata.labels || {};
+    const jobName = labels[volcanoJobNameLabel];
+    const jobNamespace = labels[volcanoJobNamespaceLabel];
+    const hasVolcanoJobLabels = Boolean(jobName && jobNamespace);
+
+    return hasVolcanoJobOwnerReference(pod) || hasVolcanoJobLabels;
+  });
+}
+
+/**
+ * Finds the Volcano Job related to a pod.
+ *
+ * Owner references are preferred because they identify the owning Job by UID.
+ * Volcano job name and namespace labels are used as a fallback.
+ *
+ * @param pod Pod whose owning Job should be resolved.
+ * @param jobs Candidate Volcano Jobs.
+ * @returns Matching Volcano Job, or `null` when no match is found.
+ */
+export function getPodJob<T extends VolcanoPodLike>(pod: T, jobs: VolcanoJob[]) {
+  const byOwnerReference = jobs.find(job =>
+    pod.metadata.ownerReferences?.some(ownerReference => referencesVolcanoJob(ownerReference, job))
+  );
+
+  if (byOwnerReference) {
+    return byOwnerReference;
+  }
+
+  const labels = pod.metadata.labels || {};
+  const jobName = labels[volcanoJobNameLabel];
+  const jobNamespace = labels[volcanoJobNamespaceLabel];
+
+  if (!jobName || !jobNamespace) {
+    return null;
+  }
+
+  return (
+    jobs.find(
+      candidate =>
+        candidate.metadata.name === jobName && candidate.metadata.namespace === jobNamespace
+    ) || null
+  );
+}
+
+/**
+ * Finds the PodGroup related to a Volcano Job.
+ *
+ * Owner references are preferred. Name-based fallbacks keep older Volcano
+ * objects connected when owner references are absent.
+ *
+ * @param job Volcano Job whose PodGroup should be resolved.
+ * @param podGroups Candidate PodGroups.
+ * @returns Matching PodGroup, or `null` when no match is found.
+ */
+export function getRelatedPodGroup(
+  job: VolcanoJob,
+  podGroups: VolcanoPodGroup[] | null | undefined
+): VolcanoPodGroup | null {
+  if (!podGroups?.length) {
+    return null;
+  }
+
+  const byOwnerReference = podGroups.find(podGroup =>
+    podGroup.metadata.ownerReferences?.some(ownerReference =>
+      referencesVolcanoJob(ownerReference, job)
+    )
+  );
+
+  if (byOwnerReference) {
+    return byOwnerReference;
+  }
+
+  // Owner refs are authoritative; name fallback keeps older objects connected when refs are absent.
+  const jobName = job.metadata.name;
+  const jobUid = job.metadata.uid;
+
+  if (jobName && jobUid) {
+    const canonicalName = `${jobName}-${jobUid}`;
+    const byCanonicalName = podGroups.find(podGroup => podGroup.metadata.name === canonicalName);
+
+    if (byCanonicalName) {
+      return byCanonicalName;
+    }
+  }
+
+  if (jobName) {
+    return podGroups.find(podGroup => podGroup.metadata.name === jobName) || null;
+  }
+
+  return null;
+}

--- a/volcano/src/utils/volcanoRoutes.ts
+++ b/volcano/src/utils/volcanoRoutes.ts
@@ -1,0 +1,25 @@
+export const volcanoRouteNames = {
+  jobsList: 'volcano-jobs-list',
+  jobDetail: 'volcano-job-detail',
+  jobTemplatesList: 'volcano-jobtemplates-list',
+  jobTemplateDetail: 'volcano-jobtemplate-detail',
+  jobFlowsList: 'volcano-jobflows-list',
+  jobFlowDetail: 'volcano-jobflow-detail',
+  queuesList: 'volcano-queues-list',
+  queueDetail: 'volcano-queue-detail',
+  podGroupsList: 'volcano-podgroups-list',
+  podGroupDetail: 'volcano-podgroup-detail',
+} as const;
+
+export const volcanoRoutePaths = {
+  jobsList: '/volcano/jobs',
+  jobDetail: '/volcano/jobs/:namespace/:name',
+  jobTemplatesList: '/volcano/jobtemplates',
+  jobTemplateDetail: '/volcano/jobtemplates/:namespace/:name',
+  jobFlowsList: '/volcano/jobflows',
+  jobFlowDetail: '/volcano/jobflows/:namespace/:name',
+  queuesList: '/volcano/queues',
+  queueDetail: '/volcano/queues/:name',
+  podGroupsList: '/volcano/podgroups',
+  podGroupDetail: '/volcano/podgroups/:namespace/:name',
+} as const;

--- a/volcano/src/volcanoIcon.ts
+++ b/volcano/src/volcanoIcon.ts
@@ -1,5 +1,8 @@
 import { addIcon } from '@iconify/react';
 
+export const volcanoIconName = 'custom:volcano';
+export const volcanoIconColor = 'rgb(229, 39, 25)';
+
 const VolcanoIconBody = `<path fill="currentColor" d="M34.3,11L29,5.7c-0.1-0.1-0.1-0.3,0-0.4l5.3-5.3c0.1-0.1,0.3-0.1,0.4,0l5.3,5.3c0.1,0.1,0.1,0.3,0,0.4
 L34.7,11C34.6,11.1,34.4,11.1,34.3,11z M32.9,11.8l-4.6-4.6C28.1,7,28,7,27.9,7.1l-4.6,4.6c-0.1,0.1-0.1,0.3,0,0.4l4.6,4.6
 c0.1,0.1,0.3,0.1,0.4,0l4.6-4.6C33,12,33,11.9,32.9,11.8z M45.7,11.8l-4.6-4.6C41,7,40.8,7,40.7,7.1l-4.6,4.6
@@ -36,7 +39,7 @@ C72.9,34.2,73,34.2,73.1,34.1z M79.6,39.9l2.1-2.1c0.1-0.1,0.1-0.3,0-0.4l-2.1-2.1c
 c-0.1,0.1-0.1,0.3,0,0.4l2.1,2.1C79.3,40,79.4,40,79.6,39.9z"/>`;
 
 export function registerVolcanoIcon() {
-  addIcon('custom:volcano', {
+  addIcon(volcanoIconName, {
     body: VolcanoIconBody,
     width: 82,
     height: 40,

--- a/volcano/src/volcanoInstallChecks.ts
+++ b/volcano/src/volcanoInstallChecks.ts
@@ -1,4 +1,10 @@
 import { ApiProxy } from '@kinvolk/headlamp-plugin/lib';
+import {
+  getApiPath,
+  volcanoFlowApiVersion,
+  volcanoJobApiVersion,
+  volcanoSchedulingApiVersion,
+} from './utils/volcanoApi';
 
 async function areApiGroupsInstalled(apiPaths: string[]): Promise<boolean> {
   try {
@@ -14,11 +20,11 @@ async function areApiGroupsInstalled(apiPaths: string[]): Promise<boolean> {
 
 export async function isVolcanoCoreInstalled(): Promise<boolean> {
   return areApiGroupsInstalled([
-    '/apis/scheduling.volcano.sh/v1beta1',
-    '/apis/batch.volcano.sh/v1alpha1',
+    getApiPath(volcanoSchedulingApiVersion),
+    getApiPath(volcanoJobApiVersion),
   ]);
 }
 
 export async function isVolcanoFlowInstalled(): Promise<boolean> {
-  return areApiGroupsInstalled(['/apis/flow.volcano.sh/v1alpha1']);
+  return areApiGroupsInstalled([getApiPath(volcanoFlowApiVersion)]);
 }


### PR DESCRIPTION
## Summary
This PR refactors shared Volcano plugin logic so routes, API versions, labels, icons, and resource relationship helpers are defined in one place and reused across the plugin.
This keeps the current UI behavior the same, but makes the Volcano map integration, resource classes, list views, and detail pages easier to maintain and less duplicated.
## Changes
- centralize Volcano API groups and versions in `src/utils/volcanoApi.ts`
- centralize Volcano route names and route paths in `src/utils/volcanoRoutes.ts`
- centralize Volcano labels in `src/utils/volcanoLabels.ts`
- centralize Volcano Job, Pod, and PodGroup relationship helpers in `src/utils/volcanoRelationships.ts`
- reuse shared route constants in list/detail links
- reuse shared route paths in resource `detailsRoute` definitions
- reuse shared relationship helpers in the resource map and Job detail page
- reuse shared Volcano icon name and color in sidebar and map registration
- keep API-group-aware Volcano Job matching to avoid conflicts with Kubernetes `batch/v1` Jobs
- simplify Volcano resource route registration by passing the full list/detail paths directly
## Steps to Test
1. Build/start the Volcano plugin.
2. Open the Volcano sidebar pages.
3. Confirm Jobs, JobTemplates, JobFlows, Queues, and PodGroups list/detail pages still load correctly.
4. Open the Headlamp resource map.
5. Enable the Volcano source.
6. Confirm Queues, Jobs, PodGroups, and Volcano Pods appear.
7. Confirm Queue hierarchy edges are shown.
8. Confirm Volcano Job → PodGroup and Volcano Job → Pod edges are shown.
9. Click Volcano Job, Queue, and PodGroup nodes and confirm the side panel shows the correct Volcano details.
10. Confirm Queue links from Jobs, PodGroups, JobTemplates, and Queues still navigate correctly.
## Notes for the Reviewers
This is a refactor only PR and does not add new behavior.