### PR TITLE
kyverno: add CRDGuard Storybook stories

### DIFF
--- a/kyverno/src/components/CRDGuard.stories.tsx
+++ b/kyverno/src/components/CRDGuard.stories.tsx
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Box, Typography } from '@mui/material';
+import type { Meta } from '@storybook/react';
+import type { KyvernoCRDStatus } from '../hooks/useKyvernoCRDs';
+import { PureCRDGuard } from './CRDGuard';
+
+export default {
+  title: 'Kyverno/CRDGuard',
+  component: PureCRDGuard,
+} as Meta<typeof PureCRDGuard>;
+
+const StoryContent = () => (
+  <Box p={2}>
+    <Typography>Kyverno content is available.</Typography>
+  </Box>
+);
+
+const allAvailableStatus: KyvernoCRDStatus = {
+  legacy: true,
+  cel: true,
+  cleanup: true,
+  reports: true,
+  exceptions: true,
+  kyvernoV2Reports: true,
+  ephemeralReports: true,
+  loading: false,
+};
+
+const missingStatus: KyvernoCRDStatus = {
+  legacy: false,
+  cel: false,
+  cleanup: false,
+  reports: false,
+  exceptions: false,
+  kyvernoV2Reports: false,
+  ephemeralReports: false,
+  loading: false,
+};
+
+const loadingStatus: KyvernoCRDStatus = {
+  ...missingStatus,
+  loading: true,
+};
+
+export const Available = () => (
+  <PureCRDGuard requires="legacy" status={allAvailableStatus}>
+    <StoryContent />
+  </PureCRDGuard>
+);
+
+export const Loading = () => (
+  <PureCRDGuard requires="legacy" status={loadingStatus}>
+    <StoryContent />
+  </PureCRDGuard>
+);
+
+export const MissingLegacy = () => (
+  <PureCRDGuard requires="legacy" status={missingStatus}>
+    <StoryContent />
+  </PureCRDGuard>
+);
+
+export const MissingCEL = () => (
+  <PureCRDGuard requires="cel" status={missingStatus}>
+    <StoryContent />
+  </PureCRDGuard>
+);
+
+export const MissingCleanup = () => (
+  <PureCRDGuard requires="cleanup" status={missingStatus}>
+    <StoryContent />
+  </PureCRDGuard>
+);
+
+export const MissingReports = () => (
+  <PureCRDGuard requires="reports" status={missingStatus}>
+    <StoryContent />
+  </PureCRDGuard>
+);
+
+export const MissingExceptions = () => (
+  <PureCRDGuard requires="exceptions" status={missingStatus}>
+    <StoryContent />
+  </PureCRDGuard>
+);
+
+export const MissingKyvernoV2Reports = () => (
+  <PureCRDGuard requires="kyvernoV2Reports" status={missingStatus}>
+    <StoryContent />
+  </PureCRDGuard>
+);
+
+export const MissingEphemeralReports = () => (
+  <PureCRDGuard requires="ephemeralReports" status={missingStatus}>
+    <StoryContent />
+  </PureCRDGuard>
+);
+
+export const CustomMessage = () => (
+  <PureCRDGuard
+    requires="reports"
+    status={missingStatus}
+    message="Policy reports are not available in this cluster."
+  >
+    <StoryContent />
+  </PureCRDGuard>
+);

--- a/kyverno/src/components/CRDGuard.tsx
+++ b/kyverno/src/components/CRDGuard.tsx
@@ -21,15 +21,18 @@ import { NotInstalledBanner } from './common';
 
 export type CRDGroup = keyof Omit<KyvernoCRDStatus, 'loading'>;
 
-interface CRDGuardProps {
+export interface CRDGuardProps {
   requires: CRDGroup;
   children: ReactNode;
   message?: string;
 }
 
-export function CRDGuard({ requires, children, message }: CRDGuardProps) {
+export interface PureCRDGuardProps extends CRDGuardProps {
+  status: KyvernoCRDStatus;
+}
+
+export function PureCRDGuard({ requires, status, children, message }: PureCRDGuardProps) {
   const { t } = useTranslation();
-  const status = useKyvernoCRDs();
 
   const defaultMessages: Record<CRDGroup, string> = {
     legacy: t('Kyverno (kyverno.io/v1) was not detected on this cluster.'),
@@ -56,4 +59,10 @@ export function CRDGuard({ requires, children, message }: CRDGuardProps) {
   }
 
   return <>{children}</>;
+}
+
+export function CRDGuard(props: CRDGuardProps) {
+  const status = useKyvernoCRDs();
+
+  return <PureCRDGuard {...props} status={status} />;
 }


### PR DESCRIPTION
## Summary

Adds Storybook coverage for the Kyverno `CRDGuard` component.

This PR introduces stories covering the different CRD availability states handled by `CRDGuard`, including successful rendering, loading, missing CRDs, and custom message overrides. A small `PureCRDGuard` wrapper is used within the story file to make the component states deterministic without requiring a live cluster or hook mocking.

## Related Issue

Fixes #834 

## Changes

* Added `src/components/CRDGuard.stories.tsx`
* Added Storybook coverage for CRD availability states
* Added coverage for loading and successful rendering states
* Added coverage for custom message rendering
* Added coverage for all supported Kyverno CRD groups

## Steps to Test

1. Run `npm run lint`
2. Run `npm run storybook-build`
3. Open the `CRDGuard` stories in Storybook
4. Verify the loading, available, missing CRD, and custom message states render correctly

## Notes for the Reviewer

- Adds Storybook coverage for `CRDGuard`.
- Refactors `CRDGuard` slightly by extracting `PureCRDGuard`, so stories can reuse the same rendering logic while passing deterministic CRD status.
- No behavior change to `CRDGuard`; it still reads CRD status through `useKyvernoCRDs()`.
