### PR TITLE
plugin-catalog: Fix a11y violations

### DIFF
--- a/plugin-catalog/locales/cs/translation.json
+++ b/plugin-catalog/locales/cs/translation.json
@@ -33,6 +33,8 @@
   "Search": "",
   "No plugins found": "",
   "Loading": "",
+  "Cancel": "",
+  "Installation progress": "",
   "Official Chart": "",
   "Verified Publisher": "",
   "Update available": "",

--- a/plugin-catalog/locales/cs/translation.json
+++ b/plugin-catalog/locales/cs/translation.json
@@ -8,6 +8,7 @@
   "Name": "",
   "Description": "",
   "Available Version": "",
+  "Available version": "",
   "(latest)": "",
   "Installed Version": "",
   "Repository": "",

--- a/plugin-catalog/locales/de/translation.json
+++ b/plugin-catalog/locales/de/translation.json
@@ -33,6 +33,8 @@
   "Search": "",
   "No plugins found": "",
   "Loading": "",
+  "Cancel": "",
+  "Installation progress": "",
   "Official Chart": "",
   "Verified Publisher": "",
   "Update available": "",

--- a/plugin-catalog/locales/de/translation.json
+++ b/plugin-catalog/locales/de/translation.json
@@ -8,6 +8,7 @@
   "Name": "",
   "Description": "",
   "Available Version": "",
+  "Available version": "",
   "(latest)": "",
   "Installed Version": "",
   "Repository": "",

--- a/plugin-catalog/locales/en/translation.json
+++ b/plugin-catalog/locales/en/translation.json
@@ -33,6 +33,8 @@
   "Search": "Search",
   "No plugins found": "No plugins found",
   "Loading": "Loading",
+  "Cancel": "Cancel",
+  "Installation progress": "Installation progress",
   "Official Chart": "Official Chart",
   "Verified Publisher": "Verified Publisher",
   "Update available": "Update available",

--- a/plugin-catalog/locales/en/translation.json
+++ b/plugin-catalog/locales/en/translation.json
@@ -8,6 +8,7 @@
   "Name": "Name",
   "Description": "Description",
   "Available Version": "Available Version",
+  "Available version": "Available version",
   "(latest)": "(latest)",
   "Installed Version": "Installed Version",
   "Repository": "Repository",

--- a/plugin-catalog/locales/es/translation.json
+++ b/plugin-catalog/locales/es/translation.json
@@ -33,6 +33,8 @@
   "Search": "",
   "No plugins found": "",
   "Loading": "",
+  "Cancel": "",
+  "Installation progress": "",
   "Official Chart": "",
   "Verified Publisher": "",
   "Update available": "",

--- a/plugin-catalog/locales/es/translation.json
+++ b/plugin-catalog/locales/es/translation.json
@@ -8,6 +8,7 @@
   "Name": "",
   "Description": "",
   "Available Version": "",
+  "Available version": "",
   "(latest)": "",
   "Installed Version": "",
   "Repository": "",

--- a/plugin-catalog/locales/fr/translation.json
+++ b/plugin-catalog/locales/fr/translation.json
@@ -33,6 +33,8 @@
   "Search": "",
   "No plugins found": "",
   "Loading": "",
+  "Cancel": "",
+  "Installation progress": "",
   "Official Chart": "",
   "Verified Publisher": "",
   "Update available": "",

--- a/plugin-catalog/locales/fr/translation.json
+++ b/plugin-catalog/locales/fr/translation.json
@@ -8,6 +8,7 @@
   "Name": "",
   "Description": "",
   "Available Version": "",
+  "Available version": "",
   "(latest)": "",
   "Installed Version": "",
   "Repository": "",

--- a/plugin-catalog/locales/hu/translation.json
+++ b/plugin-catalog/locales/hu/translation.json
@@ -33,6 +33,8 @@
   "Search": "",
   "No plugins found": "",
   "Loading": "",
+  "Cancel": "",
+  "Installation progress": "",
   "Official Chart": "",
   "Verified Publisher": "",
   "Update available": "",

--- a/plugin-catalog/locales/hu/translation.json
+++ b/plugin-catalog/locales/hu/translation.json
@@ -8,6 +8,7 @@
   "Name": "",
   "Description": "",
   "Available Version": "",
+  "Available version": "",
   "(latest)": "",
   "Installed Version": "",
   "Repository": "",

--- a/plugin-catalog/locales/id/translation.json
+++ b/plugin-catalog/locales/id/translation.json
@@ -33,6 +33,8 @@
   "Search": "",
   "No plugins found": "",
   "Loading": "",
+  "Cancel": "",
+  "Installation progress": "",
   "Official Chart": "",
   "Verified Publisher": "",
   "Update available": "",

--- a/plugin-catalog/locales/id/translation.json
+++ b/plugin-catalog/locales/id/translation.json
@@ -8,6 +8,7 @@
   "Name": "",
   "Description": "",
   "Available Version": "",
+  "Available version": "",
   "(latest)": "",
   "Installed Version": "",
   "Repository": "",

--- a/plugin-catalog/locales/it/translation.json
+++ b/plugin-catalog/locales/it/translation.json
@@ -33,6 +33,8 @@
   "Search": "",
   "No plugins found": "",
   "Loading": "",
+  "Cancel": "",
+  "Installation progress": "",
   "Official Chart": "",
   "Verified Publisher": "",
   "Update available": "",

--- a/plugin-catalog/locales/it/translation.json
+++ b/plugin-catalog/locales/it/translation.json
@@ -8,6 +8,7 @@
   "Name": "",
   "Description": "",
   "Available Version": "",
+  "Available version": "",
   "(latest)": "",
   "Installed Version": "",
   "Repository": "",

--- a/plugin-catalog/locales/ja/translation.json
+++ b/plugin-catalog/locales/ja/translation.json
@@ -33,6 +33,8 @@
   "Search": "",
   "No plugins found": "",
   "Loading": "",
+  "Cancel": "",
+  "Installation progress": "",
   "Official Chart": "",
   "Verified Publisher": "",
   "Update available": "",

--- a/plugin-catalog/locales/ja/translation.json
+++ b/plugin-catalog/locales/ja/translation.json
@@ -8,6 +8,7 @@
   "Name": "",
   "Description": "",
   "Available Version": "",
+  "Available version": "",
   "(latest)": "",
   "Installed Version": "",
   "Repository": "",

--- a/plugin-catalog/locales/ko/translation.json
+++ b/plugin-catalog/locales/ko/translation.json
@@ -33,6 +33,8 @@
   "Search": "",
   "No plugins found": "",
   "Loading": "",
+  "Cancel": "",
+  "Installation progress": "",
   "Official Chart": "",
   "Verified Publisher": "",
   "Update available": "",

--- a/plugin-catalog/locales/ko/translation.json
+++ b/plugin-catalog/locales/ko/translation.json
@@ -8,6 +8,7 @@
   "Name": "",
   "Description": "",
   "Available Version": "",
+  "Available version": "",
   "(latest)": "",
   "Installed Version": "",
   "Repository": "",

--- a/plugin-catalog/locales/nl/translation.json
+++ b/plugin-catalog/locales/nl/translation.json
@@ -33,6 +33,8 @@
   "Search": "",
   "No plugins found": "",
   "Loading": "",
+  "Cancel": "",
+  "Installation progress": "",
   "Official Chart": "",
   "Verified Publisher": "",
   "Update available": "",

--- a/plugin-catalog/locales/nl/translation.json
+++ b/plugin-catalog/locales/nl/translation.json
@@ -8,6 +8,7 @@
   "Name": "",
   "Description": "",
   "Available Version": "",
+  "Available version": "",
   "(latest)": "",
   "Installed Version": "",
   "Repository": "",

--- a/plugin-catalog/locales/pl/translation.json
+++ b/plugin-catalog/locales/pl/translation.json
@@ -33,6 +33,8 @@
   "Search": "",
   "No plugins found": "",
   "Loading": "",
+  "Cancel": "",
+  "Installation progress": "",
   "Official Chart": "",
   "Verified Publisher": "",
   "Update available": "",

--- a/plugin-catalog/locales/pl/translation.json
+++ b/plugin-catalog/locales/pl/translation.json
@@ -8,6 +8,7 @@
   "Name": "",
   "Description": "",
   "Available Version": "",
+  "Available version": "",
   "(latest)": "",
   "Installed Version": "",
   "Repository": "",

--- a/plugin-catalog/locales/pt-BR/translation.json
+++ b/plugin-catalog/locales/pt-BR/translation.json
@@ -33,6 +33,8 @@
   "Search": "",
   "No plugins found": "",
   "Loading": "",
+  "Cancel": "",
+  "Installation progress": "",
   "Official Chart": "",
   "Verified Publisher": "",
   "Update available": "",

--- a/plugin-catalog/locales/pt-BR/translation.json
+++ b/plugin-catalog/locales/pt-BR/translation.json
@@ -8,6 +8,7 @@
   "Name": "",
   "Description": "",
   "Available Version": "",
+  "Available version": "",
   "(latest)": "",
   "Installed Version": "",
   "Repository": "",

--- a/plugin-catalog/locales/pt-PT/translation.json
+++ b/plugin-catalog/locales/pt-PT/translation.json
@@ -33,6 +33,8 @@
   "Search": "",
   "No plugins found": "",
   "Loading": "",
+  "Cancel": "",
+  "Installation progress": "",
   "Official Chart": "",
   "Verified Publisher": "",
   "Update available": "",

--- a/plugin-catalog/locales/pt-PT/translation.json
+++ b/plugin-catalog/locales/pt-PT/translation.json
@@ -8,6 +8,7 @@
   "Name": "",
   "Description": "",
   "Available Version": "",
+  "Available version": "",
   "(latest)": "",
   "Installed Version": "",
   "Repository": "",

--- a/plugin-catalog/locales/ru/translation.json
+++ b/plugin-catalog/locales/ru/translation.json
@@ -33,6 +33,8 @@
   "Search": "",
   "No plugins found": "",
   "Loading": "",
+  "Cancel": "",
+  "Installation progress": "",
   "Official Chart": "",
   "Verified Publisher": "",
   "Update available": "",

--- a/plugin-catalog/locales/ru/translation.json
+++ b/plugin-catalog/locales/ru/translation.json
@@ -8,6 +8,7 @@
   "Name": "",
   "Description": "",
   "Available Version": "",
+  "Available version": "",
   "(latest)": "",
   "Installed Version": "",
   "Repository": "",

--- a/plugin-catalog/locales/sv/translation.json
+++ b/plugin-catalog/locales/sv/translation.json
@@ -33,6 +33,8 @@
   "Search": "",
   "No plugins found": "",
   "Loading": "",
+  "Cancel": "",
+  "Installation progress": "",
   "Official Chart": "",
   "Verified Publisher": "",
   "Update available": "",

--- a/plugin-catalog/locales/sv/translation.json
+++ b/plugin-catalog/locales/sv/translation.json
@@ -8,6 +8,7 @@
   "Name": "",
   "Description": "",
   "Available Version": "",
+  "Available version": "",
   "(latest)": "",
   "Installed Version": "",
   "Repository": "",

--- a/plugin-catalog/locales/tr/translation.json
+++ b/plugin-catalog/locales/tr/translation.json
@@ -33,6 +33,8 @@
   "Search": "",
   "No plugins found": "",
   "Loading": "",
+  "Cancel": "",
+  "Installation progress": "",
   "Official Chart": "",
   "Verified Publisher": "",
   "Update available": "",

--- a/plugin-catalog/locales/tr/translation.json
+++ b/plugin-catalog/locales/tr/translation.json
@@ -8,6 +8,7 @@
   "Name": "",
   "Description": "",
   "Available Version": "",
+  "Available version": "",
   "(latest)": "",
   "Installed Version": "",
   "Repository": "",

--- a/plugin-catalog/locales/zh-Hans/translation.json
+++ b/plugin-catalog/locales/zh-Hans/translation.json
@@ -33,6 +33,8 @@
   "Search": "",
   "No plugins found": "",
   "Loading": "",
+  "Cancel": "",
+  "Installation progress": "",
   "Official Chart": "",
   "Verified Publisher": "",
   "Update available": "",

--- a/plugin-catalog/locales/zh-Hans/translation.json
+++ b/plugin-catalog/locales/zh-Hans/translation.json
@@ -8,6 +8,7 @@
   "Name": "",
   "Description": "",
   "Available Version": "",
+  "Available version": "",
   "(latest)": "",
   "Installed Version": "",
   "Repository": "",

--- a/plugin-catalog/locales/zh-Hant/translation.json
+++ b/plugin-catalog/locales/zh-Hant/translation.json
@@ -33,6 +33,8 @@
   "Search": "",
   "No plugins found": "",
   "Loading": "",
+  "Cancel": "",
+  "Installation progress": "",
   "Official Chart": "",
   "Verified Publisher": "",
   "Update available": "",

--- a/plugin-catalog/locales/zh-Hant/translation.json
+++ b/plugin-catalog/locales/zh-Hant/translation.json
@@ -8,6 +8,7 @@
   "Name": "",
   "Description": "",
   "Available Version": "",
+  "Available version": "",
   "(latest)": "",
   "Installed Version": "",
   "Repository": "",

--- a/plugin-catalog/src/components/plugins/Detail.tsx
+++ b/plugin-catalog/src/components/plugins/Detail.tsx
@@ -312,17 +312,18 @@ export function PurePluginDetail({
               },
               {
                 name: t('Repository'),
-                value: repoUrl && (
-                  <Link href={repoUrl} target="_blank">
-                    {pluginDetail.repository.display_name}
+                value: (
+                  <Link href={repoUrl} target="_blank" rel="noopener noreferrer">
+                    {pluginDetail.repository.display_name || pluginDetail.repository.name}
                   </Link>
                 ),
               },
               {
                 name: t('Author'),
-                value: orgUrl && (
-                  <Link href={orgUrl} target="_blank">
-                    {pluginDetail.repository.organization_display_name}
+                value: pluginDetail.repository.organization_name && (
+                  <Link href={orgUrl} target="_blank" rel="noopener noreferrer">
+                    {pluginDetail.repository.organization_display_name ||
+                      pluginDetail.repository.organization_name}
                   </Link>
                 ),
               },

--- a/plugin-catalog/src/components/plugins/Detail.tsx
+++ b/plugin-catalog/src/components/plugins/Detail.tsx
@@ -289,6 +289,7 @@ export function PurePluginDetail({
                       value={selectedVersion}
                       onChange={(event: SelectChangeEvent) => onVersionChange(event.target.value)}
                       disabled={currentAction !== null}
+                      inputProps={{ 'aria-label': t('Available version') }}
                     >
                       {sortedVersions.map(availableVersion => (
                         <MenuItem key={availableVersion.version} value={availableVersion.version}>

--- a/plugin-catalog/src/components/plugins/Detail.tsx
+++ b/plugin-catalog/src/components/plugins/Detail.tsx
@@ -222,6 +222,7 @@ export function PurePluginDetail({
                     alignSelf: 'flex-start',
                   }}
                   component="img"
+                  alt={`${pluginDetail.display_name || pluginDetail.name} logo`}
                 />
               ),
             ]}

--- a/plugin-catalog/src/components/plugins/List.tsx
+++ b/plugin-catalog/src/components/plugins/List.tsx
@@ -191,7 +191,9 @@ function OfficialSwitch(props: OfficialSwitchProps) {
   return (
     <>
       <FormControlLabel
-        control={<Switch defaultChecked size="small" />}
+        control={
+          <Switch defaultChecked size="small" inputProps={{ 'aria-label': t('Only Official') }} />
+        }
         label={<Typography>{t('Only Official')}</Typography>}
         checked={isChecked}
         onChange={() => {

--- a/plugin-catalog/src/components/plugins/LoadingButton.tsx
+++ b/plugin-catalog/src/components/plugins/LoadingButton.tsx
@@ -1,4 +1,5 @@
 import { Icon } from '@iconify/react';
+import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
 import { Box } from '@mui/material';
 import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
@@ -15,17 +16,24 @@ export interface LoadingButtonProps {
 }
 
 const LoadingButton = (props: LoadingButtonProps) => {
+  const { t } = useTranslation();
   let button = (
     <Button
       variant="contained"
       disabled
+      aria-label={t('Loading')}
       sx={{
         backgroundColor: '#000',
         color: 'white',
         textTransform: 'none',
       }}
     >
-      <CircularProgress color="primary" value={props.progress} size={20} />
+      <CircularProgress
+        color="primary"
+        value={props.progress}
+        size={20}
+        aria-label={t('Loading')}
+      />
     </Button>
   );
   if (props.progress > 0 && props.progress < 100) {
@@ -33,6 +41,7 @@ const LoadingButton = (props: LoadingButtonProps) => {
       <Button
         variant="contained"
         onClick={() => props.onCancel()}
+        aria-label={t('Cancel')}
         sx={{
           backgroundColor: '#000',
           color: 'white',
@@ -50,6 +59,7 @@ const LoadingButton = (props: LoadingButtonProps) => {
             variant="determinate"
             value={props.progress}
             size={20}
+            aria-label={t('Installation progress')}
           />
           <Box
             sx={{

--- a/plugin-catalog/src/components/plugins/PluginCard.tsx
+++ b/plugin-catalog/src/components/plugins/PluginCard.tsx
@@ -99,7 +99,7 @@ export function PluginCard(props: PluginCardProps) {
             }}
           >
             <Typography
-              component="h5"
+              component="div"
               variant="h5"
               sx={{
                 overflow: 'hidden',

--- a/plugin-catalog/src/components/plugins/PluginCard.tsx
+++ b/plugin-catalog/src/components/plugins/PluginCard.tsx
@@ -46,6 +46,7 @@ export function PluginCard(props: PluginCardProps) {
                 alignSelf: 'flex-start',
               }}
               component="img"
+              alt={`${plugin.display_name || plugin.name} logo`}
             />
           ) : (
             <PluginIcon

--- a/plugin-catalog/src/components/plugins/PluginCard.tsx
+++ b/plugin-catalog/src/components/plugins/PluginCard.tsx
@@ -136,7 +136,7 @@ export function PluginCard(props: PluginCardProps) {
               {plugin?.repository && (
                 <>
                   <InlineIcon icon="mdi:building" />{' '}
-                  <Link href={plugin.repository.url} target="_blank">
+                  <Link href={plugin.repository.url} target="_blank" rel="noopener noreferrer">
                     {plugin.repository.organization_name || plugin.repository.name}
                   </Link>
                 </>

--- a/plugin-catalog/src/components/plugins/Settings.tsx
+++ b/plugin-catalog/src/components/plugins/Settings.tsx
@@ -14,6 +14,7 @@ export function Settings(props) {
         <Box sx={{ width: '100%', display: 'flex', justifyContent: 'center' }}>
           <Switch
             checked={data?.displayOnlyOfficialPlugins ?? true}
+            inputProps={{ 'aria-label': t('Display only Official Plugins') }}
             onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
               onDataChange({ ...data, displayOnlyOfficialPlugins: event.target.checked })
             }
@@ -27,6 +28,7 @@ export function Settings(props) {
         <Box sx={{ width: '100%', display: 'flex', justifyContent: 'center' }}>
           <Switch
             checked={data?.displayOnlyVerifiedPlugins ?? true}
+            inputProps={{ 'aria-label': t('Display only Verified Plugins') }}
             onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
               onDataChange({ ...data, displayOnlyVerifiedPlugins: event.target.checked })
             }


### PR DESCRIPTION
These changes fix accessibility (a11y) violations in the plugin-catalog surfaced by an axe-core pass over the components. The catalog looks and behaves exactly as before for sighted mouse users, while becoming usable for keyboard and screen-reader users.

Fixes: #869 

### Changes
- Add alternative text to plugin logo images
- Add accessible names to the version selector, official/verified toggles, and install progress/cancel controls
- Give repository and author links discernable text plus `rel="noopener noreferrer"
- Adjust the plugin card title so headings follow a valid order