### PR TITLE
Kmesh: Implement Kmesh Daemon Health Dashboard 

### DIFF
--- a/kmesh/src/components/daemon/HealthDashboard.tsx
+++ b/kmesh/src/components/daemon/HealthDashboard.tsx
@@ -1,0 +1,117 @@
+/**
+ * Provides a comprehensive UI dashboard for monitoring Kmesh Daemon pods.
+ * It uses the Headlamp SimpleTable component to aggregate pod status and dynamically
+ * fetches the daemon version directly from each pod using a local proxy hook.
+ */
+import {
+  SectionBox,
+  SimpleTable,
+  StatusLabel,
+} from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { CircularProgress, Typography } from '@mui/material';
+import { useKmeshVersion } from '../../hooks/useDaemonRequest';
+import { type KmeshDaemonPod, useKmeshDaemonPods } from '../../hooks/useKmeshDaemonPods';
+
+/**
+ * Renders an individual table cell displaying the daemon version for a given pod.
+ * This component utilizes a hook to tunnel through the Kubernetes API server and
+ * query the specific pod's `/version` endpoint securely.
+ *
+ * @param props - Component props containing the pod data
+ * @param props.pod - The Kmesh Daemon pod to fetch the version for
+ * @returns A React component rendering the version string or an error state
+ */
+function DaemonVersionCell({ pod }: { pod: KmeshDaemonPod }) {
+  // Only query the daemon once the pod is Running+Ready to avoid noisy errors and extra load.
+  const podName = pod.phase === 'Running' && pod.ready ? pod.name : null;
+  const { status, data: version, error } = useKmeshVersion(pod.namespace, podName);
+
+  if (status === 'loading') {
+    return <CircularProgress size={16} />;
+  }
+
+  if (status === 'error') {
+    return (
+      <Typography color="error" variant="body2">
+        Error: {error as string}
+      </Typography>
+    );
+  }
+
+  if (version) {
+    return (
+      <Typography variant="body2">
+        {version.gitVersion} ({version.gitCommit?.substring(0, 7) || 'unknown'})
+      </Typography>
+    );
+  }
+
+  return (
+    <Typography variant="body2" color="textSecondary">
+      -
+    </Typography>
+  );
+}
+
+/**
+ * The main Health Dashboard component for Kmesh.
+ * This fetches all running Kmesh daemon pods in the cluster via the Kubernetes API
+ * and visualizes their deployment state alongside their dynamically queried daemon metrics.
+ *
+ * @returns A React component containing a table of daemon pods
+ */
+export default function HealthDashboard() {
+  const { pods, loading, error } = useKmeshDaemonPods();
+
+  if (error) {
+    return (
+      <SectionBox title="Kmesh Daemon Health">
+        <Typography color="error">Error loading pods: {error as string}</Typography>
+      </SectionBox>
+    );
+  }
+
+  return (
+    <SectionBox title="Kmesh Daemon Health">
+      {loading ? (
+        <CircularProgress />
+      ) : (
+        <SimpleTable
+          data={pods}
+          columns={[
+            {
+              label: 'Pod Name',
+              getter: (pod: KmeshDaemonPod) => pod.name,
+              sort: true,
+            },
+            {
+              label: 'Node',
+              getter: (pod: KmeshDaemonPod) => pod.nodeName,
+              sort: true,
+            },
+            {
+              label: 'IP',
+              getter: (pod: KmeshDaemonPod) => pod.podIP,
+              sort: true,
+            },
+            {
+              label: 'Status',
+              getter: (pod: KmeshDaemonPod) => (
+                <StatusLabel status={pod.phase === 'Running' && pod.ready ? 'success' : 'error'}>
+                  {`${pod.phase}${!pod.ready ? ' (Not Ready)' : ''}`}
+                </StatusLabel>
+              ),
+              sort: (pod: KmeshDaemonPod) => pod.phase,
+            },
+            {
+              label: 'Daemon Version (Proxy)',
+              getter: (pod: KmeshDaemonPod) => <DaemonVersionCell pod={pod} />,
+              sort: false,
+            },
+          ]}
+          emptyMessage="No kmesh-daemon pods found in the cluster."
+        />
+      )}
+    </SectionBox>
+  );
+}

--- a/kmesh/src/components/daemon/HealthDashboard.tsx
+++ b/kmesh/src/components/daemon/HealthDashboard.tsx
@@ -22,9 +22,20 @@ import { type KmeshDaemonPod, useKmeshDaemonPods } from '../../hooks/useKmeshDae
  * @returns A React component rendering the version string or an error state
  */
 function DaemonVersionCell({ pod }: { pod: KmeshDaemonPod }) {
-  // Only query the daemon once the pod is Running+Ready to avoid noisy errors and extra load.
-  const podName = pod.phase === 'Running' && pod.ready ? pod.name : null;
-  const { status, data: version, error } = useKmeshVersion(pod.namespace, podName);
+  const versionState = useKmeshVersion(
+    pod.namespace,
+    pod.phase === 'Running' && pod.ready ? pod.name : null
+  );
+
+  if (pod.phase !== 'Running' || !pod.ready) {
+    return (
+      <Typography variant="body2" color="text.secondary">
+        -
+      </Typography>
+    );
+  }
+
+  const { status, data: version, error } = versionState;
 
   if (status === 'loading') {
     return <CircularProgress size={16} />;
@@ -33,7 +44,7 @@ function DaemonVersionCell({ pod }: { pod: KmeshDaemonPod }) {
   if (status === 'error') {
     return (
       <Typography color="error" variant="body2">
-        Error: {error as string}
+        Error: {error ?? 'Unknown error'}
       </Typography>
     );
   }
@@ -41,13 +52,14 @@ function DaemonVersionCell({ pod }: { pod: KmeshDaemonPod }) {
   if (version) {
     return (
       <Typography variant="body2">
-        {version.gitVersion} ({version.gitCommit?.substring(0, 7) || 'unknown'})
+        {version.gitVersion ?? version.version ?? 'unknown'} (
+        {(version.gitCommit ?? version.gitRevision ?? '').substring(0, 7) || 'unknown'})
       </Typography>
     );
   }
 
   return (
-    <Typography variant="body2" color="textSecondary">
+    <Typography variant="body2" color="text.secondary">
       -
     </Typography>
   );
@@ -66,7 +78,7 @@ export default function HealthDashboard() {
   if (error) {
     return (
       <SectionBox title="Kmesh Daemon Health">
-        <Typography color="error">Error loading pods: {error as string}</Typography>
+        <Typography color="error">Error loading pods: {error ?? 'Unknown error'}</Typography>
       </SectionBox>
     );
   }
@@ -96,12 +108,15 @@ export default function HealthDashboard() {
             },
             {
               label: 'Status',
-              getter: (pod: KmeshDaemonPod) => (
-                <StatusLabel status={pod.phase === 'Running' && pod.ready ? 'success' : 'error'}>
-                  {`${pod.phase}${!pod.ready ? ' (Not Ready)' : ''}`}
-                </StatusLabel>
-              ),
-              sort: (pod: KmeshDaemonPod) => pod.phase,
+              getter: (pod: KmeshDaemonPod) => {
+                const displayStatus = pod.statusReason ?? pod.phase;
+                return (
+                  <StatusLabel status={pod.phase === 'Running' && pod.ready ? 'success' : 'error'}>
+                    {`${displayStatus}${!pod.ready ? ' (Not Ready)' : ''}`}
+                  </StatusLabel>
+                );
+              },
+              sort: (pod: KmeshDaemonPod) => pod.statusReason ?? pod.phase,
             },
             {
               label: 'Daemon Version (Proxy)',

--- a/kmesh/src/hooks/useKmeshDaemonPods.ts
+++ b/kmesh/src/hooks/useKmeshDaemonPods.ts
@@ -77,10 +77,22 @@ export function useKmeshDaemonPods(): UseKmeshDaemonPodsResult {
           `?labelSelector=${encodeURIComponent(KMESH_DAEMON_LABEL_SELECTOR)}`;
 
         type PodCondition = { type?: string; status?: string };
+        type ContainerStateWaiting = { reason?: string };
+        type ContainerStateTerminated = { reason?: string };
+        type ContainerState = {
+          waiting?: ContainerStateWaiting;
+          terminated?: ContainerStateTerminated;
+        };
+        type ContainerStatus = { state?: ContainerState };
         type PodItem = {
           metadata?: { name?: string; namespace?: string };
           spec?: { nodeName?: string };
-          status?: { phase?: string; podIP?: string; conditions?: PodCondition[] };
+          status?: {
+            phase?: string;
+            podIP?: string;
+            conditions?: PodCondition[];
+            containerStatuses?: ContainerStatus[];
+          };
         };
         type PodListResponse = { items?: PodItem[] };
 
@@ -92,11 +104,23 @@ export function useKmeshDaemonPods(): UseKmeshDaemonPodsResult {
             c => c.type === 'Ready' && c.status === 'True'
           );
 
+          let phase = item.status?.phase ?? 'Unknown';
+          const containerStatuses = item.status?.containerStatuses ?? [];
+          for (const status of containerStatuses) {
+            if (status.state?.waiting?.reason) {
+              phase = status.state.waiting.reason;
+              break;
+            } else if (status.state?.terminated?.reason) {
+              phase = status.state.terminated.reason;
+              break;
+            }
+          }
+
           return {
             name: item.metadata?.name ?? '',
             namespace: item.metadata?.namespace ?? KMESH_NAMESPACE,
             nodeName: item.spec?.nodeName ?? '',
-            phase: item.status?.phase ?? 'Unknown',
+            phase,
             ready,
             podIP: item.status?.podIP ?? '',
           };

--- a/kmesh/src/hooks/useKmeshDaemonPods.ts
+++ b/kmesh/src/hooks/useKmeshDaemonPods.ts
@@ -27,6 +27,8 @@ export interface KmeshDaemonPod {
   nodeName: string;
   /** Pod phase (Running / Pending / …). */
   phase: string;
+  /** Detailed reason for the pod's current state (e.g. CrashLoopBackOff) */
+  statusReason?: string;
   /** True if the PodReady condition is met. */
   ready: boolean;
   /** Pod IP — informational. */
@@ -89,6 +91,7 @@ export function useKmeshDaemonPods(): UseKmeshDaemonPodsResult {
           spec?: { nodeName?: string };
           status?: {
             phase?: string;
+            reason?: string;
             podIP?: string;
             conditions?: PodCondition[];
             containerStatuses?: ContainerStatus[];
@@ -104,15 +107,18 @@ export function useKmeshDaemonPods(): UseKmeshDaemonPodsResult {
             c => c.type === 'Ready' && c.status === 'True'
           );
 
-          let phase = item.status?.phase ?? 'Unknown';
+          const phase = item.status?.phase ?? 'Unknown';
+          let statusReason: string | undefined = item.status?.reason;
           const containerStatuses = item.status?.containerStatuses ?? [];
-          for (const status of containerStatuses) {
-            if (status.state?.waiting?.reason) {
-              phase = status.state.waiting.reason;
-              break;
-            } else if (status.state?.terminated?.reason) {
-              phase = status.state.terminated.reason;
-              break;
+          if (!statusReason) {
+            for (const status of containerStatuses) {
+              if (status.state?.waiting?.reason) {
+                statusReason = status.state.waiting.reason;
+                break;
+              } else if (status.state?.terminated?.reason) {
+                statusReason = status.state.terminated.reason;
+                break;
+              }
             }
           }
 
@@ -121,12 +127,14 @@ export function useKmeshDaemonPods(): UseKmeshDaemonPodsResult {
             namespace: item.metadata?.namespace ?? KMESH_NAMESPACE,
             nodeName: item.spec?.nodeName ?? '',
             phase,
+            statusReason,
             ready,
             podIP: item.status?.podIP ?? '',
           };
         });
 
         setPods(items);
+        setError(null);
       } catch (err) {
         if (!cancelled) {
           setError(err instanceof Error ? err.message : 'Failed to list Kmesh daemon pods');
@@ -136,9 +144,18 @@ export function useKmeshDaemonPods(): UseKmeshDaemonPodsResult {
       }
     }
 
-    fetchPods();
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+    const poll = async () => {
+      await fetchPods();
+      if (!cancelled) timeoutId = setTimeout(poll, 5000);
+    };
+
+    poll();
+
     return () => {
       cancelled = true;
+      if (timeoutId) clearTimeout(timeoutId);
     };
   }, [cluster]);
 

--- a/kmesh/src/index.test.ts
+++ b/kmesh/src/index.test.ts
@@ -2,9 +2,10 @@ import { describe, expect, it } from 'vitest';
 import { kmeshRouteNames, kmeshRoutePaths } from './utils/kmeshRoutes';
 
 describe('Kmesh Routes', () => {
-  it('should define waypoint routes correctly', () => {
+  it('should define waypoint and health routes correctly', () => {
     expect(kmeshRoutePaths.waypointsList).toBe('/kmesh/waypoints');
     expect(kmeshRoutePaths.waypointDetail).toBe('/kmesh/waypoints/:namespace/:name');
+    expect(kmeshRoutePaths.healthDashboard).toBe('/kmesh/health');
   });
 
   it('should define the xDS config dump route correctly', () => {

--- a/kmesh/src/index.tsx
+++ b/kmesh/src/index.tsx
@@ -1,7 +1,7 @@
 import { registerRoute, registerSidebarEntry } from '@kinvolk/headlamp-plugin/lib';
 import type { ComponentType } from 'react';
-import XdsConfigDump from './components/daemon/XdsConfigDump';
 import HealthDashboard from './components/daemon/HealthDashboard';
+import XdsConfigDump from './components/daemon/XdsConfigDump';
 import WaypointDetail from './components/waypoints/Detail';
 import WaypointList from './components/waypoints/List';
 import { kmeshRouteNames, kmeshRoutePaths } from './utils/kmeshRoutes';

--- a/kmesh/src/index.tsx
+++ b/kmesh/src/index.tsx
@@ -1,6 +1,7 @@
 import { registerRoute, registerSidebarEntry } from '@kinvolk/headlamp-plugin/lib';
 import type { ComponentType } from 'react';
 import XdsConfigDump from './components/daemon/XdsConfigDump';
+import HealthDashboard from './components/daemon/HealthDashboard';
 import WaypointDetail from './components/waypoints/Detail';
 import WaypointList from './components/waypoints/List';
 import { kmeshRouteNames, kmeshRoutePaths } from './utils/kmeshRoutes';
@@ -101,4 +102,20 @@ registerRoute({
   name: kmeshRouteNames.xdsConfigDump,
   exact: true,
   component: () => <XdsConfigDump />,
+});
+
+// Health Dashboard (Single Route)
+registerSidebarEntry({
+  parent: 'kmesh',
+  name: 'kmesh-health',
+  label: 'Daemon Health',
+  url: kmeshRoutePaths.healthDashboard,
+});
+
+registerRoute({
+  path: kmeshRoutePaths.healthDashboard,
+  sidebar: 'kmesh-health',
+  name: kmeshRouteNames.healthDashboard,
+  exact: true,
+  component: () => <HealthDashboard />,
 });

--- a/kmesh/src/types/daemonApi.ts
+++ b/kmesh/src/types/daemonApi.ts
@@ -27,9 +27,9 @@
 
 export interface KmeshVersion {
   /** The semantic version of the Kmesh daemon */
-  version: string;
+  gitVersion: string;
   /** Git commit hash of the build */
-  gitRevision: string;
+  gitCommit: string;
   /** Git branch of the build */
   gitBranch: string;
   /** Timestamp when the daemon was built */

--- a/kmesh/src/types/daemonApi.ts
+++ b/kmesh/src/types/daemonApi.ts
@@ -26,10 +26,14 @@
 // ---------------------------------------------------------------------------
 
 export interface KmeshVersion {
-  /** The semantic version of the Kmesh daemon */
-  gitVersion: string;
+  /** Version string of the Kmesh daemon build (as reported in `gitVersion`). */
+  gitVersion?: string;
   /** Git commit hash of the build */
-  gitCommit: string;
+  gitCommit?: string;
+  /** Legacy: The semantic version of the Kmesh daemon */
+  version?: string;
+  /** Legacy: Git commit hash of the build */
+  gitRevision?: string;
   /** Git branch of the build */
   gitBranch: string;
   /** Timestamp when the daemon was built */

--- a/kmesh/src/utils/kmeshRoutes.ts
+++ b/kmesh/src/utils/kmeshRoutes.ts
@@ -6,6 +6,7 @@ export const kmeshRouteNames = {
   waypointDetail: 'kmesh-waypoint-detail',
   /** xDS Config Dump viewer (kernel-native / ADS mode) */
   xdsConfigDump: 'kmesh-xds-config-dump',
+  healthDashboard: 'kmesh-health-dashboard',
 } as const;
 
 /**
@@ -17,4 +18,5 @@ export const kmeshRoutePaths = {
   /** xDS Config Dump viewer — surfaces clusters, listeners, and routes from
    *  the kernel-native (ADS) daemon config dump endpoint. */
   xdsConfigDump: '/kmesh/xds-config',
+  healthDashboard: '/kmesh/health',
 } as const;


### PR DESCRIPTION
### Description

**What does this PR do?**
This PR introduces the **Kmesh Daemon Health Dashboard**, providing a centralized UI to monitor the real-time status and health of the `kmesh-daemon` data plane pods running across the cluster. It leverages Headlamp's native `SimpleTable` component to securely aggregate and display connection states without requiring manual `kubectl port-forward` commands.

**Key Features & Technical Implementation:**
- **Daemon Health Dashboard:** Created `HealthDashboard.tsx` utilizing the native `SimpleTable` component to display:
  - Pod Names & Host Nodes
  - Assigned Pod IPs
  - Real-time Kubernetes Readiness Status (`Running`, `Not Ready`, `CrashLoopBackOff`, etc.)
  - Daemon Versioning (Fetched dynamically from the daemon's proxy API with Git Revisions)
- **Routing & Navigation:** Registered the daemon health view into the Headlamp sidebar (`KMesh -> Daemon Health`) and set up appropriate path routing variables in `kmeshRoutes.ts`.

**How to Test:**
1. Run a local cluster with Kmesh installed (e.g., Kind or Minikube).
2. Navigate to `KMesh` -> `Daemon Health` in the left sidebar.
3. Observe the table populate dynamically. Ensure that pods correctly display their version/commit hash when fully ready.

<img width="1509" height="171" alt="image" src="https://github.com/user-attachments/assets/28fdcacb-38cf-4d74-b60f-8f3d9bc3e014" />


