### PR TITLE
feat: Implement Argo CD Application CRD model and List View

### DIFF
--- a/argocd/README.md
+++ b/argocd/README.md
@@ -21,3 +21,53 @@ Extend the Projects view to include Argo CD context per project, showing associa
 ## Development
 
 Run `npm install` and then `npm run start` to begin development.
+
+## Local Testing with Mock Data
+
+If you don't have a full Argo CD installation, you can use the provided test manifests to create mock data in your cluster. This is useful for developing and testing the plugin UI without a full Argo CD deployment.
+
+### Steps
+
+1. **Create the Argo CD Application CRD** (this teaches Kubernetes about the Application resource type):
+
+   ```bash
+   kubectl apply -f test-files/deploy/crd.yaml
+   ```
+
+2. **Create the `argocd` namespace** (required for the sample Application):
+
+   ```bash
+   kubectl create namespace argocd
+   ```
+
+3. **Deploy the sample Application resource**:
+
+   ```bash
+   kubectl apply -f test-files/deploy/application.yaml
+   ```
+
+4. **Build and install the plugin**:
+
+   ```bash
+   npm install
+   npm run build
+   ```
+
+5. Copy the contents of the `dist/` folder to your Headlamp plugins directory:
+   - **Linux/macOS**: `~/.config/Headlamp/plugins/argocd/`
+   - **Windows**: `%APPDATA%\Headlamp\Config\plugins\argocd\`
+
+6. **Launch Headlamp** and navigate to the **Argo CD > Applications** sidebar entry to see the mock `guestbook` application.
+
+### Verifying the mock data
+
+```bash
+kubectl get applications -n argocd
+```
+
+You should see:
+
+```
+NAME        AGE
+guestbook   Xs
+```

--- a/argocd/src/components/applications/List.tsx
+++ b/argocd/src/components/applications/List.tsx
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ResourceListView, StatusLabel } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { ArgoApplication } from '../../resources/application';
+
+/**
+ * Maps an Argo CD health status string to a Headlamp StatusLabel severity.
+ *
+ * @param health - The health status string from the Application resource
+ *   (e.g., "Healthy", "Degraded", "Progressing", "Suspended", "Missing").
+ * @returns A StatusLabel status string: "success", "warning", "info", "error",
+ *   or "" for unknown values.
+ */
+function getHealthStatus(health: string): string {
+  switch (health.toLowerCase()) {
+    case 'healthy':
+      return 'success';
+    case 'suspended':
+      return 'warning';
+    case 'progressing':
+      return 'info';
+    case 'degraded':
+    case 'missing':
+      return 'error';
+    default:
+      return '';
+  }
+}
+
+/**
+ * Maps an Argo CD sync status string to a Headlamp StatusLabel severity.
+ *
+ * @param sync - The sync status string from the Application resource
+ *   (e.g., "Synced", "OutOfSync").
+ * @returns A StatusLabel status string: "success", "warning",
+ *   or "" for unknown values.
+ */
+function getSyncStatus(sync: string): string {
+  switch (sync.toLowerCase()) {
+    case 'synced':
+      return 'success';
+    case 'outofsync':
+      return 'warning';
+    default:
+      return '';
+  }
+}
+
+/**
+ * Renders a table of all Argo CD Application resources in the current cluster.
+ *
+ * Uses Headlamp's built-in {@link ResourceListView} component to display
+ * applications with custom columns for project, source repository,
+ * sync status, and health status. Status columns are rendered as
+ * color-coded badges using {@link StatusLabel}.
+ *
+ * @returns The Application list view React element.
+ */
+export default function ApplicationList() {
+  return (
+    <ResourceListView
+      title="Argo CD Applications"
+      resourceClass={ArgoApplication}
+      columns={[
+        'name',
+        'namespace',
+        {
+          id: 'project',
+          label: 'Project',
+          getValue: (app: ArgoApplication) => app.project,
+        },
+        {
+          id: 'source-repo',
+          label: 'Source Repo',
+          getValue: (app: ArgoApplication) => app.repoURL,
+        },
+        {
+          id: 'target-revision',
+          label: 'Target Revision',
+          getValue: (app: ArgoApplication) => app.targetRevision,
+        },
+        {
+          id: 'sync-status',
+          label: 'Sync Status',
+          getValue: (app: ArgoApplication) => app.syncStatus,
+          render: (app: ArgoApplication) => (
+            <StatusLabel status={getSyncStatus(app.syncStatus)}>{app.syncStatus}</StatusLabel>
+          ),
+        },
+        {
+          id: 'health-status',
+          label: 'Health Status',
+          getValue: (app: ArgoApplication) => app.healthStatus,
+          render: (app: ArgoApplication) => (
+            <StatusLabel status={getHealthStatus(app.healthStatus)}>{app.healthStatus}</StatusLabel>
+          ),
+        },
+        'age',
+      ]}
+    />
+  );
+}

--- a/argocd/src/index.test.tsx
+++ b/argocd/src/index.test.tsx
@@ -24,6 +24,21 @@ const { mockRegisterRoute, mockRegisterSidebarEntry } = vi.hoisted(() => ({
 vi.mock('@kinvolk/headlamp-plugin/lib', () => ({
   registerRoute: mockRegisterRoute,
   registerSidebarEntry: mockRegisterSidebarEntry,
+  K8s: {
+    cluster: {
+      KubeObject: class KubeObject {
+        jsonData: any;
+        constructor(jsonData: any) {
+          this.jsonData = jsonData;
+        }
+      },
+    },
+  },
+}));
+
+vi.mock('@kinvolk/headlamp-plugin/lib/CommonComponents', () => ({
+  ResourceListView: () => null,
+  StatusLabel: () => null,
 }));
 
 // Static import triggers the module's top-level registration calls.
@@ -31,12 +46,12 @@ vi.mock('@kinvolk/headlamp-plugin/lib', () => ({
 import './index';
 
 describe('argocd plugin', () => {
-  it('should register the /argocd route and sidebar entry', () => {
+  it('should register the /argocd/applications route and sidebar entries', () => {
     expect(mockRegisterRoute).toHaveBeenCalledWith(
       expect.objectContaining({
-        path: '/argocd',
-        name: 'argocd',
-        sidebar: 'argocd',
+        path: '/argocd/applications',
+        name: 'argocd-applications-list',
+        sidebar: 'argocd-applications',
         exact: true,
       })
     );
@@ -45,8 +60,17 @@ describe('argocd plugin', () => {
       expect.objectContaining({
         name: 'argocd',
         label: 'Argo CD',
-        url: '/argocd',
+        url: '/argocd/applications',
         parent: null,
+      })
+    );
+
+    expect(mockRegisterSidebarEntry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'argocd-applications',
+        label: 'Applications',
+        url: '/argocd/applications',
+        parent: 'argocd',
       })
     );
   });

--- a/argocd/src/index.tsx
+++ b/argocd/src/index.tsx
@@ -15,36 +15,27 @@
  */
 
 import { registerRoute, registerSidebarEntry } from '@kinvolk/headlamp-plugin/lib';
-
-// Below are some imports you may want to use.
-//   See README.md for links to plugin development documentation.
-// import { Headlamp, K8s, useTranslation } from '@kinvolk/headlamp-plugin/lib';
-// import { SectionBox } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
-// import { K8s } from '@kinvolk/headlamp-plugin/lib/K8s';
-// import { Typography } from '@mui/material';
-
-function ArgoCDDashboard() {
-  return <div>Argo CD Dashboard (Coming Soon)</div>;
-}
+import ApplicationList from './components/applications/List';
 
 registerRoute({
-  path: '/argocd',
-  sidebar: 'argocd',
-  name: 'argocd',
+  path: '/argocd/applications',
+  sidebar: 'argocd-applications',
+  name: 'argocd-applications-list',
   exact: true,
-  component: () => <ArgoCDDashboard />,
+  component: () => <ApplicationList />,
 });
 
 registerSidebarEntry({
   parent: null,
   name: 'argocd',
   label: 'Argo CD',
-  url: '/argocd',
+  url: '/argocd/applications',
   icon: 'mdi:application-cog',
 });
 
-// Example of using i18n (internationalization):
-// function MyComponent() {
-//   const { t } = useTranslation();
-//   return <div>{t('translation_key')}</div>;
-// }
+registerSidebarEntry({
+  parent: 'argocd',
+  name: 'argocd-applications',
+  label: 'Applications',
+  url: '/argocd/applications',
+});

--- a/argocd/src/resources/application.ts
+++ b/argocd/src/resources/application.ts
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Note: We import via K8s.cluster rather than the direct path
+// '@kinvolk/headlamp-plugin/lib/k8s/cluster' because the latter is a virtual
+// module that only resolves at build time (via Vite externals), not during
+// Vitest test runs. Other plugins using the direct path do not have unit tests
+// that exercise this import.
+import { K8s } from '@kinvolk/headlamp-plugin/lib';
+
+const { KubeObject } = K8s.cluster;
+type KubeObjectInterface = K8s.cluster.KubeObjectInterface;
+
+/** The Argo CD API group identifier used in CRD definitions. */
+export const argocdApiGroup = 'argoproj.io';
+
+/** The full API version string for Argo CD Application resources. */
+export const argocdApiVersion = 'argoproj.io/v1alpha1';
+
+/**
+ * Represents the desired state (spec) of an Argo CD Application.
+ *
+ * @see https://argo-cd.readthedocs.io/en/stable/operator-manual/declarative-setup/#applications
+ */
+export interface ArgoApplicationSpec {
+  /** The Argo CD project this application belongs to (e.g., "default"). */
+  project: string;
+  /** The Git or Helm source configuration for the application manifests. */
+  source: {
+    /** The URL of the Git repository or Helm chart repository. */
+    repoURL: string;
+    /** The Git branch, tag, or commit SHA to track (e.g., "HEAD", "main"). */
+    targetRevision?: string;
+    /** The directory path within the repository containing the manifests. */
+    path?: string;
+    /** The Helm chart name, if using a Helm chart source instead of a Git path. */
+    chart?: string;
+  };
+  /** The target Kubernetes cluster and namespace for deployment. */
+  destination: {
+    /** The API server URL of the destination cluster. */
+    server?: string;
+    /** The name of the destination cluster (alternative to server URL). */
+    name?: string;
+    /** The target namespace in the destination cluster. */
+    namespace?: string;
+  };
+}
+
+/**
+ * Represents the observed runtime state (status) of an Argo CD Application.
+ *
+ * This is populated by the Argo CD controller and reflects the live state
+ * of the application in the target cluster.
+ */
+export interface ArgoApplicationStatus {
+  /** The health assessment of the application. */
+  health?: {
+    /** The health status string (e.g., "Healthy", "Degraded", "Progressing", "Missing"). */
+    status: string;
+    /** An optional human-readable message providing additional health details. */
+    message?: string;
+  };
+  /** The synchronization state between the desired and live state. */
+  sync?: {
+    /** The sync status string (e.g., "Synced", "OutOfSync"). */
+    status: string;
+  };
+}
+
+/**
+ * The raw Kubernetes JSON shape for an Argo CD Application resource.
+ *
+ * Extends the base KubeObjectInterface with Argo CD-specific spec and status fields.
+ */
+export interface KubeArgoApplication extends KubeObjectInterface {
+  /** The desired state of the Argo CD Application. */
+  spec: ArgoApplicationSpec;
+  /** The observed runtime state of the Argo CD Application, populated by the controller. */
+  status?: ArgoApplicationStatus;
+}
+
+/**
+ * Headlamp KubeObject wrapper for the Argo CD Application CRD.
+ *
+ * This class allows Headlamp to interact with Argo CD Application resources
+ * using the standard Kubernetes API. It provides typed accessor properties
+ * for commonly used spec and status fields.
+ *
+ * @see https://argo-cd.readthedocs.io/en/stable/user-guide/application-specification/
+ */
+export class ArgoApplication extends KubeObject<KubeArgoApplication> {
+  static kind = 'Application';
+  static apiName = 'applications';
+  static apiVersion = argocdApiVersion;
+  static isNamespaced = true;
+
+  // No custom detailsRoute yet; rely on Headlamp defaults until a detail view is implemented.
+
+  /** Returns the application's desired state specification. */
+  get spec(): ArgoApplicationSpec {
+    return this.jsonData.spec;
+  }
+
+  /** Returns the application's observed runtime status, or undefined if not yet available. */
+  get status(): ArgoApplicationStatus | undefined {
+    return this.jsonData.status;
+  }
+
+  /** Returns the Argo CD project name this application belongs to. Defaults to "default". */
+  get project(): string {
+    return this.spec.project || 'default';
+  }
+
+  /** Returns the Git or Helm repository URL for the application source. */
+  get repoURL(): string {
+    return this.spec.source?.repoURL || '';
+  }
+
+  /** Returns the target Git revision (branch, tag, or SHA). Defaults to "HEAD". */
+  get targetRevision(): string {
+    return this.spec.source?.targetRevision || 'HEAD';
+  }
+
+  /** Returns the manifest path within the repository, or the Helm chart name. */
+  get path(): string {
+    return this.spec.source?.path || this.spec.source?.chart || '';
+  }
+
+  /** Returns the destination cluster API server URL or cluster name. */
+  get destinationServer(): string {
+    return this.spec.destination?.server || this.spec.destination?.name || '-';
+  }
+
+  /** Returns the destination namespace in the target cluster. Defaults to "default". */
+  get destinationNamespace(): string {
+    return this.spec.destination?.namespace || 'default';
+  }
+
+  /** Returns the health status string (e.g., "Healthy", "Degraded"). Defaults to "Unknown". */
+  get healthStatus(): string {
+    return this.status?.health?.status || 'Unknown';
+  }
+
+  /** Returns the sync status string (e.g., "Synced", "OutOfSync"). Defaults to "Unknown". */
+  get syncStatus(): string {
+    return this.status?.sync?.status || 'Unknown';
+  }
+}

--- a/argocd/test-files/deploy/application.yaml
+++ b/argocd/test-files/deploy/application.yaml
@@ -1,0 +1,28 @@
+# Sample Argo CD Application resource for local development testing.
+#
+# Prerequisites: The Application CRD must be installed first (see crd.yaml),
+# and the "argocd" namespace must exist.
+#
+# Usage:
+#   kubectl create namespace argocd
+#   kubectl apply -f test-files/deploy/crd.yaml
+#   kubectl apply -f test-files/deploy/application.yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: guestbook
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/argoproj/argocd-example-apps.git
+    targetRevision: HEAD
+    path: guestbook
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: default
+status:
+  health:
+    status: Healthy
+  sync:
+    status: Synced

--- a/argocd/test-files/deploy/crd.yaml
+++ b/argocd/test-files/deploy/crd.yaml
@@ -1,0 +1,28 @@
+# Argo CD Application CRD (Custom Resource Definition)
+#
+# Apply this CRD first to register the Application resource type with Kubernetes.
+# After the CRD is established, apply application.yaml to create sample data.
+#
+# Usage:
+#   kubectl apply -f test-files/deploy/crd.yaml
+#   kubectl apply -f test-files/deploy/application.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: applications.argoproj.io
+spec:
+  group: argoproj.io
+  names:
+    kind: Application
+    listKind: ApplicationList
+    plural: applications
+    singular: application
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: true
+    storage: true


### PR DESCRIPTION
### Summary
This PR implements the core Application UI for the Argo CD Headlamp plugin as part of the LFX Mentorship program (2026 Term 2).

Building upon the initial plugin scaffold, this PR introduces the data model for the Argo CD `Application` Custom Resource Definition (CRD) and provides a fully featured List View. Users can now see their GitOps applications natively within Headlamp, complete with customized columns for Sync and Health statuses.

### Changes
**Added**
* `src/resources/application.ts` — Defined the `ArgoApplication` KubeObject class to model the Argo CD CRD structure.
* `src/components/applications/List.tsx` — Built the Application List View using Headlamp's `ResourceListView`. Includes custom getter logic for `Target Revision`, `Sync Status`, and `Health Status` badges.
* `test-files/deploy/crd.yaml` — Added mock CRD and Application definitions for local testing purposes.

**Changed**
* `src/index.tsx` — Updated the routing to mount the `ApplicationList` component when users click the "Applications" sidebar entry.
* `src/index.test.tsx` — Updated tests to reflect the new component routing.

**Screenshots**

<img width="1917" height="713" alt="Screenshot (128)" src="https://github.com/user-attachments/assets/590d772f-14b9-46a3-b5a0-4963116a2d0b" />

### Steps to Test
1. Have a running Kubernetes cluster with Headlamp accessible.
2. Apply the mock Argo CD CRD and test data:
   ```bash
   kubectl apply -f test-files/deploy/crd.yaml