### PR TITLE
fix(ci): add workflow-level packages write permission

### DIFF
--- a/.github/workflows/build-and-publish-image.yml
+++ b/.github/workflows/build-and-publish-image.yml
@@ -14,6 +14,7 @@ on:
 
 permissions:
   contents: read
+  packages: write
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
## Summary

Fixes the `build-and-publish` workflow failing while pushing OCI images to GHCR.

The workflow currently fails with:

```txt
denied: permission_denied: write_package
```

Although the job defines `packages: write`, the workflow-level permissions only include `contents: read`.

## Changes

* Added `packages: write` to workflow-level permissions.

## Result

The workflow should now be able to successfully push container images to:

```txt
ghcr.io/headlamp-k8s/*
```

Fixes #767
