### PR TITLE
tinkerbell: Add detail views

### DIFF
--- a/tinkerbell/src/components/bmc/jobs/Detail.tsx
+++ b/tinkerbell/src/components/bmc/jobs/Detail.tsx
@@ -11,6 +11,8 @@ import { fallback, renderUnknownValue } from '../../common/detailHelpers';
 
 /**
  * Renders the Tinkerbell BMC Job detail view.
+ *
+ * @returns BMC Job detail page with machine reference, tasks, and timing.
  */
 export function BmcJobDetail() {
   const { namespace, name } = useParams<{ namespace: string; name: string }>();

--- a/tinkerbell/src/components/bmc/jobs/Detail.tsx
+++ b/tinkerbell/src/components/bmc/jobs/Detail.tsx
@@ -1,0 +1,86 @@
+import {
+  ConditionsSection,
+  DetailsGrid,
+  NameValueTable,
+  SectionBox,
+  SimpleTable,
+} from '@kinvolk/headlamp-plugin/lib/components/common';
+import { useParams } from 'react-router-dom';
+import { BmcJob } from '../../../resources/bmcJob';
+import { fallback, renderUnknownValue } from '../../common/detailHelpers';
+
+/**
+ * Renders the Tinkerbell BMC Job detail view.
+ */
+export function BmcJobDetail() {
+  const { namespace, name } = useParams<{ namespace: string; name: string }>();
+
+  return (
+    <DetailsGrid
+      resourceType={BmcJob}
+      name={name}
+      namespace={namespace}
+      withEvents
+      extraInfo={item =>
+        item
+          ? [
+              { name: 'Machine', value: fallback(item.spec?.machineRef?.name) },
+              { name: 'Tasks', value: fallback(item.spec?.tasks?.length) },
+              { name: 'Started', value: fallback(item.status?.startTime) },
+              { name: 'Completed', value: fallback(item.status?.completionTime) },
+            ]
+          : []
+      }
+      extraSections={item =>
+        item
+          ? [
+              {
+                id: 'tinkerbell.bmc-job-machine-ref',
+                section: (
+                  <SectionBox title="Machine Reference">
+                    <NameValueTable
+                      rows={[
+                        { name: 'Name', value: fallback(item.spec?.machineRef?.name) },
+                        { name: 'Namespace', value: fallback(item.spec?.machineRef?.namespace) },
+                      ]}
+                    />
+                  </SectionBox>
+                ),
+              },
+              {
+                id: 'tinkerbell.bmc-job-tasks',
+                section: (
+                  <SectionBox title="Tasks">
+                    <SimpleTable
+                      columns={[
+                        { label: 'Index', getter: (_row, index) => fallback(index + 1) },
+                        { label: 'Task', getter: row => renderUnknownValue(row) },
+                      ]}
+                      data={item.spec?.tasks ?? []}
+                    />
+                  </SectionBox>
+                ),
+              },
+              {
+                id: 'tinkerbell.bmc-job-timing',
+                section: (
+                  <SectionBox title="Timing">
+                    <NameValueTable
+                      rows={[
+                        { name: 'Started', value: fallback(item.status?.startTime) },
+                        { name: 'Completed', value: fallback(item.status?.completionTime) },
+                      ]}
+                    />
+                  </SectionBox>
+                ),
+              },
+              {
+                id: 'tinkerbell.bmc-job-conditions',
+                section: <ConditionsSection resource={item.jsonData} />,
+              },
+            ]
+          : []
+      }
+    />
+  );
+}

--- a/tinkerbell/src/components/bmc/jobs/Detail.tsx
+++ b/tinkerbell/src/components/bmc/jobs/Detail.tsx
@@ -55,10 +55,13 @@ export function BmcJobDetail() {
                   <SectionBox title="Tasks">
                     <SimpleTable
                       columns={[
-                        { label: 'Index', getter: (_row, index) => fallback(index + 1) },
-                        { label: 'Task', getter: row => renderUnknownValue(row) },
+                        { label: 'Index', getter: row => fallback(row.index) },
+                        { label: 'Task', getter: row => renderUnknownValue(row.task) },
                       ]}
-                      data={item.spec?.tasks ?? []}
+                      data={(item.spec?.tasks ?? []).map((task, index) => ({
+                        index: index + 1,
+                        task,
+                      }))}
                     />
                   </SectionBox>
                 ),

--- a/tinkerbell/src/components/bmc/machines/Detail.tsx
+++ b/tinkerbell/src/components/bmc/machines/Detail.tsx
@@ -1,0 +1,60 @@
+import {
+  ConditionsSection,
+  DetailsGrid,
+  NameValueTable,
+  SectionBox,
+} from '@kinvolk/headlamp-plugin/lib/components/common';
+import { useParams } from 'react-router-dom';
+import { BmcMachine } from '../../../resources/bmcMachine';
+import { fallback, renderRecordSection, statusValue } from '../../common/detailHelpers';
+
+/**
+ * Renders the Tinkerbell BMC Machine detail view.
+ */
+export function BmcMachineDetail() {
+  const { namespace, name } = useParams<{ namespace: string; name: string }>();
+
+  return (
+    <DetailsGrid
+      resourceType={BmcMachine}
+      name={name}
+      namespace={namespace}
+      withEvents
+      extraInfo={item =>
+        item
+          ? [
+              { name: 'Power State', value: statusValue(item.status?.powerState) },
+              {
+                name: 'Connection',
+                value: fallback(item.spec?.connection ? 'Configured' : undefined),
+              },
+            ]
+          : []
+      }
+      extraSections={item =>
+        item
+          ? [
+              {
+                id: 'tinkerbell.bmc-machine-power',
+                section: (
+                  <SectionBox title="Power Status">
+                    <NameValueTable
+                      rows={[{ name: 'Power State', value: statusValue(item.status?.powerState) }]}
+                    />
+                  </SectionBox>
+                ),
+              },
+              {
+                id: 'tinkerbell.bmc-machine-connection',
+                section: renderRecordSection('Connection', item.spec?.connection),
+              },
+              {
+                id: 'tinkerbell.bmc-machine-conditions',
+                section: <ConditionsSection resource={item.jsonData} />,
+              },
+            ]
+          : []
+      }
+    />
+  );
+}

--- a/tinkerbell/src/components/bmc/machines/Detail.tsx
+++ b/tinkerbell/src/components/bmc/machines/Detail.tsx
@@ -10,6 +10,8 @@ import { fallback, renderRecordSection, statusValue } from '../../common/detailH
 
 /**
  * Renders the Tinkerbell BMC Machine detail view.
+ *
+ * @returns BMC Machine detail page with power, connection, and conditions.
  */
 export function BmcMachineDetail() {
   const { namespace, name } = useParams<{ namespace: string; name: string }>();

--- a/tinkerbell/src/components/bmc/tasks/Detail.tsx
+++ b/tinkerbell/src/components/bmc/tasks/Detail.tsx
@@ -1,0 +1,84 @@
+import {
+  ConditionsSection,
+  DetailsGrid,
+  NameValueTable,
+  SectionBox,
+} from '@kinvolk/headlamp-plugin/lib/components/common';
+import { useParams } from 'react-router-dom';
+import { BmcTask } from '../../../resources/bmcTask';
+import { fallback, renderRecordSection, renderUnknownValue } from '../../common/detailHelpers';
+
+/**
+ * Renders the Tinkerbell BMC Task detail view.
+ */
+export function BmcTaskDetail() {
+  const { namespace, name } = useParams<{ namespace: string; name: string }>();
+
+  return (
+    <DetailsGrid
+      resourceType={BmcTask}
+      name={name}
+      namespace={namespace}
+      withEvents
+      extraInfo={item =>
+        item
+          ? [
+              {
+                name: 'Operation',
+                value: fallback(item.spec?.task?.type ?? item.spec?.task?.action),
+              },
+              {
+                name: 'Connection',
+                value: fallback(item.spec?.connection ? 'Configured' : undefined),
+              },
+              { name: 'Started', value: fallback(item.status?.startTime) },
+              { name: 'Completed', value: fallback(item.status?.completionTime) },
+            ]
+          : []
+      }
+      extraSections={item =>
+        item
+          ? [
+              {
+                id: 'tinkerbell.bmc-task-operation',
+                section: (
+                  <SectionBox title="Task">
+                    <NameValueTable
+                      rows={[
+                        {
+                          name: 'Operation',
+                          value: fallback(item.spec?.task?.type ?? item.spec?.task?.action),
+                        },
+                        { name: 'Task Data', value: renderUnknownValue(item.spec?.task) },
+                      ]}
+                    />
+                  </SectionBox>
+                ),
+              },
+              {
+                id: 'tinkerbell.bmc-task-connection',
+                section: renderRecordSection('Connection', item.spec?.connection),
+              },
+              {
+                id: 'tinkerbell.bmc-task-timing',
+                section: (
+                  <SectionBox title="Timing">
+                    <NameValueTable
+                      rows={[
+                        { name: 'Started', value: fallback(item.status?.startTime) },
+                        { name: 'Completed', value: fallback(item.status?.completionTime) },
+                      ]}
+                    />
+                  </SectionBox>
+                ),
+              },
+              {
+                id: 'tinkerbell.bmc-task-conditions',
+                section: <ConditionsSection resource={item.jsonData} />,
+              },
+            ]
+          : []
+      }
+    />
+  );
+}

--- a/tinkerbell/src/components/bmc/tasks/Detail.tsx
+++ b/tinkerbell/src/components/bmc/tasks/Detail.tsx
@@ -10,6 +10,8 @@ import { fallback, renderRecordSection, renderUnknownValue } from '../../common/
 
 /**
  * Renders the Tinkerbell BMC Task detail view.
+ *
+ * @returns BMC Task detail page with operation, connection, and timing.
  */
 export function BmcTaskDetail() {
   const { namespace, name } = useParams<{ namespace: string; name: string }>();

--- a/tinkerbell/src/components/common/detailHelpers.tsx
+++ b/tinkerbell/src/components/common/detailHelpers.tsx
@@ -1,0 +1,157 @@
+import {
+  NameValueTable,
+  NameValueTableRow,
+  SectionBox,
+  SimpleTable,
+} from '@kinvolk/headlamp-plugin/lib/components/common';
+import { Typography } from '@mui/material';
+import { booleanLabel, EMPTY_VALUE, fallback, renderStatus } from './listHelpers';
+
+export { fallback };
+
+/**
+ * Renders a status-like value as a table value.
+ *
+ * @param value - Status value read from a Tinkerbell resource.
+ * @returns A status chip or fallback text when absent.
+ */
+export function statusValue(value: unknown) {
+  return fallback(value) === EMPTY_VALUE ? EMPTY_VALUE : renderStatus(value);
+}
+
+/**
+ * Renders an optional boolean value for detail tables.
+ *
+ * @param value - Boolean value read from a Tinkerbell resource.
+ * @returns A readable boolean label or fallback.
+ */
+export function booleanValue(value: boolean | undefined): string {
+  return booleanLabel(value);
+}
+
+/**
+ * Converts a record into rows for a Headlamp NameValueTable.
+ *
+ * @param value - Record to render.
+ * @returns Name/value rows sorted by insertion order.
+ */
+export function recordToRows(value: Record<string, unknown> | undefined): NameValueTableRow[] {
+  if (!value) {
+    return [];
+  }
+
+  return Object.entries(value).map(([name, rowValue]) => ({
+    name,
+    value: renderUnknownValue(rowValue),
+  }));
+}
+
+/**
+ * Renders a section for arbitrary key/value object data.
+ *
+ * @param title - Section title.
+ * @param value - Object data to render.
+ * @returns A section with a name/value table or a fallback row.
+ */
+export function renderRecordSection(title: string, value: Record<string, unknown> | undefined) {
+  const rows = recordToRows(value);
+
+  return (
+    <SectionBox title={title}>
+      <NameValueTable rows={rows.length ? rows : [{ name: 'Data', value: EMPTY_VALUE }]} />
+    </SectionBox>
+  );
+}
+
+/**
+ * Renders a preformatted block for raw text.
+ *
+ * @param title - Section title.
+ * @param value - Text value to show.
+ * @returns A section containing preformatted text or a fallback.
+ */
+export function renderTextSection(title: string, value: string | undefined) {
+  return (
+    <SectionBox title={title}>
+      <Typography
+        component="pre"
+        sx={{
+          fontFamily: 'monospace',
+          fontSize: '0.875rem',
+          margin: 0,
+          overflowX: 'auto',
+          whiteSpace: 'pre-wrap',
+        }}
+      >
+        {fallback(value)}
+      </Typography>
+    </SectionBox>
+  );
+}
+
+/**
+ * Renders arbitrary unknown data safely in detail tables.
+ *
+ * @param value - Unknown value from a custom resource.
+ * @returns A readable primitive or formatted JSON string.
+ */
+export function renderUnknownValue(value: unknown): string {
+  if (value === undefined || value === null || value === '') {
+    return EMPTY_VALUE;
+  }
+
+  if (typeof value === 'object') {
+    return JSON.stringify(maskSensitiveValues(value), null, 2);
+  }
+
+  return String(value);
+}
+
+/**
+ * Masks common sensitive keys in nested custom resource data.
+ *
+ * @param value - Unknown data structure that may contain credentials.
+ * @returns A copy of the data with sensitive values replaced.
+ */
+export function maskSensitiveValues(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(maskSensitiveValues);
+  }
+
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).map(([key, itemValue]) => {
+      const lowerKey = key.toLowerCase();
+      const isSensitive =
+        lowerKey.includes('password') ||
+        lowerKey.includes('token') ||
+        lowerKey.includes('secret') ||
+        lowerKey.includes('credential');
+
+      return [key, isSensitive ? '******' : maskSensitiveValues(itemValue)];
+    })
+  );
+}
+
+/**
+ * Renders an array of objects as a SimpleTable with a fallback row.
+ *
+ * @param title - Section title.
+ * @param columns - Table columns.
+ * @param data - Rows to render.
+ * @returns A section containing a table or empty-state row.
+ */
+export function renderTableSection<T extends object>(
+  title: string,
+  columns: { label: string; getter: (row: T) => React.ReactNode }[],
+  data: T[] | undefined
+) {
+  return (
+    <SectionBox title={title}>
+      <SimpleTable columns={columns} data={data?.length ? data : ([] as T[])} />
+    </SectionBox>
+  );
+}

--- a/tinkerbell/src/components/common/listHelpers.tsx
+++ b/tinkerbell/src/components/common/listHelpers.tsx
@@ -1,4 +1,5 @@
-import { Chip, Typography } from '@mui/material';
+import { StatusLabel, StatusLabelProps } from '@kinvolk/headlamp-plugin/lib/components/common';
+import { Typography } from '@mui/material';
 
 /** Display value used when a list column has no data to show. */
 export const EMPTY_VALUE = '-';
@@ -77,27 +78,27 @@ export function renderFallback(value: unknown) {
 }
 
 /**
- * Renders a status-like value as a small color-coded chip.
+ * Renders a status-like value using Headlamp's standard status label.
  *
  * @param value - Status, state, or phase value read from a resource.
- * @returns A Material UI chip suitable for use in list tables.
+ * @returns A Headlamp status label suitable for use in list tables.
  */
 export function renderStatus(value: unknown) {
   const label = fallback(value);
   const normalized = label.toLowerCase();
 
-  let color: 'default' | 'success' | 'warning' | 'error' | 'info' = 'default';
+  let status: StatusLabelProps['status'] = '';
   if (['ready', 'running', 'success', 'succeeded', 'completed', 'on'].includes(normalized)) {
-    color = 'success';
+    status = 'success';
   } else if (['pending', 'unknown', EMPTY_VALUE.toLowerCase()].includes(normalized)) {
-    color = 'default';
+    status = '';
   } else if (['failed', 'failure', 'error', 'timed out', 'timeout', 'off'].includes(normalized)) {
-    color = 'error';
+    status = 'error';
   } else if (['warning', 'disabled'].includes(normalized)) {
-    color = 'warning';
+    status = 'warning';
   } else {
-    color = 'info';
+    status = '';
   }
 
-  return <Chip label={label} color={color} size="small" variant="outlined" />;
+  return <StatusLabel status={status}>{label}</StatusLabel>;
 }

--- a/tinkerbell/src/components/hardware/Detail.tsx
+++ b/tinkerbell/src/components/hardware/Detail.tsx
@@ -17,6 +17,8 @@ import {
 
 /**
  * Renders the Tinkerbell Hardware detail view.
+ *
+ * @returns Hardware detail page with interfaces, disks, references, and data sections.
  */
 export function HardwareDetail() {
   const { namespace, name } = useParams<{ namespace: string; name: string }>();

--- a/tinkerbell/src/components/hardware/Detail.tsx
+++ b/tinkerbell/src/components/hardware/Detail.tsx
@@ -1,0 +1,128 @@
+import {
+  ConditionsSection,
+  DetailsGrid,
+  NameValueTable,
+  SectionBox,
+  SimpleTable,
+} from '@kinvolk/headlamp-plugin/lib/components/common';
+import { useParams } from 'react-router-dom';
+import { Hardware } from '../../resources/hardware';
+import {
+  booleanValue,
+  fallback,
+  renderRecordSection,
+  renderTextSection,
+  statusValue,
+} from '../common/detailHelpers';
+
+/**
+ * Renders the Tinkerbell Hardware detail view.
+ */
+export function HardwareDetail() {
+  const { namespace, name } = useParams<{ namespace: string; name: string }>();
+
+  return (
+    <DetailsGrid
+      resourceType={Hardware}
+      name={name}
+      namespace={namespace}
+      withEvents
+      extraInfo={item =>
+        item
+          ? [
+              { name: 'Status', value: statusValue(item.status?.state) },
+              { name: 'Agent ID', value: fallback(item.spec?.agentID) },
+              {
+                name: 'Auto Enrollment',
+                value: booleanValue(item.spec?.auto?.enrollmentEnabled),
+              },
+              { name: 'BMC Ref', value: fallback(item.spec?.bmcRef?.name) },
+              { name: 'CPU', value: fallback(item.spec?.resources?.cpu) },
+              { name: 'Memory', value: fallback(item.spec?.resources?.memory) },
+              { name: 'Storage', value: fallback(item.spec?.resources?.storage) },
+              { name: 'Tink Version', value: fallback(item.spec?.tinkVersion) },
+            ]
+          : []
+      }
+      extraSections={item =>
+        item
+          ? [
+              {
+                id: 'tinkerbell.hardware-interfaces',
+                section: (
+                  <SectionBox title="Interfaces">
+                    <SimpleTable
+                      columns={[
+                        { label: 'MAC', getter: row => fallback(row.dhcp?.mac) },
+                        { label: 'Hostname', getter: row => fallback(row.dhcp?.hostname) },
+                        { label: 'IP Address', getter: row => fallback(row.dhcp?.ip?.address) },
+                        { label: 'Gateway', getter: row => fallback(row.dhcp?.ip?.gateway) },
+                        { label: 'Netmask', getter: row => fallback(row.dhcp?.ip?.netmask) },
+                        { label: 'Arch', getter: row => fallback(row.dhcp?.arch) },
+                        { label: 'UEFI', getter: row => booleanValue(row.dhcp?.uefi) },
+                        { label: 'PXE', getter: row => booleanValue(row.netboot?.allowPXE) },
+                        {
+                          label: 'Workflow Boot',
+                          getter: row => booleanValue(row.netboot?.allowWorkflow),
+                        },
+                      ]}
+                      data={item.spec?.interfaces ?? []}
+                    />
+                  </SectionBox>
+                ),
+              },
+              {
+                id: 'tinkerbell.hardware-disks',
+                section: (
+                  <SectionBox title="Disks">
+                    <SimpleTable
+                      columns={[
+                        { label: 'Device', getter: row => fallback(row.device) },
+                        { label: 'Wipe Table', getter: row => booleanValue(row.wipeTable) },
+                      ]}
+                      data={item.spec?.disks ?? []}
+                    />
+                  </SectionBox>
+                ),
+              },
+              {
+                id: 'tinkerbell.hardware-bmc-ref',
+                section: (
+                  <SectionBox title="BMC Reference">
+                    <NameValueTable
+                      rows={[
+                        { name: 'Name', value: fallback(item.spec?.bmcRef?.name) },
+                        { name: 'Namespace', value: fallback(item.spec?.bmcRef?.namespace) },
+                        { name: 'Kind', value: fallback(item.spec?.bmcRef?.kind) },
+                        { name: 'API Group', value: fallback(item.spec?.bmcRef?.apiGroup) },
+                      ]}
+                    />
+                  </SectionBox>
+                ),
+              },
+              {
+                id: 'tinkerbell.hardware-conditions',
+                section: <ConditionsSection resource={item.jsonData} />,
+              },
+              {
+                id: 'tinkerbell.hardware-metadata',
+                section: renderRecordSection('Hardware Metadata', item.spec?.metadata),
+              },
+              {
+                id: 'tinkerbell.hardware-references',
+                section: renderRecordSection('References', item.spec?.references),
+              },
+              {
+                id: 'tinkerbell.hardware-user-data',
+                section: renderTextSection('User Data', item.spec?.userData),
+              },
+              {
+                id: 'tinkerbell.hardware-vendor-data',
+                section: renderTextSection('Vendor Data', item.spec?.vendorData),
+              },
+            ]
+          : []
+      }
+    />
+  );
+}

--- a/tinkerbell/src/components/templates/Detail.tsx
+++ b/tinkerbell/src/components/templates/Detail.tsx
@@ -1,0 +1,215 @@
+import {
+  DetailsGrid,
+  NameValueTable,
+  SectionBox,
+  SimpleTable,
+} from '@kinvolk/headlamp-plugin/lib/components/common';
+import { useParams } from 'react-router-dom';
+import { normalizeState } from '../../resources/common';
+import { Template } from '../../resources/template';
+import { fallback, renderTextSection, statusValue } from '../common/detailHelpers';
+
+interface ParsedTemplateTask {
+  name: string;
+  worker?: string;
+  actionCount: number;
+  volumeCount: number;
+}
+
+interface ParsedTemplateAction {
+  taskName: string;
+  name: string;
+  image?: string;
+  timeout?: string;
+}
+
+interface ParsedTemplate {
+  name?: string;
+  globalTimeout?: string;
+  tasks: ParsedTemplateTask[];
+  actions: ParsedTemplateAction[];
+}
+
+/**
+ * Parses the common Tinkerbell template fields used in the detail summary.
+ *
+ * @param data - Template YAML stored in `spec.data`.
+ * @returns A best-effort parsed template summary.
+ */
+function parseTemplateData(data: string | undefined): ParsedTemplate {
+  if (!data) {
+    return { tasks: [], actions: [] };
+  }
+
+  const lines = data.split('\n');
+  const templateName = lines
+    .find(line => /^\s*name:\s*/.test(line))
+    ?.split(/name:\s*/)[1]
+    ?.trim();
+  const globalTimeout = lines
+    .find(line => /^\s*global_timeout:\s*/.test(line))
+    ?.split(/global_timeout:\s*/)[1]
+    ?.trim();
+  const tasksIndex = lines.findIndex(line => /^\s*tasks:\s*$/.test(line));
+
+  if (tasksIndex === -1) {
+    return { name: templateName, globalTimeout, tasks: [], actions: [] };
+  }
+
+  const tasksIndent = lines[tasksIndex].search(/\S/);
+  const taskEntries: { lineIndex: number; indent: number; name: string }[] = [];
+
+  for (const [offset, line] of lines.slice(tasksIndex + 1).entries()) {
+    if (!line.trim()) {
+      continue;
+    }
+
+    const indent = line.search(/\S/);
+    if (indent <= tasksIndent) {
+      break;
+    }
+
+    const name = line.match(/^\s*-\s+name:\s*"?([^"]+)"?/)?.[1];
+    if (name) {
+      taskEntries.push({ lineIndex: tasksIndex + 1 + offset, indent, name });
+    }
+  }
+
+  const taskIndent = Math.min(...taskEntries.map(task => task.indent));
+  const topLevelTasks = taskEntries.filter(task => task.indent === taskIndent);
+  const tasks = topLevelTasks.map((task, index) => {
+    const nextTask = topLevelTasks[index + 1];
+    const taskLines = lines.slice(task.lineIndex, nextTask?.lineIndex);
+    const worker = taskLines
+      .find(line => /^\s*worker:\s*/.test(line))
+      ?.split(/worker:\s*/)[1]
+      ?.replace(/"/g, '')
+      ?.trim();
+
+    return {
+      name: task.name,
+      worker,
+      actionCount: taskLines.filter(line => /^\s*-\s+name:/.test(line)).length - 1,
+      volumeCount: taskLines.filter(line => /^\s*-\s+[^:]+:[^/]*\//.test(line)).length,
+    };
+  });
+
+  const actions = topLevelTasks.flatMap((task, index) => {
+    const nextTask = topLevelTasks[index + 1];
+    const taskLines = lines.slice(task.lineIndex, nextTask?.lineIndex);
+
+    return taskLines.reduce<ParsedTemplateAction[]>((actions, line, lineIndex) => {
+      const actionName = line.match(/^\s*-\s+name:\s*"?([^"]+)"?/)?.[1];
+      if (!actionName || lineIndex === 0) {
+        return actions;
+      }
+
+      const followingLines = taskLines.slice(lineIndex, lineIndex + 8);
+      actions.push({
+        taskName: task.name,
+        name: actionName,
+        image: followingLines
+          .find(nextLine => /^\s*image:\s*/.test(nextLine))
+          ?.split(/image:\s*/)[1]
+          ?.trim(),
+        timeout: followingLines
+          .find(nextLine => /^\s*timeout:\s*/.test(nextLine))
+          ?.split(/timeout:\s*/)[1]
+          ?.trim(),
+      });
+
+      return actions;
+    }, []);
+  });
+
+  return { name: templateName, globalTimeout, tasks, actions };
+}
+
+/**
+ * Renders the Tinkerbell Template detail view.
+ */
+export function TemplateDetail() {
+  const { namespace, name } = useParams<{ namespace: string; name: string }>();
+
+  return (
+    <DetailsGrid
+      resourceType={Template}
+      name={name}
+      namespace={namespace}
+      withEvents
+      extraInfo={item => {
+        const parsedTemplate = parseTemplateData(item?.data);
+
+        return item
+          ? [
+              { name: 'Status', value: statusValue(normalizeState(item.status?.state)) },
+              { name: 'Template Name', value: fallback(parsedTemplate.name) },
+              { name: 'Global Timeout', value: fallback(parsedTemplate.globalTimeout) },
+              { name: 'Tasks', value: fallback(parsedTemplate.tasks.length) },
+              { name: 'Actions', value: fallback(parsedTemplate.actions.length) },
+              { name: 'Template Data Size', value: fallback(`${item.data?.length ?? 0} chars`) },
+            ]
+          : [];
+      }}
+      extraSections={item => {
+        const parsedTemplate = parseTemplateData(item?.data);
+
+        return item
+          ? [
+              {
+                id: 'tinkerbell.template-summary',
+                section: (
+                  <SectionBox title="Template Summary">
+                    <NameValueTable
+                      rows={[
+                        { name: 'Name', value: fallback(parsedTemplate.name) },
+                        { name: 'Global Timeout', value: fallback(parsedTemplate.globalTimeout) },
+                        { name: 'Tasks', value: fallback(parsedTemplate.tasks.length) },
+                        { name: 'Actions', value: fallback(parsedTemplate.actions.length) },
+                      ]}
+                    />
+                  </SectionBox>
+                ),
+              },
+              {
+                id: 'tinkerbell.template-tasks',
+                section: (
+                  <SectionBox title="Tasks">
+                    <SimpleTable
+                      columns={[
+                        { label: 'Name', getter: row => row.name },
+                        { label: 'Worker', getter: row => fallback(row.worker) },
+                        { label: 'Actions', getter: row => fallback(row.actionCount) },
+                        { label: 'Volumes', getter: row => fallback(row.volumeCount) },
+                      ]}
+                      data={parsedTemplate.tasks}
+                    />
+                  </SectionBox>
+                ),
+              },
+              {
+                id: 'tinkerbell.template-actions',
+                section: (
+                  <SectionBox title="Actions">
+                    <SimpleTable
+                      columns={[
+                        { label: 'Task', getter: row => row.taskName },
+                        { label: 'Action', getter: row => row.name },
+                        { label: 'Image', getter: row => fallback(row.image) },
+                        { label: 'Timeout', getter: row => fallback(row.timeout) },
+                      ]}
+                      data={parsedTemplate.actions}
+                    />
+                  </SectionBox>
+                ),
+              },
+              {
+                id: 'tinkerbell.template-data',
+                section: renderTextSection('Raw Template Data', item.data),
+              },
+            ]
+          : [];
+      }}
+    />
+  );
+}

--- a/tinkerbell/src/components/templates/Detail.tsx
+++ b/tinkerbell/src/components/templates/Detail.tsx
@@ -9,24 +9,39 @@ import { normalizeState } from '../../resources/common';
 import { Template } from '../../resources/template';
 import { fallback, renderTextSection, statusValue } from '../common/detailHelpers';
 
+/** Parsed summary for one task in a Tinkerbell template. */
 interface ParsedTemplateTask {
+  /** Task name from the template data. */
   name: string;
+  /** Worker selector or worker value used by the task. */
   worker?: string;
+  /** Number of actions parsed for this task. */
   actionCount: number;
+  /** Number of volume entries parsed for this task. */
   volumeCount: number;
 }
 
+/** Parsed summary for one action in a Tinkerbell template task. */
 interface ParsedTemplateAction {
+  /** Name of the parent task that contains this action. */
   taskName: string;
+  /** Action name from the template data. */
   name: string;
+  /** Container image used by the action, when present. */
   image?: string;
+  /** Action timeout value, when present. */
   timeout?: string;
 }
 
+/** Best-effort parsed summary of template YAML stored in `spec.data`. */
 interface ParsedTemplate {
+  /** Template name from the embedded template YAML. */
   name?: string;
+  /** Global timeout from the embedded template YAML. */
   globalTimeout?: string;
+  /** Parsed task summaries. */
   tasks: ParsedTemplateTask[];
+  /** Parsed action summaries across all tasks. */
   actions: ParsedTemplateAction[];
 }
 
@@ -127,6 +142,8 @@ function parseTemplateData(data: string | undefined): ParsedTemplate {
 
 /**
  * Renders the Tinkerbell Template detail view.
+ *
+ * @returns Template detail page with summary, parsed tasks, actions, and raw data.
  */
 export function TemplateDetail() {
   const { namespace, name } = useParams<{ namespace: string; name: string }>();

--- a/tinkerbell/src/components/workflowrulesets/Detail.tsx
+++ b/tinkerbell/src/components/workflowrulesets/Detail.tsx
@@ -10,6 +10,8 @@ import { fallback, renderRecordSection, renderUnknownValue } from '../common/det
 
 /**
  * Renders the Tinkerbell WorkflowRuleSet detail view.
+ *
+ * @returns WorkflowRuleSet detail page with rules and workflow config.
  */
 export function WorkflowRuleSetDetail() {
   const { namespace, name } = useParams<{ namespace: string; name: string }>();

--- a/tinkerbell/src/components/workflowrulesets/Detail.tsx
+++ b/tinkerbell/src/components/workflowrulesets/Detail.tsx
@@ -1,0 +1,76 @@
+import {
+  DetailsGrid,
+  NameValueTable,
+  SectionBox,
+  SimpleTable,
+} from '@kinvolk/headlamp-plugin/lib/components/common';
+import { useParams } from 'react-router-dom';
+import { WorkflowRuleSet } from '../../resources/workflowRuleSet';
+import { fallback, renderRecordSection, renderUnknownValue } from '../common/detailHelpers';
+
+/**
+ * Renders the Tinkerbell WorkflowRuleSet detail view.
+ */
+export function WorkflowRuleSetDetail() {
+  const { namespace, name } = useParams<{ namespace: string; name: string }>();
+
+  return (
+    <DetailsGrid
+      resourceType={WorkflowRuleSet}
+      name={name}
+      namespace={namespace}
+      withEvents
+      extraInfo={item =>
+        item
+          ? [
+              { name: 'Rules', value: fallback(item.spec?.rules?.length) },
+              {
+                name: 'Workflow Config',
+                value: fallback(item.spec?.workflow ? 'Configured' : undefined),
+              },
+            ]
+          : []
+      }
+      extraSections={item =>
+        item
+          ? [
+              {
+                id: 'tinkerbell.workflowruleset-summary',
+                section: (
+                  <SectionBox title="WorkflowRuleSet Summary">
+                    <NameValueTable
+                      rows={[
+                        { name: 'Rules', value: fallback(item.spec?.rules?.length) },
+                        {
+                          name: 'Workflow Config',
+                          value: fallback(item.spec?.workflow ? 'Configured' : undefined),
+                        },
+                      ]}
+                    />
+                  </SectionBox>
+                ),
+              },
+              {
+                id: 'tinkerbell.workflowruleset-rules',
+                section: (
+                  <SectionBox title="Rules">
+                    <SimpleTable
+                      columns={[
+                        { label: 'Name', getter: row => fallback(row.name) },
+                        { label: 'Rule', getter: row => renderUnknownValue(row) },
+                      ]}
+                      data={item.spec?.rules ?? []}
+                    />
+                  </SectionBox>
+                ),
+              },
+              {
+                id: 'tinkerbell.workflowruleset-workflow',
+                section: renderRecordSection('Workflow Config', item.spec?.workflow),
+              },
+            ]
+          : []
+      }
+    />
+  );
+}

--- a/tinkerbell/src/components/workflows/Detail.tsx
+++ b/tinkerbell/src/components/workflows/Detail.tsx
@@ -1,0 +1,166 @@
+import {
+  ConditionsSection,
+  DetailsGrid,
+  NameValueTable,
+  SectionBox,
+  SimpleTable,
+} from '@kinvolk/headlamp-plugin/lib/components/common';
+import { useParams } from 'react-router-dom';
+import { normalizeState } from '../../resources/common';
+import { Workflow } from '../../resources/workflow';
+import { booleanValue, fallback, renderRecordSection, statusValue } from '../common/detailHelpers';
+
+/**
+ * Renders the Tinkerbell Workflow detail view.
+ */
+export function WorkflowDetail() {
+  const { namespace, name } = useParams<{ namespace: string; name: string }>();
+
+  return (
+    <DetailsGrid
+      resourceType={Workflow}
+      name={name}
+      namespace={namespace}
+      withEvents
+      extraInfo={item =>
+        item
+          ? [
+              {
+                name: 'Status',
+                value: statusValue(normalizeState(item.status?.state ?? item.status?.currentState)),
+              },
+              { name: 'Hardware', value: fallback(item.spec?.hardwareRef) },
+              { name: 'Template', value: fallback(item.spec?.templateRef) },
+              { name: 'Disabled', value: booleanValue(item.spec?.disabled) },
+              { name: 'Agent ID', value: fallback(item.status?.agentID) },
+              { name: 'Global Timeout', value: fallback(item.status?.globalTimeout) },
+              {
+                name: 'Execution Stop',
+                value: booleanValue(item.status?.globalExecutionStop),
+              },
+            ]
+          : []
+      }
+      extraSections={item =>
+        item
+          ? [
+              {
+                id: 'tinkerbell.workflow-references',
+                section: (
+                  <SectionBox title="References">
+                    <NameValueTable
+                      rows={[
+                        { name: 'Hardware', value: fallback(item.spec?.hardwareRef) },
+                        { name: 'Template', value: fallback(item.spec?.templateRef) },
+                      ]}
+                    />
+                  </SectionBox>
+                ),
+              },
+              {
+                id: 'tinkerbell.workflow-boot-options',
+                section: (
+                  <SectionBox title="Boot Options">
+                    <NameValueTable
+                      rows={[
+                        {
+                          name: 'Spec Netboot',
+                          value: booleanValue(item.spec?.bootOptions?.netboot),
+                        },
+                        {
+                          name: 'Spec ISO Boot',
+                          value: booleanValue(item.spec?.bootOptions?.isoboot),
+                        },
+                        {
+                          name: 'Status Netboot',
+                          value: booleanValue(item.status?.bootOptions?.netboot),
+                        },
+                        {
+                          name: 'Status ISO Boot',
+                          value: booleanValue(item.status?.bootOptions?.isoboot),
+                        },
+                      ]}
+                    />
+                  </SectionBox>
+                ),
+              },
+              {
+                id: 'tinkerbell.workflow-hardware-map',
+                section: renderRecordSection('Hardware Map', item.spec?.hardwareMap),
+              },
+              {
+                id: 'tinkerbell.workflow-status',
+                section: (
+                  <SectionBox title="Workflow Status">
+                    <NameValueTable
+                      rows={[
+                        { name: 'State', value: statusValue(normalizeState(item.status?.state)) },
+                        {
+                          name: 'Current State',
+                          value: statusValue(normalizeState(item.status?.currentState)),
+                        },
+                        { name: 'Agent ID', value: fallback(item.status?.agentID) },
+                        { name: 'Global Timeout', value: fallback(item.status?.globalTimeout) },
+                        {
+                          name: 'Global Execution Stop',
+                          value: booleanValue(item.status?.globalExecutionStop),
+                        },
+                      ]}
+                    />
+                  </SectionBox>
+                ),
+              },
+              {
+                id: 'tinkerbell.workflow-tasks',
+                section: (
+                  <SectionBox title="Tasks">
+                    <SimpleTable
+                      columns={[
+                        { label: 'Name', getter: row => fallback(row.name) },
+                        { label: 'State', getter: row => statusValue(normalizeState(row.state)) },
+                        { label: 'Actions', getter: row => fallback(row.actions?.length) },
+                      ]}
+                      data={item.status?.tasks ?? []}
+                    />
+                  </SectionBox>
+                ),
+              },
+              {
+                id: 'tinkerbell.workflow-actions',
+                section: (
+                  <SectionBox title="Actions">
+                    <SimpleTable
+                      columns={[
+                        { label: 'Task', getter: row => fallback(row.taskName) },
+                        { label: 'Action', getter: row => fallback(row.name) },
+                        { label: 'State', getter: row => statusValue(normalizeState(row.state)) },
+                        { label: 'Message', getter: row => fallback(row.message) },
+                        { label: 'Started', getter: row => fallback(row.startedAt) },
+                        { label: 'Seconds', getter: row => fallback(row.seconds) },
+                      ]}
+                      data={
+                        item.status?.tasks?.flatMap(task =>
+                          (task.actions ?? []).map(action => ({
+                            taskName: task.name,
+                            ...action,
+                          }))
+                        ) ?? []
+                      }
+                    />
+                  </SectionBox>
+                ),
+              },
+              {
+                id: 'tinkerbell.workflow-template-rendering',
+                section: renderRecordSection('Template Rendering', item.status?.templateRendering),
+              },
+              {
+                id: 'tinkerbell.workflow-conditions',
+                section: <ConditionsSection resource={item.jsonData} />,
+              },
+            ]
+          : []
+      }
+    />
+  );
+}

--- a/tinkerbell/src/components/workflows/Detail.tsx
+++ b/tinkerbell/src/components/workflows/Detail.tsx
@@ -12,6 +12,8 @@ import { booleanValue, fallback, renderRecordSection, statusValue } from '../com
 
 /**
  * Renders the Tinkerbell Workflow detail view.
+ *
+ * @returns Workflow detail page with references, status, tasks, and actions.
  */
 export function WorkflowDetail() {
   const { namespace, name } = useParams<{ namespace: string; name: string }>();

--- a/tinkerbell/src/index.tsx
+++ b/tinkerbell/src/index.tsx
@@ -19,14 +19,21 @@ import {
   registerRoute,
   registerSidebarEntry,
 } from '@kinvolk/headlamp-plugin/lib';
+import { BmcJobDetail } from './components/bmc/jobs/Detail';
 import { BmcJobList } from './components/bmc/jobs/List';
+import { BmcMachineDetail } from './components/bmc/machines/Detail';
 import { BmcMachineList } from './components/bmc/machines/List';
+import { BmcTaskDetail } from './components/bmc/tasks/Detail';
 import { BmcTaskList } from './components/bmc/tasks/List';
 import { TinkerbellRouteWrapper } from './components/common/TinkerbellRouteWrapper';
 import { CrdList } from './components/crds/List';
+import { HardwareDetail } from './components/hardware/Detail';
 import { HardwareList } from './components/hardware/List';
+import { TemplateDetail } from './components/templates/Detail';
 import { TemplateList } from './components/templates/List';
+import { WorkflowRuleSetDetail } from './components/workflowrulesets/Detail';
 import { WorkflowRuleSetList } from './components/workflowrulesets/List';
+import { WorkflowDetail } from './components/workflows/Detail';
 import { WorkflowList } from './components/workflows/List';
 import { BmcJob } from './resources/bmcJob';
 import { BmcMachine } from './resources/bmcMachine';
@@ -70,6 +77,18 @@ registerRoute({
   name: 'tinkerbell-hardware',
 });
 
+registerRoute({
+  path: '/tinkerbell/hardware/:namespace/:name',
+  sidebar: 'tinkerbell-hardware',
+  component: () => (
+    <TinkerbellRouteWrapper requiredCrds={[Hardware.crdName]}>
+      <HardwareDetail />
+    </TinkerbellRouteWrapper>
+  ),
+  exact: true,
+  name: 'tinkerbell-hardware-detail',
+});
+
 registerSidebarEntry({
   parent: 'tinkerbell',
   name: 'tinkerbell-templates',
@@ -87,6 +106,18 @@ registerRoute({
   ),
   exact: true,
   name: 'tinkerbell-templates',
+});
+
+registerRoute({
+  path: '/tinkerbell/templates/:namespace/:name',
+  sidebar: 'tinkerbell-templates',
+  component: () => (
+    <TinkerbellRouteWrapper requiredCrds={[Template.crdName]}>
+      <TemplateDetail />
+    </TinkerbellRouteWrapper>
+  ),
+  exact: true,
+  name: 'tinkerbell-template-detail',
 });
 
 registerSidebarEntry({
@@ -108,6 +139,18 @@ registerRoute({
   name: 'tinkerbell-workflows',
 });
 
+registerRoute({
+  path: '/tinkerbell/workflows/:namespace/:name',
+  sidebar: 'tinkerbell-workflows',
+  component: () => (
+    <TinkerbellRouteWrapper requiredCrds={[Workflow.crdName]}>
+      <WorkflowDetail />
+    </TinkerbellRouteWrapper>
+  ),
+  exact: true,
+  name: 'tinkerbell-workflow-detail',
+});
+
 registerSidebarEntry({
   parent: 'tinkerbell',
   name: 'tinkerbell-workflow-rulesets',
@@ -125,6 +168,18 @@ registerRoute({
   ),
   exact: true,
   name: 'tinkerbell-workflow-rulesets',
+});
+
+registerRoute({
+  path: '/tinkerbell/workflows/rulesets/:namespace/:name',
+  sidebar: 'tinkerbell-workflow-rulesets',
+  component: () => (
+    <TinkerbellRouteWrapper requiredCrds={[WorkflowRuleSet.crdName]}>
+      <WorkflowRuleSetDetail />
+    </TinkerbellRouteWrapper>
+  ),
+  exact: true,
+  name: 'tinkerbell-workflow-ruleset-detail',
 });
 
 registerSidebarEntry({
@@ -153,6 +208,18 @@ registerRoute({
   name: 'tinkerbell-bmc-machines',
 });
 
+registerRoute({
+  path: '/tinkerbell/bmc/machines/:namespace/:name',
+  sidebar: 'tinkerbell-bmc-machines',
+  component: () => (
+    <TinkerbellRouteWrapper requiredCrds={[BmcMachine.crdName]}>
+      <BmcMachineDetail />
+    </TinkerbellRouteWrapper>
+  ),
+  exact: true,
+  name: 'tinkerbell-bmc-machine-detail',
+});
+
 registerSidebarEntry({
   parent: 'tinkerbell-bmc',
   name: 'tinkerbell-bmc-jobs',
@@ -172,6 +239,18 @@ registerRoute({
   name: 'tinkerbell-bmc-jobs',
 });
 
+registerRoute({
+  path: '/tinkerbell/bmc/jobs/:namespace/:name',
+  sidebar: 'tinkerbell-bmc-jobs',
+  component: () => (
+    <TinkerbellRouteWrapper requiredCrds={[BmcJob.crdName]}>
+      <BmcJobDetail />
+    </TinkerbellRouteWrapper>
+  ),
+  exact: true,
+  name: 'tinkerbell-bmc-job-detail',
+});
+
 registerSidebarEntry({
   parent: 'tinkerbell-bmc',
   name: 'tinkerbell-bmc-tasks',
@@ -189,6 +268,18 @@ registerRoute({
   ),
   exact: true,
   name: 'tinkerbell-bmc-tasks',
+});
+
+registerRoute({
+  path: '/tinkerbell/bmc/tasks/:namespace/:name',
+  sidebar: 'tinkerbell-bmc-tasks',
+  component: () => (
+    <TinkerbellRouteWrapper requiredCrds={[BmcTask.crdName]}>
+      <BmcTaskDetail />
+    </TinkerbellRouteWrapper>
+  ),
+  exact: true,
+  name: 'tinkerbell-bmc-task-detail',
 });
 
 registerSidebarEntry({


### PR DESCRIPTION
## Summary

This PR is part of LFX Mentorship 2026 Term 2.

It adds detail views for the Tinkerbell plugin resources, so users can open resources from the list views and inspect structured information in Headlamp.

## Changes

- Add DetailsGrid pages for Hardware, Templates, Workflows, WorkflowRuleSets, and BMC resources.
- Register detail routes for all Tinkerbell resource list pages.
- Show structured sections for interfaces, disks, workflow tasks/actions, template data, BMC connection/timing, conditions, and events.
- Use Headlamp StatusLabel for status rendering to better match Headlamp UI style.
- Add TSDoc documentation for new detail-view helpers and interfaces.

## Testing

- `npm exec -- prettier --config package.json --check src`
- `npm exec -- eslint --cache -c package.json --max-warnings 0 --ext .js,.ts,.tsx src/`
- `npm exec -- tsc --noEmit`
- `npm exec -- vitest -c node_modules/@kinvolk/headlamp-plugin/config/vite.config.mjs --run`
- `npm run build`

## Demo Video

https://github.com/user-attachments/assets/81c7df3d-b5c0-4ad8-8fcb-0f573f014657

