### PR TITLE
plugin-catalog: Fix svg import

### DIFF
--- a/plugin-catalog/src/components/plugins/PluginCard.tsx
+++ b/plugin-catalog/src/components/plugins/PluginCard.tsx
@@ -12,7 +12,7 @@ import {
   Typography,
 } from '@mui/material';
 import { PluginPackage } from './List';
-import PluginIcon from './plugin-icon.svg?react';
+import PluginIcon from './plugin-icon.svg';
 
 export interface PluginCardProps {
   plugin: PluginPackage;

--- a/plugin-catalog/src/headlamp-plugin.d.ts
+++ b/plugin-catalog/src/headlamp-plugin.d.ts
@@ -15,3 +15,12 @@
  */
 
 /// <reference types="@kinvolk/headlamp-plugin" />
+
+// headlamp-plugin's vite config runs vite-plugin-svgr with `include: '**/*.svg'`,
+// so a bare `*.svg` import is transformed into a React component (the `?react`
+// query is NOT honored by the build and would yield a URL string at runtime).
+// Override the default `*.svg` => string typing so tsc agrees with the build.
+declare module '*.svg' {
+  const content: React.FunctionComponent<React.SVGAttributes<SVGElement>>;
+  export default content;
+}


### PR DESCRIPTION
this patch fixes the svg import issue that is
crashing the plugin