### PR TITLE
volcano: Show gang scheduling progress on PodGroup detail

### DIFF
--- a/volcano/src/components/podgroups/Detail.tsx
+++ b/volcano/src/components/podgroups/Detail.tsx
@@ -5,6 +5,7 @@ import {
   SectionBox,
   StatusLabel,
 } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { Box, LinearProgress, Typography } from '@mui/material';
 import { useParams } from 'react-router-dom';
 import { VolcanoPodGroup } from '../../resources/podgroup';
 import { getPodGroupStatusColor } from '../../utils/status';
@@ -17,17 +18,29 @@ import { volcanoRouteNames } from '../../utils/volcanoRoutes';
  * @returns Section descriptor used by `DetailsGrid`.
  */
 function getProgressSection(podGroup: VolcanoPodGroup) {
+  const progressPercent = podGroup.gangProgressPercent;
+
   return {
     id: 'progress',
     section: (
       <SectionBox title="Progress">
         <NameValueTable
           rows={[
+            { name: 'Ready Members', value: podGroup.readyMemberCount },
+            { name: 'Gang Status', value: podGroup.gangProgressLabel },
             { name: 'Running', value: podGroup.runningCount },
             { name: 'Succeeded', value: podGroup.succeededCount },
             { name: 'Failed', value: podGroup.failedCount },
           ]}
         />
+        {progressPercent !== null && (
+          <Box sx={{ mt: 2, px: 1 }}>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+              Gang progress: {podGroup.readyMemberCount}/{podGroup.minMember} ready
+            </Typography>
+            <LinearProgress variant="determinate" value={progressPercent} />
+          </Box>
+        )}
       </SectionBox>
     ),
   };

--- a/volcano/src/resources/podgroup.ts
+++ b/volcano/src/resources/podgroup.ts
@@ -1,4 +1,9 @@
 import { KubeObject, KubeObjectInterface } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import {
+  getGangProgressLabel,
+  getGangProgressPercent,
+  getReadyMemberCount,
+} from '../utils/gangProgress';
 import { volcanoSchedulingApiVersion } from '../utils/volcanoApi';
 import { volcanoRoutePaths } from '../utils/volcanoRoutes';
 
@@ -127,5 +132,17 @@ export class VolcanoPodGroup extends KubeObject<KubeVolcanoPodGroup> {
 
   get failedCount(): number {
     return this.status?.failed || 0;
+  }
+
+  get readyMemberCount(): number {
+    return getReadyMemberCount(this.runningCount, this.succeededCount);
+  }
+
+  get gangProgressLabel(): string {
+    return getGangProgressLabel(this.minMember, this.readyMemberCount);
+  }
+
+  get gangProgressPercent(): number | null {
+    return getGangProgressPercent(this.minMember, this.readyMemberCount);
   }
 }

--- a/volcano/src/utils/gangProgress.test.ts
+++ b/volcano/src/utils/gangProgress.test.ts
@@ -1,0 +1,41 @@
+import { getGangProgressLabel, getGangProgressPercent, getReadyMemberCount } from './gangProgress';
+
+describe('getReadyMemberCount', () => {
+  it('sums running and succeeded pods', () => {
+    expect(getReadyMemberCount(3, 0)).toBe(3);
+    expect(getReadyMemberCount(1, 2)).toBe(3);
+    expect(getReadyMemberCount(0, 0)).toBe(0);
+  });
+});
+
+describe('getGangProgressLabel', () => {
+  it('reports met when ready reaches minMember', () => {
+    expect(getGangProgressLabel(3, 3)).toBe('Gang requirement met');
+    expect(getGangProgressLabel(1, 2)).toBe('Gang requirement met');
+  });
+
+  it('reports incomplete when ready is below minMember', () => {
+    expect(getGangProgressLabel(3, 2)).toBe('Gang incomplete (2/3 ready)');
+    expect(getGangProgressLabel(1, 0)).toBe('Gang incomplete (0/1 ready)');
+  });
+
+  it('returns dash when minMember is not set', () => {
+    expect(getGangProgressLabel(0, 0)).toBe('-');
+  });
+});
+
+describe('getGangProgressPercent', () => {
+  it('returns percentage capped at 100', () => {
+    expect(getGangProgressPercent(3, 3)).toBe(100);
+    expect(getGangProgressPercent(3, 1)).toBe(33);
+    expect(getGangProgressPercent(1, 0)).toBe(0);
+  });
+
+  it('returns null when minMember is not set', () => {
+    expect(getGangProgressPercent(0, 0)).toBeNull();
+  });
+
+  it('does not round incomplete gangs to 100%', () => {
+    expect(getGangProgressPercent(200, 199)).toBe(99);
+  });
+});

--- a/volcano/src/utils/gangProgress.ts
+++ b/volcano/src/utils/gangProgress.ts
@@ -1,0 +1,32 @@
+/**
+ * Gang scheduling helpers for Volcano PodGroups.
+ * A PodGroup is satisfied when ready members (running + succeeded) reach minMember.
+ */
+
+export function getReadyMemberCount(running: number, succeeded: number): number {
+  return running + succeeded;
+}
+
+export function getGangProgressLabel(minMember: number, ready: number): string {
+  if (minMember <= 0) {
+    return '-';
+  }
+
+  if (ready >= minMember) {
+    return 'Gang requirement met';
+  }
+
+  return `Gang incomplete (${ready}/${minMember} ready)`;
+}
+
+export function getGangProgressPercent(minMember: number, ready: number): number | null {
+  if (minMember <= 0) {
+    return null;
+  }
+
+  if (ready >= minMember) {
+    return 100;
+  }
+
+  return Math.floor((ready / minMember) * 100);
+}


### PR DESCRIPTION

## Summary

Adds gang scheduling progress to the Volcano PodGroup detail **Progress** section.

Related to [kubernetes-sigs/headlamp#4359](https://github.com/kubernetes-sigs/headlamp/issues/4359) (Phase 3: gang-scheduling visualization).

The PodGroup list already shows `minMember` and running counts, but the detail page did not summarize whether the gang requirement is met. This PR surfaces that at a glance:

- **Ready members** — running + succeeded pods
- **Gang status** — `Gang requirement met` or `Gang incomplete (X/Y ready)`
- **Progress bar** — visual `X/Y ready` when `minMember > 0`

## Motivation

Gang scheduling requires a minimum number of pods (`minMember`) to be ready before the group can proceed. Operators need a quick answer to: *“Is this PodGroup’s gang satisfied?”* without reading raw YAML or counting pods manually.

## Changes

- Add `gangProgress.ts` helpers: `getReadyMemberCount`, `getGangProgressLabel`, `getGangProgressPercent`
- Add `readyMemberCount`, `gangProgressLabel`, `gangProgressPercent` getters on `VolcanoPodGroup`
- Extend PodGroup detail **Progress** section with gang fields and a MUI `LinearProgress` bar
- Add unit tests for gang progress helpers (`gangProgress.test.ts`)

## Screenshots

| Scenario | PodGroup | Expected |
|----------|----------|----------|
| Gang met | `volcano-job-running` (minMember 1, 1 running) | `1/1ready`, bar at 100%, “Gang requirement met” |
<img width="1886" height="838" alt="image" src="https://github.com/user-attachments/assets/88fb2a62-c175-46e1-a721-176d2e4d4b14" />








| Gang incomplete | `volcano-job-unschedulable` (minMember 1, pending) | `0/1 ready`, bar at 0%, “Gang incomplete (0/1 ready)” |
<img width="1892" height="886" alt="image" src="https://github.com/user-attachments/assets/50534055-4931-466c-a8d0-9bf79aec045b" />


## Test plan

- [x] `npm test` — gang progress unit tests pass
- [x] `npm run build` — plugin builds successfully
- [ ] Manual: open PodGroup detail for a running gang job → progress shows `X/Y ready` and full bar
- [ ] Manual: open PodGroup detail for pending/unschedulable job → progress shows incomplete gang status
- [ ] Manual: PodGroup with `minMember: 0` → no progress bar, gang status shows `-`

Fixes part of #4359.

## Test plan

- [x] `npm test` — gang progress unit tests pass
- [x] `npm run build` — plugin builds successfully
- [ ] Manual: open PodGroup detail for a running gang job → progress shows `X/Y ready` and full bar
- [ ] Manual: open PodGroup detail for pending/unschedulable job → progress shows incomplete gang status
- [ ] Manual: PodGroup with `minMember: 0` → no progress bar, gang status shows `-`

Fixes part of #4359.