### PR TITLE
fix(app-catalog): normalize chart list for empty state

### DIFF
--- a/app-catalog/src/components/charts/List.tsx
+++ b/app-catalog/src/components/charts/List.tsx
@@ -302,7 +302,11 @@ export function ChartsList({ fetchCharts = fetchChartsFromArtifact }) {
       fetchIcons();
     }
   }, [charts]);
-
+  const chartList = charts
+    ? Object.values(charts)
+        .flatMap((value: any) => (Array.isArray(value) ? value?.slice?.(0, 1) || [] : [value]))
+        .filter(Boolean)
+    : [];
   return (
     <>
       <EditorDialog
@@ -342,7 +346,7 @@ export function ChartsList({ fetchCharts = fetchChartsFromArtifact }) {
           >
             <Loader title="" />
           </Box>
-        ) : charts.length === 0 ? (
+        ) : chartList.length === 0 ? (
           <Box mt={2} mx={2}>
             <Typography variant="h5" component="h2">
               {search
@@ -370,10 +374,7 @@ export function ChartsList({ fetchCharts = fetchChartsFromArtifact }) {
               // filter by the search term against the chart name. Filtering on the chart name
               // rather than the map key keeps search working now that the map is keyed by a
               // unique id (e.g. package_id) instead of the name.
-              Object.values(charts)
-                .flatMap((value: any) =>
-                  Array.isArray(value) ? value?.slice?.(0, 1) || [] : [value]
-                )
+              chartList
                 .filter((chart: any) => (chart?.name ?? '').includes(search))
                 .map((chart: any) => {
                   return (
@@ -592,7 +593,7 @@ export function ChartsList({ fetchCharts = fetchChartsFromArtifact }) {
           </Box>
         )}
       </Box>
-      {charts && charts.length !== 0 && (
+      {chartList.length !== 0 && (
         <Box mt={2} mx="auto" maxWidth="max-content">
           <Pagination
             size="large"


### PR DESCRIPTION

## Description

The App Catalog supports chart data from both Vanilla Helm repositories and Artifact Hub.

For Artifact Hub, charts are stored as an object keyed by `package_id`, while some parts of the UI were relying on array length checks. This could lead to incorrect empty-state and pagination behavior when chart data was returned in an object-shaped format.

This PR introduces a normalized` chartList` array derived from the chart data and uses it consistently for:

- Empty-state checks

- Chart rendering

- Pagination visibility

By normalizing the data once and reusing it throughout the component, the logic becomes consistent and works correctly regardless of the underlying chart data structure.

Testing

## Testing

* `npm run test`
* `npm run lint`
* `npm run tsc` 
