### PR TITLE
kmesh: Implement Kmesh Daemon API Proxy Layer

### DIFF
--- a/kmesh/src/hooks/useDaemonRequest.ts
+++ b/kmesh/src/hooks/useDaemonRequest.ts
@@ -1,0 +1,186 @@
+/**
+ * useDaemonRequest — generic React hook for fetching data from the Kmesh
+ * daemon admin API via the Kubernetes pod-proxy tunnel.
+ *
+ * Design pattern:
+ * - Thin React wrapper around the plain async `daemonRequestDeduped` utility.
+ * - Returns a `DaemonRequestState<T>` (status / data / error) that drives
+ *   loading spinners and error banners in components.
+ * - Ignores the in-flight request result when the component unmounts
+ *   (does not abort the network request).
+ * - Re-fetches whenever `namespace`, `podName`, or `endpoint` change.
+ *
+ * @see src/utils/kmeshDaemonProxy.ts for the underlying fetch logic.
+ * @see src/utils/kmeshDaemonApi.ts   for endpoint path constants.
+ * @see src/hooks/useKmeshDaemonPods.ts to obtain a `podName`.
+ *
+ * @example
+ * ```tsx
+ * const { readyPod } = useKmeshDaemonPods();
+ * const { status, data, error } = useDaemonRequest<KmeshVersion>(
+ *   'kmesh-system',
+ *   readyPod?.name ?? null,
+ *   DAEMON_ENDPOINTS.VERSION
+ * );
+ * ```
+ */
+
+import { useCluster } from '@kinvolk/headlamp-plugin/lib/k8s';
+import { useEffect, useState } from 'react';
+import type {
+  ConfigDump,
+  DaemonRequestState,
+  KmeshVersion,
+  LoggerInfo,
+  WorkloadBpfDump,
+  WorkloadDump,
+} from '../types/daemonApi';
+import { DAEMON_ENDPOINTS, type DaemonEndpoint } from '../utils/kmeshDaemonApi';
+import {
+  daemonRequestDeduped,
+  type DaemonRequestOptions,
+  makeErrorState,
+  makeLoadingState,
+  makeSuccessState,
+} from '../utils/kmeshDaemonProxy';
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetches data from a Kmesh daemon endpoint and tracks request lifecycle.
+ *
+ * Pass `null` for `podName` to put the hook in "idle" state (nothing fetched).
+ * This is useful while `useKmeshDaemonPods` is still resolving the ready pod.
+ *
+ * @param namespace  - Namespace of the daemon pod (usually "kmesh-system")
+ * @param podName    - Pod to proxy through, or `null` to skip the request
+ * @param endpoint   - Admin API endpoint (use DAEMON_ENDPOINTS constants)
+ * @param options    - Optional query params / request body
+ */
+export function useDaemonRequest<T = unknown>(
+  namespace: string,
+  podName: string | null,
+  endpoint: DaemonEndpoint,
+  options?: Pick<DaemonRequestOptions, 'queryParams' | 'body' | 'method'>
+): DaemonRequestState<T> {
+  const [state, setState] = useState<DaemonRequestState<T>>(
+    podName ? makeLoadingState<T>() : { status: 'idle', data: null, error: null }
+  );
+  const cluster = useCluster();
+
+  // Serialise options into stable deps so the effect doesn't re-fire on
+  // every render when the caller passes an inline object literal.
+  const method = options?.method ?? (options?.body !== undefined ? 'POST' : 'GET');
+
+  const queryParamsKey = (() => {
+    const qp = options?.queryParams;
+    if (!qp || Object.keys(qp).length === 0) return '';
+    return new URLSearchParams(
+      Object.entries(qp).sort(([a], [b]) => a.localeCompare(b))
+    ).toString();
+  })();
+
+  const bodyKey = (() => {
+    if (options?.body === undefined) return '';
+    try {
+      return JSON.stringify(options.body);
+    } catch {
+      // Avoid throwing during render; the request itself will fail and be reported via error state.
+      return '__unserializable_body__';
+    }
+  })();
+
+  useEffect(() => {
+    if (!podName) {
+      setState({ status: 'idle', data: null, error: null });
+      return;
+    }
+
+    let cancelled = false;
+    setState(makeLoadingState<T>());
+
+    daemonRequestDeduped<T>(namespace, podName, endpoint, {
+      method,
+      queryParams: options?.queryParams,
+      body: options?.body,
+    })
+      .then(data => {
+        if (!cancelled) setState(makeSuccessState<T>(data));
+      })
+      .catch(err => {
+        if (!cancelled) setState(makeErrorState<T>(err));
+      });
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cluster, namespace, podName, endpoint, method, queryParamsKey, bodyKey]);
+
+  return state;
+}
+
+// ---------------------------------------------------------------------------
+// Convenience typed hooks — one per read endpoint
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetches the daemon version from `/version`.
+ *
+ * @example
+ * const { data: version } = useKmeshVersion('kmesh-system', pod?.name ?? null);
+ */
+export function useKmeshVersion(namespace: string, podName: string | null) {
+  return useDaemonRequest<KmeshVersion>(namespace, podName, DAEMON_ENDPOINTS.VERSION);
+}
+
+/**
+ * Fetches the workload config dump from `/debug/config_dump/dual-engine`.
+ * Returns 400 (error state) if the daemon is running in kernel-native mode.
+ */
+export function useWorkloadConfigDump(namespace: string, podName: string | null) {
+  return useDaemonRequest<WorkloadDump>(namespace, podName, DAEMON_ENDPOINTS.CONFIG_DUMP_WORKLOAD);
+}
+
+/**
+ * Fetches the ADS / kernel-native config dump from
+ * `/debug/config_dump/kernel-native`.
+ * Returns 400 (error state) if the daemon is running in dual-engine mode.
+ */
+export function useAdsConfigDump(namespace: string, podName: string | null) {
+  return useDaemonRequest<ConfigDump>(namespace, podName, DAEMON_ENDPOINTS.CONFIG_DUMP_ADS);
+}
+
+/**
+ * Fetches the BPF map dump for dual-engine mode
+ * from `/debug/config_dump/bpf/dual-engine`.
+ */
+export function useWorkloadBpfMaps(namespace: string, podName: string | null) {
+  return useDaemonRequest<WorkloadBpfDump>(namespace, podName, DAEMON_ENDPOINTS.BPF_WORKLOAD_MAPS);
+}
+
+/**
+ * Fetches the BPF map dump for kernel-native mode
+ * from `/debug/config_dump/bpf/kernel-native`.
+ */
+export function useAdsBpfMaps(namespace: string, podName: string | null) {
+  return useDaemonRequest<unknown>(namespace, podName, DAEMON_ENDPOINTS.BPF_ADS_MAPS);
+}
+
+/**
+ * Fetches the list of available loggers from `/debug/loggers`.
+ */
+export function useKmeshLoggers(namespace: string, podName: string | null) {
+  return useDaemonRequest<string[]>(namespace, podName, DAEMON_ENDPOINTS.LOGGERS);
+}
+
+/**
+ * Fetches the level for a single named logger.
+ */
+export function useKmeshLoggerLevel(namespace: string, podName: string | null, loggerName: string) {
+  return useDaemonRequest<LoggerInfo>(namespace, podName, DAEMON_ENDPOINTS.LOGGERS, {
+    queryParams: { name: loggerName },
+  });
+}

--- a/kmesh/src/hooks/useKmeshDaemonPods.ts
+++ b/kmesh/src/hooks/useKmeshDaemonPods.ts
@@ -1,0 +1,124 @@
+/**
+ * useKmeshDaemonPods — React hook that lists Kmesh daemon pods.
+ *
+ * Kmesh runs as a DaemonSet in the `kmesh-system` namespace with the label
+ * `app=kmesh`.  This hook surfaces those pods so that other hooks and
+ * components can pick a pod (typically the one on the same node as the
+ * workload being inspected) and proxy requests to its admin API.
+ *
+ * Pattern: thin React wrapper around a plain async utility, with cleanup on unmount.
+ */
+
+import { ApiProxy } from '@kinvolk/headlamp-plugin/lib';
+import { useCluster } from '@kinvolk/headlamp-plugin/lib/k8s';
+import { useEffect, useState } from 'react';
+import { KMESH_DAEMON_LABEL_SELECTOR, KMESH_NAMESPACE } from '../utils/kmeshDaemonApi';
+
+// ---------------------------------------------------------------------------
+// Minimal Pod shape — we only need name + node for routing decisions
+// ---------------------------------------------------------------------------
+
+export interface KmeshDaemonPod {
+  /** Pod name (used to build the pod-proxy path). */
+  name: string;
+  /** Namespace (always `kmesh-system`). */
+  namespace: string;
+  /** Node the pod is scheduled on — handy for co-location routing. */
+  nodeName: string;
+  /** Pod phase (Running / Pending / …). */
+  phase: string;
+  /** True if the PodReady condition is met. */
+  ready: boolean;
+  /** Pod IP — informational. */
+  podIP: string;
+}
+
+export interface UseKmeshDaemonPodsResult {
+  /** True while the initial pod list fetch is in flight. */
+  loading: boolean;
+  /** Non-null when the fetch fails. */
+  error: string | null;
+  /** All kmesh-daemon pods found in the cluster. */
+  pods: KmeshDaemonPod[];
+  /** The first Running + Ready pod, or null if none are ready yet. */
+  readyPod: KmeshDaemonPod | null;
+}
+
+// ---------------------------------------------------------------------------
+// Hook implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Lists all Kmesh daemon pods in the `kmesh-system` namespace.
+ *
+ * @example
+ * ```tsx
+ * const { readyPod, loading, error } = useKmeshDaemonPods();
+ * if (loading) return <CircularProgress />;
+ * if (!readyPod) return <NotInstalledBanner />;
+ * ```
+ */
+export function useKmeshDaemonPods(): UseKmeshDaemonPodsResult {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [pods, setPods] = useState<KmeshDaemonPod[]>([]);
+  const cluster = useCluster();
+
+  useEffect(() => {
+    setLoading(true);
+    setError(null);
+    setPods([]);
+    let cancelled = false;
+
+    async function fetchPods() {
+      try {
+        const path =
+          `/api/v1/namespaces/${KMESH_NAMESPACE}/pods` +
+          `?labelSelector=${encodeURIComponent(KMESH_DAEMON_LABEL_SELECTOR)}`;
+
+        type PodCondition = { type?: string; status?: string };
+        type PodItem = {
+          metadata?: { name?: string; namespace?: string };
+          spec?: { nodeName?: string };
+          status?: { phase?: string; podIP?: string; conditions?: PodCondition[] };
+        };
+        type PodListResponse = { items?: PodItem[] };
+
+        const response = (await ApiProxy.request(path)) as PodListResponse;
+        if (cancelled) return;
+
+        const items: KmeshDaemonPod[] = (response.items ?? []).map(item => {
+          const ready = (item.status?.conditions ?? []).some(
+            c => c.type === 'Ready' && c.status === 'True'
+          );
+
+          return {
+            name: item.metadata?.name ?? '',
+            namespace: item.metadata?.namespace ?? KMESH_NAMESPACE,
+            nodeName: item.spec?.nodeName ?? '',
+            phase: item.status?.phase ?? 'Unknown',
+            ready,
+            podIP: item.status?.podIP ?? '',
+          };
+        });
+
+        setPods(items);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to list Kmesh daemon pods');
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    fetchPods();
+    return () => {
+      cancelled = true;
+    };
+  }, [cluster]);
+
+  const readyPod = pods.find(p => p.phase === 'Running' && p.ready) ?? null;
+
+  return { loading, error, pods, readyPod };
+}

--- a/kmesh/src/types/daemonApi.ts
+++ b/kmesh/src/types/daemonApi.ts
@@ -1,0 +1,288 @@
+/**
+ * TypeScript types for the Kmesh Daemon Admin API (port 15200).
+ *
+ * These mirror the Go structs defined in:
+ *   - kmesh.net/kmesh/pkg/status/api.go
+ *   - kmesh.net/kmesh/pkg/status/status_server.go
+ *
+ * Endpoint reference:
+ *   GET  /version                              → KmeshVersion
+ *   GET  /debug/ready                          → string ("OK")
+ *   GET  /debug/loggers[?name=<logger>]        → string[] | LoggerInfo
+ *   POST /debug/loggers                        → (body: LoggerInfo)
+ *   GET  /debug/config_dump/kernel-native      → ConfigDump (ADS / kernel-native mode)
+ *   GET  /debug/config_dump/dual-engine        → WorkloadDump (workload / dual-engine mode)
+ *   GET  /debug/config_dump/bpf/kernel-native  → (BPF map dump, ADS mode)
+ *   GET  /debug/config_dump/bpf/dual-engine    → WorkloadBpfDump
+ *   POST /accesslog?enable=<bool>
+ *   POST /monitoring?enable=<bool>
+ *   POST /workload_metrics?enable=<bool>
+ *   POST /connection_metrics?enable=<bool>
+ *   POST /authz?enable=<bool>
+ */
+
+// ---------------------------------------------------------------------------
+// /version
+// ---------------------------------------------------------------------------
+
+export interface KmeshVersion {
+  /** The semantic version of the Kmesh daemon */
+  version: string;
+  /** Git commit hash of the build */
+  gitRevision: string;
+  /** Git branch of the build */
+  gitBranch: string;
+  /** Timestamp when the daemon was built */
+  buildTime: string;
+  /** Go runtime version used for the build */
+  goVersion: string;
+  /** Operating system of the build */
+  os: string;
+  /** Architecture of the build (e.g., amd64, arm64) */
+  arch: string;
+}
+
+// ---------------------------------------------------------------------------
+// /debug/loggers
+// ---------------------------------------------------------------------------
+
+export interface LoggerInfo {
+  /** Name of the logger component */
+  name: string;
+  /** Current logging level (e.g., info, debug, error) */
+  level: string;
+}
+
+// ---------------------------------------------------------------------------
+// /debug/config_dump/dual-engine  (workload / dual-engine mode)
+// ---------------------------------------------------------------------------
+
+export interface Locality {
+  /** Region of the locality */
+  region?: string;
+  /** Zone of the locality */
+  zone?: string;
+  /** Subzone of the locality */
+  subzone?: string;
+}
+
+export interface ApplicationTunnel {
+  /** Tunnel protocol (e.g., HBONE) */
+  protocol: string;
+  /** Port used for the application tunnel */
+  port?: number;
+}
+
+/**
+ * Represents a single workload endpoint configured in the daemon.
+ * Mapped from kmesh/pkg/status/api.go
+ */
+export interface DaemonWorkload {
+  /** Unique identifier for the workload (e.g., pod UID) */
+  uid?: string;
+  /** List of IP addresses associated with this workload */
+  addresses: string[];
+  /** Optional waypoint proxy address assigned to this workload */
+  waypoint?: string;
+  /** Traffic protocol used by the workload (e.g., HTTP, TCP) */
+  protocol: string;
+  /** Name of the pod or workload instance */
+  name: string;
+  /** Kubernetes namespace where the workload resides */
+  namespace: string;
+  /** Service account associated with the workload */
+  serviceAccount: string;
+  /** Name of the parent workload (e.g., Deployment name) */
+  workloadName: string;
+  /** Type of the parent workload (e.g., Deployment, DaemonSet) */
+  workloadType: string;
+  /** Canonical name used for telemetry and routing */
+  canonicalName: string;
+  /** Canonical revision used for telemetry and routing */
+  canonicalRevision: string;
+  /** ID of the cluster where the workload is running */
+  clusterId: string;
+  /** Trust domain for mTLS identity */
+  trustDomain?: string;
+  /** Locality information (region, zone, subzone) */
+  locality?: Locality;
+  /** Name of the node where the workload is scheduled */
+  node: string;
+  /** Network identifier for the workload */
+  network?: string;
+  /** Current operational status of the workload */
+  status: string;
+  /** Configuration for application-level tunneling (e.g., HBONE) */
+  applicationTunnel?: ApplicationTunnel;
+  /** List of service names associated with this workload */
+  services?: string[];
+  /** List of authorization policy names applied to this workload */
+  authorizationPolicies?: string[];
+}
+
+/** Network port mapping for a service. */
+export interface Port {
+  /** The port exposed by the service */
+  servicePort: number;
+  /** The underlying target port on the pods */
+  targetPort: number;
+}
+
+/** Load balancing configuration for a service. */
+export interface LoadBalancer {
+  /** Load balancing algorithm/mode */
+  mode: string;
+  /** Routing preferences for traffic distribution */
+  routingPreferences: string[];
+}
+
+/** Waypoint proxy configuration for a service. */
+export interface DaemonWaypoint {
+  /** Destination address of the waypoint proxy */
+  destination: string;
+}
+
+/**
+ * Represents a Kubernetes service as seen by the Kmesh daemon.
+ * Mapped from kmesh/pkg/status/api.go
+ */
+export interface DaemonService {
+  /** Name of the Kubernetes service */
+  name: string;
+  /** Namespace where the service is defined */
+  namespace: string;
+  /** Fully qualified hostname of the service */
+  hostname: string;
+  /** Virtual IPs (ClusterIPs) assigned to the service */
+  vips: string[];
+  /** List of port mappings for the service */
+  ports: Port[];
+  /** Load balancing configuration and preferences */
+  loadBalancer?: LoadBalancer;
+  /** Waypoint proxy configuration assigned to handle traffic for this service */
+  waypoint?: DaemonWaypoint;
+}
+
+/**
+ * Opaque rule for authorization, mirrors security.Rule proto.
+ */
+export interface SecurityRule {
+  // Opaque — mirrors security.Rule proto; keep as unknown for now
+  [key: string]: unknown;
+}
+
+/**
+ * Represents an AuthorizationPolicy enforced by the Kmesh daemon.
+ * Mapped from kmesh/pkg/status/api.go
+ */
+export interface DaemonAuthorizationPolicy {
+  /** Name of the AuthorizationPolicy resource */
+  name: string;
+  /** Namespace where the policy is defined */
+  namespace: string;
+  /** Scope of the policy (e.g., global, namespace, workload) */
+  scope: string;
+  /** Action taken when rules match (ALLOW, DENY, CUSTOM, AUDIT) */
+  action: string;
+  /** List of rules evaluated by the policy */
+  rules: SecurityRule[];
+}
+
+/** Response shape for GET /debug/config_dump/dual-engine */
+export interface WorkloadDump {
+  workloads: DaemonWorkload[];
+  services: DaemonService[];
+  policies: DaemonAuthorizationPolicy[];
+}
+
+// ---------------------------------------------------------------------------
+// /debug/config_dump/bpf/dual-engine  (BPF map dump, workload mode)
+// ---------------------------------------------------------------------------
+
+export interface BpfServiceValue {
+  /** Number of endpoints associated with this service */
+  endpointCount: string;
+  /** Load balancing policy applied to the service */
+  lbPolicy: string;
+  /** Service port */
+  servicePort?: string;
+  /** Target port */
+  targetPort?: string;
+  /** Address of the waypoint proxy handling this service */
+  waypointAddr?: string;
+  /** Port of the waypoint proxy */
+  waypointPort?: number;
+}
+
+export interface BpfBackendValue {
+  /** IP address of the backend endpoint */
+  ip: string;
+  /** Number of services pointing to this backend */
+  serviceCount: number;
+  /** List of service names this backend belongs to */
+  services: string[];
+  /** Address of the waypoint proxy for this backend */
+  waypointAddr?: string;
+  /** Port of the waypoint proxy */
+  waypointPort?: number;
+}
+
+export interface BpfFrontendValue {
+  /** Upstream identifier for the frontend */
+  upstreamId?: string;
+}
+
+export interface BpfWorkloadPolicyValue {
+  /** List of policy identifiers applied to the workload */
+  policyIds?: string[];
+}
+
+export interface BpfEndpointValue {
+  /** Unique identifier of the backend providing this endpoint */
+  backendUid?: string;
+}
+
+/** Response shape for GET /debug/config_dump/bpf/dual-engine */
+export interface WorkloadBpfDump {
+  workloadPolicies: BpfWorkloadPolicyValue[];
+  backends: BpfBackendValue[];
+  endpoints: BpfEndpointValue[];
+  frontends: BpfFrontendValue[];
+  services: BpfServiceValue[];
+}
+
+// ---------------------------------------------------------------------------
+// /debug/config_dump/kernel-native  (ADS / kernel-native mode)
+// ---------------------------------------------------------------------------
+
+/** Opaque xDS resource — proto-JSON encoded */
+export type XdsResource = Record<string, unknown>;
+
+export interface ConfigResources {
+  /** Dump of all dynamic cluster configurations */
+  clusterConfigs?: XdsResource[];
+  /** Dump of all dynamic listener configurations */
+  listenerConfigs?: XdsResource[];
+  /** Dump of all dynamic route configurations */
+  routeConfigs?: XdsResource[];
+}
+
+/** Response shape for GET /debug/config_dump/kernel-native */
+export interface ConfigDump {
+  dynamicResources?: ConfigResources;
+}
+
+// ---------------------------------------------------------------------------
+// Generic daemon request state
+// ---------------------------------------------------------------------------
+
+export type DaemonRequestStatus = 'idle' | 'loading' | 'success' | 'error';
+
+export interface DaemonRequestState<T> {
+  /** Current lifecycle status of the request. */
+  status: DaemonRequestStatus;
+  /** Populated on success. */
+  data: T | null;
+  /** Populated on error. */
+  error: string | null;
+}

--- a/kmesh/src/utils/kmeshDaemonApi.test.ts
+++ b/kmesh/src/utils/kmeshDaemonApi.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Tests for kmeshDaemonApi.ts
+ * - KMESH_DAEMON_PORT constant
+ * - buildDaemonProxyPath path construction
+ * - buildDefaultDaemonProxyPath convenience wrapper
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  buildDaemonProxyPath,
+  buildDefaultDaemonProxyPath,
+  DAEMON_ENDPOINTS,
+  KMESH_DAEMON_PORT,
+  KMESH_NAMESPACE,
+} from './kmeshDaemonApi';
+
+describe('kmeshDaemonApi constants', () => {
+  it('should export port 15200', () => {
+    expect(KMESH_DAEMON_PORT).toBe(15200);
+  });
+
+  it('should export default namespace', () => {
+    expect(KMESH_NAMESPACE).toBe('kmesh-system');
+  });
+
+  it('should export all expected endpoints', () => {
+    expect(DAEMON_ENDPOINTS.VERSION).toBe('/version');
+    expect(DAEMON_ENDPOINTS.READY).toBe('/debug/ready');
+    expect(DAEMON_ENDPOINTS.LOGGERS).toBe('/debug/loggers');
+    expect(DAEMON_ENDPOINTS.CONFIG_DUMP_ADS).toBe('/debug/config_dump/kernel-native');
+    expect(DAEMON_ENDPOINTS.CONFIG_DUMP_WORKLOAD).toBe('/debug/config_dump/dual-engine');
+    expect(DAEMON_ENDPOINTS.BPF_ADS_MAPS).toBe('/debug/config_dump/bpf/kernel-native');
+    expect(DAEMON_ENDPOINTS.BPF_WORKLOAD_MAPS).toBe('/debug/config_dump/bpf/dual-engine');
+    expect(DAEMON_ENDPOINTS.ACCESSLOG).toBe('/accesslog');
+    expect(DAEMON_ENDPOINTS.MONITORING).toBe('/monitoring');
+    expect(DAEMON_ENDPOINTS.WORKLOAD_METRICS).toBe('/workload_metrics');
+    expect(DAEMON_ENDPOINTS.CONNECTION_METRICS).toBe('/connection_metrics');
+    expect(DAEMON_ENDPOINTS.AUTHZ).toBe('/authz');
+  });
+});
+
+describe('buildDaemonProxyPath', () => {
+  const NS = 'kmesh-system';
+  const POD = 'kmesh-daemon-abc12';
+
+  it('should build the correct pod-proxy path for /version', () => {
+    const path = buildDaemonProxyPath(NS, POD, DAEMON_ENDPOINTS.VERSION);
+    expect(path).toBe(
+      `/api/v1/namespaces/kmesh-system/pods/kmesh-daemon-abc12:15200/proxy/version`
+    );
+  });
+
+  it('should build the correct path for /debug/ready', () => {
+    const path = buildDaemonProxyPath(NS, POD, DAEMON_ENDPOINTS.READY);
+    expect(path).toBe(
+      `/api/v1/namespaces/kmesh-system/pods/kmesh-daemon-abc12:15200/proxy/debug/ready`
+    );
+  });
+
+  it('should build the correct path for /debug/config_dump/dual-engine', () => {
+    const path = buildDaemonProxyPath(NS, POD, DAEMON_ENDPOINTS.CONFIG_DUMP_WORKLOAD);
+    expect(path).toBe(
+      `/api/v1/namespaces/kmesh-system/pods/kmesh-daemon-abc12:15200/proxy/debug/config_dump/dual-engine`
+    );
+  });
+
+  it('should append query params for toggle endpoints', () => {
+    const path = buildDaemonProxyPath(NS, POD, DAEMON_ENDPOINTS.ACCESSLOG, {
+      enable: 'true',
+    });
+    expect(path).toBe(
+      `/api/v1/namespaces/kmesh-system/pods/kmesh-daemon-abc12:15200/proxy/accesslog?enable=true`
+    );
+  });
+
+  it('should handle multiple query params', () => {
+    const path = buildDaemonProxyPath(NS, POD, DAEMON_ENDPOINTS.LOGGERS, {
+      name: 'bpf',
+    });
+    expect(path).toBe(
+      `/api/v1/namespaces/kmesh-system/pods/kmesh-daemon-abc12:15200/proxy/debug/loggers?name=bpf`
+    );
+  });
+
+  it('should support a custom namespace', () => {
+    const path = buildDaemonProxyPath('custom-ns', POD, DAEMON_ENDPOINTS.VERSION);
+    expect(path).toBe(`/api/v1/namespaces/custom-ns/pods/kmesh-daemon-abc12:15200/proxy/version`);
+  });
+});
+
+describe('buildDefaultDaemonProxyPath', () => {
+  it('should use KMESH_NAMESPACE automatically', () => {
+    const path = buildDefaultDaemonProxyPath('kmesh-daemon-abc12', DAEMON_ENDPOINTS.READY);
+    expect(path).toBe(
+      `/api/v1/namespaces/kmesh-system/pods/kmesh-daemon-abc12:15200/proxy/debug/ready`
+    );
+  });
+
+  it('should pass query params through', () => {
+    const path = buildDefaultDaemonProxyPath('kmesh-daemon-abc12', DAEMON_ENDPOINTS.MONITORING, {
+      enable: 'false',
+    });
+    expect(path).toBe(
+      `/api/v1/namespaces/kmesh-system/pods/kmesh-daemon-abc12:15200/proxy/monitoring?enable=false`
+    );
+  });
+});

--- a/kmesh/src/utils/kmeshDaemonApi.ts
+++ b/kmesh/src/utils/kmeshDaemonApi.ts
@@ -1,0 +1,162 @@
+/**
+ * Kmesh Daemon Admin API — endpoint constants and pod-proxy path builder.
+ *
+ * The Kmesh daemon runs an HTTP admin server on port 15200 (localhost-only)
+ * inside every kmesh-daemon DaemonSet pod.  Headlamp reaches it through the
+ * Kubernetes API Server pod-proxy tunnel:
+ *
+ *   /api/v1/namespaces/<ns>/pods/<pod>:<port>/proxy/<endpoint>
+ *
+ * This is the same pattern used by tools like `kubectl port-forward` or
+ * istioctl proxy-config to reach cluster-local APIs.
+ *
+ * @see pkg/status/status_server.go for the authoritative endpoint list.
+ */
+
+// ---------------------------------------------------------------------------
+// Core constants
+// ---------------------------------------------------------------------------
+
+/** Port the Kmesh daemon admin HTTP server listens on. */
+export const KMESH_DAEMON_PORT = 15200;
+
+/** Namespace where the kmesh-daemon DaemonSet runs. */
+export const KMESH_NAMESPACE = 'kmesh-system';
+
+/** Label selector for kmesh daemon pods. */
+export const KMESH_DAEMON_LABEL_SELECTOR = 'app=kmesh';
+
+// ---------------------------------------------------------------------------
+// Endpoint path constants  (matching status_server.go)
+// ---------------------------------------------------------------------------
+
+export const DAEMON_ENDPOINTS = {
+  /** GET → KmeshVersion JSON */
+  VERSION: '/version',
+
+  /** GET → "OK" string — use as liveness/readiness check */
+  READY: '/debug/ready',
+
+  /**
+   * GET  → string[] (logger names) when no ?name= param
+   * GET  → LoggerInfo when ?name=<logger>
+   * POST → (body: LoggerInfo) to change a logger level
+   */
+  LOGGERS: '/debug/loggers',
+
+  /**
+   * GET → ConfigDump (proto-JSON, ADS / kernel-native mode).
+   * Returns 400 if daemon is running in workload mode.
+   */
+  CONFIG_DUMP_ADS: '/debug/config_dump/kernel-native',
+
+  /**
+   * GET → WorkloadDump JSON (dual-engine / workload mode).
+   * Returns 400 if daemon is running in kernel-native mode.
+   */
+  CONFIG_DUMP_WORKLOAD: '/debug/config_dump/dual-engine',
+
+  /**
+   * GET → BPF map dump (ADS / kernel-native mode).
+   * Returns 400 if daemon is running in workload mode.
+   */
+  BPF_ADS_MAPS: '/debug/config_dump/bpf/kernel-native',
+
+  /**
+   * GET → WorkloadBpfDump JSON (dual-engine / workload mode).
+   * Returns 400 if daemon is running in kernel-native mode.
+   */
+  BPF_WORKLOAD_MAPS: '/debug/config_dump/bpf/dual-engine',
+
+  /**
+   * POST /accesslog?enable=<bool>
+   * Toggles workload access logging.
+   */
+  ACCESSLOG: '/accesslog',
+
+  /**
+   * POST /monitoring?enable=<bool>
+   * Master switch — enables/disables all monitoring (metrics + accesslog).
+   */
+  MONITORING: '/monitoring',
+
+  /**
+   * POST /workload_metrics?enable=<bool>
+   * Toggles per-workload metrics collection.
+   */
+  WORKLOAD_METRICS: '/workload_metrics',
+
+  /**
+   * POST /connection_metrics?enable=<bool>
+   * Toggles per-connection metrics collection.
+   */
+  CONNECTION_METRICS: '/connection_metrics',
+
+  /**
+   * POST /authz?enable=<bool>
+   * Toggles eBPF authorization offloading.
+   */
+  AUTHZ: '/authz',
+} as const;
+
+export type DaemonEndpoint = (typeof DAEMON_ENDPOINTS)[keyof typeof DAEMON_ENDPOINTS];
+
+// ---------------------------------------------------------------------------
+// Pod-proxy path builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds the Kubernetes API Server pod-proxy URL for a Kmesh daemon endpoint.
+ *
+ * Headlamp's `ApiProxy.request()` prepends the cluster API server base URL,
+ * so this function only needs to return the path segment after that base.
+ *
+ * @param namespace   - Namespace of the kmesh daemon pod (usually "kmesh-system")
+ * @param podName     - Name of the kmesh daemon pod
+ * @param endpoint    - One of the DAEMON_ENDPOINTS values
+ * @param queryParams - Optional key/value pairs appended as query string
+ *
+ * @example
+ * buildDaemonProxyPath('kmesh-system', 'kmesh-daemon-abc12', DAEMON_ENDPOINTS.VERSION)
+ * // → "/api/v1/namespaces/kmesh-system/pods/kmesh-daemon-abc12:15200/proxy/version"
+ *
+ * buildDaemonProxyPath('kmesh-system', 'kmesh-daemon-abc12', DAEMON_ENDPOINTS.ACCESSLOG, { enable: 'true' })
+ * // → "/api/v1/namespaces/kmesh-system/pods/kmesh-daemon-abc12:15200/proxy/accesslog?enable=true"
+ */
+export function buildDaemonProxyPath(
+  namespace: string,
+  podName: string,
+  endpoint: DaemonEndpoint,
+  queryParams?: Record<string, string>
+): string {
+  // The Kubernetes pod proxy path strips the leading '/' from the sub-path,
+  // so we normalise it here.
+  const subPath = endpoint.startsWith('/') ? endpoint.slice(1) : endpoint;
+
+  let path =
+    `/api/v1/namespaces/${namespace}/pods/` + `${podName}:${KMESH_DAEMON_PORT}/proxy/${subPath}`;
+
+  if (queryParams && Object.keys(queryParams).length > 0) {
+    const qs = new URLSearchParams(
+      Object.entries(queryParams).sort(([a], [b]) => a.localeCompare(b))
+    ).toString();
+    path = `${path}?${qs}`;
+  }
+
+  return path;
+}
+
+/**
+ * Convenience overload that uses the default Kmesh namespace and port.
+ *
+ * @example
+ * buildDefaultDaemonProxyPath('kmesh-daemon-abc12', DAEMON_ENDPOINTS.READY)
+ * // → "/api/v1/namespaces/kmesh-system/pods/kmesh-daemon-abc12:15200/proxy/debug/ready"
+ */
+export function buildDefaultDaemonProxyPath(
+  podName: string,
+  endpoint: DaemonEndpoint,
+  queryParams?: Record<string, string>
+): string {
+  return buildDaemonProxyPath(KMESH_NAMESPACE, podName, endpoint, queryParams);
+}

--- a/kmesh/src/utils/kmeshDaemonProxy.test.ts
+++ b/kmesh/src/utils/kmeshDaemonProxy.test.ts
@@ -1,0 +1,93 @@
+import { ApiProxy } from '@kinvolk/headlamp-plugin/lib';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DAEMON_ENDPOINTS } from './kmeshDaemonApi';
+import { daemonRequestDeduped } from './kmeshDaemonProxy';
+
+vi.mock('@kinvolk/headlamp-plugin/lib', () => ({
+  ApiProxy: {
+    request: vi.fn(),
+  },
+}));
+
+vi.mock('@kinvolk/headlamp-plugin/lib/Utils', () => ({
+  getCluster: vi.fn(() => 'test-cluster'),
+}));
+
+describe('kmeshDaemonProxy deduplication', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should deduplicate concurrent identical GET requests', async () => {
+    // Setup the mock to delay resolving so we can fire multiple concurrent requests
+    let resolveRequest: (val: any) => void;
+    const requestPromise = new Promise(resolve => {
+      resolveRequest = resolve;
+    });
+    vi.mocked(ApiProxy.request).mockReturnValue(requestPromise as any);
+
+    // Fire 3 concurrent requests with the same parameters
+    const req1 = daemonRequestDeduped('ns1', 'pod1', DAEMON_ENDPOINTS.VERSION);
+    const req2 = daemonRequestDeduped('ns1', 'pod1', DAEMON_ENDPOINTS.VERSION);
+    const req3 = daemonRequestDeduped('ns1', 'pod1', DAEMON_ENDPOINTS.VERSION);
+
+    // The underlying ApiProxy.request should only have been called ONCE at this point
+    expect(ApiProxy.request).toHaveBeenCalledTimes(1);
+
+    // Resolve the underlying promise
+    resolveRequest!({ version: '1.2.3' });
+
+    // Wait for all three deduplicated promises to resolve
+    const [res1, res2, res3] = await Promise.all([req1, req2, req3]);
+
+    // All should get the same response
+    expect(res1).toEqual({ version: '1.2.3' });
+    expect(res2).toEqual({ version: '1.2.3' });
+    expect(res3).toEqual({ version: '1.2.3' });
+  });
+
+  it('should not deduplicate POST requests even if concurrent', async () => {
+    vi.mocked(ApiProxy.request).mockResolvedValue({ status: 'ok' } as any);
+
+    const req1 = daemonRequestDeduped('ns1', 'pod1', DAEMON_ENDPOINTS.ACCESSLOG, {
+      method: 'POST',
+      body: { enable: true },
+    });
+    const req2 = daemonRequestDeduped('ns1', 'pod1', DAEMON_ENDPOINTS.ACCESSLOG, {
+      method: 'POST',
+      body: { enable: true },
+    });
+
+    await Promise.all([req1, req2]);
+
+    // Both requests should go through
+    expect(ApiProxy.request).toHaveBeenCalledTimes(2);
+  });
+
+  it('should clear the cache after the request completes (resolves or rejects)', async () => {
+    vi.mocked(ApiProxy.request).mockResolvedValueOnce({ version: 'first' } as any);
+
+    // Fire first request and let it complete
+    const res1 = await daemonRequestDeduped('ns1', 'pod1', DAEMON_ENDPOINTS.VERSION);
+    expect(res1).toEqual({ version: 'first' });
+
+    vi.mocked(ApiProxy.request).mockResolvedValueOnce({ version: 'second' } as any);
+
+    // Fire second request sequentially, it should trigger a new ApiProxy.request
+    const res2 = await daemonRequestDeduped('ns1', 'pod1', DAEMON_ENDPOINTS.VERSION);
+    expect(res2).toEqual({ version: 'second' });
+
+    expect(ApiProxy.request).toHaveBeenCalledTimes(2);
+  });
+
+  it('should reject when a GET request includes a body', async () => {
+    await expect(
+      daemonRequestDeduped('ns1', 'pod1', DAEMON_ENDPOINTS.VERSION, {
+        method: 'GET',
+        body: { foo: 'bar' },
+      })
+    ).rejects.toThrow('daemonRequest: GET requests cannot include a request body');
+
+    expect(ApiProxy.request).not.toHaveBeenCalled();
+  });
+});

--- a/kmesh/src/utils/kmeshDaemonProxy.ts
+++ b/kmesh/src/utils/kmeshDaemonProxy.ts
@@ -1,0 +1,245 @@
+/**
+ * Kmesh Daemon Proxy — core fetch logic for the admin API on port 15200.
+ *
+ * Design pattern:
+ * - A single shared module-level in-flight promise per (pod, endpoint) key
+ *   prevents duplicate in-flight requests when multiple components mount.
+ * - Results are returned as plain async functions so hooks can wrap them with
+ *   React state; the cache layer lives here, not in React state.
+ *
+ * Why pod-proxy instead of port-forward?
+ * ----------------------------------------
+ * The Kmesh daemon binds on *localhost*:15200, so it is reachable only from
+ * within the pod.  The Kubernetes API Server pod-proxy mechanism
+ * (`/api/v1/namespaces/<ns>/pods/<name>:<port>/proxy/…`) tunnels HTTP
+ * requests through the API server to the pod without requiring `kubectl
+ * port-forward` or an Ingress.  This is exactly the same mechanism that
+ * `kmeshctl` uses under the hood when it calls the daemon admin endpoints.
+ *
+ * @see src/utils/kmeshDaemonApi.ts for endpoint constants and path builder.
+ * @see src/hooks/useDaemonRequest.ts for the React hook wrapper.
+ */
+
+import { ApiProxy } from '@kinvolk/headlamp-plugin/lib';
+import { getCluster } from '@kinvolk/headlamp-plugin/lib/Utils';
+import type { DaemonRequestState } from '../types/daemonApi';
+import { buildDaemonProxyPath, DAEMON_ENDPOINTS, type DaemonEndpoint } from './kmeshDaemonApi';
+
+// ---------------------------------------------------------------------------
+// Internal request options
+// ---------------------------------------------------------------------------
+
+export interface DaemonRequestOptions {
+  method?: 'GET' | 'POST';
+  /** Query parameters appended to the URL. */
+  queryParams?: Record<string, string>;
+  /** JSON-serialisable body for POST requests. */
+  body?: unknown;
+  /** AbortSignal for cancellation (e.g. from React useEffect cleanup). */
+  signal?: AbortSignal;
+  /** Whether ApiProxy should parse the response body as JSON (defaults to true). */
+  isJSON?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Core request function
+// ---------------------------------------------------------------------------
+
+/**
+ * Sends a request to the Kmesh daemon admin API via the Kubernetes API Server
+ * pod-proxy tunnel and returns the response body as returned by `ApiProxy.request()`.
+ *
+ * Throws on HTTP errors or network failures so that callers / hooks can handle
+ * the error state themselves.
+ *
+ * @param namespace   - Namespace the daemon pod runs in
+ * @param podName     - Name of the daemon pod
+ * @param endpoint    - Daemon endpoint path (e.g. DAEMON_ENDPOINTS.VERSION)
+ * @param options     - Optional method, queryParams, body, signal
+ * @returns           - Parsed JSON response (typed as T by the caller)
+ *
+ * @example
+ * const version = await daemonRequest<KmeshVersion>(
+ *   'kmesh-system',
+ *   'kmesh-daemon-xyz',
+ *   DAEMON_ENDPOINTS.VERSION
+ * );
+ */
+export async function daemonRequest<T = unknown>(
+  namespace: string,
+  podName: string,
+  endpoint: DaemonEndpoint,
+  options: DaemonRequestOptions = {}
+): Promise<T> {
+  const { method: methodOverride, queryParams, body, signal, isJSON = true } = options;
+  const method = methodOverride ?? (body !== undefined ? 'POST' : 'GET');
+
+  if (body !== undefined && method === 'GET') {
+    throw new Error('daemonRequest: GET requests cannot include a request body');
+  }
+
+  const path = buildDaemonProxyPath(namespace, podName, endpoint, queryParams);
+
+  const requestInit: RequestInit & { isJSON?: boolean } = { method, signal, isJSON };
+  if (body !== undefined) {
+    requestInit.headers = { 'Content-Type': 'application/json' };
+    requestInit.body = JSON.stringify(body);
+  }
+
+  // ApiProxy.request returns parsed JSON by default.
+  // When `isJSON: false` is passed, it returns the raw `Response` so callers can inspect status/body.
+  // It automatically picks up the current cluster context set in Headlamp.
+  const result = await ApiProxy.request(path, requestInit);
+  return result as T;
+}
+
+// ---------------------------------------------------------------------------
+// Module-level in-flight promise cache
+// ---------------------------------------------------------------------------
+
+const _inFlight = new Map<string, Promise<unknown>>();
+
+function cacheKey(
+  namespace: string,
+  podName: string,
+  endpoint: DaemonEndpoint,
+  method: string,
+  queryParams?: Record<string, string>
+): string {
+  const qs =
+    queryParams && Object.keys(queryParams).length > 0
+      ? new URLSearchParams(
+          Object.entries(queryParams).sort(([a], [b]) => a.localeCompare(b))
+        ).toString()
+      : '';
+  const cluster = getCluster() || 'default';
+  return `${cluster}|${method}|${namespace}|${podName}|${endpoint}|${qs}`;
+}
+
+/**
+ * Like `daemonRequest` but deduplicates concurrent calls with the same
+ * (cluster, namespace, podName, endpoint, method, queryParams) key.
+ * The in-flight promise is cleared after it resolves or rejects so the next
+ * call always re-fetches fresh data.
+ *
+ * Use this for expensive read-only GET requests (e.g. config dumps, BPF maps)
+ * that multiple components might trigger simultaneously on page load.
+ */
+export async function daemonRequestDeduped<T = unknown>(
+  namespace: string,
+  podName: string,
+  endpoint: DaemonEndpoint,
+  options: DaemonRequestOptions = {}
+): Promise<T> {
+  const { method = 'GET', queryParams, body, signal, isJSON = true } = options;
+
+  // Avoid deduping non-idempotent requests (or requests tied to a caller-specific AbortSignal).
+  // Also avoid deduping when isJSON is false because the return type/shape differs (raw Response vs parsed JSON).
+  if (method !== 'GET' || body !== undefined || signal || isJSON === false) {
+    return daemonRequest<T>(namespace, podName, endpoint, options);
+  }
+
+  const key = cacheKey(namespace, podName, endpoint, method, queryParams);
+
+  const existing = _inFlight.get(key) as Promise<T> | undefined;
+  if (existing) return existing;
+
+  const promise = daemonRequest<T>(namespace, podName, endpoint, options).finally(() => {
+    _inFlight.delete(key);
+  });
+
+  _inFlight.set(key, promise);
+  return promise;
+}
+
+// ---------------------------------------------------------------------------
+// Readiness probe helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Checks whether the Kmesh daemon on the given pod is ready.
+ * Returns `true` if the `/debug/ready` endpoint responds with HTTP 200.
+ *
+ * @example
+ * const ready = await isDaemonReady('kmesh-system', 'kmesh-daemon-abc12');
+ */
+export async function isDaemonReady(namespace: string, podName: string): Promise<boolean> {
+  try {
+    const res = await daemonRequest<Response>(namespace, podName, DAEMON_ENDPOINTS.READY, {
+      isJSON: false,
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Toggle helpers (POST endpoints)
+// ---------------------------------------------------------------------------
+
+export type ToggleEndpoint =
+  | typeof DAEMON_ENDPOINTS.ACCESSLOG
+  | typeof DAEMON_ENDPOINTS.MONITORING
+  | typeof DAEMON_ENDPOINTS.WORKLOAD_METRICS
+  | typeof DAEMON_ENDPOINTS.CONNECTION_METRICS
+  | typeof DAEMON_ENDPOINTS.AUTHZ;
+
+/**
+ * Sends a POST request to a toggle endpoint on the Kmesh daemon.
+ *
+ * @param namespace  - Namespace of the daemon pod
+ * @param podName    - Name of the daemon pod
+ * @param endpoint   - One of the POST-only toggle endpoints
+ * @param enable     - Whether to enable or disable the feature
+ *
+ * @example
+ * await toggleDaemonFeature('kmesh-system', 'kmesh-daemon-abc12', '/accesslog', true);
+ */
+export async function toggleDaemonFeature(
+  namespace: string,
+  podName: string,
+  endpoint: ToggleEndpoint,
+  enable: boolean
+): Promise<void> {
+  const res = await daemonRequest<Response>(namespace, podName, endpoint, {
+    method: 'POST',
+    queryParams: { enable: String(enable) },
+    isJSON: false,
+  });
+  if (!res.ok) {
+    throw new Error(`Kmesh daemon toggle failed: ${res.status} ${res.statusText}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Serialise a DaemonRequestState for initial render (before data arrives)
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the canonical "loading" initial state for `useDaemonRequest`.
+ * Factored out here so both the hook and tests reuse the same implementation.
+ */
+export function makeLoadingState<T>(): DaemonRequestState<T> {
+  return { status: 'loading', data: null, error: null };
+}
+
+/**
+ * Returns a success state wrapping `data`.
+ */
+export function makeSuccessState<T>(data: T): DaemonRequestState<T> {
+  return { status: 'success', data, error: null };
+}
+
+/**
+ * Returns an error state with a human-readable message.
+ */
+export function makeErrorState<T>(error: unknown): DaemonRequestState<T> {
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === 'string'
+      ? error
+      : 'Unknown error contacting the Kmesh daemon';
+  return { status: 'error', data: null, error: message };
+}


### PR DESCRIPTION
## Overview
This PR implements the foundational API proxy layer required for the Kmesh Headlamp plugin to communicate with the `kmesh-daemon` pods. 

Since the Kmesh daemon exposes its debug/admin API on `localhost:15200` inside the pod, this layer handles routing HTTP requests from the Headlamp UI through the **Kubernetes API Server pod-proxy tunnel** (`/api/v1/namespaces/kmesh-system/pods/.../proxy/`). This enables direct communication with cluster-local daemon APIs.

## What was implemented

This PR is logically split into 3 commits:

### 1. Types & Constants
* Mapped the backend Go structs from `kmesh/pkg/status/api.go` into strict TypeScript interfaces (`DaemonWorkload`, `WorkloadBpfDump`, `KmeshVersion`, etc.) to ensure complete type safety across the plugin.
* Added `DAEMON_ENDPOINTS` constants for all debug routes.
* Implemented the `buildDaemonProxyPath` URL builder.

### 2. Core Proxy Engine
* Added `daemonRequest`, a wrapper around Headlamp's `ApiProxy.request` that automatically handles the pod-proxy tunnelling.
* Implemented a module-level deduplication cache (`daemonRequestDeduped`) to ensure that if multiple components mount simultaneously, only a single in-flight network request is made to the cluster.
* Added `toggleDaemonFeature` helper for POST requests (enabling/disabling metrics, authz, and access logs).

### 3. React Hooks
* Added `useKmeshDaemonPods` to automatically discover active Kmesh daemon pods running in the cluster.
* Added a robust `useDaemonRequest` hook with proper unmount-cancellation support.
* Exported ready-to-use hooks for UI development:
  * `useKmeshVersion()`
  * `useWorkloadConfigDump()` & `useAdsConfigDump()`
  * `useWorkloadBpfMaps()` & `useAdsBpfMaps()`
  * `useKmeshLoggers()`

## How to test
1. Run `npm install && npm run tsc` to verify no TypeScript regressions.
2. Run `npm test` to verify the 11 new unit tests for the API constants and proxy path builder pass successfully.

<img width="853" height="128" alt="image" src="https://github.com/user-attachments/assets/18500125-1531-4f06-8afc-490a06098c60" />

##  Next Steps
With this plumbing layer merged, the following UI features are now unblocked and ready to be built:
1. **xDS Config Dump Viewer** (rendering tables for Workloads, Services, and Policies).
2. **eBPF Map Viewer** (displaying the 5 raw BPF map dumps).
3. **Daemon Control Panel** (toggling access logs and monitoring metrics).
