### PR TITLE
prometheus: knative: Fix metrics render and add translation

### DIFF
--- a/prometheus/locales/en/translation.json
+++ b/prometheus/locales/en/translation.json
@@ -116,5 +116,9 @@
   "Failed Healthchecks / s": "Failed Healthchecks / s",
   "Client Cache Wait (s)": "Client Cache Wait (s)",
   "Cache Hits / s": "Cache Hits / s",
-  "Cache Misses / s": "Cache Misses / s"
+  "Cache Misses / s": "Cache Misses / s",
+  "Request Rate": "Request Rate",
+  "Latency": "Latency",
+  "Resources": "Resources",
+  "By Revision": "By Revision"
 }

--- a/prometheus/src/components/Chart/KnativeChart/KnativeChart.tsx
+++ b/prometheus/src/components/Chart/KnativeChart/KnativeChart.tsx
@@ -68,8 +68,9 @@ export function KnativeChart({
 }) {
   const { t } = useTranslation();
   const cluster = useCluster() || '';
-  const configStore = useMemo(() => getConfigStore(), []);
-  const clusterConfig = configStore.useConfig();
+  const configStore = getConfigStore();
+  const useClusterConfig = configStore.useConfig();
+  const clusterConfig = useClusterConfig();
   const theme = useTheme();
 
   // Build chart configs: include "By Revision" only on KService view (no revisionName)
@@ -106,7 +107,7 @@ export function KnativeChart({
     }
 
     return configs;
-  }, [revisionName]);
+  }, [revisionName, t]);
 
   const [refresh, setRefresh] = useState<boolean>(true);
   const [prometheusPrefix, setPrometheusPrefix] = useState<string | null>(null);


### PR DESCRIPTION
## Description

This PR fixes knative metrics rendering by calling hook `useClusterConfig()`, adds `t` to the dependency array for correct label rendering, and adds translation to `en/translation.json`.

## Related Issue

#486 (LFX)