### PR TITLE
kyverno: Restore dropped fixes for ViolationsView scope and Policy ready status

### DIFF
--- a/kyverno/src/components/ViolationsView.tsx
+++ b/kyverno/src/components/ViolationsView.tsx
@@ -32,6 +32,7 @@ import { useMemo, useState } from 'react';
 import {
   ClusterPolicyReport,
   PolicyReport,
+  PolicyReportInterface,
   PolicyReportResult,
   PolicyResultStatus,
 } from '../resources/policyReport';
@@ -41,6 +42,7 @@ type GroupBy = 'none' | 'policy' | 'namespace' | 'kind';
 
 interface ViolationEntry extends PolicyReportResult {
   reportNamespace?: string;
+  scope?: PolicyReportInterface['scope'];
 }
 
 const VIOLATION_STATUSES: PolicyResultStatus[] = ['fail', 'warn', 'error'];
@@ -57,6 +59,7 @@ function collectViolations(
         violations.push({
           ...result,
           reportNamespace: report.jsonData.metadata.namespace,
+          scope: report.jsonData.scope,
         });
       }
     }
@@ -65,7 +68,10 @@ function collectViolations(
   for (const report of clusterPolicyReports || []) {
     for (const result of report.results) {
       if (VIOLATION_STATUSES.includes(result.result)) {
-        violations.push({ ...result });
+        violations.push({
+          ...result,
+          scope: report.jsonData.scope,
+        });
       }
     }
   }
@@ -78,9 +84,9 @@ function getGroupKey(entry: ViolationEntry, groupBy: GroupBy): string {
     case 'policy':
       return entry.policy || 'Unknown';
     case 'namespace':
-      return entry.resources?.[0]?.namespace || entry.reportNamespace || 'cluster-scoped';
+      return entry.resources?.[0]?.namespace || entry.scope?.namespace || entry.reportNamespace || 'cluster-scoped';
     case 'kind':
-      return entry.resources?.[0]?.kind || 'Unknown';
+      return entry.resources?.[0]?.kind || entry.scope?.kind || 'Unknown';
     default:
       return '';
   }
@@ -154,15 +160,15 @@ export function ViolationsView() {
     () => [
       {
         header: t('Resource'),
-        accessorFn: (v: ViolationEntry) => v.resources?.[0]?.name || '-',
+        accessorFn: (v: ViolationEntry) => v.resources?.[0]?.name || v.scope?.name || '-',
       },
       {
         header: t('Kind'),
-        accessorFn: (v: ViolationEntry) => v.resources?.[0]?.kind || '-',
+        accessorFn: (v: ViolationEntry) => v.resources?.[0]?.kind || v.scope?.kind || '-',
       },
       {
         header: t('Namespace'),
-        accessorFn: (v: ViolationEntry) => v.resources?.[0]?.namespace || v.reportNamespace || '-',
+        accessorFn: (v: ViolationEntry) => v.resources?.[0]?.namespace || v.scope?.namespace || v.reportNamespace || '-',
       },
       {
         header: t('Policy'),

--- a/kyverno/src/resources/kyvernoPolicy.ts
+++ b/kyverno/src/resources/kyvernoPolicy.ts
@@ -128,7 +128,9 @@ abstract class KyvernoPolicyBase extends KubeObject<KyvernoPolicyInterface> {
   }
 
   get ready(): boolean {
-    return this.status?.ready ?? false;
+    const conditions = this.status?.conditions || [];
+    const readyCond = conditions.find(c => c.type === 'Ready');
+    return readyCond?.status === 'True';
   }
 
   get rules(): PolicyRule[] {


### PR DESCRIPTION
### Description
This PR restores a couple of fixes that were accidentally dropped during recent force-pushes/rebases on the `add-kyverno-plugin` branch.

**Restored Fixes:**
1. **ViolationsView Missing Pod Names:** 
   When Kyverno generates per-resource policy reports, the resource information is stored in the report's `scope` rather than the individual result's `resources` array. This PR restores the fallback to the report scope so that pod names, kinds, and namespaces are displayed correctly in the Violations table instead of `-`. (Originally fixed in #677)

2. **Policy Ready Status Logic:**
   During the refactoring into `KyvernoPolicyBase`, the logic to compute the `ready` status from policy conditions was overwritten with the older `this.status?.ready` implementation. This restores the logic to correctly check for the `Ready` condition in the `status.conditions` array. (Originally fixed in #678)


