### PR TITLE
karpenter: Add unit tests for parseRam helper

### DIFF
--- a/karpenter/src/helpers/parseRam.test.ts
+++ b/karpenter/src/helpers/parseRam.test.ts
@@ -1,0 +1,42 @@
+import { parseRam } from './parseRam';
+
+const Ki = 1024;
+const Mi = Ki * Ki;
+const Gi = Mi * Ki;
+const Ti = Gi * Ki;
+
+describe('parseRam', () => {
+  it('returns 0 for empty input', () => {
+    expect(parseRam('')).toBe(0);
+  });
+
+  it('returns 0 for values it cannot parse', () => {
+    expect(parseRam('abc')).toBe(0);
+    expect(parseRam('1.5Gi')).toBe(0); // decimals are not supported
+    expect(parseRam('100Pi')).toBe(0); // unknown unit
+  });
+
+  it('treats a plain number as bytes', () => {
+    expect(parseRam('0')).toBe(0);
+    expect(parseRam('1024')).toBe(1024);
+  });
+
+  it('parses binary units (Ki, Mi, Gi, Ti)', () => {
+    expect(parseRam('1Ki')).toBe(Ki);
+    expect(parseRam('1Mi')).toBe(Mi);
+    expect(parseRam('2Gi')).toBe(2 * Gi);
+    expect(parseRam('1Ti')).toBe(Ti);
+  });
+
+  it('treats the K/M/G/T suffixes the same as their Ki/Mi/Gi/Ti forms', () => {
+    expect(parseRam('1K')).toBe(Ki);
+    expect(parseRam('1M')).toBe(Mi);
+    expect(parseRam('1G')).toBe(Gi);
+    expect(parseRam('1T')).toBe(Ti);
+  });
+
+  it('is case-insensitive', () => {
+    expect(parseRam('512mi')).toBe(512 * Mi);
+    expect(parseRam('2gi')).toBe(2 * Gi);
+  });
+});


### PR DESCRIPTION
## Summary

`parseRam` parses Kubernetes memory quantity strings (like 512Mi, 2Gi) into bytes. It is used in the karpenter NodePool list and details views to compute memory usage and limits, and it had no unit tests.

This adds tests for the helper covering empty and invalid input, plain byte values, all binary units (Ki, Mi, Gi, Ti), the K/M/G/T suffixes behaving the same as Ki/Mi/Gi/Ti, and case-insensitivity. The tests also pin the current behavior for decimals and unknown units (both return 0).

## Changes

Added `karpenter/src/helpers/parseRam.test.ts` (6 tests).

## Steps to Test

`cd karpenter && npm install && npm test`
