### PR TITLE
kueue: Add Kueue ClusterQueue views

### DIFF
--- a/kueue/README.md
+++ b/kueue/README.md
@@ -6,24 +6,26 @@ See the [Kueue getting started guide](https://kueue.sigs.k8s.io/docs/getting-sta
 
 ## Current Scope
 
-This first skeleton focuses on reading Kueue `ResourceFlavor` resources from the Kubernetes API and displaying them in a basic list page. It registers a Kueue sidebar section with a `ResourceFlavors` entry.
+This plugin currently reads Kueue `ClusterQueue` and `ResourceFlavor` resources from the Kubernetes API and displays them in basic list and detail pages. It registers a Kueue sidebar section with entries for both resources.
 
-Kueue resources such as `ClusterQueue`, `LocalQueue`, `Workload`, and additional queueing views will be added in later PRs.
+Kueue resources such as `LocalQueue`, `Workload`, and additional queueing views will be added in later PRs.
 
 ## Prerequisites
 
 Kueue CRDs must be installed in the cluster before the plugin can list resources. See the [Kueue installation guide](https://kueue.sigs.k8s.io/docs/getting-started/installation/) for installation instructions.
 
-You can check for the `ResourceFlavor` CRD and resources with:
+You can check for the `ClusterQueue` and `ResourceFlavor` CRDs and resources with:
 
 ```bash
+kubectl get crd clusterqueues.kueue.x-k8s.io
 kubectl get crd resourceflavors.kueue.x-k8s.io
+kubectl get clusterqueues
 kubectl get resourceflavors
 ```
 
 ## Test Files
 
-Sample `ResourceFlavor` manifests are available in `test-files/deploy/`.
+Sample `ClusterQueue` and `ResourceFlavor` manifests are available in `test-files/deploy/`.
 
 Apply them to a cluster with Kueue installed:
 
@@ -31,9 +33,10 @@ Apply them to a cluster with Kueue installed:
 kubectl apply -f test-files/deploy/resourceflavor-default.yaml
 kubectl apply -f test-files/deploy/resourceflavor-spot.yaml
 kubectl apply -f test-files/deploy/resourceflavor-topology.yaml
+kubectl apply -f test-files/deploy/clusterqueue-team-a.yaml
 ```
 
-After applying the examples, open `Kueue` > `ResourceFlavors` in Headlamp.
+After applying the examples, open `Kueue` > `ClusterQueues` or `Kueue` > `ResourceFlavors` in Headlamp.
 
 ## Development
 

--- a/kueue/src/components/clusterqueues/Detail.tsx
+++ b/kueue/src/components/clusterqueues/Detail.tsx
@@ -13,6 +13,7 @@ import {
   ResourceQuota,
 } from '../../resources/clusterQueue';
 import { kueueRouteNames } from '../../utils/kueueRoutes';
+import KueueAdminResourceAccess from '../common/KueueAdminResourceAccess';
 
 /** Flattened row rendered in the ClusterQueue resource groups table. */
 interface ResourceGroupRow {
@@ -285,91 +286,93 @@ export default function ClusterQueueDetail() {
   const { name } = useParams<{ name: string }>();
 
   return (
-    <DetailsGrid
-      resourceType={ClusterQueue}
-      name={name}
-      withEvents
-      extraInfo={clusterQueue =>
-        clusterQueue
-          ? [
-              {
-                name: 'Cohort',
-                value: clusterQueue.cohortName,
-              },
-              {
-                name: 'Queueing Strategy',
-                value: clusterQueue.queueingStrategy,
-              },
-              {
-                name: 'Stop Policy',
-                value: clusterQueue.stopPolicy,
-              },
-              {
-                name: 'Namespace Selector',
-                value: clusterQueue.namespaceSelectorDisplay,
-              },
-              {
-                name: 'Pending Workloads',
-                value: clusterQueue.pendingWorkloads,
-              },
-              {
-                name: 'Admitted Workloads',
-                value: clusterQueue.admittedWorkloads,
-              },
-              {
-                name: 'Reserving Workloads',
-                value: clusterQueue.reservingWorkloads,
-              },
-              {
-                name: 'Status',
-                value: clusterQueue.statusDisplay,
-              },
-              {
-                name: 'Referenced ResourceFlavors',
-                value: clusterQueue.referencedFlavorNamesDisplay,
-              },
-              {
-                name: 'Preemption',
-                value: clusterQueue.preemptionDisplay,
-              },
-              {
-                name: 'Flavor Fungibility',
-                value: clusterQueue.flavorFungibilityDisplay,
-              },
-              {
-                name: 'Fair Sharing',
-                value: clusterQueue.fairSharingDisplay,
-              },
-              {
-                name: 'Admission Scope',
-                value: clusterQueue.admissionScopeDisplay,
-              },
-              {
-                name: 'Concurrent Admission',
-                value: clusterQueue.concurrentAdmissionPolicyDisplay,
-              },
-            ]
-          : []
-      }
-      extraSections={clusterQueue =>
-        clusterQueue
-          ? [
-              getConditionsSection(clusterQueue),
-              getResourceGroupsSection(clusterQueue),
-              getAdmissionChecksSection(clusterQueue),
-              getFlavorUsageSection(
-                'Flavor Reservations',
-                'flavor-reservations',
-                clusterQueue.status.flavorsReservation
-              ),
-              getFlavorUsageSection(
-                'Flavor Usage',
-                'flavor-usage',
-                clusterQueue.status.flavorsUsage
-              ),
-            ].filter(Boolean)
-          : []
-      }
-    />
+    <KueueAdminResourceAccess resourceClass={ClusterQueue} resourceLabel="ClusterQueues" verb="get">
+      <DetailsGrid
+        resourceType={ClusterQueue}
+        name={name}
+        withEvents
+        extraInfo={clusterQueue =>
+          clusterQueue
+            ? [
+                {
+                  name: 'Cohort',
+                  value: clusterQueue.cohortName,
+                },
+                {
+                  name: 'Queueing Strategy',
+                  value: clusterQueue.queueingStrategy,
+                },
+                {
+                  name: 'Stop Policy',
+                  value: clusterQueue.stopPolicy,
+                },
+                {
+                  name: 'Namespace Selector',
+                  value: clusterQueue.namespaceSelectorDisplay,
+                },
+                {
+                  name: 'Pending Workloads',
+                  value: clusterQueue.pendingWorkloads,
+                },
+                {
+                  name: 'Admitted Workloads',
+                  value: clusterQueue.admittedWorkloads,
+                },
+                {
+                  name: 'Reserving Workloads',
+                  value: clusterQueue.reservingWorkloads,
+                },
+                {
+                  name: 'Status',
+                  value: clusterQueue.statusDisplay,
+                },
+                {
+                  name: 'Referenced ResourceFlavors',
+                  value: clusterQueue.referencedFlavorNamesDisplay,
+                },
+                {
+                  name: 'Preemption',
+                  value: clusterQueue.preemptionDisplay,
+                },
+                {
+                  name: 'Flavor Fungibility',
+                  value: clusterQueue.flavorFungibilityDisplay,
+                },
+                {
+                  name: 'Fair Sharing',
+                  value: clusterQueue.fairSharingDisplay,
+                },
+                {
+                  name: 'Admission Scope',
+                  value: clusterQueue.admissionScopeDisplay,
+                },
+                {
+                  name: 'Concurrent Admission',
+                  value: clusterQueue.concurrentAdmissionPolicyDisplay,
+                },
+              ]
+            : []
+        }
+        extraSections={clusterQueue =>
+          clusterQueue
+            ? [
+                getConditionsSection(clusterQueue),
+                getResourceGroupsSection(clusterQueue),
+                getAdmissionChecksSection(clusterQueue),
+                getFlavorUsageSection(
+                  'Flavor Reservations',
+                  'flavor-reservations',
+                  clusterQueue.status.flavorsReservation
+                ),
+                getFlavorUsageSection(
+                  'Flavor Usage',
+                  'flavor-usage',
+                  clusterQueue.status.flavorsUsage
+                ),
+              ].filter(Boolean)
+            : []
+        }
+      />
+    </KueueAdminResourceAccess>
   );
 }

--- a/kueue/src/components/clusterqueues/Detail.tsx
+++ b/kueue/src/components/clusterqueues/Detail.tsx
@@ -1,0 +1,97 @@
+import { DetailsGrid } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { useParams } from 'react-router-dom';
+import { ClusterQueue } from '../../resources/clusterQueue';
+
+export default function ClusterQueueDetail() {
+  const { name } = useParams<{ name: string }>();
+
+  return (
+    <DetailsGrid
+      resourceType={ClusterQueue}
+      name={name}
+      withEvents
+      extraInfo={clusterQueue =>
+        clusterQueue
+          ? [
+              {
+                name: 'Cohort',
+                value: clusterQueue.cohortName,
+              },
+              {
+                name: 'Queueing Strategy',
+                value: clusterQueue.queueingStrategy,
+              },
+              {
+                name: 'Stop Policy',
+                value: clusterQueue.stopPolicy,
+              },
+              {
+                name: 'Namespace Selector',
+                value: clusterQueue.namespaceSelectorDisplay,
+              },
+              {
+                name: 'Pending Workloads',
+                value: clusterQueue.pendingWorkloads,
+              },
+              {
+                name: 'Admitted Workloads',
+                value: clusterQueue.admittedWorkloads,
+              },
+              {
+                name: 'Reserving Workloads',
+                value: clusterQueue.reservingWorkloads,
+              },
+              {
+                name: 'Status',
+                value: clusterQueue.statusDisplay,
+              },
+              {
+                name: 'Conditions',
+                value: clusterQueue.conditionsDisplay,
+              },
+              {
+                name: 'Resource Groups',
+                value: clusterQueue.resourceGroupsDetailDisplay,
+              },
+              {
+                name: 'Referenced ResourceFlavors',
+                value: clusterQueue.referencedFlavorNamesDisplay,
+              },
+              {
+                name: 'Preemption',
+                value: clusterQueue.preemptionDisplay,
+              },
+              {
+                name: 'Admission Checks',
+                value: clusterQueue.admissionChecksDisplay,
+              },
+              {
+                name: 'Flavor Fungibility',
+                value: clusterQueue.flavorFungibilityDisplay,
+              },
+              {
+                name: 'Flavor Reservations',
+                value: clusterQueue.flavorsReservationDisplay,
+              },
+              {
+                name: 'Flavor Usage',
+                value: clusterQueue.flavorsUsageDisplay,
+              },
+              {
+                name: 'Fair Sharing',
+                value: clusterQueue.fairSharingDisplay,
+              },
+              {
+                name: 'Admission Scope',
+                value: clusterQueue.admissionScopeDisplay,
+              },
+              {
+                name: 'Concurrent Admission',
+                value: clusterQueue.concurrentAdmissionPolicyDisplay,
+              },
+            ]
+          : []
+      }
+    />
+  );
+}

--- a/kueue/src/components/clusterqueues/Detail.tsx
+++ b/kueue/src/components/clusterqueues/Detail.tsx
@@ -1,7 +1,286 @@
-import { DetailsGrid } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import {
+  ConditionsSection,
+  DetailsGrid,
+  Link,
+  SectionBox,
+  SimpleTable,
+} from '@kinvolk/headlamp-plugin/lib/components/common';
 import { useParams } from 'react-router-dom';
-import { ClusterQueue } from '../../resources/clusterQueue';
+import {
+  ClusterQueue,
+  FlavorUsage,
+  ResourceGroup,
+  ResourceQuota,
+} from '../../resources/clusterQueue';
+import { kueueRouteNames } from '../../utils/kueueRoutes';
 
+/** Flattened row rendered in the ClusterQueue resource groups table. */
+interface ResourceGroupRow {
+  /** Display label for the resource group index from spec.resourceGroups. */
+  group: string;
+  /** Comma-separated resources covered by this group, such as cpu and memory. */
+  coveredResources: string;
+  /** ResourceFlavor name associated with this resource quota row. */
+  flavor: string;
+  /** Resource name within the flavor quota, for example cpu or memory. */
+  resource: string;
+  /** Guaranteed quota configured for the resource and flavor pair. */
+  nominalQuota: string | number;
+  /** Optional quota this ClusterQueue can borrow from the cohort. */
+  borrowingLimit?: string | number;
+  /** Optional quota this ClusterQueue can lend to the cohort. */
+  lendingLimit?: string | number;
+}
+
+/** Flattened row rendered for status flavor reservations or flavor usage. */
+interface FlavorUsageRow {
+  /** ResourceFlavor name reported by ClusterQueue status. */
+  flavor: string;
+  /** Resource name reported under the flavor. */
+  resource: string;
+  /** Total reserved or used quantity for the resource. */
+  total?: string | number;
+  /** Quantity currently borrowed from the cohort. */
+  borrowed?: string | number;
+}
+
+/** Admission check row from spec.admissionChecksStrategy. */
+interface AdmissionCheckRow {
+  /** AdmissionCheck resource name. */
+  name: string;
+  /** Flavor names this AdmissionCheck applies to; empty means all flavors. */
+  flavors: string[];
+}
+
+/** Render a ResourceFlavor name as a Headlamp link to its detail page. */
+function renderFlavorLink(flavorName: string) {
+  return (
+    <Link routeName={kueueRouteNames.resourceFlavorDetail} params={{ name: flavorName }}>
+      {flavorName}
+    </Link>
+  );
+}
+
+/** Convert nested ClusterQueue resource groups into table rows. */
+function getResourceGroupRows(resourceGroups: ResourceGroup[]): ResourceGroupRow[] {
+  return resourceGroups.flatMap((group, groupIndex): ResourceGroupRow[] => {
+    const groupLabel = `Group ${groupIndex + 1}`;
+    const coveredResources = group.coveredResources?.join(', ') || '-';
+
+    if (!group.flavors?.length) {
+      return [
+        {
+          group: groupLabel,
+          coveredResources,
+          flavor: '-',
+          resource: '-',
+          nominalQuota: '-',
+        },
+      ];
+    }
+
+    return group.flavors.flatMap((flavor): ResourceGroupRow[] => {
+      if (!flavor.resources?.length) {
+        return [
+          {
+            group: groupLabel,
+            coveredResources,
+            flavor: flavor.name,
+            resource: '-',
+            nominalQuota: '-',
+          },
+        ];
+      }
+
+      return flavor.resources.map((resource: ResourceQuota) => ({
+        group: groupLabel,
+        coveredResources,
+        flavor: flavor.name,
+        resource: resource.name,
+        nominalQuota: resource.nominalQuota,
+        borrowingLimit: resource.borrowingLimit,
+        lendingLimit: resource.lendingLimit,
+      }));
+    });
+  });
+}
+
+/** Convert status flavor usage or reservation entries into table rows. */
+function getFlavorUsageRows(flavorUsage: FlavorUsage[] = []): FlavorUsageRow[] {
+  return flavorUsage.flatMap(flavor => {
+    if (!flavor.resources?.length) {
+      return [
+        {
+          flavor: flavor.name,
+          resource: '-',
+        },
+      ];
+    }
+
+    return flavor.resources.map(resource => ({
+      flavor: flavor.name,
+      resource: resource.name,
+      total: resource.total,
+      borrowed: resource.borrowed,
+    }));
+  });
+}
+
+/** Extract admission checks and their flavor scope from the ClusterQueue spec. */
+function getAdmissionCheckRows(clusterQueue: ClusterQueue): AdmissionCheckRow[] {
+  return (
+    clusterQueue.spec.admissionChecksStrategy?.admissionChecks?.map(check => ({
+      name: check.name,
+      flavors: check.onFlavors || [],
+    })) || []
+  );
+}
+
+/** Build the extra detail section that shows spec.resourceGroups as a table. */
+function getResourceGroupsSection(clusterQueue: ClusterQueue) {
+  const rows = getResourceGroupRows(clusterQueue.resourceGroups);
+
+  if (rows.length === 0) {
+    return null;
+  }
+
+  return {
+    id: 'resource-groups',
+    section: (
+      <SectionBox title="Resource Groups">
+        <SimpleTable
+          data={rows}
+          columns={[
+            {
+              label: 'Group',
+              getter: (row: ResourceGroupRow) => row.group,
+            },
+            {
+              label: 'Covered Resources',
+              getter: (row: ResourceGroupRow) => row.coveredResources,
+            },
+            {
+              label: 'ResourceFlavor',
+              getter: (row: ResourceGroupRow) =>
+                row.flavor === '-' ? '-' : renderFlavorLink(row.flavor),
+            },
+            {
+              label: 'Resource',
+              getter: (row: ResourceGroupRow) => row.resource,
+            },
+            {
+              label: 'Nominal Quota',
+              getter: (row: ResourceGroupRow) => row.nominalQuota,
+            },
+            {
+              label: 'Borrowing Limit',
+              getter: (row: ResourceGroupRow) => row.borrowingLimit ?? '-',
+            },
+            {
+              label: 'Lending Limit',
+              getter: (row: ResourceGroupRow) => row.lendingLimit ?? '-',
+            },
+          ]}
+        />
+      </SectionBox>
+    ),
+  };
+}
+
+/** Build a table section for ClusterQueue status flavor reservations or usage. */
+function getFlavorUsageSection(title: string, id: string, flavorUsage?: FlavorUsage[]) {
+  const rows = getFlavorUsageRows(flavorUsage);
+
+  if (rows.length === 0) {
+    return null;
+  }
+
+  return {
+    id,
+    section: (
+      <SectionBox title={title}>
+        <SimpleTable
+          data={rows}
+          columns={[
+            {
+              label: 'ResourceFlavor',
+              getter: (row: FlavorUsageRow) =>
+                row.flavor === '-' ? '-' : renderFlavorLink(row.flavor),
+            },
+            {
+              label: 'Resource',
+              getter: (row: FlavorUsageRow) => row.resource,
+            },
+            {
+              label: 'Total',
+              getter: (row: FlavorUsageRow) => row.total ?? '-',
+            },
+            {
+              label: 'Borrowed',
+              getter: (row: FlavorUsageRow) => row.borrowed ?? '-',
+            },
+          ]}
+        />
+      </SectionBox>
+    ),
+  };
+}
+
+/** Build the extra detail section for configured admission checks. */
+function getAdmissionChecksSection(clusterQueue: ClusterQueue) {
+  const rows = getAdmissionCheckRows(clusterQueue);
+
+  if (rows.length === 0) {
+    return null;
+  }
+
+  return {
+    id: 'admission-checks',
+    section: (
+      <SectionBox title="Admission Checks">
+        <SimpleTable
+          data={rows}
+          columns={[
+            {
+              label: 'Name',
+              getter: (row: AdmissionCheckRow) => row.name,
+            },
+            {
+              label: 'ResourceFlavors',
+              getter: (row: AdmissionCheckRow) =>
+                row.flavors.length ? (
+                  <>
+                    {row.flavors.map((flavor, index) => (
+                      <span key={flavor}>
+                        {index > 0 ? ', ' : ''}
+                        {renderFlavorLink(flavor)}
+                      </span>
+                    ))}
+                  </>
+                ) : (
+                  'All flavors'
+                ),
+            },
+          ]}
+        />
+      </SectionBox>
+    ),
+  };
+}
+
+/** Build the standard Headlamp conditions section for ClusterQueue status. */
+function getConditionsSection(clusterQueue: ClusterQueue) {
+  if (!clusterQueue.conditions.length) {
+    return null;
+  }
+
+  return {
+    id: 'conditions',
+    section: <ConditionsSection resource={clusterQueue.jsonData} />,
+  };
+}
+
+/** Detail view for a cluster-scoped Kueue ClusterQueue resource. */
 export default function ClusterQueueDetail() {
   const { name } = useParams<{ name: string }>();
 
@@ -46,14 +325,6 @@ export default function ClusterQueueDetail() {
                 value: clusterQueue.statusDisplay,
               },
               {
-                name: 'Conditions',
-                value: clusterQueue.conditionsDisplay,
-              },
-              {
-                name: 'Resource Groups',
-                value: clusterQueue.resourceGroupsDetailDisplay,
-              },
-              {
                 name: 'Referenced ResourceFlavors',
                 value: clusterQueue.referencedFlavorNamesDisplay,
               },
@@ -62,20 +333,8 @@ export default function ClusterQueueDetail() {
                 value: clusterQueue.preemptionDisplay,
               },
               {
-                name: 'Admission Checks',
-                value: clusterQueue.admissionChecksDisplay,
-              },
-              {
                 name: 'Flavor Fungibility',
                 value: clusterQueue.flavorFungibilityDisplay,
-              },
-              {
-                name: 'Flavor Reservations',
-                value: clusterQueue.flavorsReservationDisplay,
-              },
-              {
-                name: 'Flavor Usage',
-                value: clusterQueue.flavorsUsageDisplay,
               },
               {
                 name: 'Fair Sharing',
@@ -90,6 +349,25 @@ export default function ClusterQueueDetail() {
                 value: clusterQueue.concurrentAdmissionPolicyDisplay,
               },
             ]
+          : []
+      }
+      extraSections={clusterQueue =>
+        clusterQueue
+          ? [
+              getConditionsSection(clusterQueue),
+              getResourceGroupsSection(clusterQueue),
+              getAdmissionChecksSection(clusterQueue),
+              getFlavorUsageSection(
+                'Flavor Reservations',
+                'flavor-reservations',
+                clusterQueue.status.flavorsReservation
+              ),
+              getFlavorUsageSection(
+                'Flavor Usage',
+                'flavor-usage',
+                clusterQueue.status.flavorsUsage
+              ),
+            ].filter(Boolean)
           : []
       }
     />

--- a/kueue/src/components/clusterqueues/List.tsx
+++ b/kueue/src/components/clusterqueues/List.tsx
@@ -1,0 +1,50 @@
+import { ResourceListView } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { ClusterQueue } from '../../resources/clusterQueue';
+
+export default function ClusterQueueList() {
+  return (
+    <ResourceListView
+      title="Kueue ClusterQueues"
+      resourceClass={ClusterQueue}
+      columns={[
+        'name',
+        {
+          id: 'cohort',
+          label: 'Cohort',
+          getValue: (clusterQueue: ClusterQueue) => clusterQueue.cohortName,
+        },
+        {
+          id: 'queueingStrategy',
+          label: 'Queueing Strategy',
+          getValue: (clusterQueue: ClusterQueue) => clusterQueue.queueingStrategy,
+        },
+        {
+          id: 'resourceGroups',
+          label: 'Resource Groups',
+          getValue: (clusterQueue: ClusterQueue) => clusterQueue.resourceGroupsDisplay,
+        },
+        {
+          id: 'resourceFlavors',
+          label: 'Resource Flavors',
+          getValue: (clusterQueue: ClusterQueue) => clusterQueue.referencedFlavorNamesDisplay,
+        },
+        {
+          id: 'pendingWorkloads',
+          label: 'Pending Workloads',
+          getValue: (clusterQueue: ClusterQueue) => clusterQueue.pendingWorkloads,
+        },
+        {
+          id: 'admittedWorkloads',
+          label: 'Admitted Workloads',
+          getValue: (clusterQueue: ClusterQueue) => clusterQueue.admittedWorkloads,
+        },
+        {
+          id: 'status',
+          label: 'Status',
+          getValue: (clusterQueue: ClusterQueue) => clusterQueue.statusDisplay,
+        },
+        'age',
+      ]}
+    />
+  );
+}

--- a/kueue/src/components/clusterqueues/List.tsx
+++ b/kueue/src/components/clusterqueues/List.tsx
@@ -1,50 +1,57 @@
 import { ResourceListView } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 import { ClusterQueue } from '../../resources/clusterQueue';
+import KueueAdminResourceAccess from '../common/KueueAdminResourceAccess';
 
 export default function ClusterQueueList() {
   return (
-    <ResourceListView
-      title="Kueue ClusterQueues"
+    <KueueAdminResourceAccess
       resourceClass={ClusterQueue}
-      columns={[
-        'name',
-        {
-          id: 'cohort',
-          label: 'Cohort',
-          getValue: (clusterQueue: ClusterQueue) => clusterQueue.cohortName,
-        },
-        {
-          id: 'queueingStrategy',
-          label: 'Queueing Strategy',
-          getValue: (clusterQueue: ClusterQueue) => clusterQueue.queueingStrategy,
-        },
-        {
-          id: 'resourceGroups',
-          label: 'Resource Groups',
-          getValue: (clusterQueue: ClusterQueue) => clusterQueue.resourceGroupsDisplay,
-        },
-        {
-          id: 'resourceFlavors',
-          label: 'Resource Flavors',
-          getValue: (clusterQueue: ClusterQueue) => clusterQueue.referencedFlavorNamesDisplay,
-        },
-        {
-          id: 'pendingWorkloads',
-          label: 'Pending Workloads',
-          getValue: (clusterQueue: ClusterQueue) => clusterQueue.pendingWorkloads,
-        },
-        {
-          id: 'admittedWorkloads',
-          label: 'Admitted Workloads',
-          getValue: (clusterQueue: ClusterQueue) => clusterQueue.admittedWorkloads,
-        },
-        {
-          id: 'status',
-          label: 'Status',
-          getValue: (clusterQueue: ClusterQueue) => clusterQueue.statusDisplay,
-        },
-        'age',
-      ]}
-    />
+      resourceLabel="ClusterQueues"
+      verb="list"
+    >
+      <ResourceListView
+        title="Kueue ClusterQueues"
+        resourceClass={ClusterQueue}
+        columns={[
+          'name',
+          {
+            id: 'cohort',
+            label: 'Cohort',
+            getValue: (clusterQueue: ClusterQueue) => clusterQueue.cohortName,
+          },
+          {
+            id: 'queueingStrategy',
+            label: 'Queueing Strategy',
+            getValue: (clusterQueue: ClusterQueue) => clusterQueue.queueingStrategy,
+          },
+          {
+            id: 'resourceGroups',
+            label: 'Resource Groups',
+            getValue: (clusterQueue: ClusterQueue) => clusterQueue.resourceGroupsDisplay,
+          },
+          {
+            id: 'resourceFlavors',
+            label: 'Resource Flavors',
+            getValue: (clusterQueue: ClusterQueue) => clusterQueue.referencedFlavorNamesDisplay,
+          },
+          {
+            id: 'pendingWorkloads',
+            label: 'Pending Workloads',
+            getValue: (clusterQueue: ClusterQueue) => clusterQueue.pendingWorkloads,
+          },
+          {
+            id: 'admittedWorkloads',
+            label: 'Admitted Workloads',
+            getValue: (clusterQueue: ClusterQueue) => clusterQueue.admittedWorkloads,
+          },
+          {
+            id: 'status',
+            label: 'Status',
+            getValue: (clusterQueue: ClusterQueue) => clusterQueue.statusDisplay,
+          },
+          'age',
+        ]}
+      />
+    </KueueAdminResourceAccess>
   );
 }

--- a/kueue/src/components/common/KueueAdminResourceAccess.tsx
+++ b/kueue/src/components/common/KueueAdminResourceAccess.tsx
@@ -1,0 +1,51 @@
+import {
+  AuthVisible,
+  EmptyContent,
+  Loader,
+  SectionBox,
+} from '@kinvolk/headlamp-plugin/lib/components/common';
+import { KubeObjectClass } from '@kinvolk/headlamp-plugin/lib/lib/k8s/KubeObject';
+import { ReactNode, useState } from 'react';
+
+interface KueueAdminResourceAccessProps {
+  /** Kueue admin resource class to check access for. */
+  resourceClass: KubeObjectClass;
+  /** Human-readable resource name shown in loading and denied messages. */
+  resourceLabel: string;
+  /** Kubernetes verb to verify before rendering the page. */
+  verb: 'get' | 'list';
+  /** Page content to render after the user is authorized. */
+  children: ReactNode;
+}
+
+export default function KueueAdminResourceAccess({
+  resourceClass,
+  resourceLabel,
+  verb,
+  children,
+}: KueueAdminResourceAccessProps) {
+  const [allowed, setAllowed] = useState<boolean | null>(null);
+
+  return (
+    <>
+      {allowed === null && <Loader title={`Checking access to Kueue ${resourceLabel}`} />}
+      {allowed === false && (
+        <SectionBox title={`Kueue ${resourceLabel}`}>
+          <EmptyContent color="text.secondary">
+            {`Kueue ${resourceLabel} are cluster-scoped admin resources. Your current Kubernetes credentials are not authorized to ${
+              verb === 'get' ? 'view' : 'list'
+            } this page.`}
+          </EmptyContent>
+        </SectionBox>
+      )}
+      <AuthVisible
+        item={resourceClass}
+        authVerb={verb}
+        onAuthResult={result => setAllowed(result.allowed)}
+        onError={() => setAllowed(false)}
+      >
+        {children}
+      </AuthVisible>
+    </>
+  );
+}

--- a/kueue/src/components/resourceflavors/Detail.tsx
+++ b/kueue/src/components/resourceflavors/Detail.tsx
@@ -1,37 +1,44 @@
 import { DetailsGrid } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 import { useParams } from 'react-router-dom';
 import { ResourceFlavor } from '../../resources/resourceFlavor';
+import KueueAdminResourceAccess from '../common/KueueAdminResourceAccess';
 
 export default function ResourceFlavorDetail() {
   const { name } = useParams<{ name: string }>();
 
   return (
-    <DetailsGrid
-      resourceType={ResourceFlavor}
-      name={name}
-      withEvents
-      extraInfo={resourceFlavor =>
-        resourceFlavor
-          ? [
-              {
-                name: 'Node Labels',
-                value: resourceFlavor.nodeLabelsDisplay,
-              },
-              {
-                name: 'Node Taints',
-                value: resourceFlavor.nodeTaintsDisplay,
-              },
-              {
-                name: 'Tolerations',
-                value: resourceFlavor.tolerationsDisplay,
-              },
-              {
-                name: 'Topology',
-                value: resourceFlavor.topologyName,
-              },
-            ]
-          : []
-      }
-    />
+    <KueueAdminResourceAccess
+      resourceClass={ResourceFlavor}
+      resourceLabel="ResourceFlavors"
+      verb="get"
+    >
+      <DetailsGrid
+        resourceType={ResourceFlavor}
+        name={name}
+        withEvents
+        extraInfo={resourceFlavor =>
+          resourceFlavor
+            ? [
+                {
+                  name: 'Node Labels',
+                  value: resourceFlavor.nodeLabelsDisplay,
+                },
+                {
+                  name: 'Node Taints',
+                  value: resourceFlavor.nodeTaintsDisplay,
+                },
+                {
+                  name: 'Tolerations',
+                  value: resourceFlavor.tolerationsDisplay,
+                },
+                {
+                  name: 'Topology',
+                  value: resourceFlavor.topologyName,
+                },
+              ]
+            : []
+        }
+      />
+    </KueueAdminResourceAccess>
   );
 }

--- a/kueue/src/components/resourceflavors/List.tsx
+++ b/kueue/src/components/resourceflavors/List.tsx
@@ -1,35 +1,42 @@
 import { ResourceListView } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 import { ResourceFlavor } from '../../resources/resourceFlavor';
+import KueueAdminResourceAccess from '../common/KueueAdminResourceAccess';
 
 export default function ResourceFlavorList() {
   return (
-    <ResourceListView
-      title="Kueue ResourceFlavors"
+    <KueueAdminResourceAccess
       resourceClass={ResourceFlavor}
-      columns={[
-        'name',
-        {
-          id: 'nodeLabels',
-          label: 'Node Labels',
-          getValue: (resourceFlavor: ResourceFlavor) => resourceFlavor.nodeLabelsDisplay,
-        },
-        {
-          id: 'nodeTaints',
-          label: 'Node Taints',
-          getValue: (resourceFlavor: ResourceFlavor) => resourceFlavor.nodeTaintsDisplay,
-        },
-        {
-          id: 'tolerations',
-          label: 'Tolerations',
-          getValue: (resourceFlavor: ResourceFlavor) => resourceFlavor.tolerationsDisplay,
-        },
-        {
-          id: 'topology',
-          label: 'Topology',
-          getValue: (resourceFlavor: ResourceFlavor) => resourceFlavor.topologyName,
-        },
-        'age',
-      ]}
-    />
+      resourceLabel="ResourceFlavors"
+      verb="list"
+    >
+      <ResourceListView
+        title="Kueue ResourceFlavors"
+        resourceClass={ResourceFlavor}
+        columns={[
+          'name',
+          {
+            id: 'nodeLabels',
+            label: 'Node Labels',
+            getValue: (resourceFlavor: ResourceFlavor) => resourceFlavor.nodeLabelsDisplay,
+          },
+          {
+            id: 'nodeTaints',
+            label: 'Node Taints',
+            getValue: (resourceFlavor: ResourceFlavor) => resourceFlavor.nodeTaintsDisplay,
+          },
+          {
+            id: 'tolerations',
+            label: 'Tolerations',
+            getValue: (resourceFlavor: ResourceFlavor) => resourceFlavor.tolerationsDisplay,
+          },
+          {
+            id: 'topology',
+            label: 'Topology',
+            getValue: (resourceFlavor: ResourceFlavor) => resourceFlavor.topologyName,
+          },
+          'age',
+        ]}
+      />
+    </KueueAdminResourceAccess>
   );
 }

--- a/kueue/src/index.tsx
+++ b/kueue/src/index.tsx
@@ -1,4 +1,6 @@
 import { registerRoute, registerSidebarEntry } from '@kinvolk/headlamp-plugin/lib';
+import ClusterQueueDetail from './components/clusterqueues/Detail';
+import ClusterQueueList from './components/clusterqueues/List';
 import ResourceFlavorDetail from './components/resourceflavors/Detail';
 import ResourceFlavorList from './components/resourceflavors/List';
 import { kueueRouteNames, kueueRoutePaths } from './utils/kueueRoutes';
@@ -8,7 +10,14 @@ registerSidebarEntry({
   name: 'kueue',
   label: 'Kueue',
   icon: 'mdi:queue-first-in-last-out',
-  url: kueueRoutePaths.resourceFlavorsList,
+  url: kueueRoutePaths.clusterQueuesList,
+});
+
+registerSidebarEntry({
+  parent: 'kueue',
+  name: 'kueue-clusterqueues',
+  label: 'ClusterQueues',
+  url: kueueRoutePaths.clusterQueuesList,
 });
 
 registerSidebarEntry({
@@ -16,6 +25,22 @@ registerSidebarEntry({
   name: 'kueue-resourceflavors',
   label: 'ResourceFlavors',
   url: kueueRoutePaths.resourceFlavorsList,
+});
+
+registerRoute({
+  path: kueueRoutePaths.clusterQueuesList,
+  sidebar: 'kueue-clusterqueues',
+  name: kueueRouteNames.clusterQueuesList,
+  exact: true,
+  component: () => <ClusterQueueList />,
+});
+
+registerRoute({
+  path: kueueRoutePaths.clusterQueueDetail,
+  sidebar: 'kueue-clusterqueues',
+  name: kueueRouteNames.clusterQueueDetail,
+  exact: true,
+  component: () => <ClusterQueueDetail />,
 });
 
 registerRoute({

--- a/kueue/src/resources/clusterQueue.test.ts
+++ b/kueue/src/resources/clusterQueue.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getUniqueFlavorNames,
+  renderClusterQueueStatus,
+  renderLabelSelector,
+  renderResourceGroupsSummary,
+} from './clusterQueueFormatters';
+
+describe('ClusterQueue formatters', () => {
+  it('summarizes resource groups and unique referenced flavors', () => {
+    const resourceGroups = [
+      {
+        coveredResources: ['cpu', 'memory'],
+        flavors: [
+          { name: 'default', resources: [{ name: 'cpu', nominalQuota: '8' }] },
+          { name: 'spot', resources: [{ name: 'cpu', nominalQuota: '16' }] },
+        ],
+      },
+      {
+        coveredResources: ['nvidia.com/gpu'],
+        flavors: [{ name: 'default', resources: [{ name: 'nvidia.com/gpu', nominalQuota: '2' }] }],
+      },
+    ];
+
+    expect(renderResourceGroupsSummary(resourceGroups)).toBe('2 groups, 3 flavors');
+    expect(getUniqueFlavorNames(resourceGroups)).toEqual(['default', 'spot']);
+  });
+
+  it('derives a readable status from the Active condition', () => {
+    expect(renderClusterQueueStatus({ type: 'Active', status: 'True', reason: 'Ready' })).toBe(
+      'Active'
+    );
+    expect(
+      renderClusterQueueStatus({ type: 'Active', status: 'False', reason: 'FlavorNotFound' })
+    ).toBe('Inactive');
+    expect(renderClusterQueueStatus()).toBe('Unknown');
+  });
+
+  it('formats namespace selectors', () => {
+    expect(renderLabelSelector()).toBe('All namespaces');
+    expect(renderLabelSelector({})).toBe('All namespaces');
+    expect(renderLabelSelector({ matchLabels: { team: 'platform' } })).toBe('team=platform');
+    expect(
+      renderLabelSelector({
+        matchExpressions: [{ key: 'environment', operator: 'In', values: ['dev', 'prod'] }],
+      })
+    ).toBe('environment In (dev, prod)');
+  });
+});

--- a/kueue/src/resources/clusterQueue.ts
+++ b/kueue/src/resources/clusterQueue.ts
@@ -1,0 +1,766 @@
+import { KubeObject, KubeObjectInterface } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import { kueueApiVersions } from '../utils/kueueApi';
+import { kueueRoutePaths } from '../utils/kueueRoutes';
+import {
+  getUniqueFlavorNames,
+  renderAdmissionChecks,
+  renderClusterQueueStatus,
+  renderConcurrentAdmissionPolicy,
+  renderConditions,
+  renderFairSharing,
+  renderFlavorFungibility,
+  renderFlavorUsage,
+  renderLabelSelector,
+  renderPreemption,
+  renderResourceGroups,
+  renderResourceGroupsSummary,
+  renderStringList,
+} from './clusterQueueFormatters';
+
+const CLUSTER_QUEUE_API_DOCS =
+  'https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#clusterqueue';
+const CLUSTER_QUEUE_SPEC_DOCS =
+  'https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#clusterqueuespec';
+const CLUSTER_QUEUE_STATUS_DOCS =
+  'https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#clusterqueuestatus';
+
+/**
+ * Kubernetes resource quantity encoded as a string by the API.
+ *
+ * @see https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/quantity/
+ */
+export type ResourceQuantity = string | number;
+
+/**
+ * Standard Kubernetes condition status value.
+ *
+ * @see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#condition-v1-meta
+ */
+export type ConditionStatus = 'True' | 'False' | 'Unknown';
+
+/**
+ * Kubernetes condition reported by Kueue status fields.
+ *
+ * @see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#condition-v1-meta
+ */
+export interface KueueCondition {
+  /**
+   * Condition type, such as `Active`.
+   *
+   * @see https://github.com/kubernetes-sigs/kueue/blob/main/apis/kueue/v1beta2/clusterqueue_types.go
+   */
+  type: string;
+  /**
+   * Current condition status.
+   *
+   * @see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#condition-v1-meta
+   */
+  status: ConditionStatus;
+  /**
+   * Last observed generation for the condition.
+   *
+   * @see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#condition-v1-meta
+   */
+  observedGeneration?: number;
+  /**
+   * Last condition transition time.
+   *
+   * @see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#condition-v1-meta
+   */
+  lastTransitionTime?: string;
+  /**
+   * Machine-readable reason for the condition transition.
+   *
+   * @see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#condition-v1-meta
+   */
+  reason?: string;
+  /**
+   * Human-readable condition message.
+   *
+   * @see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#condition-v1-meta
+   */
+  message?: string;
+}
+
+/**
+ * Kubernetes label selector used by ClusterQueue namespace policy.
+ *
+ * @see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#labelselector-v1-meta
+ */
+export interface LabelSelector {
+  /**
+   * Exact label matches required by the selector.
+   *
+   * @see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#labelselector-v1-meta
+   */
+  matchLabels?: Record<string, string>;
+  /**
+   * Set-based label selector requirements.
+   *
+   * @see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#labelselectorrequirement-v1-meta
+   */
+  matchExpressions?: LabelSelectorRequirement[];
+}
+
+/**
+ * Set-based label selector requirement.
+ *
+ * @see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#labelselectorrequirement-v1-meta
+ */
+export interface LabelSelectorRequirement {
+  /**
+   * Label key that the selector applies to.
+   *
+   * @see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#labelselectorrequirement-v1-meta
+   */
+  key: string;
+  /**
+   * Selector operator.
+   *
+   * @see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#labelselectorrequirement-v1-meta
+   */
+  operator: 'In' | 'NotIn' | 'Exists' | 'DoesNotExist';
+  /**
+   * Values used by `In` and `NotIn` operators.
+   *
+   * @see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#labelselectorrequirement-v1-meta
+   */
+  values?: string[];
+}
+
+/**
+ * Queueing strategy supported by Kueue ClusterQueue.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#queueingstrategy
+ */
+export type QueueingStrategy = 'StrictFIFO' | 'BestEffortFIFO';
+
+/**
+ * Stop policy controlling whether a ClusterQueue admits or drains workloads.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#stoppolicy
+ */
+export type StopPolicy = 'None' | 'Hold' | 'HoldAndDrain';
+
+/**
+ * Resource quota configured for a ResourceFlavor in a ClusterQueue resource group.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#resourcequota
+ */
+export interface ResourceQuota {
+  /**
+   * Resource name, such as `cpu`, `memory`, or an extended resource.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#resourcequota
+   */
+  name: string;
+  /**
+   * Nominal resource quota available to workloads admitted by this ClusterQueue.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#resourcequota
+   */
+  nominalQuota: ResourceQuantity;
+  /**
+   * Maximum quota that can be borrowed from other ClusterQueues in the cohort.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#resourcequota
+   */
+  borrowingLimit?: ResourceQuantity;
+  /**
+   * Maximum unused quota that can be lent to other ClusterQueues in the cohort.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#resourcequota
+   */
+  lendingLimit?: ResourceQuantity;
+}
+
+/**
+ * Quotas for one ResourceFlavor in a ClusterQueue resource group.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#flavorquotas
+ */
+export interface FlavorQuotas {
+  /**
+   * ResourceFlavor name referenced by this ClusterQueue.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#flavorquotas
+   */
+  name: string;
+  /**
+   * Resource quotas provided by this flavor.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#flavorquotas
+   */
+  resources?: ResourceQuota[];
+}
+
+/**
+ * Group of covered resources and ResourceFlavors that provide quotas for them.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#resourcegroup
+ */
+export interface ResourceGroup {
+  /**
+   * Resource names covered by this group.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#resourcegroup
+   */
+  coveredResources?: string[];
+  /**
+   * ResourceFlavors that provide quotas for the covered resources.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#resourcegroup
+   */
+  flavors?: FlavorQuotas[];
+}
+
+/**
+ * Policy used by flavor fungibility settings.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#flavorfungibility
+ */
+export type FlavorFungibilityPolicy = 'MayStopSearch' | 'TryNextFlavor';
+
+/**
+ * Preference used when both borrowing and preemption may be needed.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#flavorfungibility
+ */
+export type FlavorFungibilityPreference = 'BorrowingOverPreemption' | 'PreemptionOverBorrowing';
+
+/**
+ * Controls whether workloads try the next flavor before borrowing or preempting.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#flavorfungibility
+ */
+export interface FlavorFungibility {
+  /**
+   * Behavior when admission would require borrowing quota.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#flavorfungibility
+   */
+  whenCanBorrow?: FlavorFungibilityPolicy;
+  /**
+   * Behavior when admission would require preemption.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#flavorfungibility
+   */
+  whenCanPreempt?: FlavorFungibilityPolicy;
+  /**
+   * Preference when both borrowing and preemption are possible.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#flavorfungibility
+   */
+  preference?: FlavorFungibilityPreference;
+}
+
+/**
+ * ClusterQueue preemption policy value.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#preemptionpolicy
+ */
+export type PreemptionPolicy = 'Never' | 'Any' | 'LowerPriority' | 'LowerOrNewerEqualPriority';
+
+/**
+ * Borrow-within-cohort policy value.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#borrowwithincohort
+ */
+export type BorrowWithinCohortPolicy = 'Never' | 'LowerPriority';
+
+/**
+ * Preemption settings for borrowing quota from other ClusterQueues in a cohort.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#borrowwithincohort
+ */
+export interface BorrowWithinCohort {
+  /**
+   * Policy for preempting workloads in other ClusterQueues while borrowing.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#borrowwithincohort
+   */
+  policy?: BorrowWithinCohortPolicy;
+  /**
+   * Maximum priority threshold of workloads that may be preempted.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#borrowwithincohort
+   */
+  maxPriorityThreshold?: number;
+}
+
+/**
+ * Preemption configuration for a ClusterQueue.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#clusterqueuepreemption
+ */
+export interface ClusterQueuePreemption {
+  /**
+   * Whether a workload can preempt workloads in other ClusterQueues to reclaim nominal quota.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#clusterqueuepreemption
+   */
+  reclaimWithinCohort?: PreemptionPolicy;
+  /**
+   * Whether a borrowing workload can preempt workloads in other ClusterQueues.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#clusterqueuepreemption
+   */
+  borrowWithinCohort?: BorrowWithinCohort;
+  /**
+   * Whether a workload can preempt lower-priority workloads inside this ClusterQueue.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#clusterqueuepreemption
+   */
+  withinClusterQueue?: PreemptionPolicy;
+}
+
+/**
+ * AdmissionCheck strategy rule for a ClusterQueue.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#admissioncheckstrategyrule
+ */
+export interface AdmissionCheckStrategyRule {
+  /**
+   * AdmissionCheck name.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#admissioncheckstrategyrule
+   */
+  name: string;
+  /**
+   * ResourceFlavor names for which this AdmissionCheck should run.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#admissioncheckstrategyrule
+   */
+  onFlavors?: string[];
+}
+
+/**
+ * Strategy for determining which ResourceFlavors require AdmissionChecks.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#admissionchecksstrategy
+ */
+export interface AdmissionChecksStrategy {
+  /**
+   * AdmissionCheck strategy rules.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#admissionchecksstrategy
+   */
+  admissionChecks?: AdmissionCheckStrategyRule[];
+}
+
+/**
+ * FairSharing settings for a ClusterQueue.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#fairsharing
+ */
+export interface FairSharing {
+  /**
+   * Comparative weight used when competing for unused cohort resources.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#fairsharing
+   */
+  weight?: ResourceQuantity;
+}
+
+/**
+ * Current FairSharing status reported by Kueue.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#fairsharingstatus
+ */
+export interface FairSharingStatus {
+  /**
+   * Weighted share calculated for this ClusterQueue.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#fairsharingstatus
+   */
+  weightedShare: number;
+}
+
+/**
+ * Admission Fair Sharing mode.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#admissionscope
+ */
+export type AdmissionMode = 'UsageBasedAdmissionFairSharing' | 'NoAdmissionFairSharing';
+
+/**
+ * Admission Fair Sharing scope for a ClusterQueue.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#admissionscope
+ */
+export interface AdmissionScope {
+  /**
+   * Admission Fair Sharing mode.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#admissionscope
+   */
+  admissionMode?: AdmissionMode;
+}
+
+/**
+ * Concurrent admission migration mode.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#concurrentadmissionmigrationmode
+ */
+export type ConcurrentAdmissionMigrationMode = 'TryPreferredFlavors' | 'RetainFirstAdmission';
+
+/**
+ * Constraints for concurrent admission migration.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#concurrentadmissionconstraints
+ */
+export interface ConcurrentAdmissionConstraints {
+  /**
+   * Last acceptable ResourceFlavor for workload migration.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#concurrentadmissionconstraints
+   */
+  lastAcceptableFlavorName?: string;
+}
+
+/**
+ * Concurrent admission migration configuration.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#concurrentadmissionmigration
+ */
+export interface ConcurrentAdmissionMigration {
+  /**
+   * Workload migration mode.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#concurrentadmissionmigration
+   */
+  mode?: ConcurrentAdmissionMigrationMode;
+  /**
+   * Workload migration constraints.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#concurrentadmissionmigration
+   */
+  constraints?: ConcurrentAdmissionConstraints;
+}
+
+/**
+ * Concurrent admission policy for a ClusterQueue.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#concurrentadmissionpolicy
+ */
+export interface ConcurrentAdmissionPolicy {
+  /**
+   * Workload migration policy.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#concurrentadmissionpolicy
+   */
+  migration?: ConcurrentAdmissionMigration;
+}
+
+/**
+ * Desired state of a Kueue ClusterQueue.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#clusterqueuespec
+ */
+export interface ClusterQueueSpec {
+  /**
+   * Resource groups with the resources and ResourceFlavors that provide quotas.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#clusterqueuespec
+   */
+  resourceGroups?: ResourceGroup[];
+  /**
+   * Cohort name this ClusterQueue belongs to.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#clusterqueuespec
+   */
+  cohortName?: string;
+  /**
+   * Queueing strategy for workloads across queues in this ClusterQueue.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#clusterqueuespec
+   */
+  queueingStrategy?: QueueingStrategy;
+  /**
+   * Namespaces allowed to submit workloads to this ClusterQueue.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#clusterqueuespec
+   */
+  namespaceSelector?: LabelSelector;
+  /**
+   * Flavor fungibility behavior while evaluating borrowing and preemption.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#clusterqueuespec
+   */
+  flavorFungibility?: FlavorFungibility;
+  /**
+   * Preemption policy configuration.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#clusterqueuespec
+   */
+  preemption?: ClusterQueuePreemption;
+  /**
+   * Strategy mapping AdmissionChecks to ResourceFlavors.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#clusterqueuespec
+   */
+  admissionChecksStrategy?: AdmissionChecksStrategy;
+  /**
+   * Stop policy for admission and draining behavior.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#clusterqueuespec
+   */
+  stopPolicy?: StopPolicy;
+  /**
+   * FairSharing settings.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#clusterqueuespec
+   */
+  fairSharing?: FairSharing;
+  /**
+   * Admission Fair Sharing scope.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#clusterqueuespec
+   */
+  admissionScope?: AdmissionScope;
+  /**
+   * Concurrent admission policy.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#clusterqueuespec
+   */
+  concurrentAdmissionPolicy?: ConcurrentAdmissionPolicy;
+}
+
+/**
+ * Resource usage reported for a ResourceFlavor.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#resourceusage
+ */
+export interface ResourceUsage {
+  /**
+   * Resource name.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#resourceusage
+   */
+  name: string;
+  /**
+   * Total used quota, including borrowed quota.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#resourceusage
+   */
+  total?: ResourceQuantity;
+  /**
+   * Quota borrowed from the cohort.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#resourceusage
+   */
+  borrowed?: ResourceQuantity;
+}
+
+/**
+ * Per-flavor reservation or usage status.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#flavorusage
+ */
+export interface FlavorUsage {
+  /**
+   * ResourceFlavor name.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#flavorusage
+   */
+  name: string;
+  /**
+   * Resources reported for this flavor.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#flavorusage
+   */
+  resources?: ResourceUsage[];
+}
+
+/**
+ * Observed state of a Kueue ClusterQueue.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#clusterqueuestatus
+ */
+export interface ClusterQueueStatus {
+  /**
+   * Latest observations of ClusterQueue state.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#clusterqueuestatus
+   */
+  conditions?: KueueCondition[];
+  /**
+   * Reserved quotas currently used by workloads assigned to this ClusterQueue.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#clusterqueuestatus
+   */
+  flavorsReservation?: FlavorUsage[];
+  /**
+   * Used quotas currently used by workloads admitted in this ClusterQueue.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#clusterqueuestatus
+   */
+  flavorsUsage?: FlavorUsage[];
+  /**
+   * Number of workloads waiting to be admitted.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#clusterqueuestatus
+   */
+  pendingWorkloads?: number;
+  /**
+   * Number of workloads currently reserving quota.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#clusterqueuestatus
+   */
+  reservingWorkloads?: number;
+  /**
+   * Number of admitted workloads that have not finished yet.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#clusterqueuestatus
+   */
+  admittedWorkloads?: number;
+  /**
+   * Current FairSharing state.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#clusterqueuestatus
+   */
+  fairSharing?: FairSharingStatus;
+}
+
+/**
+ * Kubernetes ClusterQueue object returned by the Kueue API.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#clusterqueue
+ */
+export interface KubeClusterQueue extends KubeObjectInterface {
+  /**
+   * Kubernetes object metadata for the ClusterQueue.
+   *
+   * @see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#objectmeta-v1-meta
+   */
+  metadata: KubeObjectInterface['metadata'];
+  /**
+   * ClusterQueue desired state.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#clusterqueuespec
+   */
+  spec?: ClusterQueueSpec;
+  /**
+   * ClusterQueue observed state.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#clusterqueuestatus
+   */
+  status?: ClusterQueueStatus;
+}
+
+export class ClusterQueue extends KubeObject<KubeClusterQueue> {
+  static kind = 'ClusterQueue';
+  static apiName = 'clusterqueues';
+  static apiVersion = kueueApiVersions;
+  static isNamespaced = false;
+
+  static get detailsRoute() {
+    return kueueRoutePaths.clusterQueueDetail;
+  }
+
+  get spec(): ClusterQueueSpec {
+    return this.jsonData.spec ?? {};
+  }
+
+  get status(): ClusterQueueStatus {
+    return this.jsonData.status ?? {};
+  }
+
+  get cohortName() {
+    return this.spec.cohortName || '-';
+  }
+
+  get queueingStrategy() {
+    return this.spec.queueingStrategy || '-';
+  }
+
+  get stopPolicy() {
+    return this.spec.stopPolicy || '-';
+  }
+
+  get resourceGroups() {
+    return this.spec.resourceGroups || [];
+  }
+
+  get resourceGroupsDisplay() {
+    return renderResourceGroupsSummary(this.resourceGroups);
+  }
+
+  get referencedFlavorNames() {
+    return getUniqueFlavorNames(this.resourceGroups);
+  }
+
+  get referencedFlavorNamesDisplay() {
+    return renderStringList(this.referencedFlavorNames);
+  }
+
+  get pendingWorkloads() {
+    return this.status.pendingWorkloads ?? 0;
+  }
+
+  get admittedWorkloads() {
+    return this.status.admittedWorkloads ?? 0;
+  }
+
+  get reservingWorkloads() {
+    return this.status.reservingWorkloads ?? 0;
+  }
+
+  get conditions() {
+    return this.status.conditions || [];
+  }
+
+  get activeCondition() {
+    return this.conditions.find(condition => condition.type === 'Active');
+  }
+
+  get statusDisplay() {
+    return renderClusterQueueStatus(this.activeCondition);
+  }
+
+  get namespaceSelectorDisplay() {
+    return renderLabelSelector(this.spec.namespaceSelector);
+  }
+
+  get resourceGroupsDetailDisplay() {
+    return renderResourceGroups(this.resourceGroups);
+  }
+
+  get conditionsDisplay() {
+    return renderConditions(this.conditions);
+  }
+
+  get preemptionDisplay() {
+    return renderPreemption(this.spec.preemption);
+  }
+
+  get admissionChecksDisplay() {
+    return renderAdmissionChecks(this.spec.admissionChecksStrategy);
+  }
+
+  get flavorFungibilityDisplay() {
+    return renderFlavorFungibility(this.spec.flavorFungibility);
+  }
+
+  get flavorsReservationDisplay() {
+    return renderFlavorUsage(this.status.flavorsReservation);
+  }
+
+  get flavorsUsageDisplay() {
+    return renderFlavorUsage(this.status.flavorsUsage);
+  }
+
+  get fairSharingDisplay() {
+    return renderFairSharing(this.spec.fairSharing, this.status.fairSharing);
+  }
+
+  get admissionScopeDisplay() {
+    return this.spec.admissionScope?.admissionMode || '-';
+  }
+
+  get concurrentAdmissionPolicyDisplay() {
+    return renderConcurrentAdmissionPolicy(this.spec.concurrentAdmissionPolicy);
+  }
+}
+
+export { CLUSTER_QUEUE_API_DOCS, CLUSTER_QUEUE_SPEC_DOCS, CLUSTER_QUEUE_STATUS_DOCS };

--- a/kueue/src/resources/clusterQueueFormatters.ts
+++ b/kueue/src/resources/clusterQueueFormatters.ts
@@ -1,0 +1,363 @@
+/** Kubernetes condition status values used by ClusterQueue status conditions. */
+type ConditionStatus = 'True' | 'False' | 'Unknown';
+
+/** Minimal condition shape needed to summarize ClusterQueue readiness. */
+export interface ClusterQueueConditionLike {
+  /** Condition type, for example Active. */
+  type: string;
+  /** Kubernetes condition status for the condition type. */
+  status: ConditionStatus;
+  /** Optional machine-readable reason reported by Kueue. */
+  reason?: string;
+  /** Optional human-readable status message reported by Kueue. */
+  message?: string;
+}
+
+/** Resource quota entry within a ClusterQueue flavor. */
+export interface ResourceQuotaLike {
+  /** Resource name, for example cpu or memory. */
+  name: string;
+  /** Guaranteed quota configured for this resource. */
+  nominalQuota: string | number;
+  /** Optional amount that can be borrowed from the cohort. */
+  borrowingLimit?: string | number;
+  /** Optional amount that can be lent to the cohort. */
+  lendingLimit?: string | number;
+}
+
+/** ResourceFlavor quota entry within a ClusterQueue resource group. */
+export interface FlavorQuotasLike {
+  /** Referenced ResourceFlavor name. */
+  name: string;
+  /** Resource quota values configured for this flavor. */
+  resources?: ResourceQuotaLike[];
+}
+
+/** Resource group entry from spec.resourceGroups. */
+export interface ResourceGroupLike {
+  /** Resources covered by this group, such as cpu and memory. */
+  coveredResources?: string[];
+  /** ResourceFlavors available for the covered resources. */
+  flavors?: FlavorQuotasLike[];
+}
+
+/** Namespace selector used to decide where a ClusterQueue can admit workloads. */
+export interface LabelSelectorLike {
+  /** Exact label matches required by the selector. */
+  matchLabels?: Record<string, string>;
+  /** Set-based label requirements required by the selector. */
+  matchExpressions?: Array<{
+    /** Label key evaluated by the selector expression. */
+    key: string;
+    /** Kubernetes selector operator. */
+    operator: 'In' | 'NotIn' | 'Exists' | 'DoesNotExist';
+    /** Optional values used by In and NotIn operators. */
+    values?: string[];
+  }>;
+}
+
+/** Preemption policy configured for a ClusterQueue. */
+export interface ClusterQueuePreemptionLike {
+  /** Reclaim policy for workloads within the same cohort. */
+  reclaimWithinCohort?: string;
+  /** Borrowing preemption policy within the same cohort. */
+  borrowWithinCohort?: {
+    /** Borrowing policy name. */
+    policy?: string;
+    /** Optional priority threshold for borrowing preemption. */
+    maxPriorityThreshold?: number;
+  };
+  /** Preemption policy for workloads within this ClusterQueue. */
+  withinClusterQueue?: string;
+}
+
+/** Admission check strategy configured for a ClusterQueue. */
+export interface AdmissionChecksStrategyLike {
+  /** Admission checks and optional flavor scopes. */
+  admissionChecks?: Array<{
+    /** AdmissionCheck resource name. */
+    name: string;
+    /** ResourceFlavor names this check applies to; empty means all flavors. */
+    onFlavors?: string[];
+  }>;
+}
+
+/** Flavor fungibility policy for borrowing and preemption decisions. */
+export interface FlavorFungibilityLike {
+  /** Policy for whether this ClusterQueue can borrow resources. */
+  whenCanBorrow?: string;
+  /** Policy for whether this ClusterQueue can preempt workloads. */
+  whenCanPreempt?: string;
+  /** Optional flavor preference policy. */
+  preference?: string;
+}
+
+/** Status usage entry for a ResourceFlavor. */
+export interface FlavorUsageLike {
+  /** ResourceFlavor name reported by ClusterQueue status. */
+  name: string;
+  /** Resource usage values reported under this flavor. */
+  resources?: Array<{
+    /** Resource name, for example cpu or memory. */
+    name: string;
+    /** Total reserved or used quantity. */
+    total?: string | number;
+    /** Quantity currently borrowed from the cohort. */
+    borrowed?: string | number;
+  }>;
+}
+
+/** Fair sharing configuration for a ClusterQueue. */
+export interface FairSharingLike {
+  /** Optional queue weight used by Kueue fair sharing. */
+  weight?: string | number;
+}
+
+/** Fair sharing status reported by Kueue. */
+export interface FairSharingStatusLike {
+  /** Current weighted share value reported in status. */
+  weightedShare: number;
+}
+
+/** Concurrent admission migration policy configured for a ClusterQueue. */
+export interface ConcurrentAdmissionPolicyLike {
+  /** Optional migration settings for concurrent admission. */
+  migration?: {
+    /** Migration mode. */
+    mode?: string;
+    /** Optional constraints for migration behavior. */
+    constraints?: {
+      /** Last flavor name that is still acceptable during migration. */
+      lastAcceptableFlavorName?: string;
+    };
+  };
+}
+
+/** Render the user-facing ClusterQueue status from its Active condition. */
+export function renderClusterQueueStatus(activeCondition?: ClusterQueueConditionLike) {
+  if (!activeCondition) {
+    return 'Unknown';
+  }
+
+  if (activeCondition.status === 'True') {
+    return 'Active';
+  }
+
+  if (activeCondition.status === 'False') {
+    return 'Inactive';
+  }
+
+  return 'Unknown';
+}
+
+/** Return unique ResourceFlavor names referenced by ClusterQueue resource groups. */
+export function getUniqueFlavorNames(resourceGroups: ResourceGroupLike[]) {
+  const names = resourceGroups.flatMap(group => group.flavors?.map(flavor => flavor.name) || []);
+
+  return Array.from(new Set(names)).filter(Boolean).sort();
+}
+
+/** Render a compact resource group and flavor count for ClusterQueue lists. */
+export function renderResourceGroupsSummary(resourceGroups: ResourceGroupLike[]) {
+  if (resourceGroups.length === 0) {
+    return '-';
+  }
+
+  const flavorCount = resourceGroups.reduce(
+    (count, group) => count + (group.flavors?.length || 0),
+    0
+  );
+  const groupLabel = resourceGroups.length === 1 ? 'group' : 'groups';
+  const flavorLabel = flavorCount === 1 ? 'flavor' : 'flavors';
+
+  return `${resourceGroups.length} ${groupLabel}, ${flavorCount} ${flavorLabel}`;
+}
+
+/** Render a comma-separated list, falling back to '-' when empty. */
+export function renderStringList(values: string[]) {
+  return values.length > 0 ? values.join(', ') : '-';
+}
+
+/** Render a Kubernetes label selector as compact detail text. */
+export function renderLabelSelector(selector?: LabelSelectorLike) {
+  if (!selector) {
+    return 'All namespaces';
+  }
+
+  const labels = Object.entries(selector.matchLabels || {}).map(
+    ([key, value]) => `${key}=${value}`
+  );
+  const expressions = (selector.matchExpressions || []).map(expression => {
+    const values = expression.values?.length ? ` (${expression.values.join(', ')})` : '';
+    return `${expression.key} ${expression.operator}${values}`;
+  });
+  const parts = [...labels, ...expressions];
+
+  return parts.length > 0 ? parts.join('; ') : 'All namespaces';
+}
+
+/** Render all resource groups and nested flavors as multiline detail text. */
+export function renderResourceGroups(resourceGroups: ResourceGroupLike[]) {
+  if (resourceGroups.length === 0) {
+    return '-';
+  }
+
+  return resourceGroups
+    .map((group, index) => {
+      const resources = renderStringList(group.coveredResources || []);
+      const flavors = (group.flavors || []).map(renderFlavorQuotas).join('; ') || '-';
+
+      return `Group ${index + 1}: resources ${resources}; flavors ${flavors}`;
+    })
+    .join('\n');
+}
+
+/** Render one ResourceFlavor quota block for a resource group summary. */
+function renderFlavorQuotas(flavor: FlavorQuotasLike) {
+  const resources = (flavor.resources || []).map(renderResourceQuota).join(', ') || '-';
+
+  return `${flavor.name} [${resources}]`;
+}
+
+/** Render one resource quota entry with nominal, borrow, and lend values. */
+function renderResourceQuota(resource: ResourceQuotaLike) {
+  const limits = [
+    `nominal ${resource.nominalQuota}`,
+    resource.borrowingLimit !== undefined ? `borrow ${resource.borrowingLimit}` : undefined,
+    resource.lendingLimit !== undefined ? `lend ${resource.lendingLimit}` : undefined,
+  ].filter(Boolean);
+
+  return `${resource.name}: ${limits.join(', ')}`;
+}
+
+/** Render ClusterQueue conditions as multiline status text. */
+export function renderConditions(conditions: ClusterQueueConditionLike[]) {
+  if (conditions.length === 0) {
+    return '-';
+  }
+
+  return conditions
+    .map(condition => {
+      const reason = condition.reason ? ` (${condition.reason})` : '';
+      const message = condition.message ? `: ${condition.message}` : '';
+
+      return `${condition.type}=${condition.status}${reason}${message}`;
+    })
+    .join('\n');
+}
+
+/** Render ClusterQueue preemption policies for the detail page. */
+export function renderPreemption(preemption?: ClusterQueuePreemptionLike) {
+  if (!preemption) {
+    return '-';
+  }
+
+  const borrowWithinCohort = preemption.borrowWithinCohort
+    ? [
+        preemption.borrowWithinCohort.policy
+          ? `policy ${preemption.borrowWithinCohort.policy}`
+          : undefined,
+        preemption.borrowWithinCohort.maxPriorityThreshold !== undefined
+          ? `max priority ${preemption.borrowWithinCohort.maxPriorityThreshold}`
+          : undefined,
+      ]
+        .filter(Boolean)
+        .join(', ') || '-'
+    : '-';
+
+  return [
+    `Reclaim within cohort: ${preemption.reclaimWithinCohort || '-'}`,
+    `Borrow within cohort: ${borrowWithinCohort}`,
+    `Within ClusterQueue: ${preemption.withinClusterQueue || '-'}`,
+  ].join('; ');
+}
+
+/** Render admission checks and their flavor scopes for the detail page. */
+export function renderAdmissionChecks(strategy?: AdmissionChecksStrategyLike) {
+  const checks = strategy?.admissionChecks || [];
+
+  if (checks.length === 0) {
+    return '-';
+  }
+
+  return checks
+    .map(check => {
+      const flavors = check.onFlavors?.length ? check.onFlavors.join(', ') : 'all flavors';
+      return `${check.name} (${flavors})`;
+    })
+    .join('; ');
+}
+
+/** Render ClusterQueue flavor fungibility settings for the detail page. */
+export function renderFlavorFungibility(flavorFungibility?: FlavorFungibilityLike) {
+  if (!flavorFungibility) {
+    return '-';
+  }
+
+  return [
+    flavorFungibility.whenCanBorrow
+      ? `When can borrow: ${flavorFungibility.whenCanBorrow}`
+      : undefined,
+    flavorFungibility.whenCanPreempt
+      ? `When can preempt: ${flavorFungibility.whenCanPreempt}`
+      : undefined,
+    flavorFungibility.preference ? `Preference: ${flavorFungibility.preference}` : undefined,
+  ]
+    .filter(Boolean)
+    .join('; ');
+}
+
+/** Render ClusterQueue status usage or reservations grouped by flavor. */
+export function renderFlavorUsage(flavorUsage?: FlavorUsageLike[]) {
+  if (!flavorUsage?.length) {
+    return '-';
+  }
+
+  return flavorUsage
+    .map(flavor => {
+      const resources = (flavor.resources || [])
+        .map(resource => {
+          const values = [
+            resource.total !== undefined ? `total ${resource.total}` : undefined,
+            resource.borrowed !== undefined ? `borrowed ${resource.borrowed}` : undefined,
+          ].filter(Boolean);
+
+          return `${resource.name}: ${values.join(', ') || '-'}`;
+        })
+        .join(', ');
+
+      return `${flavor.name} [${resources || '-'}]`;
+    })
+    .join('; ');
+}
+
+/** Render ClusterQueue fair sharing configuration and status. */
+export function renderFairSharing(
+  fairSharing?: FairSharingLike,
+  fairSharingStatus?: FairSharingStatusLike
+) {
+  const values = [
+    fairSharing?.weight !== undefined ? `Weight: ${fairSharing.weight}` : undefined,
+    fairSharingStatus?.weightedShare !== undefined
+      ? `Weighted share: ${fairSharingStatus.weightedShare}`
+      : undefined,
+  ].filter(Boolean);
+
+  return values.length > 0 ? values.join('; ') : '-';
+}
+
+/** Render ClusterQueue concurrent admission migration policy. */
+export function renderConcurrentAdmissionPolicy(policy?: ConcurrentAdmissionPolicyLike) {
+  if (!policy?.migration) {
+    return '-';
+  }
+
+  const values = [
+    policy.migration.mode ? `Mode: ${policy.migration.mode}` : undefined,
+    policy.migration.constraints?.lastAcceptableFlavorName
+      ? `Last acceptable flavor: ${policy.migration.constraints.lastAcceptableFlavorName}`
+      : undefined,
+  ].filter(Boolean);
+
+  return values.length > 0 ? values.join('; ') : '-';
+}

--- a/kueue/src/utils/kueueApi.test.ts
+++ b/kueue/src/utils/kueueApi.test.ts
@@ -12,4 +12,9 @@ describe('Kueue API constants', () => {
     expect(kueueRoutePaths.resourceFlavorsList).toBe('/kueue/resourceflavors');
     expect(kueueRoutePaths.resourceFlavorDetail).toBe('/kueue/resourceflavors/:name');
   });
+
+  it('defines ClusterQueue list and detail routes', () => {
+    expect(kueueRoutePaths.clusterQueuesList).toBe('/kueue/clusterqueues');
+    expect(kueueRoutePaths.clusterQueueDetail).toBe('/kueue/clusterqueues/:name');
+  });
 });

--- a/kueue/src/utils/kueueRoutes.ts
+++ b/kueue/src/utils/kueueRoutes.ts
@@ -1,9 +1,13 @@
 export const kueueRouteNames = {
+  clusterQueuesList: 'kueue-clusterqueues-list',
+  clusterQueueDetail: 'kueue-clusterqueue-detail',
   resourceFlavorsList: 'kueue-resourceflavors-list',
   resourceFlavorDetail: 'kueue-resourceflavor-detail',
 } as const;
 
 export const kueueRoutePaths = {
+  clusterQueuesList: '/kueue/clusterqueues',
+  clusterQueueDetail: '/kueue/clusterqueues/:name',
   resourceFlavorsList: '/kueue/resourceflavors',
   resourceFlavorDetail: '/kueue/resourceflavors/:name',
 } as const;

--- a/kueue/test-files/deploy/clusterqueue-team-a.yaml
+++ b/kueue/test-files/deploy/clusterqueue-team-a.yaml
@@ -1,0 +1,30 @@
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ClusterQueue
+metadata:
+  name: team-a
+spec:
+  cohortName: default
+  queueingStrategy: BestEffortFIFO
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  resourceGroups:
+    - coveredResources:
+        - cpu
+        - memory
+      flavors:
+        - name: default
+          resources:
+            - name: cpu
+              nominalQuota: "8"
+            - name: memory
+              nominalQuota: 32Gi
+        - name: spot
+          resources:
+            - name: cpu
+              nominalQuota: "16"
+            - name: memory
+              nominalQuota: 64Gi
+  preemption:
+    reclaimWithinCohort: LowerPriority
+    withinClusterQueue: LowerPriority


### PR DESCRIPTION
## Summary

Adds support for Kueue `ClusterQueue` resources in the Headlamp Kueue plugin.

## Changes

- Adds a typed `ClusterQueue` resource model for `kueue.x-k8s.io/v1beta2`
- Adds ClusterQueue list and detail pages
- Registers ClusterQueue sidebar entry and routes
- Displays resource groups, referenced ResourceFlavors, workload counts, conditions, preemption, admission checks, and fair sharing details
- Adds formatter tests and a sample ClusterQueue manifest
- Updates the Kueue README with ClusterQueue usage notes

##Screenshots
<img width="1430" height="805" alt="Screenshot 2026-07-05 at 10 09 40 AM" src="https://github.com/user-attachments/assets/0103f320-35db-4981-8442-48a3d8e510cf" />
<img width="1440" height="810" alt="Screenshot 2026-07-05 at 10 10 00 AM" src="https://github.com/user-attachments/assets/6d68bfba-4773-4d59-ae1f-a79cbf74cebf" />
<img width="1440" height="810" alt="Screenshot 2026-07-05 at 10 10 17 AM" src="https://github.com/user-attachments/assets/82f8e4f4-2407-48d3-885b-6354aa083a8d" />

https://github.com/user-attachments/assets/919dd1ef-d672-46a9-b6fb-ea6c05ecbb75


## Testing

```bash
cd kueue
npm run tsc
npm run lint
node_modules/.bin/vitest run -c node_modules/@kinvolk/headlamp-plugin/config/vite.config.mjs
npm run build


