### PR TITLE
flux: Fix ForceReconciliationAction dialog and snackbar text

### DIFF
--- a/flux/src/actions/index.tsx
+++ b/flux/src/actions/index.tsx
@@ -41,8 +41,8 @@ function ForceReconciliationAction(props) {
             .then(response => {
               enqueueSnackbar(
                 response.spec.force
-                  ? `Successfully Disabled force reconciliation for ${resource.metadata.name}`
-                  : `Successfully Enabled force reconciliation for ${resource.metadata.name}`,
+                  ? `Successfully Enabled force reconciliation for ${resource.metadata.name}`
+                  : `Successfully Disabled force reconciliation for ${resource.metadata.name}`,
                 { variant: 'success' }
               );
             })
@@ -51,13 +51,15 @@ function ForceReconciliationAction(props) {
             });
         }}
         title={
-          resource.jsonData.force ? 'Enable Force Reconciliation' : 'Disable Force Reconciliation'
+          resource.jsonData.spec.force
+            ? 'Disable Force Reconciliation'
+            : 'Enable Force Reconciliation'
         }
         description={`${
-          resource.jsonData.force
-            ? 'Are you sure you want to enable force reconciliation for '
-            : 'Are you sure you want to disable force reconciliation for '
-        }${resource?.jsonData.metadata.name}?`}
+          resource.jsonData.spec.force
+            ? 'Are you sure you want to disable force reconciliation for '
+            : 'Are you sure you want to enable force reconciliation for '
+        }${resource.metadata.name}?`}
       />
     </>
   );


### PR DESCRIPTION
Fixes two bugs in ForceReconciliationAction reported in #122 (comment by siegenthalerroger):

Bug 1 - ConfirmDialog always showed "Disable Force Reconciliation"
title and description were using resource.jsonData.force instead of resource.jsonData.spec.force — since jsonData.force is always undefined, the condition always evaluated to false, showing "Disable" regardless of current state.

Bug 2 - Success snackbar labels were swapped
When response.spec.force was true (force just enabled), the message said "Successfully Disabled" and vice versa.