### PR TITLE
prometheus: Add Volcano Queue metrics charts

### DIFF
--- a/prometheus/src/components/Chart/VolcanoChart/VolcanoChart.tsx
+++ b/prometheus/src/components/Chart/VolcanoChart/VolcanoChart.tsx
@@ -1,0 +1,327 @@
+import { Icon } from '@iconify/react';
+import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
+import { Loader, SectionBox } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { useCluster } from '@kinvolk/headlamp-plugin/lib/k8s';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import ListSubheader from '@mui/material/ListSubheader';
+import MenuItem from '@mui/material/MenuItem';
+import Paper from '@mui/material/Paper';
+import Select from '@mui/material/Select';
+import { useTheme } from '@mui/material/styles';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
+import { useEffect, useState } from 'react';
+import {
+  createTickTimestampFormatter,
+  getConfigStore,
+  getPrometheusInterval,
+  getPrometheusPrefix,
+  getPrometheusResolution,
+  getPrometheusSubPath,
+} from '../../../util';
+import { PrometheusNotFoundBanner } from '../common';
+import { CustomToggleButton } from '../GenericMetricsChart/GenericMetricsChart';
+import { VolcanoQueueCPUChart } from '../VolcanoQueueCPUChart/VolcanoQueueCPUChart';
+import { VolcanoQueueMemoryChart } from '../VolcanoQueueMemoryChart/VolcanoQueueMemoryChart';
+import { VolcanoQueuePodGroupsChart } from '../VolcanoQueuePodGroupsChart/VolcanoQueuePodGroupsChart';
+
+enum PrometheusState {
+  UNKNOWN,
+  LOADING,
+  ERROR,
+  INSTALLED,
+}
+
+interface ChartConfig {
+  key: string;
+  label: string;
+  icon: string;
+  queries: Record<string, string>;
+  component: React.ComponentType<any>;
+}
+
+interface VolcanoChartProps {
+  chartConfigs: ChartConfig[];
+  defaultChart?: string;
+}
+
+function escapePrometheusLabelValue(value: string) {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n');
+}
+
+function getVolcanoQueueMetricQuery(metricName: string, queueName: string) {
+  return `${metricName}{queue_name="${queueName}"}`;
+}
+
+export function getVolcanoQueueChartConfigs(queueName: string): ChartConfig[] {
+  const queueLabel = escapePrometheusLabelValue(queueName);
+
+  return [
+    {
+      key: 'cpu',
+      label: 'CPU',
+      icon: 'mdi:chip',
+      queries: {
+        allocatedQuery: getVolcanoQueueMetricQuery('volcano_queue_allocated_milli_cpu', queueLabel),
+        requestQuery: getVolcanoQueueMetricQuery('volcano_queue_request_milli_cpu', queueLabel),
+        deservedQuery: getVolcanoQueueMetricQuery('volcano_queue_deserved_milli_cpu', queueLabel),
+        capacityQuery: getVolcanoQueueMetricQuery('volcano_queue_capacity_milli_cpu', queueLabel),
+      },
+      component: VolcanoQueueCPUChart,
+    },
+    {
+      key: 'memory',
+      label: 'Memory',
+      icon: 'mdi:memory',
+      queries: {
+        allocatedQuery: getVolcanoQueueMetricQuery(
+          'volcano_queue_allocated_memory_bytes',
+          queueLabel
+        ),
+        requestQuery: getVolcanoQueueMetricQuery('volcano_queue_request_memory_bytes', queueLabel),
+        deservedQuery: getVolcanoQueueMetricQuery(
+          'volcano_queue_deserved_memory_bytes',
+          queueLabel
+        ),
+        capacityQuery: getVolcanoQueueMetricQuery(
+          'volcano_queue_capacity_memory_bytes',
+          queueLabel
+        ),
+      },
+      component: VolcanoQueueMemoryChart,
+    },
+    {
+      key: 'podgroups',
+      label: 'PodGroups',
+      icon: 'mdi:account-group',
+      queries: {
+        inqueueQuery: getVolcanoQueueMetricQuery(
+          'volcano_queue_pod_group_inqueue_count',
+          queueLabel
+        ),
+        pendingQuery: getVolcanoQueueMetricQuery(
+          'volcano_queue_pod_group_pending_count',
+          queueLabel
+        ),
+        runningQuery: getVolcanoQueueMetricQuery(
+          'volcano_queue_pod_group_running_count',
+          queueLabel
+        ),
+        completedQuery: getVolcanoQueueMetricQuery(
+          'volcano_queue_pod_group_completed_count',
+          queueLabel
+        ),
+        unknownQuery: getVolcanoQueueMetricQuery(
+          'volcano_queue_pod_group_unknown_count',
+          queueLabel
+        ),
+      },
+      component: VolcanoQueuePodGroupsChart,
+    },
+  ];
+}
+
+export function VolcanoChart(props: VolcanoChartProps) {
+  const { t } = useTranslation();
+  const cluster = useCluster();
+  const configStore = getConfigStore();
+  const useClusterConfig = configStore.useConfig();
+  const clusterConfig = useClusterConfig();
+  const theme = useTheme();
+
+  const [refresh, setRefresh] = useState<boolean>(true);
+  const [prometheusPrefix, setPrometheusPrefix] = useState<string | null>(null);
+  const [state, setState] = useState<PrometheusState>(PrometheusState.LOADING);
+  const [isVisible, setIsVisible] = useState<boolean>(false);
+  const [selectedChart, setSelectedChart] = useState<string>(
+    props.defaultChart || props.chartConfigs[0]?.key || ''
+  );
+
+  useEffect(() => {
+    const isEnabled = clusterConfig?.[cluster]?.isMetricsEnabled || false;
+    setIsVisible(isEnabled);
+
+    if (!isEnabled) {
+      setState(PrometheusState.UNKNOWN);
+      setPrometheusPrefix(null);
+      return;
+    }
+
+    setState(PrometheusState.LOADING);
+    (async () => {
+      try {
+        const prefix = await getPrometheusPrefix(cluster);
+        if (prefix) {
+          setPrometheusPrefix(prefix);
+          setState(PrometheusState.INSTALLED);
+        } else {
+          setState(PrometheusState.UNKNOWN);
+        }
+      } catch (e) {
+        console.error('Error checking Prometheus installation:', e);
+        setState(PrometheusState.ERROR);
+      }
+    })();
+  }, [clusterConfig, cluster]);
+
+  const interval = getPrometheusInterval(cluster);
+  const graphResolution = getPrometheusResolution(cluster);
+  const subPath = getPrometheusSubPath(cluster);
+
+  const [timespan, setTimespan] = useState(interval ?? '1h');
+  const [resolution, setResolution] = useState(graphResolution ?? 'medium');
+
+  if (!isVisible || props.chartConfigs.length === 0) {
+    return null;
+  }
+
+  const handleChartVariantChange = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setSelectedChart(event.currentTarget.value);
+  };
+
+  const CustomTooltip = ({ active, payload, label, valueFormatter }) => {
+    if (active && payload && payload.length) {
+      const formatter = createTickTimestampFormatter(timespan);
+      return (
+        <Box
+          sx={{
+            backgroundColor: 'background.paper',
+            border: `1px solid ${theme.palette.divider}`,
+            borderRadius: 1,
+            p: 1,
+          }}
+        >
+          <p>{t('Time: {{ time }}', { time: formatter(label) })}</p>
+          {payload.map((item, index) => (
+            <p key={index} style={{ color: item.color }}>
+              {`${item.name}: ${valueFormatter ? valueFormatter(item.value) : item.value}`}
+            </p>
+          ))}
+        </Box>
+      );
+    }
+    return null;
+  };
+
+  const currentChartConfig = props.chartConfigs.find(config => config.key === selectedChart);
+
+  return (
+    <SectionBox>
+      <Paper variant="outlined" sx={{ p: 1 }}>
+        {state === PrometheusState.INSTALLED && (
+          <>
+            <Box display="flex" gap={1} justifyContent="space-between" mb={2}>
+              <Box display="flex" gap={1}>
+                <ToggleButtonGroup
+                  onChange={handleChartVariantChange}
+                  size="small"
+                  aria-label={t('metric chooser')}
+                  value={selectedChart}
+                  exclusive
+                >
+                  {props.chartConfigs.map(config => (
+                    <CustomToggleButton
+                      key={config.key}
+                      label={t(config.label)}
+                      value={config.key}
+                      icon={config.icon}
+                    />
+                  ))}
+                </ToggleButtonGroup>
+              </Box>
+              <Box display="flex" gap={1}>
+                <Button
+                  variant="outlined"
+                  size="small"
+                  onClick={() => {
+                    setRefresh(refresh => !refresh);
+                  }}
+                  startIcon={<Icon icon={refresh ? 'mdi:pause' : 'mdi:play'} />}
+                  sx={{ filter: 'grayscale(1.0)' }}
+                >
+                  {refresh ? t('Pause') : t('Resume')}
+                </Button>
+                <Select
+                  variant="outlined"
+                  size="small"
+                  name="Time"
+                  value={timespan}
+                  onChange={e => setTimespan(e.target.value)}
+                >
+                  <MenuItem value={'10m'}>{t('10 minutes')}</MenuItem>
+                  <MenuItem value={'30m'}>{t('30 minutes')}</MenuItem>
+                  <MenuItem value={'1h'}>{t('1 hour')}</MenuItem>
+                  <MenuItem value={'3h'}>{t('3 hours')}</MenuItem>
+                  <MenuItem value={'6h'}>{t('6 hours')}</MenuItem>
+                  <MenuItem value={'12h'}>{t('12 hours')}</MenuItem>
+                  <MenuItem value={'24h'}>{t('24 hours')}</MenuItem>
+                  <MenuItem value={'48h'}>{t('48 hours')}</MenuItem>
+                  <MenuItem value={'today'}>{t('Today')}</MenuItem>
+                  <MenuItem value={'yesterday'}>{t('Yesterday')}</MenuItem>
+                  <MenuItem value={'week'}>{t('Week')}</MenuItem>
+                  <MenuItem value={'lastweek'}>{t('Last week')}</MenuItem>
+                  <MenuItem value={'7d'}>{t('7 days')}</MenuItem>
+                  <MenuItem value={'14d'}>{t('14 days')}</MenuItem>
+                </Select>
+                <Select
+                  variant="outlined"
+                  size="small"
+                  name="Resolution"
+                  value={resolution}
+                  onChange={e => setResolution(e.target.value)}
+                >
+                  <ListSubheader>{t('Automatic resolution')}</ListSubheader>
+                  <MenuItem value="low">{t('Low res.')}</MenuItem>
+                  <MenuItem value="medium">{t('Medium res.')}</MenuItem>
+                  <MenuItem value="high">{t('High res.')}</MenuItem>
+
+                  <ListSubheader>{t('Fixed resolution')}</ListSubheader>
+                  <MenuItem value="10s">10s</MenuItem>
+                  <MenuItem value="30s">30s</MenuItem>
+                  <MenuItem value="1m">1m</MenuItem>
+                  <MenuItem value="5m">5m</MenuItem>
+                  <MenuItem value="15m">15m</MenuItem>
+                  <MenuItem value="1h">1h</MenuItem>
+                </Select>
+              </Box>
+            </Box>
+
+            <Box
+              sx={{
+                height: '400px',
+                border: `1px solid ${theme.palette.divider}`,
+                borderRadius: 1,
+                p: 2,
+              }}
+            >
+              {currentChartConfig && (
+                <currentChartConfig.component
+                  refresh={refresh}
+                  prometheusPrefix={prometheusPrefix}
+                  resolution={resolution}
+                  subPath={subPath}
+                  timespan={timespan}
+                  CustomTooltip={CustomTooltip}
+                  {...currentChartConfig.queries}
+                />
+              )}
+            </Box>
+          </>
+        )}
+
+        {state === PrometheusState.LOADING ? (
+          <Box m={2}>
+            <Loader title={t('Loading Prometheus Info')} />
+          </Box>
+        ) : state === PrometheusState.ERROR ? (
+          <Box m={2}>
+            <Alert severity="warning">{t('Error fetching Prometheus Info')}</Alert>
+          </Box>
+        ) : state === PrometheusState.UNKNOWN ? (
+          <PrometheusNotFoundBanner />
+        ) : null}
+      </Paper>
+    </SectionBox>
+  );
+}

--- a/prometheus/src/components/Chart/VolcanoQueueCPUChart/VolcanoQueueCPUChart.tsx
+++ b/prometheus/src/components/Chart/VolcanoQueueCPUChart/VolcanoQueueCPUChart.tsx
@@ -1,0 +1,119 @@
+import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
+import { blue, green, orange, red } from '@mui/material/colors';
+import { alpha, useTheme } from '@mui/material/styles';
+import { fetchMetrics } from '../../../request';
+import {
+  ChartDataPoint,
+  createDataProcessor,
+  createTickTimestampFormatter,
+  PrometheusResponse,
+} from '../../../util';
+import Chart from '../Chart/Chart';
+
+interface VolcanoQueueCPUChartProps {
+  refresh: boolean;
+  prometheusPrefix: string;
+  resolution: string;
+  subPath: string;
+  timespan: string;
+  allocatedQuery: string;
+  requestQuery: string;
+  deservedQuery: string;
+  capacityQuery: string;
+  CustomTooltip: (props: any) => JSX.Element | null;
+}
+
+function milliCpuDataProcessor(response: PrometheusResponse): ChartDataPoint[] {
+  const values = createDataProcessor(0)(response);
+
+  return values.map(({ timestamp, y }) => ({
+    timestamp,
+    y: y === null ? null : y / 1000,
+  }));
+}
+
+export function VolcanoQueueCPUChart(props: VolcanoQueueCPUChartProps) {
+  const { t } = useTranslation();
+  const xTickFormatter = createTickTimestampFormatter(props.timespan);
+  const theme = useTheme();
+
+  return (
+    <Chart
+      plots={[
+        {
+          query: props.allocatedQuery,
+          name: t('Allocated'),
+          strokeColor: alpha(blue[600], 0.8),
+          fillColor: alpha(blue[400], 0.1),
+          stackId: null,
+          dataProcessor: milliCpuDataProcessor,
+        },
+        {
+          query: props.requestQuery,
+          name: t('Requested'),
+          strokeColor: alpha(orange[600], 0.8),
+          fillColor: alpha(orange[400], 0.1),
+          stackId: null,
+          dataProcessor: milliCpuDataProcessor,
+        },
+        {
+          query: props.deservedQuery,
+          name: t('Deserved'),
+          strokeColor: alpha(green[600], 0.8),
+          fillColor: alpha(green[400], 0.1),
+          stackId: null,
+          dataProcessor: milliCpuDataProcessor,
+        },
+        {
+          query: props.capacityQuery,
+          name: t('Capacity'),
+          strokeColor: alpha(red[600], 0.8),
+          fillColor: alpha(red[400], 0.1),
+          stackId: null,
+          dataProcessor: milliCpuDataProcessor,
+        },
+      ]}
+      xAxisProps={{
+        dataKey: 'timestamp',
+        tickLine: false,
+        tick: tickProps => {
+          const value = xTickFormatter(tickProps.payload.value);
+          if (!value) return null;
+
+          return (
+            <g
+              transform={`translate(${tickProps.x},${tickProps.y})`}
+              fill={theme.palette.chartStyles.labelColor}
+            >
+              <text x={0} y={10} dy={0} textAnchor="middle">
+                {value}
+              </text>
+            </g>
+          );
+        },
+      }}
+      yAxisProps={{
+        domain: [0, 'auto'],
+        width: 80,
+        label: {
+          value: t('CPU cores'),
+          angle: -90,
+          position: 'insideLeft',
+          style: { textAnchor: 'middle' },
+        },
+      }}
+      CustomTooltip={tooltipProps =>
+        props.CustomTooltip({
+          ...tooltipProps,
+          valueFormatter: value => Number(value).toFixed(3),
+        })
+      }
+      fetchMetrics={fetchMetrics}
+      autoRefresh={props.refresh}
+      prometheusPrefix={props.prometheusPrefix}
+      interval={props.timespan}
+      resolution={props.resolution}
+      subPath={props.subPath}
+    />
+  );
+}

--- a/prometheus/src/components/Chart/VolcanoQueueMemoryChart/VolcanoQueueMemoryChart.tsx
+++ b/prometheus/src/components/Chart/VolcanoQueueMemoryChart/VolcanoQueueMemoryChart.tsx
@@ -1,0 +1,107 @@
+import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
+import { blue, green, orange, red } from '@mui/material/colors';
+import { alpha, useTheme } from '@mui/material/styles';
+import { fetchMetrics } from '../../../request';
+import { createDataProcessor, createTickTimestampFormatter, formatBytes } from '../../../util';
+import Chart from '../Chart/Chart';
+
+interface VolcanoQueueMemoryChartProps {
+  refresh: boolean;
+  prometheusPrefix: string;
+  resolution: string;
+  subPath: string;
+  timespan: string;
+  allocatedQuery: string;
+  requestQuery: string;
+  deservedQuery: string;
+  capacityQuery: string;
+  CustomTooltip: (props: any) => JSX.Element | null;
+}
+
+export function VolcanoQueueMemoryChart(props: VolcanoQueueMemoryChartProps) {
+  const { t } = useTranslation();
+  const xTickFormatter = createTickTimestampFormatter(props.timespan);
+  const dataProcessor = createDataProcessor(0);
+  const theme = useTheme();
+
+  return (
+    <Chart
+      plots={[
+        {
+          query: props.allocatedQuery,
+          name: t('Allocated'),
+          strokeColor: alpha(blue[600], 0.8),
+          fillColor: alpha(blue[400], 0.1),
+          stackId: null,
+          dataProcessor,
+        },
+        {
+          query: props.requestQuery,
+          name: t('Requested'),
+          strokeColor: alpha(orange[600], 0.8),
+          fillColor: alpha(orange[400], 0.1),
+          stackId: null,
+          dataProcessor,
+        },
+        {
+          query: props.deservedQuery,
+          name: t('Deserved'),
+          strokeColor: alpha(green[600], 0.8),
+          fillColor: alpha(green[400], 0.1),
+          stackId: null,
+          dataProcessor,
+        },
+        {
+          query: props.capacityQuery,
+          name: t('Capacity'),
+          strokeColor: alpha(red[600], 0.8),
+          fillColor: alpha(red[400], 0.1),
+          stackId: null,
+          dataProcessor,
+        },
+      ]}
+      xAxisProps={{
+        dataKey: 'timestamp',
+        tickLine: false,
+        tick: tickProps => {
+          const value = xTickFormatter(tickProps.payload.value);
+          if (!value) return null;
+
+          return (
+            <g
+              transform={`translate(${tickProps.x},${tickProps.y})`}
+              fill={theme.palette.chartStyles.labelColor}
+            >
+              <text x={0} y={10} dy={0} textAnchor="middle">
+                {value}
+              </text>
+            </g>
+          );
+        },
+      }}
+      yAxisProps={{
+        domain: [0, 'auto'],
+        tick: ({ x, y, payload }) => (
+          <g transform={`translate(${x},${y})`} fill={theme.palette.chartStyles.labelColor}>
+            <text x={-35} y={0} dy={0} textAnchor="middle">
+              {formatBytes(payload.value)}
+            </text>
+          </g>
+        ),
+        width: 90,
+      }}
+      CustomTooltip={tooltipProps =>
+        props.CustomTooltip({
+          ...tooltipProps,
+          valueFormatter: formatBytes,
+        })
+      }
+      fetchMetrics={fetchMetrics}
+      autoRefresh={props.refresh}
+      prometheusPrefix={props.prometheusPrefix}
+      interval={props.timespan}
+      resolution={props.resolution}
+      subPath={props.subPath}
+    />
+  );
+}

--- a/prometheus/src/components/Chart/VolcanoQueuePodGroupsChart/VolcanoQueuePodGroupsChart.tsx
+++ b/prometheus/src/components/Chart/VolcanoQueuePodGroupsChart/VolcanoQueuePodGroupsChart.tsx
@@ -1,0 +1,110 @@
+import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
+import { blue, green, grey, orange, purple } from '@mui/material/colors';
+import { alpha, useTheme } from '@mui/material/styles';
+import { fetchMetrics } from '../../../request';
+import { createDataProcessor, createTickTimestampFormatter } from '../../../util';
+import Chart from '../Chart/Chart';
+
+interface VolcanoQueuePodGroupsChartProps {
+  refresh: boolean;
+  prometheusPrefix: string;
+  resolution: string;
+  subPath: string;
+  timespan: string;
+  inqueueQuery: string;
+  pendingQuery: string;
+  runningQuery: string;
+  completedQuery: string;
+  unknownQuery: string;
+  CustomTooltip: (props: any) => JSX.Element | null;
+}
+
+export function VolcanoQueuePodGroupsChart(props: VolcanoQueuePodGroupsChartProps) {
+  const { t } = useTranslation();
+  const xTickFormatter = createTickTimestampFormatter(props.timespan);
+  const dataProcessor = createDataProcessor(0);
+  const theme = useTheme();
+
+  return (
+    <Chart
+      plots={[
+        {
+          query: props.inqueueQuery,
+          name: t('Inqueue'),
+          strokeColor: alpha(purple[600], 0.8),
+          fillColor: alpha(purple[400], 0.1),
+          stackId: null,
+          dataProcessor,
+        },
+        {
+          query: props.pendingQuery,
+          name: t('Pending'),
+          strokeColor: alpha(orange[600], 0.8),
+          fillColor: alpha(orange[400], 0.1),
+          stackId: null,
+          dataProcessor,
+        },
+        {
+          query: props.runningQuery,
+          name: t('Running'),
+          strokeColor: alpha(blue[600], 0.8),
+          fillColor: alpha(blue[400], 0.1),
+          stackId: null,
+          dataProcessor,
+        },
+        {
+          query: props.completedQuery,
+          name: t('Completed'),
+          strokeColor: alpha(green[600], 0.8),
+          fillColor: alpha(green[400], 0.1),
+          stackId: null,
+          dataProcessor,
+        },
+        {
+          query: props.unknownQuery,
+          name: t('Unknown'),
+          strokeColor: alpha(grey[600], 0.8),
+          fillColor: alpha(grey[400], 0.1),
+          stackId: null,
+          dataProcessor,
+        },
+      ]}
+      xAxisProps={{
+        dataKey: 'timestamp',
+        tickLine: false,
+        tick: tickProps => {
+          const value = xTickFormatter(tickProps.payload.value);
+          if (!value) return null;
+
+          return (
+            <g
+              transform={`translate(${tickProps.x},${tickProps.y})`}
+              fill={theme.palette.chartStyles.labelColor}
+            >
+              <text x={0} y={10} dy={0} textAnchor="middle">
+                {value}
+              </text>
+            </g>
+          );
+        },
+      }}
+      yAxisProps={{
+        domain: [0, 'auto'],
+        width: 80,
+        label: {
+          value: t('PodGroups'),
+          angle: -90,
+          position: 'insideLeft',
+          style: { textAnchor: 'middle' },
+        },
+      }}
+      CustomTooltip={props.CustomTooltip}
+      fetchMetrics={fetchMetrics}
+      autoRefresh={props.refresh}
+      prometheusPrefix={props.prometheusPrefix}
+      interval={props.timespan}
+      resolution={props.resolution}
+      subPath={props.subPath}
+    />
+  );
+}

--- a/prometheus/src/index.tsx
+++ b/prometheus/src/index.tsx
@@ -13,6 +13,10 @@ import { KedaChart } from './components/Chart/KedaChart/KedaChart';
 import { KnativeChart } from './components/Chart/KnativeChart/KnativeChart';
 import { getKafkaChartConfigs, StrimziChart } from './components/Chart/StrimziChart/StrimziChart';
 import {
+  getVolcanoQueueChartConfigs,
+  VolcanoChart,
+} from './components/Chart/VolcanoChart/VolcanoChart';
+import {
   getClusterChartConfigs,
   getKubeadmControlPlaneChartConfigs,
   getMachineChartConfigs,
@@ -168,6 +172,16 @@ function PrometheusMetrics(resource: KubeObject) {
       />
     );
   }
+
+  if (
+    resourceKind === 'Queue' &&
+    resource.jsonData?.apiVersion === 'scheduling.volcano.sh/v1beta1'
+  ) {
+    const name = resource.jsonData.metadata.name;
+
+    return <VolcanoChart chartConfigs={getVolcanoQueueChartConfigs(name)} defaultChart="cpu" />;
+  }
+
   // cluster api resources
   if (resource.kind === 'Cluster') {
     const name = resource.jsonData.metadata.name;

--- a/prometheus/src/util.test.ts
+++ b/prometheus/src/util.test.ts
@@ -127,6 +127,17 @@ describe('supportsPrometheusMetrics', () => {
       { kind: 'ScaledObject', jsonData: { kind: 'ScaledObject', apiVersion: 'keda.sh/v1alpha1' } },
       true,
     ],
+    [
+      'supports Volcano Queues',
+      { kind: 'Queue', jsonData: { kind: 'Queue', apiVersion: 'scheduling.volcano.sh/v1beta1' } },
+      true,
+    ],
+    [
+      'rejects non-Volcano Queues with same kind',
+      { kind: 'Queue', jsonData: { kind: 'Queue', apiVersion: 'example.com/v1' } },
+      false,
+    ],
+    ['rejects Queues without apiVersion', { kind: 'Queue', jsonData: { kind: 'Queue' } }, false],
     ['rejects unknown kinds', { kind: 'VolcanoJob', jsonData: { kind: 'VolcanoJob' } }, false],
     ['rejects missing resources', undefined, false],
   ])('%s', (_, resource, expected) => {

--- a/prometheus/src/util.ts
+++ b/prometheus/src/util.ts
@@ -163,6 +163,7 @@ function getResourceApiVersion(resource?: ResourceIdentity): string | undefined 
 
 const resourceApiVersionRules: Record<string, RegExp> = {
   Job: /^batch\/v1$/,
+  Queue: /^scheduling\.volcano\.sh\/v1beta1$/,
   Cluster: /^cluster\.x-k8s\.io\//,
   Machine: /^cluster\.x-k8s\.io\//,
   MachineDeployment: /^cluster\.x-k8s\.io\//,
@@ -205,6 +206,7 @@ const ChartEnabledKinds = [
   'Kafka',
   'Service',
   'Revision',
+  'Queue',
   'Cluster',
   'MachineDeployment',
   'MachineSet',


### PR DESCRIPTION
## Summary
This PR adds Prometheus metrics charts for Volcano Queues so users can inspect queue CPU, memory, and PodGroup status metrics directly from the Queue details page.
<img width="1037" height="437" alt="image" src="https://github.com/user-attachments/assets/fe37887b-5a8d-41de-a349-d520a581b40d" />
<img width="1040" height="398" alt="image" src="https://github.com/user-attachments/assets/0647f09a-11a9-44dd-a912-bd267fedbe28" />

## Changes
- add Volcano Queue support to Prometheus metric visibility
- gate Volcano Queue metrics on `scheduling.volcano.sh/v1beta1`
- add CPU charts for:
  - allocated
  - requested
  - deserved
  - capacity
- add memory charts for:
  - allocated
  - requested
  - deserved
  - capacity
- add PodGroup status charts for:
  - inqueue
  - pending
  - running
  - completed
  - unknown
- reuse the existing Prometheus chart controls for pause/resume, time range, and resolution
- reuse the shared Prometheus chart data processor
- avoid showing fake zero data when a Volcano metric is not returned by Prometheus
- keep Volcano queue metrics unstacked because these series are independent gauges
## Steps to Test
1. Install Volcano and Volcano plugin in a connected cluster.
3. Build/start the Prometheus plugin.
4. Open a Volcano Queue details page.
5. Enable Prometheus metrics from the details header action.
6. Confirm the CPU chart shows Volcano Queue allocated, requested, deserved, and capacity metrics when available.
7. Confirm the Memory chart shows Volcano Queue allocated, requested, deserved, and capacity metrics when available.
8. Confirm the PodGroups chart shows inqueue, pending, running, completed, and unknown counts.
9. Apply a Volcano Job with CPU and memory requests in the Queue.
10. Confirm the CPU and Memory charts update after Prometheus scrapes the new metrics.