### PR TITLE
ai-assistant: docs/proposals: Add consent-poc adversarial testing harness

### DIFF
--- a/ai-assistant/docs/proposals/consent-poc/.gitignore
+++ b/ai-assistant/docs/proposals/consent-poc/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+test-results/
+playwright-report/
+package-lock.json

--- a/ai-assistant/docs/proposals/consent-poc/README.md
+++ b/ai-assistant/docs/proposals/consent-poc/README.md
@@ -1,0 +1,139 @@
+# COOP Popup Consent — Proof of Concept
+
+Minimal proof of concept for the same-port consent popup security model described in
+[`backend-and-mcp.md`](../backend-and-mcp.md).
+
+**No third-party dependencies.** Pure Node.js + minimal HTML/JS.
+
+## Quick start
+
+```bash
+cd docs/proposals/consent-poc
+node server.cjs
+# Open http://localhost:4466
+```
+
+## What it proves
+
+The PoC demonstrates that a **same-port popup** can be securely isolated from the
+page that opens it, using three coordinated browser mechanisms:
+
+| Layer | Mechanism | What it stops |
+|-------|-----------|---------------|
+| 1 | **Sec-Fetch filtering** | `fetch()`, XHR, `<iframe>`, `<object>` — server only responds to top-level navigation |
+| 2 | **COOP** (`Cross-Origin-Opener-Policy: same-origin`) | Parent page reading popup DOM or extracting the nonce via `window.opener` |
+| 3 | **Server-side nonce** | Approval requires a one-time nonce embedded in the consent page HTML |
+| 4 | **SW registration blocking** | Server rejects requests with `Service-Worker: script` header |
+
+## How it works
+
+1. **Main page** (`/`) — simulates Headlamp with a plugin. No COOP header (defaults to `unsafe-none`).
+2. Plugin calls `POST /api/request-consent` → server generates `consentId` + cryptographic `nonce`.
+3. Headlamp opens `window.open('/consent/{consentId}')` via user gesture (click).
+4. Server serves consent page **only** when `Sec-Fetch-Dest: document` + `Sec-Fetch-Mode: navigate`.
+   Response includes `Cross-Origin-Opener-Policy: same-origin` → COOP mismatch with parent → opener severed.
+5. User clicks "Approve" → form POSTs nonce to `/consent/{id}/approve`.
+6. Server validates nonce (one-time), records approval. Plugin polls `/api/consent-status/{id}`.
+
+## Attack tests
+
+Click each attack button on the main page to verify:
+
+| # | Attack | Expected result |
+|---|--------|----------------|
+| 1 | `fetch('/consent/{id}')` | HTTP 403 — `Sec-Fetch-Dest: empty` rejected |
+| 2 | XHR to consent page | HTTP 403 — same reason |
+| 3 | `<iframe>` consent page | HTTP 403 — `Sec-Fetch-Dest: iframe` rejected |
+| 4 | POST approve with wrong nonce | HTTP 403 — invalid nonce |
+| 5 | Read popup DOM via `window.open()` ref | `SecurityError` — COOP severed the relationship |
+| 6 | Register Service Worker | Rejected — server blocks `Service-Worker: script` |
+
+## Browser requirements
+
+- **COOP**: Chrome 83+, Firefox 79+, Safari 15.2+
+- **Sec-Fetch-\***: Chrome 76+, Firefox 90+, Safari 16.1+
+
+For older browsers without `Sec-Fetch-*` headers, the server allows the request
+(headers are absent), but COOP + nonce still provide protection. The consent page
+would be visible to `fetch()` but the nonce can't be replayed after use.
+
+## E2E tests (Playwright)
+
+The attack table above is verified by a comprehensive Playwright suite that
+runs across **Chromium, Firefox, and WebKit** — 53 tests per browser
+(**159 total**).
+
+```bash
+cd docs/proposals/consent-poc
+npm install
+npm run test:install   # downloads chromium + firefox + webkit
+npm test
+```
+
+The Playwright config auto-starts **two** servers as `webServer`:
+
+- `server.cjs` on port `4466` — the protected server under test.
+- `vulnerable-server.cjs` on port `4467` — a deliberately-vulnerable twin with
+  the three server-side protections (Sec-Fetch, COOP, Service-Worker block)
+  removed.
+
+The twin is used as a **negative control**: every protection test is paired
+with the same attack against the twin, which must succeed there. This proves
+the positive tests aren't tautological false positives — they would genuinely
+catch a regression that removed the protection.
+
+### Test suites
+
+- `tests/consent-poc.spec.ts` — 19 tests covering the attack table above
+  (HTTP-level Sec-Fetch filtering, COOP header, nonce validation, nonce
+  replay, Service Worker blocking) and browser-level attack buttons.
+- `tests/consent-poc-adversarial.spec.ts` — 34 additional tests that attack
+  from different angles:
+  - **Negative-control twin**: twin serves `/consent` without COOP, leaks
+    nonce to `fetch()`, serves `/sw.js` despite `Service-Worker: script`.
+  - **Raw-socket header verification**: Node `net.Socket` sends hand-crafted
+    HTTP/1.1 and asserts on literal response bytes
+    (`Cross-Origin-Opener-Policy: same-origin` present on main, absent on twin;
+    403 body contains no 32-hex string).
+  - **`Sec-Fetch-Dest` fuzz**: 17 destinations × (main blocked, twin leaks).
+  - **`Service-Worker` header block**: across 5 paths + lowercase variant +
+    without-header control.
+  - **Inside the popup**: `window.opener === null` (cross-browser-portable
+    COOP assertion).
+  - **`postMessage` isolation**: opener → popup `postMessage` does not arrive.
+  - **Nonce entropy**: 20 consents yield 20 distinct 32-hex nonces.
+  - **Browser negative control**: the twin's main page actually leaks the
+    nonce via `fetch()` from a real page context.
+
+### Browser compatibility notes
+
+All 159 tests pass on Chromium, Firefox, and WebKit. A few mechanisms differ
+in *how* they block — but in every case they block, and the tests are written
+to accept the different legitimate outcomes:
+
+| Aspect | Chromium | Firefox | WebKit |
+|--------|----------|---------|--------|
+| `popup.document.title` on COOP-severed popup | throws `SecurityError` | returns `''` (WindowProxy) | returns `''` (WindowProxy) |
+| `popup.location.href` on COOP-severed popup | throws `SecurityError` | returns `''` | returns `'about:blank'` |
+| `window.opener` inside the popup | `null` | `null` | `null` |
+| `postMessage` from opener → COOP-severed popup | not delivered | not delivered | not delivered |
+
+In all three browsers the attacker cannot read the real title
+("Approve Command") or the real URL (which contains the `consentId`), so the
+security property holds. `window.opener === null` inside the popup is the
+cross-browser-portable primitive and is asserted by
+`consent-poc-adversarial.spec.ts`.
+
+## Files
+
+- `server.cjs` — Node.js HTTP server (no dependencies). Implements all endpoints,
+  security checks, and serves HTML inline. Uses `.cjs` extension because the parent
+  `ai/package.json` has `"type": "module"`.
+- `vulnerable-server.cjs` — deliberately-vulnerable twin (port 4467) used as a
+  negative control by the adversarial tests.
+- `playwright.config.ts` — Playwright config; auto-starts both servers and
+  runs the suite on chromium, firefox, and webkit.
+- `tests/consent-poc.spec.ts` — 19 e2e tests covering the attack table above.
+- `tests/consent-poc-adversarial.spec.ts` — 34 adversarial / negative-control
+  tests.
+- `package.json` — only `@playwright/test` as a dev dependency.

--- a/ai-assistant/docs/proposals/consent-poc/package.json
+++ b/ai-assistant/docs/proposals/consent-poc/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "consent-poc",
+  "version": "1.0.0",
+  "private": true,
+  "description": "COOP popup consent proof of concept with Playwright e2e tests",
+  "scripts": {
+    "start": "node server.cjs",
+    "test": "playwright test",
+    "test:install": "playwright install chromium firefox webkit"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.42.1"
+  }
+}

--- a/ai-assistant/docs/proposals/consent-poc/playwright.config.ts
+++ b/ai-assistant/docs/proposals/consent-poc/playwright.config.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { defineConfig, devices } from '@playwright/test';
+
+const PORT = 4466;
+const VULN_PORT = 4467;
+const baseURL = `http://localhost:${PORT}`;
+const vulnURL = `http://localhost:${VULN_PORT}`;
+
+export default defineConfig({
+  testDir: './tests',
+  testMatch: '*.pw-spec.ts',
+  timeout: 30 * 1000,
+  expect: { timeout: 5000 },
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: process.env.CI ? 'list' : 'html',
+  use: {
+    baseURL,
+    actionTimeout: 0,
+    trace: 'on-first-retry',
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+    { name: 'firefox', use: { ...devices['Desktop Firefox'] } },
+    { name: 'webkit', use: { ...devices['Desktop Safari'] } },
+  ],
+  // Start BOTH the protected server and the deliberately-vulnerable twin.
+  // The adversarial tests cross-check every protection against the twin
+  // to prove the tests would actually fail if the protection disappeared.
+  webServer: [
+    {
+      command: 'node server.cjs',
+      url: baseURL,
+      reuseExistingServer: !process.env.CI,
+      timeout: 10 * 1000,
+    },
+    {
+      command: 'node vulnerable-server.cjs',
+      url: vulnURL,
+      reuseExistingServer: !process.env.CI,
+      timeout: 10 * 1000,
+    },
+  ],
+});

--- a/ai-assistant/docs/proposals/consent-poc/server.cjs
+++ b/ai-assistant/docs/proposals/consent-poc/server.cjs
@@ -1,0 +1,439 @@
+#!/usr/bin/env node
+// COOP Popup Consent — Proof of Concept
+// No third-party dependencies. Run: node server.cjs
+// Then open http://localhost:4466 in your browser.
+
+const http = require('http');
+const crypto = require('crypto');
+
+const PORT = 4466;
+
+// ── Server-side state ───────────────────────────────────────────────
+// Map<consentId, { nonce, command, approved, used }>
+const consents = new Map();
+
+// ── Helpers ─────────────────────────────────────────────────────────
+function randomId() {
+  return crypto.randomBytes(16).toString('hex');
+}
+
+function parseBody(req) {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    req.on('data', chunk => (data += chunk));
+    req.on('end', () => resolve(data));
+    req.on('error', reject);
+  });
+}
+
+function json(res, status, obj) {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(obj));
+}
+
+// ── Security check: reject Service Worker registration ──────────────
+function blockServiceWorker(req, res) {
+  if (req.headers['service-worker'] === 'script') {
+    res.writeHead(403, { 'Content-Type': 'text/plain' });
+    res.end('Service Worker registration blocked by server policy');
+    return true;
+  }
+  return false;
+}
+
+// ── Security check: Sec-Fetch-* filtering for consent pages ─────────
+// Only allow top-level navigation (popup/tab). Reject fetch(), XHR,
+// iframe, object, embed, prefetch, etc.
+function requireNavigation(req, res) {
+  const dest = req.headers['sec-fetch-dest'];
+  const mode = req.headers['sec-fetch-mode'];
+
+  // Sec-Fetch headers are only sent by browsers (Chrome 76+, Firefox 90+).
+  // If missing (curl, older browser), allow — console users are trusted.
+  if (!dest && !mode) return true;
+
+  if (dest === 'document' && mode === 'navigate') return true;
+
+  res.writeHead(403, { 'Content-Type': 'text/plain' });
+  res.end(
+    `Blocked: Sec-Fetch-Dest=${dest}, Sec-Fetch-Mode=${mode}. ` +
+      'Only top-level navigation allowed.'
+  );
+  return false;
+}
+
+// ── Pages ───────────────────────────────────────────────────────────
+
+// Main page — simulates Headlamp with a "plugin" that tries attacks
+function mainPage() {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Headlamp — COOP Consent PoC (main page)</title>
+  <style>
+    body { font-family: system-ui, sans-serif; max-width: 800px; margin: 2rem auto; }
+    h1 { color: #333; }
+    button { padding: 8px 16px; margin: 4px; cursor: pointer; }
+    .ok { color: green; } .fail { color: red; }
+    #log { background: #f5f5f5; padding: 1rem; font-family: monospace;
+           font-size: 13px; white-space: pre-wrap; max-height: 600px; overflow-y: auto; }
+  </style>
+</head>
+<body>
+  <h1>COOP Popup Consent — Proof of Concept</h1>
+  <p>This page simulates the Headlamp main page (where plugins run).
+     Click buttons to test each attack vector.</p>
+
+  <h2>Legitimate flow</h2>
+  <button onclick="legitimateFlow()">✅ Open consent popup (user gesture)</button>
+
+  <h2>Attack simulations (all should fail)</h2>
+  <button onclick="attackFetch()">🔒 Attack 1: fetch() consent page</button>
+  <button onclick="attackXHR()">🔒 Attack 2: XHR consent page</button>
+  <button onclick="attackIframe()">🔒 Attack 3: iframe consent page</button>
+  <button onclick="attackApproveNoNonce()">🔒 Attack 4: POST approve (no nonce)</button>
+  <button onclick="attackReadPopup()">🔒 Attack 5: read popup DOM via opener</button>
+  <button onclick="attackSW()">🔒 Attack 6: register Service Worker</button>
+
+  <h2>Log</h2>
+  <div id="log"></div>
+
+  <script>
+    let currentConsentId = null;
+    let popupRef = null;
+
+    function log(msg, ok) {
+      const el = document.getElementById('log');
+      const cls = ok === true ? 'ok' : ok === false ? 'fail' : '';
+      el.innerHTML += '<span class="' + cls + '">' +
+        new Date().toISOString().slice(11, 19) + ' ' + msg + '</span>\\n';
+      el.scrollTop = el.scrollHeight;
+    }
+
+    // ── Step 1: request a command consent from the backend ──────────
+    async function requestConsent() {
+      const res = await fetch('/api/request-consent', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ command: 'minikube status' })
+      });
+      const data = await res.json();
+      currentConsentId = data.consentId;
+      log('Consent requested: ' + data.consentId);
+      return data.consentId;
+    }
+
+    // ── Legitimate flow ─────────────────────────────────────────────
+    async function legitimateFlow() {
+      const id = await requestConsent();
+      log('Opening popup via user gesture...');
+      popupRef = window.open('/consent/' + id, 'consent', 'width=500,height=400');
+      if (!popupRef || popupRef.closed) {
+        log('Popup blocked — falling back to full-page navigation', false);
+        return;
+      }
+      log('Popup opened. Polling for approval...');
+      pollApproval(id);
+    }
+
+    async function pollApproval(id) {
+      for (let i = 0; i < 30; i++) {
+        await new Promise(r => setTimeout(r, 1000));
+        const res = await fetch('/api/consent-status/' + id);
+        const data = await res.json();
+        if (data.approved) {
+          log('✅ Command approved by user!', true);
+          return;
+        }
+      }
+      log('Timed out waiting for approval', false);
+    }
+
+    // ── Attack 1: fetch() the consent page to read nonce ────────────
+    async function attackFetch() {
+      const id = await requestConsent();
+      try {
+        const res = await fetch('/consent/' + id);
+        if (res.ok) {
+          const text = await res.text();
+          if (text.includes('nonce')) {
+            log('❌ VULNERABILITY: fetch() returned consent page with nonce!', false);
+          } else {
+            log('fetch() got response but no nonce visible', false);
+          }
+        } else {
+          log('✅ fetch() blocked by server (HTTP ' + res.status + ')', true);
+        }
+      } catch (e) {
+        log('✅ fetch() error: ' + e.message, true);
+      }
+    }
+
+    // ── Attack 2: XHR the consent page ──────────────────────────────
+    async function attackXHR() {
+      const id = await requestConsent();
+      const xhr = new XMLHttpRequest();
+      xhr.open('GET', '/consent/' + id);
+      xhr.onload = () => {
+        if (xhr.status === 200 && xhr.responseText.includes('nonce')) {
+          log('❌ VULNERABILITY: XHR returned consent page with nonce!', false);
+        } else {
+          log('✅ XHR blocked by server (HTTP ' + xhr.status + ')', true);
+        }
+      };
+      xhr.onerror = () => log('✅ XHR error (blocked)', true);
+      xhr.send();
+    }
+
+    // ── Attack 3: iframe the consent page ───────────────────────────
+    async function attackIframe() {
+      const id = await requestConsent();
+      const iframe = document.createElement('iframe');
+      iframe.src = '/consent/' + id;
+      iframe.style.display = 'none';
+      iframe.onload = () => {
+        try {
+          const doc = iframe.contentDocument;
+          const nonce = doc ? doc.querySelector('[name=nonce]') : null;
+          if (nonce) {
+            log('❌ VULNERABILITY: read nonce from iframe!', false);
+          } else {
+            log('✅ iframe loaded but content blocked or empty', true);
+          }
+        } catch (e) {
+          log('✅ iframe DOM access blocked: ' + e.message, true);
+        }
+        iframe.remove();
+      };
+      iframe.onerror = () => {
+        log('✅ iframe load blocked', true);
+        iframe.remove();
+      };
+      document.body.appendChild(iframe);
+    }
+
+    // ── Attack 4: POST approve without nonce ────────────────────────
+    async function attackApproveNoNonce() {
+      const id = await requestConsent();
+      try {
+        const res = await fetch('/consent/' + id + '/approve', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: 'nonce=guess123'
+        });
+        const data = await res.json();
+        if (data.approved) {
+          log('❌ VULNERABILITY: approved with guessed nonce!', false);
+        } else {
+          log('✅ approve rejected: ' + data.error, true);
+        }
+      } catch (e) {
+        log('✅ approve blocked: ' + e.message, true);
+      }
+    }
+
+    // ── Attack 5: read popup DOM via opener reference ────────────────
+    async function attackReadPopup() {
+      const id = await requestConsent();
+      popupRef = window.open('/consent/' + id, 'consent', 'width=500,height=400');
+      if (!popupRef) {
+        log('Popup blocked (can\\'t test opener access)', false);
+        return;
+      }
+      // Wait for popup to load
+      await new Promise(r => setTimeout(r, 1500));
+
+      // Semantic check: the attacker has leaked real data only if they can
+      // observe the real title ("Approve Command") or the real URL that
+      // contains the consentId. Empty strings / "about:blank" / throws all
+      // mean the browser kept the opener severed.
+      let title = null, locHref = null, titleErr = null, locErr = null;
+      try { title = popupRef.document.title; } catch (e) { titleErr = e.message; }
+      try { locHref = popupRef.location.href; } catch (e) { locErr = e.message; }
+
+      const realTitleLeaked = title && title.includes('Approve Command');
+      const realUrlLeaked = locHref && /\\/consent\\/[a-f0-9]/.test(locHref);
+
+      if (realTitleLeaked) {
+        log('❌ VULNERABILITY: read real popup title: ' + title, false);
+      } else if (titleErr) {
+        log('✅ popup title access blocked (throw): ' + titleErr, true);
+      } else {
+        log('✅ popup title access yielded no real data: "' + (title || '') + '"', true);
+      }
+
+      if (realUrlLeaked) {
+        log('❌ VULNERABILITY: read real popup location: ' + locHref, false);
+      } else if (locErr) {
+        log('✅ popup location access blocked (throw): ' + locErr, true);
+      } else {
+        log('✅ popup location access yielded no real data: "' + (locHref || '') + '"', true);
+      }
+    }
+
+    // ── Attack 6: register Service Worker ───────────────────────────
+    async function attackSW() {
+      if (!navigator.serviceWorker) {
+        log('ServiceWorker API not available (non-HTTPS?)', false);
+        return;
+      }
+      try {
+        const reg = await navigator.serviceWorker.register('/sw.js');
+        log('❌ VULNERABILITY: Service Worker registered!', false);
+        await reg.unregister();
+      } catch (e) {
+        log('✅ Service Worker registration blocked: ' + e.message, true);
+      }
+    }
+  </script>
+</body>
+</html>`;
+}
+
+// Consent page — served with COOP + nonce
+function consentPage(consentId, nonce, command) {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Approve Command</title>
+  <style>
+    body { font-family: system-ui, sans-serif; max-width: 500px; margin: 2rem auto;
+           background: #f9f9f9; }
+    .card { background: white; border: 1px solid #ddd; border-radius: 8px;
+            padding: 1.5rem; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+    h1 { color: #333; font-size: 1.3rem; }
+    .command { background: #1a1a1a; color: #4caf50; padding: 1rem;
+               border-radius: 4px; font-family: monospace; font-size: 1rem; }
+    button { padding: 10px 24px; font-size: 1rem; cursor: pointer;
+             border: none; border-radius: 4px; margin-right: 8px; }
+    .approve { background: #4caf50; color: white; }
+    .deny { background: #ccc; color: #333; }
+    .info { color: #666; font-size: 0.85rem; margin-top: 1rem; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>🔒 Command Approval Required</h1>
+    <p>A plugin wants to run this command:</p>
+    <div class="command">${command}</div>
+    <form method="POST" action="/consent/${consentId}/approve" style="margin-top: 1.5rem;">
+      <input type="hidden" name="nonce" value="${nonce}">
+      <button type="submit" class="approve" autofocus>✅ Approve</button>
+      <button type="button" class="deny" onclick="window.close()">❌ Deny</button>
+    </form>
+    <p class="info">
+      This popup is protected by COOP — the page that opened it cannot read
+      its content or auto-approve the command.
+    </p>
+  </div>
+</body>
+</html>`;
+}
+
+// ── HTTP server ─────────────────────────────────────────────────────
+const server = http.createServer(async (req, res) => {
+  // ── Global: block Service Worker registration ─────────────────────
+  if (blockServiceWorker(req, res)) return;
+
+  const url = new URL(req.url, `http://localhost:${PORT}`);
+  const method = req.method;
+
+  // ── Main page (no COOP — simulates Headlamp app) ─────────────────
+  if (url.pathname === '/' && method === 'GET') {
+    res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+    res.end(mainPage());
+    return;
+  }
+
+  // ── API: request consent ──────────────────────────────────────────
+  if (url.pathname === '/api/request-consent' && method === 'POST') {
+    const body = await parseBody(req);
+    const { command } = JSON.parse(body);
+    const consentId = randomId();
+    const nonce = randomId();
+    consents.set(consentId, { nonce, command, approved: false, used: false });
+    json(res, 200, { consentId });
+    return;
+  }
+
+  // ── API: poll consent status ──────────────────────────────────────
+  const statusMatch = url.pathname.match(/^\/api\/consent-status\/([a-f0-9]+)$/);
+  if (statusMatch && method === 'GET') {
+    const entry = consents.get(statusMatch[1]);
+    if (!entry) return json(res, 404, { error: 'not found' });
+    json(res, 200, { approved: entry.approved });
+    return;
+  }
+
+  // ── Consent page (COOP + Sec-Fetch protected) ─────────────────────
+  const consentMatch = url.pathname.match(/^\/consent\/([a-f0-9]+)$/);
+  if (consentMatch && method === 'GET') {
+    // Sec-Fetch filter: only top-level navigation allowed
+    if (!requireNavigation(req, res)) return;
+
+    const entry = consents.get(consentMatch[1]);
+    if (!entry) {
+      res.writeHead(404, { 'Content-Type': 'text/plain' });
+      res.end('Consent not found');
+      return;
+    }
+
+    res.writeHead(200, {
+      'Content-Type': 'text/html; charset=utf-8',
+      // KEY: COOP severs the opener relationship with the main page
+      'Cross-Origin-Opener-Policy': 'same-origin',
+    });
+    res.end(consentPage(consentMatch[1], entry.nonce, entry.command));
+    return;
+  }
+
+  // ── Consent approve (POST with nonce) ─────────────────────────────
+  const approveMatch = url.pathname.match(/^\/consent\/([a-f0-9]+)\/approve$/);
+  if (approveMatch && method === 'POST') {
+    const body = await parseBody(req);
+    const params = new URLSearchParams(body);
+    const submittedNonce = params.get('nonce');
+    const entry = consents.get(approveMatch[1]);
+
+    if (!entry) return json(res, 404, { error: 'not found' });
+    if (entry.used) return json(res, 409, { error: 'already used', approved: false });
+    if (submittedNonce !== entry.nonce) {
+      return json(res, 403, { error: 'invalid nonce', approved: false });
+    }
+
+    entry.approved = true;
+    entry.used = true;
+
+    // Respond with a page that closes the popup
+    res.writeHead(200, {
+      'Content-Type': 'text/html; charset=utf-8',
+      'Cross-Origin-Opener-Policy': 'same-origin',
+    });
+    res.end(`<!DOCTYPE html>
+<html><head><title>Approved</title></head>
+<body style="font-family: system-ui; text-align: center; padding: 2rem;">
+  <h2>✅ Command approved</h2>
+  <p>You can close this window.</p>
+  <script>setTimeout(() => window.close(), 1500);</script>
+</body></html>`);
+    return;
+  }
+
+  // ── Catch-all 404 ─────────────────────────────────────────────────
+  res.writeHead(404, { 'Content-Type': 'text/plain' });
+  res.end('Not found');
+});
+
+server.listen(PORT, () => {
+  console.log(`
+╔══════════════════════════════════════════════════════════════╗
+║  COOP Popup Consent — Proof of Concept                      ║
+║  Open http://localhost:${PORT} in your browser              ║
+║                                                              ║
+║  Click "Open consent popup" for the legitimate flow.         ║
+║  Click attack buttons to verify each vector is blocked.      ║
+╚══════════════════════════════════════════════════════════════╝
+`);
+});

--- a/ai-assistant/docs/proposals/consent-poc/tests/consent-poc-adversarial.pw-spec.ts
+++ b/ai-assistant/docs/proposals/consent-poc/tests/consent-poc-adversarial.pw-spec.ts
@@ -1,0 +1,317 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// Adversarial / negative-control tests for the consent-poc.
+//
+// Rationale: the positive tests in consent-poc.spec.ts could theoretically
+// pass for the wrong reason (e.g. a 403 that comes from an unrelated bug,
+// or a `null` we always see regardless of COOP). These tests attack the
+// same vectors from different angles AND pair each protection with a
+// negative control against a deliberately-vulnerable twin server
+// (vulnerable-server.cjs on :4467) where the SAME attack MUST succeed.
+//
+// If the tests here pass against the main server AND the paired attack
+// succeeds against the twin, we know:
+//   (a) the protection is actually doing the blocking (not a test bug); and
+//   (b) the tests would catch a real regression that removed the protection.
+
+import net from 'net';
+import { expect, request as pwRequest, test } from '@playwright/test';
+
+const MAIN_URL = 'http://localhost:4466';
+const VULN_URL = 'http://localhost:4467';
+
+// ─── Raw TCP request so we can see the exact bytes on the wire ─────────
+function rawHttp(host: string, port: number, request: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const sock = net.createConnection({ host, port }, () => sock.write(request));
+    const chunks: Buffer[] = [];
+    sock.on('data', c => chunks.push(c));
+    sock.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+    sock.on('error', reject);
+    // Safety timeout.
+    setTimeout(() => {
+      sock.destroy();
+      resolve(Buffer.concat(chunks).toString('utf8'));
+    }, 3000);
+  });
+}
+
+async function newConsent(base: string): Promise<string> {
+  const req = await pwRequest.newContext({ baseURL: base });
+  try {
+    const res = await req.post('/api/request-consent', {
+      data: { command: 'minikube status' },
+    });
+    expect(res.status()).toBe(200);
+    const { consentId } = await res.json();
+    return consentId;
+  } finally {
+    await req.dispose();
+  }
+}
+
+// ─── NEGATIVE CONTROL: the twin must actually be vulnerable ────────────
+test.describe('negative control — vulnerable twin really is vulnerable', () => {
+  test('twin serves /consent with NO COOP header', async () => {
+    const consentId = await newConsent(VULN_URL);
+    const req = await pwRequest.newContext({ baseURL: VULN_URL });
+    const res = await req.get(`/consent/${consentId}`);
+    expect(res.status()).toBe(200);
+    expect(res.headers()['cross-origin-opener-policy']).toBeUndefined();
+    await req.dispose();
+  });
+
+  test('twin leaks nonce to fetch() (Sec-Fetch-Dest: empty)', async () => {
+    const consentId = await newConsent(VULN_URL);
+    const req = await pwRequest.newContext({ baseURL: VULN_URL });
+    const res = await req.get(`/consent/${consentId}`, {
+      headers: { 'Sec-Fetch-Dest': 'empty', 'Sec-Fetch-Mode': 'cors' },
+    });
+    expect(res.status()).toBe(200);
+    expect(await res.text()).toMatch(/name="nonce" value="[a-f0-9]{32}"/);
+    await req.dispose();
+  });
+
+  test('twin serves /sw.js even with Service-Worker: script header', async () => {
+    const req = await pwRequest.newContext({ baseURL: VULN_URL });
+    const res = await req.get('/sw.js', { headers: { 'Service-Worker': 'script' } });
+    expect(res.status()).toBe(200);
+    expect(res.headers()['content-type']).toContain('javascript');
+    await req.dispose();
+  });
+});
+
+// ─── Raw-socket header verification ────────────────────────────────────
+test.describe('raw-socket header verification', () => {
+  test('protected /consent response literally contains "Cross-Origin-Opener-Policy: same-origin"', async () => {
+    const consentId = await newConsent(MAIN_URL);
+    const raw = await rawHttp(
+      'localhost',
+      4466,
+      `GET /consent/${consentId} HTTP/1.1\r\nHost: localhost:4466\r\nSec-Fetch-Dest: document\r\nSec-Fetch-Mode: navigate\r\nConnection: close\r\n\r\n`
+    );
+    const [headerBlock] = raw.split('\r\n\r\n', 1);
+    expect(headerBlock).toMatch(/^HTTP\/1\.1 200 /);
+    // Case-insensitive search; Node may emit headers in various cases.
+    expect(headerBlock.toLowerCase()).toContain(
+      'cross-origin-opener-policy: same-origin'
+    );
+  });
+
+  test('twin /consent response has NO Cross-Origin-Opener-Policy header on the wire', async () => {
+    const consentId = await newConsent(VULN_URL);
+    const raw = await rawHttp(
+      'localhost',
+      4467,
+      `GET /consent/${consentId} HTTP/1.1\r\nHost: localhost:4467\r\nConnection: close\r\n\r\n`
+    );
+    const [headerBlock] = raw.split('\r\n\r\n', 1);
+    expect(headerBlock).toMatch(/^HTTP\/1\.1 200 /);
+    expect(headerBlock.toLowerCase()).not.toContain('cross-origin-opener-policy');
+  });
+
+  test('protected 403 body does NOT contain any 32-hex string (no nonce leak)', async () => {
+    const consentId = await newConsent(MAIN_URL);
+    const raw = await rawHttp(
+      'localhost',
+      4466,
+      `GET /consent/${consentId} HTTP/1.1\r\nHost: localhost:4466\r\nSec-Fetch-Dest: empty\r\nSec-Fetch-Mode: cors\r\nConnection: close\r\n\r\n`
+    );
+    expect(raw).toMatch(/^HTTP\/1\.1 403 /);
+    // Split header/body then assert nonce shape is absent from the whole response.
+    expect(raw).not.toMatch(/[a-f0-9]{32}/);
+  });
+});
+
+// ─── Sec-Fetch-Dest fuzz (many destinations, all should be blocked) ────
+const FUZZ_DESTS = [
+  { dest: 'empty', mode: 'cors' },
+  { dest: 'empty', mode: 'no-cors' },
+  { dest: 'audio', mode: 'no-cors' },
+  { dest: 'video', mode: 'no-cors' },
+  { dest: 'worker', mode: 'same-origin' },
+  { dest: 'sharedworker', mode: 'same-origin' },
+  { dest: 'serviceworker', mode: 'same-origin' },
+  { dest: 'image', mode: 'no-cors' },
+  { dest: 'script', mode: 'no-cors' },
+  { dest: 'font', mode: 'no-cors' },
+  { dest: 'style', mode: 'no-cors' },
+  { dest: 'manifest', mode: 'cors' },
+  { dest: 'embed', mode: 'no-cors' },
+  { dest: 'track', mode: 'no-cors' },
+  { dest: 'iframe', mode: 'navigate' },
+  { dest: 'object', mode: 'no-cors' },
+  { dest: 'report', mode: 'no-cors' },
+];
+
+test.describe('Sec-Fetch-Dest fuzz — every non-navigation destination rejected', () => {
+  for (const { dest, mode } of FUZZ_DESTS) {
+    test(`dest=${dest} mode=${mode} → 403 on protected server, 200+nonce on twin`, async () => {
+      const protectedId = await newConsent(MAIN_URL);
+      const vulnId = await newConsent(VULN_URL);
+
+      const good = await pwRequest.newContext({ baseURL: MAIN_URL });
+      const bad = await pwRequest.newContext({ baseURL: VULN_URL });
+      try {
+        const p = await good.get(`/consent/${protectedId}`, {
+          headers: { 'Sec-Fetch-Dest': dest, 'Sec-Fetch-Mode': mode },
+        });
+        expect(p.status(), `protected server should block dest=${dest}`).toBe(403);
+        expect(await p.text()).not.toMatch(/[a-f0-9]{32}/);
+
+        // The twin has no Sec-Fetch filter, so it leaks the nonce.
+        const v = await bad.get(`/consent/${vulnId}`, {
+          headers: { 'Sec-Fetch-Dest': dest, 'Sec-Fetch-Mode': mode },
+        });
+        expect(v.status(), `twin server should NOT block dest=${dest}`).toBe(200);
+        expect(await v.text()).toMatch(/name="nonce" value="[a-f0-9]{32}"/);
+      } finally {
+        await good.dispose();
+        await bad.dispose();
+      }
+    });
+  }
+});
+
+// ─── Service-Worker header block: case + path variations ───────────────
+test.describe('Service-Worker header block is broad', () => {
+  const SW_PATHS = ['/sw.js', '/service-worker.js', '/consent/abc/sw.js', '/', '/api/request-consent'];
+
+  for (const path of SW_PATHS) {
+    test(`SW header → 403 at ${path}`, async () => {
+      const req = await pwRequest.newContext({ baseURL: MAIN_URL });
+      const res = await req.get(path, { headers: { 'Service-Worker': 'script' } });
+      expect(res.status()).toBe(403);
+      expect(await res.text()).toContain('Service Worker registration blocked');
+      await req.dispose();
+    });
+  }
+
+  test('lowercase service-worker header is also blocked (HTTP is case-insensitive)', async () => {
+    const req = await pwRequest.newContext({ baseURL: MAIN_URL });
+    const res = await req.get('/sw.js', { headers: { 'service-worker': 'script' } });
+    expect(res.status()).toBe(403);
+    await req.dispose();
+  });
+
+  test('without SW header, same path is NOT blocked (proves header is the trigger)', async () => {
+    const req = await pwRequest.newContext({ baseURL: MAIN_URL });
+    // No Service-Worker header. /sw.js is not served, so expect 404, NOT 403.
+    const res = await req.get('/sw.js');
+    expect(res.status()).toBe(404);
+    await req.dispose();
+  });
+});
+
+// ─── Inside-the-popup assertions ───────────────────────────────────────
+test.describe('browser: inside the popup after COOP isolation', () => {
+  test('window.opener is null inside the consent popup', async ({ page, context, browserName }) => {
+    await page.goto(MAIN_URL);
+    const popupPromise = context.waitForEvent('page');
+    await page.getByRole('button', { name: /Open consent popup/i }).click();
+    const popup = await popupPromise;
+    await popup.waitForLoadState('domcontentloaded');
+
+    const opener = await popup.evaluate(() => (window.opener === null ? 'null' : typeof window.opener));
+    // In all three browsers, COOP: same-origin on the popup + no COOP on the
+    // opener puts them in different browsing-context groups, so opener is null.
+    // If a browser ever deviates, this assertion localises the incompatibility.
+    expect(opener, `window.opener in popup (${browserName})`).toBe('null');
+  });
+
+  test('postMessage from opener to popup does NOT arrive (COOP isolation)', async ({ page, context, browserName }) => {
+    await page.goto(MAIN_URL);
+    const popupPromise = context.waitForEvent('page');
+    await page.getByRole('button', { name: /Open consent popup/i }).click();
+    const popup = await popupPromise;
+    await popup.waitForLoadState('domcontentloaded');
+
+    // Install a receiver in the popup that records any message it gets.
+    await popup.evaluate(() => {
+      (window as unknown as { __received: unknown[] }).__received = [];
+      window.addEventListener('message', e => {
+        (window as unknown as { __received: unknown[] }).__received.push(e.data);
+      });
+    });
+
+    // From the opener, attempt postMessage on the popup handle.
+    // With a severed opener the browser should either throw or silently drop.
+    const senderResult = await page.evaluate(() => {
+      try {
+        // `popupRef` is defined in mainPage().
+        const ref = (window as unknown as { popupRef: Window | null }).popupRef;
+        if (!ref) return 'no-ref';
+        ref.postMessage('HELLO_FROM_OPENER', '*');
+        return 'sent';
+      } catch (e) {
+        return 'threw:' + (e as Error).message;
+      }
+    });
+
+    // Give the message event loop a moment.
+    await popup.waitForTimeout(500);
+    const received = await popup.evaluate(
+      () => (window as unknown as { __received: unknown[] }).__received
+    );
+
+    expect(
+      received,
+      `popup should NOT receive message from COOP-severed opener (${browserName}, sender=${senderResult})`
+    ).toEqual([]);
+  });
+});
+
+// ─── Nonce entropy: many consents yield many distinct nonces ───────────
+test('nonce entropy: 20 consents have 20 distinct 32-hex nonces', async () => {
+  const req = await pwRequest.newContext({ baseURL: MAIN_URL });
+  try {
+    const nonces = new Set<string>();
+    for (let i = 0; i < 20; i++) {
+      const r = await req.post('/api/request-consent', { data: { command: 'x' } });
+      const { consentId } = await r.json();
+      const page = await req.get(`/consent/${consentId}`, {
+        headers: {
+          'Sec-Fetch-Dest': 'document',
+          'Sec-Fetch-Mode': 'navigate',
+          'Sec-Fetch-Site': 'none',
+        },
+      });
+      const m = (await page.text()).match(/name="nonce" value="([a-f0-9]{32})"/);
+      expect(m, 'nonce must be present and 32 hex chars').not.toBeNull();
+      nonces.add(m![1]);
+    }
+    expect(nonces.size).toBe(20);
+  } finally {
+    await req.dispose();
+  }
+});
+
+// ─── Paired browser-flow negative control ──────────────────────────────
+test.describe('browser negative control — attacks succeed on vulnerable twin', () => {
+  test('twin: fetch() in-page DOES return the nonce (proves the block on main is meaningful)', async ({
+    page,
+  }) => {
+    await page.goto(VULN_URL);
+    // Twin main page has no attack UI; drive it directly.
+    const leaked = await page.evaluate(async () => {
+      const r = await fetch('/api/request-consent', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ command: 'x' }),
+      });
+      const { consentId } = await r.json();
+      const page = await fetch('/consent/' + consentId);
+      const text = await page.text();
+      return /name="nonce" value="[a-f0-9]{32}"/.test(text);
+    });
+    expect(leaked, 'on the vulnerable twin, fetch() must leak the nonce').toBe(true);
+  });
+});

--- a/ai-assistant/docs/proposals/consent-poc/tests/consent-poc.pw-spec.ts
+++ b/ai-assistant/docs/proposals/consent-poc/tests/consent-poc.pw-spec.ts
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { APIRequestContext, expect, test } from '@playwright/test';
+
+async function requestConsent(
+  req: APIRequestContext,
+  command = 'minikube status'
+): Promise<{ consentId: string }> {
+  const res = await req.post('/api/request-consent', { data: { command } });
+  expect(res.status()).toBe(200);
+  return res.json();
+}
+
+async function getConsentPageAsNavigation(
+  req: APIRequestContext,
+  consentId: string
+) {
+  return req.get(`/consent/${consentId}`, {
+    headers: {
+      'Sec-Fetch-Dest': 'document',
+      'Sec-Fetch-Mode': 'navigate',
+      'Sec-Fetch-Site': 'none',
+    },
+  });
+}
+
+test.describe('consent-poc — HTTP security model', () => {
+  test('main page loads without COOP (simulates plugin host)', async ({ request }) => {
+    const res = await request.get('/');
+    expect(res.status()).toBe(200);
+    // Main page must NOT set COOP — it simulates the untrusted host.
+    expect(res.headers()['cross-origin-opener-policy']).toBeUndefined();
+    expect(await res.text()).toContain('COOP Popup Consent');
+  });
+
+  test('request-consent returns a hex consentId', async ({ request }) => {
+    const { consentId } = await requestConsent(request);
+    expect(consentId).toMatch(/^[a-f0-9]{32}$/);
+  });
+
+  test('top-level navigation to consent page allowed + sets COOP', async ({ request }) => {
+    const { consentId } = await requestConsent(request);
+    const res = await getConsentPageAsNavigation(request, consentId);
+    expect(res.status()).toBe(200);
+    // KEY: COOP header severs opener relationship with untrusted parent.
+    expect(res.headers()['cross-origin-opener-policy']).toBe('same-origin');
+    const html = await res.text();
+    expect(html).toContain('Approve Command');
+    expect(html).toMatch(/name="nonce" value="[a-f0-9]{32}"/);
+  });
+
+  test('fetch() to consent page blocked (Sec-Fetch-Dest: empty)', async ({ request }) => {
+    const { consentId } = await requestConsent(request);
+    const res = await request.get(`/consent/${consentId}`, {
+      headers: { 'Sec-Fetch-Dest': 'empty', 'Sec-Fetch-Mode': 'cors' },
+    });
+    expect(res.status()).toBe(403);
+    const body = await res.text();
+    expect(body).toContain('Only top-level navigation allowed');
+    // Crucially, the nonce must NOT leak in the 403 body.
+    expect(body).not.toMatch(/[a-f0-9]{32}/);
+  });
+
+  test('iframe to consent page blocked (Sec-Fetch-Dest: iframe)', async ({ request }) => {
+    const { consentId } = await requestConsent(request);
+    const res = await request.get(`/consent/${consentId}`, {
+      headers: { 'Sec-Fetch-Dest': 'iframe', 'Sec-Fetch-Mode': 'navigate' },
+    });
+    expect(res.status()).toBe(403);
+  });
+
+  test('object embed blocked (Sec-Fetch-Dest: object)', async ({ request }) => {
+    const { consentId } = await requestConsent(request);
+    const res = await request.get(`/consent/${consentId}`, {
+      headers: { 'Sec-Fetch-Dest': 'object', 'Sec-Fetch-Mode': 'no-cors' },
+    });
+    expect(res.status()).toBe(403);
+  });
+
+  test('approve with invalid nonce rejected', async ({ request }) => {
+    const { consentId } = await requestConsent(request);
+    const res = await request.post(`/consent/${consentId}/approve`, {
+      form: { nonce: 'deadbeef' },
+    });
+    expect(res.status()).toBe(403);
+    const body = await res.json();
+    expect(body).toEqual({ error: 'invalid nonce', approved: false });
+
+    // And the consent status is still not approved.
+    const status = await request.get(`/api/consent-status/${consentId}`);
+    expect(await status.json()).toEqual({ approved: false });
+  });
+
+  test('approve with correct nonce succeeds and status flips to approved', async ({
+    request,
+  }) => {
+    const { consentId } = await requestConsent(request);
+    const pageRes = await getConsentPageAsNavigation(request, consentId);
+    const html = await pageRes.text();
+    const nonce = html.match(/name="nonce" value="([a-f0-9]+)"/)![1];
+
+    const approve = await request.post(`/consent/${consentId}/approve`, {
+      form: { nonce },
+    });
+    expect(approve.status()).toBe(200);
+    expect(approve.headers()['cross-origin-opener-policy']).toBe('same-origin');
+
+    const status = await request.get(`/api/consent-status/${consentId}`);
+    expect(await status.json()).toEqual({ approved: true });
+  });
+
+  test('nonce replay rejected (409) after first use', async ({ request }) => {
+    const { consentId } = await requestConsent(request);
+    const pageRes = await getConsentPageAsNavigation(request, consentId);
+    const nonce = (await pageRes.text()).match(/name="nonce" value="([a-f0-9]+)"/)![1];
+
+    const first = await request.post(`/consent/${consentId}/approve`, { form: { nonce } });
+    expect(first.status()).toBe(200);
+
+    const replay = await request.post(`/consent/${consentId}/approve`, { form: { nonce } });
+    expect(replay.status()).toBe(409);
+    const body = await replay.json();
+    expect(body).toEqual({ error: 'already used', approved: false });
+  });
+
+  test('Service Worker registration blocked by server policy', async ({ request }) => {
+    const res = await request.get('/sw.js', {
+      headers: { 'Service-Worker': 'script' },
+    });
+    expect(res.status()).toBe(403);
+    expect(await res.text()).toContain('Service Worker registration blocked');
+  });
+
+  test('Service Worker header blocks even the main page', async ({ request }) => {
+    // The block is global — a malicious plugin cannot register a SW
+    // scoped to any path on the origin.
+    const res = await request.get('/', {
+      headers: { 'Service-Worker': 'script' },
+    });
+    expect(res.status()).toBe(403);
+  });
+
+  test('status endpoint returns 404 for unknown consentId', async ({ request }) => {
+    const res = await request.get('/api/consent-status/0000000000000000');
+    expect(res.status()).toBe(404);
+  });
+
+  test('approve endpoint returns 404 for unknown consentId', async ({ request }) => {
+    const res = await request.post('/consent/0000000000000000/approve', {
+      form: { nonce: 'whatever' },
+    });
+    expect(res.status()).toBe(404);
+  });
+});
+
+test.describe('consent-poc — browser flow', () => {
+  test('legitimate flow: popup opens, user approves, status polls to approved', async ({
+    page,
+    context,
+  }) => {
+    await page.goto('/');
+
+    const popupPromise = context.waitForEvent('page');
+    await page.getByRole('button', { name: /Open consent popup/i }).click();
+    const popup = await popupPromise;
+    await popup.waitForLoadState('domcontentloaded');
+
+    await expect(popup).toHaveTitle('Approve Command');
+    await expect(popup.getByText('minikube status')).toBeVisible();
+
+    await popup.getByRole('button', { name: /Approve/i }).click();
+
+    // Poller on main page should detect approval within 30s (checks every 1s).
+    await expect(page.locator('#log')).toContainText(
+      'Command approved by user',
+      { timeout: 10_000 }
+    );
+    await expect(page.locator('#log')).not.toContainText('VULNERABILITY');
+  });
+
+  test('COOP severs opener: main page cannot read popup DOM or location', async ({ page, browserName }) => {
+    await page.goto('/');
+    await page.getByRole('button', { name: /Attack 5:/i }).click();
+
+    // Cross-browser semantics differ for a COOP-severed opener:
+    //   - Chromium: accessing popup.document / popup.location throws SecurityError.
+    //   - Firefox:  returns a cross-origin WindowProxy; title === '', location.href === ''.
+    //   - WebKit:   returns empty title and location.href === 'about:blank'.
+    // In every case the browser prevents the real title ("Approve Command") and
+    // the real URL (which contains the consentId) from leaking. The PoC's attack
+    // code distinguishes "throw", "no real data", and "real data leaked"; we only
+    // accept the first two and forbid anything resembling a real leak.
+    await expect(page.locator('#log')).toContainText(
+      /popup title access (blocked|yielded no real data)/,
+      { timeout: 5000 }
+    );
+    await expect(page.locator('#log')).toContainText(
+      /popup location access (blocked|yielded no real data)/,
+      { timeout: 5000 }
+    );
+    const logText = await page.locator('#log').innerText();
+    expect(logText, `browser=${browserName}`).not.toContain('VULNERABILITY');
+  });
+
+  test('attack 1 (fetch) blocked from the page', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('button', { name: /Attack 1:/i }).click();
+    await expect(page.locator('#log')).toContainText('fetch() blocked by server', {
+      timeout: 5000,
+    });
+    await expect(page.locator('#log')).not.toContainText('VULNERABILITY');
+  });
+
+  test('attack 2 (XHR) blocked from the page', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('button', { name: /Attack 2:/i }).click();
+    await expect(page.locator('#log')).toContainText(/XHR blocked by server|XHR error/, {
+      timeout: 5000,
+    });
+    await expect(page.locator('#log')).not.toContainText('VULNERABILITY');
+  });
+
+  test('attack 3 (iframe) blocked from the page', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('button', { name: /Attack 3:/i }).click();
+    // Either the iframe fails to load (403) or its document is empty/inaccessible.
+    await expect(page.locator('#log')).toContainText(
+      /iframe load blocked|iframe .* blocked or empty|iframe DOM access blocked/,
+      { timeout: 5000 }
+    );
+    await expect(page.locator('#log')).not.toContainText('VULNERABILITY');
+  });
+
+  test('attack 4 (wrong nonce) rejected from the page', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('button', { name: /Attack 4:/i }).click();
+    await expect(page.locator('#log')).toContainText('approve rejected: invalid nonce', {
+      timeout: 5000,
+    });
+    await expect(page.locator('#log')).not.toContainText('VULNERABILITY');
+  });
+});

--- a/ai-assistant/docs/proposals/consent-poc/vulnerable-server.cjs
+++ b/ai-assistant/docs/proposals/consent-poc/vulnerable-server.cjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// Vulnerable TWIN of server.cjs used as a NEGATIVE CONTROL for the
+// consent-poc tests. It exposes the same API and HTML, but
+// deliberately removes the 3 server-side protections:
+//
+//   1. No Sec-Fetch-Dest/Mode filtering on /consent/:id
+//   2. No `Cross-Origin-Opener-Policy` header on the consent page
+//   3. No `Service-Worker: script` block
+//
+// Adversarial tests run each attack against BOTH servers:
+//   - Against server.cjs       → attack MUST fail (protection works)
+//   - Against this twin server → attack MUST succeed (without the
+//                                protection the attack really works)
+//
+// This proves the positive tests aren't tautological false positives.
+
+const http = require('http');
+const crypto = require('crypto');
+
+const PORT = Number(process.env.VULN_PORT) || 4467;
+
+const consents = new Map();
+
+function randomId() {
+  return crypto.randomBytes(16).toString('hex');
+}
+
+function parseBody(req) {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    req.on('data', chunk => (data += chunk));
+    req.on('end', () => resolve(data));
+    req.on('error', reject);
+  });
+}
+
+function json(res, status, obj) {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(obj));
+}
+
+function consentPage(consentId, nonce, command) {
+  return `<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>Approve Command</title></head>
+<body>
+  <form method="POST" action="/consent/${consentId}/approve">
+    <input type="hidden" name="nonce" value="${nonce}">
+    <button type="submit" autofocus>Approve</button>
+  </form>
+  <p>Command: ${command}</p>
+</body></html>`;
+}
+
+const server = http.createServer(async (req, res) => {
+  // NOTE: intentionally no `Service-Worker: script` block.
+  // NOTE: intentionally no Sec-Fetch filtering.
+  // NOTE: intentionally no COOP header.
+
+  const url = new URL(req.url, `http://localhost:${PORT}`);
+  const method = req.method;
+
+  if (url.pathname === '/' && method === 'GET') {
+    res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+    res.end('<!DOCTYPE html><title>vulnerable twin</title><body>twin</body>');
+    return;
+  }
+
+  if (url.pathname === '/api/request-consent' && method === 'POST') {
+    const body = await parseBody(req);
+    const { command } = JSON.parse(body);
+    const consentId = randomId();
+    const nonce = randomId();
+    consents.set(consentId, { nonce, command, approved: false, used: false });
+    json(res, 200, { consentId });
+    return;
+  }
+
+  const statusMatch = url.pathname.match(/^\/api\/consent-status\/([a-f0-9]+)$/);
+  if (statusMatch && method === 'GET') {
+    const entry = consents.get(statusMatch[1]);
+    if (!entry) return json(res, 404, { error: 'not found' });
+    json(res, 200, { approved: entry.approved });
+    return;
+  }
+
+  const consentMatch = url.pathname.match(/^\/consent\/([a-f0-9]+)$/);
+  if (consentMatch && method === 'GET') {
+    const entry = consents.get(consentMatch[1]);
+    if (!entry) {
+      res.writeHead(404, { 'Content-Type': 'text/plain' });
+      res.end('Consent not found');
+      return;
+    }
+    // No Sec-Fetch filter, no COOP header — deliberately vulnerable.
+    res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+    res.end(consentPage(consentMatch[1], entry.nonce, entry.command));
+    return;
+  }
+
+  const approveMatch = url.pathname.match(/^\/consent\/([a-f0-9]+)\/approve$/);
+  if (approveMatch && method === 'POST') {
+    const body = await parseBody(req);
+    const params = new URLSearchParams(body);
+    const submittedNonce = params.get('nonce');
+    const entry = consents.get(approveMatch[1]);
+    if (!entry) return json(res, 404, { error: 'not found' });
+    if (entry.used) return json(res, 409, { error: 'already used', approved: false });
+    if (submittedNonce !== entry.nonce) {
+      return json(res, 403, { error: 'invalid nonce', approved: false });
+    }
+    entry.approved = true;
+    entry.used = true;
+    json(res, 200, { approved: true });
+    return;
+  }
+
+  // Return a minimal valid Service Worker for registration attempts.
+  if (url.pathname === '/sw.js' && method === 'GET') {
+    res.writeHead(200, { 'Content-Type': 'application/javascript' });
+    res.end('// vulnerable twin service worker\nself.addEventListener("install",()=>{});');
+    return;
+  }
+
+  res.writeHead(404, { 'Content-Type': 'text/plain' });
+  res.end('Not found');
+});
+
+server.listen(PORT, () => {
+  console.log(`[vulnerable-twin] listening on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
Adds `docs/proposals/consent-poc/` — a Playwright-based proof-of-concept adversarial test harness for validating the AI assistant's consent and approval flows, including a vulnerable test server for adversarial scenario reproduction.

Assisted by Copilot.

Part of the ai-assistant design proposals.