### PR TITLE
knative: kserivce: Fix validation for revision name

### DIFF
--- a/knative/src/components/kservices/detail/hooks/useKServiceActions.tsx
+++ b/knative/src/components/kservices/detail/hooks/useKServiceActions.tsx
@@ -226,6 +226,7 @@ export function useKServiceActions(
         spec: {
           template: {
             metadata: {
+              name: null as any,
               annotations: {
                 'knative.headlamp.dev/redeployAt': now,
               },

--- a/knative/src/resources/knative/kservice.ts
+++ b/knative/src/resources/knative/kservice.ts
@@ -47,7 +47,8 @@ type AutoscalingPatchBody = {
   spec: {
     template: {
       metadata?: {
-        annotations: Record<string, string>;
+        name?: string | null;
+        annotations?: Record<string, string>;
       };
       spec?: {
         containerConcurrency?: number;
@@ -193,7 +194,10 @@ export class KService extends KubeObject<KServiceResource> {
     return {
       spec: {
         template: {
-          ...(hasAnnotationsPatch ? { metadata: { annotations: annotationsPatch } } : {}),
+          metadata: {
+            name: null as any,
+            ...(hasAnnotationsPatch ? { annotations: annotationsPatch } : {}),
+          },
           ...(hasTemplateSpecPatch ? { spec: templateSpecPatch } : {}),
         },
       },


### PR DESCRIPTION
## Description

This PR fixes validation error by adding name to the metadata in resource definition, and allowing it to be null.
Error was earlier being raised as the newest revision was being edited instead of a new revision being made, which threw a validation error.

## Related Issue
#486 (LFX)
