### PR TITLE
fix: cluster-api/overview: add Updating as negative condition

### DIFF
--- a/cluster-api/src/components/overview/clusterHealth.ts
+++ b/cluster-api/src/components/overview/clusterHealth.ts
@@ -35,6 +35,7 @@ const NEGATIVE_CONDITIONS = new Set([
   'ScalingUp',
   'Paused',
   'Deleting',
+  'Updating',
 ]);
 
 export function isNegativeConditionType(type?: string): boolean {


### PR DESCRIPTION
Hi all,

This PR adds the "Updating" condition found on Machines to a negative condition.

As of right now when Updating is False it's shown in the overview as a warning state, when according to CAPI documentation, the warning state is "True"

<img width="1408" height="668" alt="image" src="https://github.com/user-attachments/assets/f7cab51c-989c-4c45-b353-82ce4df71159" />
<img width="1408" height="230" alt="image" src="https://github.com/user-attachments/assets/e1baaa2e-c38c-4b2a-84d8-d8358a9a8643" />

This is shown once per affected node, so big clusters report a lot of false warnings.