### PR TITLE
volcano: Add overview dashboard

### DIFF
--- a/volcano/src/components/overview/Overview.tsx
+++ b/volcano/src/components/overview/Overview.tsx
@@ -1,0 +1,353 @@
+import {
+  DateLabel,
+  Link,
+  SectionBox,
+  SimpleTable,
+  StatusLabel,
+} from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { Box, Button, CircularProgress, Grid, Typography } from '@mui/material';
+import { useMemo, useState } from 'react';
+import { VolcanoJob } from '../../resources/job';
+import { VolcanoPodGroup } from '../../resources/podgroup';
+import { VolcanoQueue } from '../../resources/queue';
+import { getJobStatusColor, getPodGroupStatusColor } from '../../utils/status';
+import { volcanoRouteNames } from '../../utils/volcanoRoutes';
+import { VolcanoCoreInstallCheck } from '../common/CommonComponents';
+import { SummaryCard } from './OverviewCards';
+import {
+  AttentionRow,
+  countBy,
+  getAttentionReason,
+  getAttentionRows,
+  getAttentionStatus,
+  getErrorText,
+  visibleSchedulingIssuesLimit,
+} from './overviewStats';
+
+function getAttentionLink(row: AttentionRow) {
+  if (row.type === 'Job') {
+    return (
+      <Link
+        routeName={volcanoRouteNames.jobDetail}
+        params={{ namespace: row.namespace, name: row.name }}
+      >
+        {row.name}
+      </Link>
+    );
+  }
+
+  if (row.type === 'PodGroup') {
+    return (
+      <Link
+        routeName={volcanoRouteNames.podGroupDetail}
+        params={{ namespace: row.namespace, name: row.name }}
+      >
+        {row.name}
+      </Link>
+    );
+  }
+
+  return (
+    <Link routeName={volcanoRouteNames.queueDetail} params={{ name: row.name }}>
+      {row.name}
+    </Link>
+  );
+}
+
+function getAttentionQueue(row: AttentionRow) {
+  if (row.type === 'Job' || row.type === 'PodGroup') {
+    return (
+      <Link routeName={volcanoRouteNames.queueDetail} params={{ name: row.resource.queue }}>
+        {row.resource.queue}
+      </Link>
+    );
+  }
+
+  return '-';
+}
+
+function getCreationTimestampMs(resource: { metadata: { creationTimestamp?: string } }) {
+  return Date.parse(resource.metadata.creationTimestamp || '') || 0;
+}
+
+export default function Overview() {
+  const [showAllIssues, setShowAllIssues] = useState(false);
+  const [jobs, jobsError] = VolcanoJob.useList();
+  const [queues, queuesError] = VolcanoQueue.useList();
+  const [podGroups, podGroupsError] = VolcanoPodGroup.useList();
+
+  const isLoading =
+    (jobs === null && !jobsError) ||
+    (queues === null && !queuesError) ||
+    (podGroups === null && !podGroupsError);
+
+  const jobCounts = useMemo(() => countBy((jobs || []).map(job => job.phase)), [jobs]);
+  const queueCounts = useMemo(() => countBy((queues || []).map(queue => queue.state)), [queues]);
+  const podGroupCounts = useMemo(
+    () => countBy((podGroups || []).map(podGroup => podGroup.phase)),
+    [podGroups]
+  );
+  const recentJobs = useMemo(
+    () =>
+      [...(jobs || [])]
+        .sort((first, second) => getCreationTimestampMs(second) - getCreationTimestampMs(first))
+        .slice(0, 5),
+    [jobs]
+  );
+  const recentPodGroups = useMemo(
+    () =>
+      [...(podGroups || [])]
+        .sort((first, second) => getCreationTimestampMs(second) - getCreationTimestampMs(first))
+        .slice(0, 5),
+    [podGroups]
+  );
+  const attentionRows = useMemo(
+    () => getAttentionRows(jobs, queues, podGroups),
+    [jobs, queues, podGroups]
+  );
+  const visibleAttentionRows = showAllIssues
+    ? attentionRows
+    : attentionRows.slice(0, visibleSchedulingIssuesLimit);
+
+  if (isLoading) {
+    return (
+      <VolcanoCoreInstallCheck>
+        <Box display="flex" alignItems="center" justifyContent="center" minHeight="240px">
+          <CircularProgress />
+          <Typography sx={{ ml: 2 }}>Loading Volcano overview...</Typography>
+        </Box>
+      </VolcanoCoreInstallCheck>
+    );
+  }
+
+  const jobsErrorText = getErrorText(jobsError);
+  const queuesErrorText = getErrorText(queuesError);
+  const podGroupsErrorText = getErrorText(podGroupsError);
+  const schedulingPressure =
+    (jobCounts.Pending || 0) + (podGroupCounts.Pending || 0) + (podGroupCounts.Inqueue || 0);
+
+  return (
+    <VolcanoCoreInstallCheck>
+      <Box sx={{ p: 2 }}>
+        <Box sx={{ mb: 3 }}>
+          <Typography variant="h4" component="h1" sx={{ fontWeight: 700 }}>
+            Volcano Overview
+          </Typography>
+          <Typography variant="body1" color="text.secondary">
+            Cluster scheduling snapshot for Volcano workloads, queues, and PodGroups.
+          </Typography>
+        </Box>
+
+        <Grid container spacing={3} sx={{ mb: 4 }}>
+          <Grid item xs={12} sm={6} md={3}>
+            <SummaryCard
+              title="Jobs"
+              value={jobsErrorText || jobs?.length || 0}
+              icon="mdi:briefcase-outline"
+              subtitle={`Running ${jobCounts.Running || 0}, pending ${
+                jobCounts.Pending || 0
+              }, completed ${jobCounts.Completed || 0}, failed ${jobCounts.Failed || 0}`}
+            />
+          </Grid>
+          <Grid item xs={12} sm={6} md={3}>
+            <SummaryCard
+              title="Queues"
+              value={queuesErrorText || queues?.length || 0}
+              icon="mdi:format-list-group"
+              subtitle={`Open ${queueCounts.Open || 0}, closing ${
+                queueCounts.Closing || 0
+              }, closed ${queueCounts.Closed || 0}`}
+            />
+          </Grid>
+          <Grid item xs={12} sm={6} md={3}>
+            <SummaryCard
+              title="PodGroups"
+              value={podGroupsErrorText || podGroups?.length || 0}
+              icon="mdi:cube-outline"
+              subtitle={`Running ${podGroupCounts.Running || 0}, pending ${
+                podGroupCounts.Pending || 0
+              }, inqueue ${podGroupCounts.Inqueue || 0}`}
+            />
+          </Grid>
+          <Grid item xs={12} sm={6} md={3}>
+            <SummaryCard
+              title="Pending Pressure"
+              value={schedulingPressure}
+              icon="mdi:gauge"
+              subtitle="Pending Jobs plus pending or inqueue PodGroups"
+            />
+          </Grid>
+        </Grid>
+
+        <Grid container spacing={2}>
+          <Grid item xs={12}>
+            <SectionBox title="Scheduling Issues">
+              <SimpleTable
+                data={visibleAttentionRows}
+                columns={[
+                  { label: 'Type', getter: (row: AttentionRow) => row.type, sort: true },
+                  {
+                    label: 'Name',
+                    getter: (row: AttentionRow) => getAttentionLink(row),
+                    sort: (row: AttentionRow) => row.name,
+                  },
+                  {
+                    label: 'Queue',
+                    getter: (row: AttentionRow) => getAttentionQueue(row),
+                    sort: (row: AttentionRow) =>
+                      row.type === 'Job' || row.type === 'PodGroup' ? row.resource.queue : '',
+                  },
+                  {
+                    getter: (row: AttentionRow) => ('namespace' in row ? row.namespace : '-'),
+                    sort: (row: AttentionRow) => ('namespace' in row ? row.namespace : ''),
+                    label: 'Namespace',
+                  },
+                  {
+                    label: 'Status',
+                    getter: (row: AttentionRow) => (
+                      <StatusLabel status={getAttentionStatus(row)}>{row.status}</StatusLabel>
+                    ),
+                    sort: (row: AttentionRow) => row.status,
+                  },
+                  {
+                    label: 'Details',
+                    getter: (row: AttentionRow) => getAttentionReason(row),
+                    sort: (row: AttentionRow) => getAttentionReason(row),
+                  },
+                ]}
+                emptyMessage="No failed, blocked, or closed Volcano resources found."
+              />
+              {attentionRows.length > visibleSchedulingIssuesLimit && (
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 1 }}>
+                  <Typography variant="caption" color="text.secondary">
+                    {showAllIssues
+                      ? `Showing all ${attentionRows.length} scheduling issues.`
+                      : `Showing ${visibleAttentionRows.length} of ${attentionRows.length} scheduling issues.`}
+                  </Typography>
+                  <Button size="small" onClick={() => setShowAllIssues(value => !value)}>
+                    {showAllIssues ? 'Show less' : 'Show all'}
+                  </Button>
+                </Box>
+              )}
+            </SectionBox>
+          </Grid>
+
+          <Grid item xs={12} lg={7}>
+            <SectionBox title="Recent Jobs">
+              <SimpleTable
+                data={recentJobs}
+                columns={[
+                  {
+                    label: 'Name',
+                    getter: (job: VolcanoJob) => (
+                      <Link
+                        routeName={volcanoRouteNames.jobDetail}
+                        params={{ namespace: job.getNamespace(), name: job.getName() }}
+                      >
+                        {job.getName()}
+                      </Link>
+                    ),
+                    sort: (job: VolcanoJob) => job.getName(),
+                  },
+                  {
+                    label: 'Namespace',
+                    getter: (job: VolcanoJob) => job.getNamespace(),
+                    sort: true,
+                  },
+                  {
+                    label: 'Queue',
+                    getter: (job: VolcanoJob) => (
+                      <Link routeName={volcanoRouteNames.queueDetail} params={{ name: job.queue }}>
+                        {job.queue}
+                      </Link>
+                    ),
+                    sort: (job: VolcanoJob) => job.queue,
+                  },
+                  {
+                    label: 'Status',
+                    getter: (job: VolcanoJob) => (
+                      <StatusLabel status={getJobStatusColor(job.phase)}>{job.phase}</StatusLabel>
+                    ),
+                    sort: (job: VolcanoJob) => job.phase,
+                  },
+                  {
+                    label: 'Replicas',
+                    getter: (job: VolcanoJob) => job.replicaCount,
+                    sort: (job: VolcanoJob) => job.replicaCount,
+                  },
+                  {
+                    label: 'Min Available',
+                    getter: (job: VolcanoJob) => job.minAvailable,
+                    sort: (job: VolcanoJob) => job.minAvailable,
+                  },
+                  {
+                    label: 'Created',
+                    getter: (job: VolcanoJob) => <DateLabel date={job.getCreationTs()} />,
+                    sort: (job: VolcanoJob) => job.metadata.creationTimestamp || '',
+                  },
+                ]}
+                emptyMessage="No Volcano Jobs found."
+              />
+            </SectionBox>
+          </Grid>
+
+          <Grid item xs={12} lg={5}>
+            <SectionBox title="Recent PodGroups">
+              <SimpleTable
+                data={recentPodGroups}
+                columns={[
+                  {
+                    label: 'Name',
+                    getter: (podGroup: VolcanoPodGroup) => (
+                      <Link
+                        routeName={volcanoRouteNames.podGroupDetail}
+                        params={{ namespace: podGroup.getNamespace(), name: podGroup.getName() }}
+                      >
+                        {podGroup.getName()}
+                      </Link>
+                    ),
+                    sort: (podGroup: VolcanoPodGroup) => podGroup.getName(),
+                  },
+                  {
+                    label: 'Queue',
+                    getter: (podGroup: VolcanoPodGroup) => (
+                      <Link
+                        routeName={volcanoRouteNames.queueDetail}
+                        params={{ name: podGroup.queue }}
+                      >
+                        {podGroup.queue}
+                      </Link>
+                    ),
+                    sort: (podGroup: VolcanoPodGroup) => podGroup.queue,
+                  },
+                  {
+                    label: 'Status',
+                    getter: (podGroup: VolcanoPodGroup) => (
+                      <StatusLabel status={getPodGroupStatusColor(podGroup.phase)}>
+                        {podGroup.phase}
+                      </StatusLabel>
+                    ),
+                    sort: (podGroup: VolcanoPodGroup) => podGroup.phase,
+                  },
+                  {
+                    label: 'Min Member',
+                    getter: (podGroup: VolcanoPodGroup) => podGroup.minMember,
+                    sort: (podGroup: VolcanoPodGroup) => podGroup.minMember,
+                  },
+                  {
+                    label: 'Created',
+                    getter: (podGroup: VolcanoPodGroup) => (
+                      <DateLabel date={podGroup.getCreationTs()} />
+                    ),
+                    sort: (podGroup: VolcanoPodGroup) => podGroup.metadata.creationTimestamp || '',
+                  },
+                ]}
+                emptyMessage="No Volcano PodGroups found."
+              />
+            </SectionBox>
+          </Grid>
+        </Grid>
+      </Box>
+    </VolcanoCoreInstallCheck>
+  );
+}

--- a/volcano/src/components/overview/OverviewCards.tsx
+++ b/volcano/src/components/overview/OverviewCards.tsx
@@ -1,0 +1,30 @@
+import { Icon } from '@iconify/react';
+import { Box, Card, CardContent, Typography } from '@mui/material';
+
+interface SummaryCardProps {
+  title: string;
+  value: string | number;
+  icon: string;
+  subtitle: string;
+}
+
+export function SummaryCard({ title, value, icon, subtitle }: SummaryCardProps) {
+  return (
+    <Card variant="outlined" sx={{ borderRadius: '4px', height: '100%' }}>
+      <CardContent sx={{ py: 3, display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', mb: 1, color: 'text.primary' }}>
+          <Icon icon={icon} width="28" height="28" style={{ marginRight: '8px' }} />
+          <Typography variant="subtitle2" sx={{ fontWeight: 'bold', textTransform: 'uppercase' }}>
+            {title}
+          </Typography>
+        </Box>
+        <Typography variant="h3" sx={{ fontWeight: 800, fontSize: '2.5rem' }}>
+          {value}
+        </Typography>
+        <Typography variant="caption" color="text.secondary" sx={{ textAlign: 'center' }}>
+          {subtitle}
+        </Typography>
+      </CardContent>
+    </Card>
+  );
+}

--- a/volcano/src/components/overview/overviewStats.ts
+++ b/volcano/src/components/overview/overviewStats.ts
@@ -1,0 +1,106 @@
+import { JobPhase, VolcanoJob } from '../../resources/job';
+import { PodGroupPhase, VolcanoPodGroup } from '../../resources/podgroup';
+import { QueueState, VolcanoQueue } from '../../resources/queue';
+import { getJobStatusColor, getPodGroupStatusColor, getQueueStatusColor } from '../../utils/status';
+
+export type ResourceError = { status?: number; message?: string } | null | undefined;
+
+export type AttentionRow =
+  | { type: 'Job'; name: string; namespace: string; status: JobPhase; resource: VolcanoJob }
+  | {
+      type: 'PodGroup';
+      name: string;
+      namespace: string;
+      status: PodGroupPhase;
+      resource: VolcanoPodGroup;
+    }
+  | { type: 'Queue'; name: string; status: QueueState; resource: VolcanoQueue };
+
+export const visibleSchedulingIssuesLimit = 5;
+
+export function getErrorText(error: ResourceError) {
+  if (!error) {
+    return null;
+  }
+
+  if (error.status === 403) {
+    return 'Not authorized';
+  }
+
+  if (error.status === 404) {
+    return 'Not installed';
+  }
+
+  return error.message || 'Unavailable';
+}
+
+export function countBy<T extends string>(items: T[]) {
+  return items.reduce<Partial<Record<T, number>>>((counts, item) => {
+    counts[item] = (counts[item] ?? 0) + 1;
+    return counts;
+  }, {});
+}
+
+export function getAttentionRows(
+  jobs: VolcanoJob[] | null,
+  queues: VolcanoQueue[] | null,
+  podGroups: VolcanoPodGroup[] | null
+): AttentionRow[] {
+  return [
+    ...(jobs || [])
+      .filter(job => ['Failed', 'Aborted', 'Terminated', 'Pending'].includes(job.phase))
+      .map(job => ({
+        type: 'Job' as const,
+        name: job.getName(),
+        namespace: job.getNamespace(),
+        status: job.phase,
+        resource: job,
+      })),
+    ...(podGroups || [])
+      .filter(podGroup => ['Pending', 'Inqueue', 'Unknown'].includes(podGroup.phase))
+      .map(podGroup => ({
+        type: 'PodGroup' as const,
+        name: podGroup.getName(),
+        namespace: podGroup.getNamespace(),
+        status: podGroup.phase,
+        resource: podGroup,
+      })),
+    ...(queues || [])
+      .filter(queue => queue.state !== 'Open')
+      .map(queue => ({
+        type: 'Queue' as const,
+        name: queue.getName(),
+        status: queue.state,
+        resource: queue,
+      })),
+  ];
+}
+
+export function getAttentionStatus(row: AttentionRow) {
+  if (row.type === 'Job') {
+    return getJobStatusColor(row.status);
+  }
+
+  if (row.type === 'PodGroup') {
+    return getPodGroupStatusColor(row.status);
+  }
+
+  return getQueueStatusColor(row.status);
+}
+
+export function getAttentionReason(row: AttentionRow) {
+  if (row.type === 'Job') {
+    const detail = row.resource.status?.state?.reason || row.resource.status?.state?.message;
+    return detail && detail !== row.status ? detail : '-';
+  }
+
+  if (row.type === 'PodGroup') {
+    const conditions = row.resource.status?.conditions;
+    const latestCondition =
+      conditions && conditions.length > 0 ? conditions[conditions.length - 1] : undefined;
+    const detail = latestCondition?.reason || latestCondition?.message;
+    return detail && detail !== row.status ? detail : '-';
+  }
+
+  return row.status === 'Closed' ? 'Queue is closed' : row.status;
+}

--- a/volcano/src/index.tsx
+++ b/volcano/src/index.tsx
@@ -6,6 +6,7 @@ import JobDetail from './components/jobs/Detail';
 import JobList from './components/jobs/List';
 import JobTemplateDetail from './components/jobtemplates/Detail';
 import JobTemplateList from './components/jobtemplates/List';
+import Overview from './components/overview/Overview';
 import PodGroupDetail from './components/podgroups/Detail';
 import PodGroupList from './components/podgroups/List';
 import QueueDetail from './components/queues/Detail';
@@ -85,7 +86,22 @@ registerSidebarEntry({
   name: 'volcano',
   label: 'Volcano',
   icon: volcanoIconName,
-  url: volcanoRoutePaths.jobsList,
+  url: volcanoRoutePaths.overview,
+});
+
+registerRoute({
+  path: volcanoRoutePaths.overview,
+  sidebar: 'volcano-overview',
+  name: volcanoRouteNames.overview,
+  exact: true,
+  component: () => <Overview />,
+});
+
+registerSidebarEntry({
+  parent: 'volcano',
+  name: 'volcano-overview',
+  label: 'Overview',
+  url: volcanoRoutePaths.overview,
 });
 
 const volcanoResources: VolcanoResourceRegistration[] = [

--- a/volcano/src/utils/volcanoRoutes.ts
+++ b/volcano/src/utils/volcanoRoutes.ts
@@ -1,4 +1,5 @@
 export const volcanoRouteNames = {
+  overview: 'volcano-overview',
   jobsList: 'volcano-jobs-list',
   jobDetail: 'volcano-job-detail',
   jobTemplatesList: 'volcano-jobtemplates-list',
@@ -12,6 +13,7 @@ export const volcanoRouteNames = {
 } as const;
 
 export const volcanoRoutePaths = {
+  overview: '/volcano',
   jobsList: '/volcano/jobs',
   jobDetail: '/volcano/jobs/:namespace/:name',
   jobTemplatesList: '/volcano/jobtemplates',


### PR DESCRIPTION
## Summary
This PR adds a Volcano overview dashboard so users can quickly inspect scheduling health across Volcano Jobs, Queues, and PodGroups.

The overview is available from the main Volcano sidebar entry and includes summary cards, scheduling issues, recent Jobs, and recent PodGroups.

<img width="1604" height="817" alt="image" src="https://github.com/user-attachments/assets/5a5baac3-94bb-4118-81d4-73bb215b0223" />
<img width="1598" height="539" alt="image" src="https://github.com/user-attachments/assets/f8bfc56f-6825-4c89-b181-bf0d02ab7950" />


## Changes
- add a new `/volcano` overview route
- make the main Volcano sidebar entry open the overview page
- add an Overview sidebar item under Volcano
- add summary cards for:
  - Jobs
  - Queues
  - PodGroups
  - Pending Pressure
- add a Scheduling Issues section for:
  - pending/failed Volcano Jobs
  - pending/inqueue/unknown PodGroups
  - non-open Queues
- add Show all / Show less handling for scheduling issues
- add Recent Jobs and Recent PodGroups sections
- split overview card and aggregation helpers into separate files

## Steps to Test
1. Open the Volcano section in Headlamp.
2. Confirm the Overview page is shown from the main Volcano sidebar entry.
3. Confirm the summary cards show Jobs, Queues, PodGroups, and Pending Pressure counts.
4. Create or use pending/failed Volcano Jobs and pending PodGroups.
5. Confirm Scheduling Issues shows those resources.
6. Confirm Show all / Show less works when there are more than 5 scheduling issues.
7. Confirm Recent Jobs and Recent PodGroups link to their detail pages.