### PR TITLE
app-catalog: Show error feedback when helm install fails

### DIFF
--- a/app-catalog/src/components/charts/EditorDialog.tsx
+++ b/app-catalog/src/components/charts/EditorDialog.tsx
@@ -129,26 +129,49 @@ export function EditorDialog(props: {
 
   function checkInstallStatus(releaseName: string) {
     setTimeout(() => {
-      getActionStatus(releaseName, 'install').then((response: any) => {
-        if (response.status === 'processing') {
-          checkInstallStatus(releaseName);
-        } else if (!response.status || response.status !== 'success') {
+      getActionStatus(releaseName, 'install')
+        .then((response: any) => {
+          if (response.status === 'processing') {
+            checkInstallStatus(releaseName);
+          } else if (response.status !== 'success') {
+            enqueueSnackbar(
+              t('Error installing release {{ releaseName }}: {{ message }}', {
+                releaseName,
+                message: response.message || t('unknown error'),
+              }),
+              {
+                variant: 'error',
+                autoHideDuration: 5000,
+              }
+            );
+            handleEditor(false);
+            setInstallLoading(false);
+          } else {
+            enqueueSnackbar(
+              t('Release {{ releaseName }} installed successfully', { releaseName }),
+              {
+                variant: 'success',
+                autoHideDuration: 5000,
+              }
+            );
+            handleEditor(false);
+            setInstallLoading(false);
+          }
+        })
+        .catch((err: Error) => {
           enqueueSnackbar(
-            t('Error creating release {{ message }}', { message: response.message }),
+            t('Error checking install status for {{ releaseName }}: {{ message }}', {
+              releaseName,
+              message: err?.message || t('unknown error'),
+            }),
             {
               variant: 'error',
+              autoHideDuration: 5000,
             }
           );
           handleEditor(false);
           setInstallLoading(false);
-        } else {
-          enqueueSnackbar(t('Release {{ releaseName }} created successfully', { releaseName }), {
-            variant: 'success',
-          });
-          handleEditor(false);
-          setInstallLoading(false);
-        }
-      });
+        });
     }, 2000);
   }
 
@@ -212,23 +235,39 @@ export function EditorDialog(props: {
               t('Installation request for {{ releaseName }} accepted', { releaseName }),
               {
                 variant: 'info',
+                autoHideDuration: 5000,
               }
             );
-            handleEditor(false);
             checkInstallStatus(releaseName);
           })
-          .catch(error => {
+          .catch((error: Error) => {
+            setInstallLoading(false);
             handleEditor(false);
-            enqueueSnackbar(t('Error creating release request {{ error }}', { error }), {
-              variant: 'error',
-            });
+            enqueueSnackbar(
+              t('Error creating release {{ releaseName }}: {{ message }}', {
+                releaseName,
+                message: error?.message || String(error),
+              }),
+              {
+                variant: 'error',
+                autoHideDuration: 5000,
+              }
+            );
           });
       })
-      .catch(error => {
+      .catch((error: Error) => {
+        setInstallLoading(false);
         handleEditor(false);
-        enqueueSnackbar(t('Error adding repository {{ error }}', { error }), {
-          variant: 'error',
-        });
+        enqueueSnackbar(
+          t('Error adding repository {{ repoName }}: {{ message }}', {
+            repoName,
+            message: error?.message || String(error),
+          }),
+          {
+            variant: 'error',
+            autoHideDuration: 5000,
+          }
+        );
       });
   }
 


### PR DESCRIPTION
Closes #225

When a helm chart installation failed, the UI gave no feedback - the dialog would silently stay in a loading state or close without any error message.

Root causes fixed:
- checkInstallStatus had no .catch() on the getActionStatus polling call - network errors were silently swallowed.

- Both .catch() blocks in installAndCreateReleaseHandler called handleEditor(false) but never called setInstallLoading(false) leaving the install button stuck in "Installing..." indefinitely after failure.

- Dialog was being closed prematurely before the status polling completed.

- Error snackbars now include the specific error message and autoHideDuration: 5000