### PR TITLE
flux: canaries: Fix crash on older Headlamp hosts

### DIFF
--- a/flux/src/flagger/canaries.tsx
+++ b/flux/src/flagger/canaries.tsx
@@ -7,19 +7,17 @@ import {
   SectionBox,
   Table,
 } from '@kinvolk/headlamp-plugin/lib/components/common';
-import { ApiError } from '@kinvolk/headlamp-plugin/lib/k8s/api/v2/ApiError';
 import type { KubeCRD } from '@kinvolk/headlamp-plugin/lib/k8s/crd';
 import { Box } from '@mui/material';
 import React from 'react';
 import FlaggerAvailabilityCheck, { useCanary } from './availabilitycheck';
+import { getCanaryResourceClass } from './canaryResourceClass';
 import CanaryStatus from './canarystatus';
 import { DeploymentProgress } from './deploymentprogress';
 
 export default function Canaries() {
   const [canary] = useCanary();
-  const canaryResourceClass = React.useMemo(() => {
-    return !canary || canary instanceof ApiError ? undefined : canary.makeCRClass();
-  }, [canary]);
+  const canaryResourceClass = React.useMemo(() => getCanaryResourceClass(canary), [canary]);
 
   return (
     <FlaggerAvailabilityCheck>

--- a/flux/src/flagger/canaryResourceClass.test.ts
+++ b/flux/src/flagger/canaryResourceClass.test.ts
@@ -1,0 +1,14 @@
+import { getCanaryResourceClass } from './canaryResourceClass';
+
+test('returns undefined while the canary is still loading', () => {
+  expect(getCanaryResourceClass(null)).toBeUndefined();
+});
+
+test('returns undefined when the canary is an error without makeCRClass', () => {
+  expect(getCanaryResourceClass({ message: 'not found' })).toBeUndefined();
+});
+
+test('returns the resource class for a loaded canary', () => {
+  class FakeCanaryClass {}
+  expect(getCanaryResourceClass({ makeCRClass: () => FakeCanaryClass })).toBe(FakeCanaryClass);
+});

--- a/flux/src/flagger/canaryResourceClass.ts
+++ b/flux/src/flagger/canaryResourceClass.ts
@@ -1,0 +1,7 @@
+// Duck-type makeCRClass instead of importing ApiError: that import resolves to a host
+// API path older Headlamp versions don't provide, which crashes the page at load.
+export function getCanaryResourceClass(canary: unknown) {
+  return canary && typeof (canary as { makeCRClass?: unknown }).makeCRClass === 'function'
+    ? (canary as { makeCRClass: () => unknown }).makeCRClass()
+    : undefined;
+}


### PR DESCRIPTION
fixes #447. opening the flux canaries page crashes with "Cannot read properties of undefined (reading 'ApiError')" on older headlamp hosts (reported on 0.37.0, fine on the v0.4 plugin).

root cause: b1e9742 added an import of ApiError from @kinvolk/headlamp-plugin/lib/k8s/api/v2/ApiError to guard against the canary being an error. older hosts don't provide that api path, so the externalized import resolves to undefined and accessing .ApiError on it crashes the page at load. eloo-abi already narrowed it to that commit.

the fix drops the host-specific ApiError import and detects a non-resource canary by duck-typing makeCRClass (the method we're about to call). that keeps the original guard's intent without depending on a host api path, so it works across versions. pulled the check into a small lib-free helper with a unit test.

verified: tsc, lint, format clean, and the new test passes (loading / error-like / valid cases).