### PR TITLE
kyverno: add Storybook stories for CELPolicyViewer

### DIFF
--- a/kyverno/src/components/CELPolicyViewer.stories.tsx
+++ b/kyverno/src/components/CELPolicyViewer.stories.tsx
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Meta } from '@storybook/react';
+import {
+  DeletingPolicy,
+  GeneratingPolicy,
+  MutatingPolicy,
+  ValidatingPolicy,
+} from '../resources/celPolicies';
+import { CELPolicyViewer } from './CELPolicyViewer';
+
+const baseMetadata = {
+  creationTimestamp: '2026-05-12T09:30:00Z',
+  name: 'example-cel-policy',
+  resourceVersion: '1',
+  uid: 'fixture-uid',
+};
+
+const readyStatus = {
+  conditionStatus: {
+    ready: true,
+  },
+};
+
+const podResourceRules = [
+  {
+    apiGroups: [''],
+    apiVersions: ['v1'],
+    operations: ['CREATE', 'UPDATE'],
+    resources: ['pods'],
+  },
+];
+
+const validatingPolicy = new ValidatingPolicy({
+  apiVersion: 'policies.kyverno.io/v1',
+  kind: 'ValidatingPolicy',
+  metadata: {
+    ...baseMetadata,
+    name: 'disallow-privileged-containers',
+  },
+  spec: {
+    validationActions: ['Enforce'],
+    matchConstraints: {
+      resourceRules: podResourceRules,
+    },
+    variables: [
+      {
+        name: 'containers',
+        expression: 'object.spec.containers',
+      },
+    ],
+    validations: [
+      {
+        expression:
+          'variables.containers.all(c, !has(c.securityContext) || !c.securityContext.privileged)',
+        message: 'Privileged containers are not allowed.',
+        reason: 'Forbidden',
+      },
+    ],
+    auditAnnotations: [
+      {
+        key: 'policy',
+        valueExpression: '"disallow-privileged-containers"',
+      },
+    ],
+  },
+  status: readyStatus,
+});
+
+const mutatingPolicy = new MutatingPolicy({
+  apiVersion: 'policies.kyverno.io/v1',
+  kind: 'MutatingPolicy',
+  metadata: {
+    ...baseMetadata,
+    name: 'add-default-labels',
+  },
+  spec: {
+    matchConstraints: {
+      resourceRules: podResourceRules,
+    },
+    variables: [
+      {
+        name: 'team',
+        expression: '"platform"',
+      },
+    ],
+    mutations: [
+      {
+        patchType: 'ApplyConfiguration',
+        applyConfiguration: {
+          expression: 'Object{metadata: Object.metadata{labels: {"team": variables.team}}}',
+        },
+      },
+    ],
+  },
+  status: readyStatus,
+});
+
+const generatingPolicy = new GeneratingPolicy({
+  apiVersion: 'policies.kyverno.io/v1',
+  kind: 'GeneratingPolicy',
+  metadata: {
+    ...baseMetadata,
+    name: 'generate-network-policy',
+  },
+  spec: {
+    matchConstraints: {
+      resourceRules: [
+        {
+          apiGroups: [''],
+          apiVersions: ['v1'],
+          operations: ['CREATE'],
+          resources: ['namespaces'],
+        },
+      ],
+    },
+    generate: [
+      {
+        expression: 'Object{spec: Object.spec{podSelector: {}}}',
+        name: 'default-deny',
+        namespace: 'object.metadata.name',
+      },
+    ],
+  },
+  status: readyStatus,
+});
+
+const deletingPolicy = new DeletingPolicy({
+  apiVersion: 'policies.kyverno.io/v1',
+  kind: 'DeletingPolicy',
+  metadata: {
+    ...baseMetadata,
+    name: 'cleanup-completed-jobs',
+  },
+  spec: {
+    schedule: '0 0 * * *',
+    matchConstraints: {
+      resourceRules: [
+        {
+          apiGroups: ['batch'],
+          apiVersions: ['v1'],
+          operations: ['DELETE'],
+          resources: ['jobs'],
+        },
+      ],
+    },
+    conditions: {
+      all: [
+        {
+          key: '{{ request.object.status.completionTime }}',
+          operator: 'NotEquals',
+          value: '',
+        },
+      ],
+    },
+  },
+  status: readyStatus,
+});
+
+export default {
+  title: 'Kyverno/CELPolicyViewer',
+  component: CELPolicyViewer,
+} as Meta<typeof CELPolicyViewer>;
+
+export const Validating = () => <CELPolicyViewer policy={validatingPolicy} />;
+
+export const Mutating = () => <CELPolicyViewer policy={mutatingPolicy} />;
+
+export const Generating = () => <CELPolicyViewer policy={generatingPolicy} />;
+
+export const Deleting = () => <CELPolicyViewer policy={deletingPolicy} />;


### PR DESCRIPTION
## Summary

Adds Storybook coverage for the Kyverno `CELPolicyViewer` component.

This PR introduces stories for all supported CEL policy types:

* ValidatingPolicy
* MutatingPolicy
* GeneratingPolicy
* DeletingPolicy

The stories use representative policy fixtures to exercise the different sections rendered by the viewer without requiring a live cluster.

## Related Issue

Fixes #845 

## Changes

* Added `src/components/CELPolicyViewer.stories.tsx`
* Added Storybook coverage for all supported CEL policy types
* Added representative fixtures for validations, mutations, generators, audit annotations, and deletion conditions

## Steps to Test

```bash
npm run format
npm run lint-fix
npm run lint
npm run tsc
npm run test
npm run storybook-build
```

## Notes for the Reviewer

* Adds Storybook coverage for `CELPolicyViewer`.
* Uses static policy fixtures for deterministic rendering.
* No functional changes.
