### PR TITLE
flux: fix Next Reconciliation showing "<invalid>"

### DIFF
--- a/flux/src/common/RemainingTimeDisplay.test.tsx
+++ b/flux/src/common/RemainingTimeDisplay.test.tsx
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { formatRemainingTime } from './remainingTime';
+
+describe('formatRemainingTime', () => {
+  const now = 1700000000000;
+
+  it('formats a seconds-scale future time', () => {
+    expect(formatRemainingTime(now + 45 * 1000, now)).toBe('45s');
+  });
+
+  it('formats a minute-scale future time', () => {
+    expect(formatRemainingTime(now + 5 * 60 * 1000, now)).toBe('5m');
+  });
+});

--- a/flux/src/common/RemainingTimeDisplay.tsx
+++ b/flux/src/common/RemainingTimeDisplay.tsx
@@ -1,10 +1,11 @@
 import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
 import { HoverInfoLabel } from '@kinvolk/headlamp-plugin/lib/components/common';
 import { KubeCondition, KubeObject } from '@kinvolk/headlamp-plugin/lib/lib/k8s/cluster';
-import { localeDate, timeAgo } from '@kinvolk/headlamp-plugin/lib/Utils';
+import { localeDate } from '@kinvolk/headlamp-plugin/lib/Utils';
 import { Box, Typography } from '@mui/material';
 import React from 'react';
 import { parseDuration } from '../helpers';
+import { formatRemainingTime } from './remainingTime';
 
 export interface RemainingTimeDisplayProps {
   item: KubeObject;
@@ -169,7 +170,7 @@ export default function RemainingTimeDisplay(props: RemainingTimeDisplayProps) {
         <Typography>{t('In progress…')}</Typography>
       ) : (
         <HoverInfoLabel
-          label={t('In {{time}}', { time: timeAgo(nextAttemptStatus.nextAttempt) })}
+          label={t('In {{time}}', { time: formatRemainingTime(nextAttemptStatus.nextAttempt) })}
           hoverInfo={localeDate(new Date(nextAttemptStatus.nextAttempt))}
           icon="mdi:calendar"
         />

--- a/flux/src/common/remainingTime.ts
+++ b/flux/src/common/remainingTime.ts
@@ -1,0 +1,5 @@
+import { formatDuration } from '@kinvolk/headlamp-plugin/lib/Utils';
+
+export function formatRemainingTime(nextAttempt: number, now: number = Date.now()): string {
+  return formatDuration(nextAttempt - now);
+}


### PR DESCRIPTION
## Summary
Fixes #727. Since headlamp 0.42.0 the Flux "Next Reconciliation" field shows `<invalid>`.

## Root cause
`RemainingTimeDisplay` rendered `In ${timeAgo(nextAttempt)}`, but `nextAttempt` is a future timestamp. `timeAgo(date)` is `formatDuration(now - date)`, so a future date gives a negative duration, which headlamp 0.42.0 renders as `<invalid>`.

## Fix
Format the forward duration instead (`formatDuration(nextAttempt - now)`) via a small `formatRemainingTime` helper. The component only renders this branch when the time is still in the future, so the duration is always positive.

## Test plan
- [x] `npm run tsc`, `npm run lint`, `npm test`, `npm run build` pass
- [x] added a unit test for `formatRemainingTime`