### PR TITLE
fix(radius): show 100% health for empty resource sets

### DIFF
--- a/radius/src/models/radius.ts
+++ b/radius/src/models/radius.ts
@@ -545,12 +545,6 @@ export function useRadiusResources(): [UCPResource[] | null, Error | null, boole
         const results = await Promise.all(promises);
         const allResources = results.flat();
 
-        if (allResources.length === 0) {
-          throw new Error(
-            'Failed to fetch Radius resources from all configured providers and resource types.'
-          );
-        }
-
         if (mounted) {
           setResources(allResources);
           setError(null);

--- a/radius/src/radius-overview/index.tsx
+++ b/radius/src/radius-overview/index.tsx
@@ -83,28 +83,20 @@ function ResourceStatusChart({ resources, title }: ResourceStatusChartProps) {
   const theme = useTheme();
   const total = resources.length;
 
-  if (total === 0) {
-    return (
-      <Box sx={{ textAlign: 'center', p: 3 }}>
-        <Typography variant="h4" gutterBottom>
-          0
-        </Typography>
-        <Typography variant="body2" color="text.secondary">
-          {title}
-        </Typography>
-      </Box>
-    );
-  }
+  const isEmpty = total === 0;
 
   const status = getResourceStatus(resources);
 
   // Calculate percentages ensuring they sum to 100%
-  const percentages = [
-    Math.round((status.success / total) * 100),
-    Math.round((status.failed / total) * 100),
-    Math.round((status.processing / total) * 100),
-    Math.round((status.suspended / total) * 100),
-  ];
+  const percentages =
+    total === 0
+      ? [100, 0, 0, 0]
+      : [
+          Math.round((status.success / total) * 100),
+          Math.round((status.failed / total) * 100),
+          Math.round((status.processing / total) * 100),
+          Math.round((status.suspended / total) * 100),
+        ];
 
   // Adjust to ensure total is 100% by modifying the largest percentage
   const sum = percentages.reduce((a, b) => a + b, 0);
@@ -154,6 +146,11 @@ function ResourceStatusChart({ resources, title }: ResourceStatusChartProps) {
       <Typography variant="body2" fontWeight="medium" gutterBottom>
         {title}
       </Typography>
+      {isEmpty && (
+        <Typography variant="caption" display="block" color="text.secondary">
+          No resources detected
+        </Typography>
+      )}
       {status.success > 0 && (
         <Typography variant="caption" display="block" color="text.secondary">
           {status.success} Succeeded

--- a/radius/src/radius-overview/index.tsx
+++ b/radius/src/radius-overview/index.tsx
@@ -148,7 +148,7 @@ function ResourceStatusChart({ resources, title }: ResourceStatusChartProps) {
       </Typography>
       {isEmpty && (
         <Typography variant="caption" display="block" color="text.secondary">
-          No resources detected
+          No resources in this category
         </Typography>
       )}
       {status.success > 0 && (


### PR DESCRIPTION
## Summary

Fixes the Radius Overview dashboard to render a healthy 100% TileChart when no resources are present.

## Changes

- Removed the early return for empty resource sets
- Added safe percentage handling for `total === 0`
- Defaulted empty states to `100%` success
- Added empty-state legend messaging

## Result

Empty environments now display a healthy chart instead of a plain `0` state, matching behavior used in other Headlamp plugins and avoiding misleading empty dashboards.

fixes : #707 