### PR TITLE
flux: fix inventory crash on cluster-scoped resources with a built-in kind name

### DIFF
--- a/flux/src/helm-releases/Inventory.test.tsx
+++ b/flux/src/helm-releases/Inventory.test.tsx
@@ -1,0 +1,44 @@
+import { K8s } from '@kinvolk/headlamp-plugin/lib';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { inventoryNameLink } from './Inventory';
+
+vi.mock('../common/Table', () => ({ default: () => null }));
+
+type HelmItem = Parameters<typeof inventoryNameLink>[0];
+
+function clusterScopedRoleItem(): HelmItem {
+  return {
+    kind: 'Role',
+    groupName: 'iam.aws.upbound.io',
+    apiVersion: 'iam.aws.upbound.io/v1beta1',
+    metadata: { name: 'some-role', namespace: undefined },
+  } as unknown as HelmItem;
+}
+
+function namespacedRoleItem(): HelmItem {
+  return {
+    kind: 'Role',
+    groupName: 'rbac.authorization.k8s.io',
+    apiVersion: 'rbac.authorization.k8s.io/v1',
+    metadata: { name: 'some-role', namespace: 'default' },
+  } as unknown as HelmItem;
+}
+
+describe('helm-releases inventoryNameLink', () => {
+  beforeEach(() => {
+    window.history.pushState({}, '', '/c/test-cluster/');
+  });
+
+  it('resolves a colliding Kind to the built-in namespaced class', () => {
+    expect(K8s.ResourceClasses['Role'].isNamespaced).toBe(true);
+  });
+
+  it('renders the plain name for a cluster-scoped resource with a built-in namespaced Kind', () => {
+    expect(inventoryNameLink(clusterScopedRoleItem())).toBe('some-role');
+  });
+
+  it('still links a namespaced resource that has a namespace', () => {
+    expect(React.isValidElement(inventoryNameLink(namespacedRoleItem()))).toBe(true);
+  });
+});

--- a/flux/src/helm-releases/Inventory.tsx
+++ b/flux/src/helm-releases/Inventory.tsx
@@ -274,7 +274,7 @@ async function fetchResources(
  * @param {Object} item - A Kubernetes resource object.
  * @returns {React.ReactNode} - A link to the resource.
  */
-function inventoryNameLink(item: HelmResourceKind): React.ReactNode {
+export function inventoryNameLink(item: HelmResourceKind): React.ReactNode {
   const kind = item.kind;
   const groupName = item.groupName;
   const pluralName = PluralName(kind);
@@ -303,7 +303,9 @@ function inventoryNameLink(item: HelmResourceKind): React.ReactNode {
   const resourceClass = K8s.ResourceClasses[kind];
   if (resourceClass) {
     const resource = new resourceClass(item);
-    if (resource?.getDetailsLink?.()) {
+    // skip namespaced details link when cluster-scoped resource has no namespace
+    const canBuildLink = !(resource.isNamespaced && !item.metadata.namespace);
+    if (canBuildLink && resource?.getDetailsLink?.()) {
       return <Link kubeObject={resource}>{item.metadata.name}</Link>;
     }
     return item.metadata.name;

--- a/flux/src/kustomizations/Inventory.test.tsx
+++ b/flux/src/kustomizations/Inventory.test.tsx
@@ -1,0 +1,61 @@
+import { K8s } from '@kinvolk/headlamp-plugin/lib';
+import type { KubeObject } from '@kinvolk/headlamp-plugin/lib/lib/k8s/cluster';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { inventoryNameLink } from './Inventory';
+
+vi.mock('../common/Table', () => ({ default: () => null }));
+
+function clusterScopedRoleItem(): KubeObject {
+  return {
+    kind: 'Role',
+    jsonData: {
+      apiVersion: 'iam.aws.upbound.io/v1beta1',
+      kind: 'Role',
+      metadata: { name: 'some-role', creationTimestamp: '2024-01-01T00:00:00Z' },
+    },
+    metadata: {
+      name: 'some-role',
+      namespace: undefined,
+      creationTimestamp: '2024-01-01T00:00:00Z',
+    },
+  } as unknown as KubeObject;
+}
+
+function namespacedRoleItem(): KubeObject {
+  return {
+    kind: 'Role',
+    jsonData: {
+      apiVersion: 'rbac.authorization.k8s.io/v1',
+      kind: 'Role',
+      metadata: {
+        name: 'some-role',
+        namespace: 'default',
+        creationTimestamp: '2024-01-01T00:00:00Z',
+      },
+    },
+    metadata: {
+      name: 'some-role',
+      namespace: 'default',
+      creationTimestamp: '2024-01-01T00:00:00Z',
+    },
+  } as unknown as KubeObject;
+}
+
+describe('inventoryNameLink', () => {
+  beforeEach(() => {
+    window.history.pushState({}, '', '/c/test-cluster/');
+  });
+
+  it('resolves a colliding Kind to the built-in namespaced class', () => {
+    expect(K8s.ResourceClasses['Role'].isNamespaced).toBe(true);
+  });
+
+  it('renders the plain name for a cluster-scoped resource with a built-in namespaced Kind', () => {
+    expect(inventoryNameLink(clusterScopedRoleItem())).toBe('some-role');
+  });
+
+  it('still links a namespaced resource that has a namespace', () => {
+    expect(React.isValidElement(inventoryNameLink(namespacedRoleItem()))).toBe(true);
+  });
+});

--- a/flux/src/kustomizations/Inventory.tsx
+++ b/flux/src/kustomizations/Inventory.tsx
@@ -129,7 +129,7 @@ export function GetResourcesFromInventory(
   );
 }
 
-function inventoryNameLink(item: KubeObject) {
+export function inventoryNameLink(item: KubeObject) {
   // return the name and not a link if we could not query the resource
   if (!item.metadata.creationTimestamp) {
     return item.metadata.name;
@@ -181,7 +181,9 @@ function inventoryNameLink(item: KubeObject) {
   const resourceKind = K8s.ResourceClasses[kind];
   if (resourceKind) {
     const resource = new resourceKind(item);
-    if (resource?.getDetailsLink && resource.getDetailsLink()) {
+    // skip namespaced details link when cluster scoped resource has no namespace
+    const canBuildLink = !(resource.isNamespaced && !item.metadata.namespace);
+    if (canBuildLink && resource?.getDetailsLink && resource.getDetailsLink()) {
       return <Link kubeObject={resource}>{item.metadata.name}</Link>;
     }
     return item.metadata.name;


### PR DESCRIPTION
Fixes #363.

Opening a Flux Kustomization or HelmRelease whose inventory contains a cluster-scoped resource crashes the view.

Root cause: `inventoryNameLink` resolves the resource class with `K8s.ResourceClasses[kind]`, which is keyed by kind name only. A cluster-scoped resource whose kind matches a built-in namespaced kind (the report used an Upbound `Role` from `iam.aws.upbound.io`) resolves to the built-in namespaced class. It has no namespace, so `getDetailsLink()` builds the namespaced route with an undefined `namespace` and throws `Expected "namespace" to be defined`.

Fix: only build the namespaced details link when the class has a namespace, otherwise fall back to the plain name. Applied to both inventory tables (`kustomizations/Inventory.tsx` and `helm-releases/Inventory.tsx`).

Added regression tests for both tables. `npm run tsc`, `npm run lint`, and `npm test` pass.