### PR TITLE
cert-manager: Fix ready status getters and add condition tests

### DIFF
--- a/cert-manager/src/resources/certificate.ts
+++ b/cert-manager/src/resources/certificate.ts
@@ -1,6 +1,7 @@
 import { KubeObject } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
 import { KubeObjectInterface } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
 import { Condition, IssuerReference, SecretKeySelector } from './common';
+import { isConditionTrue } from './conditions';
 
 export type KeyUsage =
   | 'signing'
@@ -122,10 +123,9 @@ export class Certificate extends KubeObject<CertManagerCertificate> {
   static apiVersion = 'cert-manager.io/v1';
   static isNamespaced = true;
 
+  /** True only when the 'Ready' condition status is 'True'. */
   get ready() {
-    return (
-      this.status?.conditions?.find(condition => condition.type === 'Ready')?.status === 'True'
-    );
+    return isConditionTrue(this.status?.conditions, 'Ready');
   }
 
   // Note: This workaround is needed to make the plugin compatible with older versions of Headlamp

--- a/cert-manager/src/resources/certificateRequest.ts
+++ b/cert-manager/src/resources/certificateRequest.ts
@@ -2,6 +2,7 @@ import { KubeObjectInterface } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
 import { KubeObject } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
 import { KeyUsage } from './certificate';
 import { Condition, IssuerReference } from './common';
+import { getConditionStatus, isConditionTrue } from './conditions';
 
 export interface CertManagerCertificateRequest extends KubeObjectInterface {
   spec: {
@@ -42,15 +43,18 @@ export class CertificateRequest extends KubeObject<CertManagerCertificateRequest
     return this.jsonData.spec;
   }
 
+  /** Raw 'Approved' condition status ('True' | 'False' | 'Unknown'), or undefined when absent. */
   get approved() {
-    return this.status?.conditions?.find(condition => condition.type === 'Approved')?.status;
+    return getConditionStatus(this.status?.conditions, 'Approved');
   }
 
+  /** Raw 'Denied' condition status ('True' | 'False' | 'Unknown'), or undefined when absent. */
   get denied() {
-    return this.status?.conditions?.find(condition => condition.type === 'Denied')?.status;
+    return getConditionStatus(this.status?.conditions, 'Denied');
   }
 
+  /** True only when the 'Ready' condition status is 'True'. */
   get ready() {
-    return this.status?.conditions?.find(condition => condition.type === 'Ready')?.status;
+    return isConditionTrue(this.status?.conditions, 'Ready');
   }
 }

--- a/cert-manager/src/resources/conditions.test.ts
+++ b/cert-manager/src/resources/conditions.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { Condition, ConditionStatus } from './common';
+import { getConditionStatus, isConditionTrue } from './conditions';
+
+const cond = (type: string, status: ConditionStatus): Condition => ({ type, status });
+
+describe('getConditionStatus', () => {
+  it('returns the status of the matching condition', () => {
+    expect(getConditionStatus([cond('Ready', 'True')], 'Ready')).toBe('True');
+    expect(getConditionStatus([cond('Approved', 'False')], 'Approved')).toBe('False');
+  });
+
+  it('returns undefined when the condition type is absent', () => {
+    expect(getConditionStatus([cond('Ready', 'True')], 'Approved')).toBeUndefined();
+    expect(getConditionStatus([], 'Ready')).toBeUndefined();
+  });
+
+  it('returns undefined when conditions is undefined', () => {
+    expect(getConditionStatus(undefined, 'Ready')).toBeUndefined();
+  });
+
+  it('returns the first match when a type repeats', () => {
+    expect(getConditionStatus([cond('Ready', 'False'), cond('Ready', 'True')], 'Ready')).toBe(
+      'False'
+    );
+  });
+});
+
+describe('isConditionTrue', () => {
+  it('is true only when the condition status is exactly True', () => {
+    expect(isConditionTrue([cond('Ready', 'True')], 'Ready')).toBe(true);
+  });
+
+  // Regression: a 'False'/'Unknown' status is a truthy string, so reading it
+  // directly made a not-ready resource render as "Ready".
+  it('is false for a False or Unknown status', () => {
+    expect(isConditionTrue([cond('Ready', 'False')], 'Ready')).toBe(false);
+    expect(isConditionTrue([cond('Ready', 'Unknown')], 'Ready')).toBe(false);
+  });
+
+  it('is false when the condition is absent or conditions is undefined', () => {
+    expect(isConditionTrue([], 'Ready')).toBe(false);
+    expect(isConditionTrue(undefined, 'Ready')).toBe(false);
+  });
+});

--- a/cert-manager/src/resources/conditions.ts
+++ b/cert-manager/src/resources/conditions.ts
@@ -1,0 +1,20 @@
+import { Condition, ConditionStatus } from './common';
+
+/**
+ * Returns the status of the condition with the given type, or undefined when
+ * the condition is not present.
+ */
+export function getConditionStatus(
+  conditions: Condition[] | undefined,
+  type: string
+): ConditionStatus | undefined {
+  return conditions?.find(condition => condition.type === type)?.status;
+}
+
+/**
+ * Returns true only when the condition with the given type is present and set
+ * to 'True'. A missing condition, or a 'False'/'Unknown' status, is not ready.
+ */
+export function isConditionTrue(conditions: Condition[] | undefined, type: string): boolean {
+  return getConditionStatus(conditions, type) === 'True';
+}

--- a/cert-manager/src/resources/issuer.ts
+++ b/cert-manager/src/resources/issuer.ts
@@ -1,6 +1,7 @@
 import { KubeObject } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
 import { KubeObjectInterface } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
 import { ACMEIssuerStatus, Condition, IssuerSpec } from './common';
+import { isConditionTrue } from './conditions';
 
 export interface IssuerStatus {
   conditions: Condition[];
@@ -26,8 +27,9 @@ export class Issuer extends KubeObject<CertManagerIssuer> {
     return this.jsonData.spec;
   }
 
+  /** True only when the 'Ready' condition status is 'True' (matches Certificate.ready). */
   get ready() {
-    return this.status?.conditions?.find(condition => condition.type === 'Ready')?.status;
+    return isConditionTrue(this.status?.conditions, 'Ready');
   }
 
   // Note: This workaround is needed to make the plugin compatible with older versions of Headlamp


### PR DESCRIPTION
## What

Three cert-manager resource getters derive readiness from status conditions. `Certificate.ready` correctly returned `status === 'True'`, but `Issuer.ready` and `CertificateRequest.ready` returned the raw condition status string. Their consumers use a truthy check (for example `issuer.ready ? 'Ready' : 'Not Ready'` in `issuers/List.tsx`, and the same in `certificateRequests/Detail.tsx`), so a `False` or `Unknown` status, being a non-empty string, rendered a not-ready resource as **Ready**.

This pulls the condition lookup into a small `conditions.ts` helper (`getConditionStatus`, `isConditionTrue`), points the getters at it, and adds unit tests. `approved` and `denied` keep returning the raw status, since their consumers already compare against `'True'`.

## Why

A not-ready Issuer or CertificateRequest showing "Ready" is misleading. Sharing the lookup also removes the duplicated condition-finding across the three resources and makes the logic testable; the plugin had no unit tests before this.

## Testing

`cd cert-manager && npm test` (also ran `tsc`, `lint`, `format --check` and `build`, all clean):

```
 src/resources/conditions.test.ts (7 tests) 4ms

 Test Files  1 passed | 1 skipped (2)
      Tests  7 passed | 1 skipped (8)
```

cc @illume
