### PR TITLE
prometheus: Fix formatBytes invalid output

### DIFF
--- a/prometheus/src/util.test.ts
+++ b/prometheus/src/util.test.ts
@@ -1,4 +1,4 @@
-import { getTimeRangeAndStepSize, supportsPrometheusMetrics } from './util';
+import { formatBytes, getTimeRangeAndStepSize, supportsPrometheusMetrics } from './util';
 
 beforeAll(async () => {
   global.TextEncoder = require('util').TextEncoder;
@@ -142,5 +142,17 @@ describe('supportsPrometheusMetrics', () => {
     ['rejects missing resources', undefined, false],
   ])('%s', (_, resource, expected) => {
     expect(supportsPrometheusMetrics(resource)).toBe(expected);
+  });
+});
+
+describe('formatBytes', () => {
+  test.each([
+    [-1, '0.00B'],
+    [NaN, '0.00B'],
+    [Infinity, '0.00B'],
+    [0, '0.00B'],
+    [1023, '1023.00B'],
+  ])('should format %s to %s', (bytes, expected) => {
+    expect(formatBytes(bytes)).toBe(expected);
   });
 });

--- a/prometheus/src/util.ts
+++ b/prometheus/src/util.ts
@@ -335,6 +335,9 @@ export function createDataProcessor(
  * formatBytes(1234567) // Returns "1.18MB"
  */
 export function formatBytes(bytes: number) {
+  if (bytes < 0 || !Number.isFinite(bytes)) {
+    return '0.00B';
+  }
   const units = ['B', 'KB', 'MB', 'GB', 'TB'];
   const i = bytes === 0 ? 0 : Math.floor(Math.log(bytes) / Math.log(1024));
   return (bytes / Math.pow(1024, i)).toFixed(2) + units[i];


### PR DESCRIPTION
 ###  Summary
This PR addresses an issue where the `formatBytes` utility function produces invalid output strings (such as `NaNundefined`) when it receives negative, `NaN`, or non-finite inputs.

Fixes: #853 

### Problem
In `prometheus/src/util.ts`, the `formatBytes` function calculates the logarithm of the input to determine the formatting scale (KB, MB, etc.). However, when the input is:
- **Negative (e.g., `-1`)**: `Math.log(-1)` returns `NaN`, leading to `NaNundefined` UI outputs. This case frequently arises briefly during counter resets or delta calculations in Prometheus metrics.
- **NaN / Infinity**: The scaling calculation evaluates to `NaN` or out-of-bounds indices, causing the UI to render `NaNundefined`.

### Solution
- **Input Validation**: Added validation in `formatBytes` to return a graceful fallback of `"0.00B"` if the input is negative (`bytes < 0`) or not finite (`!Number. isFinite(bytes)`). This aligns with the formatting of `0` bytes.
- **Unit Tests**: Added test coverage in `util.test.ts` to verify the handling.