### PR TITLE
volcano: fix JobLogsViewer Storybook Redux Provider

### DIFF
--- a/volcano/src/components/jobs/JobLogsViewer.stories.tsx
+++ b/volcano/src/components/jobs/JobLogsViewer.stories.tsx
@@ -9,6 +9,7 @@ import Switch from '@mui/material/Switch';
 import Typography from '@mui/material/Typography';
 import type { Meta, StoryFn } from '@storybook/react';
 import React from 'react';
+import { ReduxDecorator } from '../../helpers/storybook';
 
 type JobLogsViewerStoryProps = {
   helperMessage: string | null;
@@ -137,6 +138,7 @@ function JobLogsViewerStoryHarness({
 const meta = {
   title: 'Jobs/JobLogsViewer',
   component: JobLogsViewerStoryHarness,
+  decorators: [ReduxDecorator],
 } satisfies Meta<typeof JobLogsViewerStoryHarness>;
 
 export default meta;

--- a/volcano/src/helpers/storybook.tsx
+++ b/volcano/src/helpers/storybook.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import shortcutsReducer from '@kinvolk/headlamp-plugin/lib/redux/shortcutsSlice';
+import { configureStore } from '@reduxjs/toolkit';
+import type { Decorator } from '@storybook/react';
+import { Provider } from 'react-redux';
+
+const minimalStore = configureStore({
+  reducer: {
+    shortcuts: shortcutsReducer,
+  },
+});
+
+/**
+ * Storybook decorator that wraps stories in a Redux Provider.
+ *
+ * Usage in story files:
+ * ```
+ * import { ReduxDecorator } from '../../helpers/storybook';
+ *
+ * export default {
+ *   decorators: [ReduxDecorator],
+ * } as Meta;
+ * ```
+ */
+export const ReduxDecorator: Decorator = Story => (
+  <Provider store={minimalStore}>
+    <Story />
+  </Provider>
+);


### PR DESCRIPTION
## Summary
- Add a shared Storybook `ReduxDecorator` with Headlamp's `shortcutsReducer`
- Wrap `JobLogsViewer` stories so `LogViewer` can use `useShortcut` without crashing in Storybook

## Test plan
- [ ] `cd volcano && npx storybook dev -p 6007 -c node_modules/@kinvolk/headlamp-plugin/config/.storybook`
- [ ] Open **Jobs → JobLogsViewer → SinglePod**
- [ ] Confirm mock log line renders and no Redux Provider error appears
- [ ] Check **AllPods**, **NoPods**, and **ReconnectVisible** stories