### PR TITLE
metal3: Add Metal3Machine and Metal3MachineTemplate views

### DIFF
--- a/metal3/src/Metal3Machine/Details.tsx
+++ b/metal3/src/Metal3Machine/Details.tsx
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DetailsGrid } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { useParams } from 'react-router-dom';
+import { CRDGuard } from '../common/CRDGuard';
+import { metal3MachineClass } from './List';
+
+/** Label Cluster API stamps on a Metal3Machine to record its owning cluster. */
+const CLUSTER_NAME_LABEL = 'cluster.x-k8s.io/cluster-name';
+
+/** Annotation that links a Metal3Machine back to the BareMetalHost it claimed. */
+const HOST_ANNOTATION = 'metal3.io/BareMetalHost';
+
+/**
+ * Detail view for a single Metal3Machine.
+ *
+ * `DetailsGrid` renders the standard metadata and the Events section; the
+ * `extraInfo` callback supplies the Metal3Machine-specific fields, including the
+ * BareMetalHost it is bound to, which the provider records on the
+ * `metal3.io/BareMetalHost` annotation rather than as a typed spec field.
+ *
+ * @param props.name - Machine name; falls back to the `:name` route param.
+ * @param props.namespace - Machine namespace; falls back to the `:namespace` route param.
+ */
+export function Metal3MachineDetail(props: { name?: string; namespace?: string }) {
+  const params = useParams<{ name: string; namespace: string }>();
+  const { name = params.name, namespace = params.namespace } = props;
+
+  return (
+    <CRDGuard
+      crdName="metal3machines.infrastructure.cluster.x-k8s.io"
+      resourceLabel="Metal3 Machine"
+    >
+      <DetailsGrid
+        resourceType={metal3MachineClass()}
+        name={name}
+        namespace={namespace}
+        withEvents
+        extraInfo={(item: any) =>
+          item && [
+            {
+              name: 'Provisioned',
+              value:
+                item.jsonData.status?.initialization?.provisioned === undefined
+                  ? 'Unknown'
+                  : item.jsonData.status.initialization.provisioned
+                  ? 'Yes'
+                  : 'No',
+            },
+            {
+              name: 'Provider ID',
+              value: item.jsonData.spec?.providerID || '-',
+            },
+            {
+              name: 'Cluster',
+              value: item.jsonData.metadata?.labels?.[CLUSTER_NAME_LABEL] || '-',
+            },
+            {
+              name: 'Image',
+              value: item.jsonData.spec?.image?.url || '-',
+            },
+            {
+              name: 'BareMetalHost',
+              value: item.jsonData.metadata?.annotations?.[HOST_ANNOTATION] || '-',
+            },
+          ]
+        }
+      />
+    </CRDGuard>
+  );
+}

--- a/metal3/src/Metal3Machine/List.tsx
+++ b/metal3/src/Metal3Machine/List.tsx
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ResourceListView } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { StatusLabel } from '@kinvolk/headlamp-plugin/lib/components/common';
+import type { KubeObject } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import { makeCustomResourceClass } from '@kinvolk/headlamp-plugin/lib/lib/k8s/crd';
+import { CRDGuard } from '../common/CRDGuard';
+
+/** Label Cluster API stamps on a Metal3Machine to record its owning cluster. */
+const CLUSTER_NAME_LABEL = 'cluster.x-k8s.io/cluster-name';
+
+/** Defines the Metal3Machine custom resource (group/version/kind) for the plugin. */
+export function metal3MachineClass() {
+  const group = 'infrastructure.cluster.x-k8s.io';
+  const version = 'v1beta2';
+  const Metal3Machine = makeCustomResourceClass({
+    apiInfo: [{ group, version }],
+    kind: 'Metal3Machine',
+    pluralName: 'metal3machines',
+    singularName: 'Metal3Machine',
+    isNamespaced: true,
+  });
+
+  // Links the Name column to the detail route; the resource's name and
+  // namespace are passed as route params.
+  return class extendedMetal3MachineClass extends Metal3Machine {
+    static get detailsRoute() {
+      return 'metal3machine-detail';
+    }
+  };
+}
+
+/** List view for Metal3Machine resources, guarded by CRD presence. */
+export function Metal3Machines() {
+  return (
+    <CRDGuard
+      crdName="metal3machines.infrastructure.cluster.x-k8s.io"
+      resourceLabel="Metal3 Machine"
+    >
+      <ResourceListView
+        title="Metal3 Machines"
+        resourceClass={metal3MachineClass()}
+        columns={[
+          'name',
+          'namespace',
+          {
+            // status.initialization.provisioned is the v1beta2 readiness signal,
+            // replacing the v1beta1 status.ready boolean.
+            id: 'provisioned',
+            label: 'Provisioned',
+            // An absent status.initialization.provisioned (no controller yet) is
+            // Unknown, which is distinct from an explicit false.
+            getValue: (m: KubeObject) => {
+              const provisioned = m.jsonData.status?.initialization?.provisioned;
+              return provisioned === undefined ? 'Unknown' : provisioned ? 'Yes' : 'No';
+            },
+            render: (m: KubeObject) => {
+              const provisioned = m.jsonData.status?.initialization?.provisioned;
+              const label = provisioned === undefined ? 'Unknown' : provisioned ? 'Yes' : 'No';
+              // Yes is a success; an explicit No is a warning; Unknown stays neutral.
+              const status =
+                provisioned === true ? 'success' : provisioned === false ? 'warning' : '';
+              return <StatusLabel status={status}>{label}</StatusLabel>;
+            },
+          },
+          {
+            id: 'providerID',
+            label: 'Provider ID',
+            getValue: (m: KubeObject) => m.jsonData.spec?.providerID || '-',
+          },
+          {
+            id: 'cluster',
+            label: 'Cluster',
+            getValue: (m: KubeObject) => m.jsonData.metadata?.labels?.[CLUSTER_NAME_LABEL] || '-',
+          },
+          'age',
+        ]}
+      />
+    </CRDGuard>
+  );
+}

--- a/metal3/src/Metal3MachineTemplate/Details.tsx
+++ b/metal3/src/Metal3MachineTemplate/Details.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DetailsGrid } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { useParams } from 'react-router-dom';
+import { CRDGuard } from '../common/CRDGuard';
+import { metal3MachineTemplateClass } from './List';
+
+/**
+ * Detail view for a single Metal3MachineTemplate.
+ *
+ * A Metal3MachineTemplate is a blueprint that Cluster API stamps Metal3Machines
+ * from; its `spec.template.spec` is the embedded machine spec. `DetailsGrid`
+ * renders the standard metadata and Events section; the `extraInfo` callback
+ * surfaces the blueprint's key fields.
+ *
+ * @param props.name - Template name; falls back to the `:name` route param.
+ * @param props.namespace - Template namespace; falls back to the `:namespace` route param.
+ */
+export function Metal3MachineTemplateDetail(props: { name?: string; namespace?: string }) {
+  const params = useParams<{ name: string; namespace: string }>();
+  const { name = params.name, namespace = params.namespace } = props;
+
+  return (
+    <CRDGuard
+      crdName="metal3machinetemplates.infrastructure.cluster.x-k8s.io"
+      resourceLabel="Metal3 Machine Template"
+    >
+      <DetailsGrid
+        resourceType={metal3MachineTemplateClass()}
+        name={name}
+        namespace={namespace}
+        withEvents
+        extraInfo={(item: any) =>
+          item && [
+            {
+              name: 'Node Reuse',
+              value: item.jsonData.spec?.nodeReuse ? 'Yes' : 'No',
+            },
+            {
+              name: 'Image',
+              value: item.jsonData.spec?.template?.spec?.image?.url || '-',
+            },
+            {
+              name: 'Automated Cleaning Mode',
+              value: item.jsonData.spec?.template?.spec?.automatedCleaningMode || '-',
+            },
+            {
+              name: 'Data Template',
+              value: item.jsonData.spec?.template?.spec?.dataTemplate?.name || '-',
+            },
+          ]
+        }
+      />
+    </CRDGuard>
+  );
+}

--- a/metal3/src/Metal3MachineTemplate/Details.tsx
+++ b/metal3/src/Metal3MachineTemplate/Details.tsx
@@ -17,6 +17,7 @@
 import { DetailsGrid } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 import { useParams } from 'react-router-dom';
 import { CRDGuard } from '../common/CRDGuard';
+import { formatHostSelector } from './hostSelector';
 import { metal3MachineTemplateClass } from './List';
 
 /**
@@ -46,6 +47,10 @@ export function Metal3MachineTemplateDetail(props: { name?: string; namespace?: 
         withEvents
         extraInfo={(item: any) =>
           item && [
+            {
+              name: 'Host Selector',
+              value: formatHostSelector(item.jsonData.spec?.template?.spec?.hostSelector),
+            },
             {
               name: 'Node Reuse',
               value: item.jsonData.spec?.nodeReuse ? 'Yes' : 'No',

--- a/metal3/src/Metal3MachineTemplate/List.tsx
+++ b/metal3/src/Metal3MachineTemplate/List.tsx
@@ -18,6 +18,7 @@ import { ResourceListView } from '@kinvolk/headlamp-plugin/lib/CommonComponents'
 import type { KubeObject } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
 import { makeCustomResourceClass } from '@kinvolk/headlamp-plugin/lib/lib/k8s/crd';
 import { CRDGuard } from '../common/CRDGuard';
+import { formatHostSelector } from './hostSelector';
 
 /** Defines the Metal3MachineTemplate custom resource (group/version/kind) for the plugin. */
 export function metal3MachineTemplateClass() {
@@ -64,6 +65,13 @@ export function Metal3MachineTemplates() {
             id: 'image',
             label: 'Image',
             getValue: (t: KubeObject) => t.jsonData.spec?.template?.spec?.image?.url || '-',
+          },
+          {
+            // hostSelector chooses which BareMetalHosts a stamped machine may land on.
+            id: 'hostSelector',
+            label: 'Host Selector',
+            getValue: (t: KubeObject) =>
+              formatHostSelector(t.jsonData.spec?.template?.spec?.hostSelector),
           },
           'age',
         ]}

--- a/metal3/src/Metal3MachineTemplate/List.tsx
+++ b/metal3/src/Metal3MachineTemplate/List.tsx
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ResourceListView } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import type { KubeObject } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import { makeCustomResourceClass } from '@kinvolk/headlamp-plugin/lib/lib/k8s/crd';
+import { CRDGuard } from '../common/CRDGuard';
+
+/** Defines the Metal3MachineTemplate custom resource (group/version/kind) for the plugin. */
+export function metal3MachineTemplateClass() {
+  const group = 'infrastructure.cluster.x-k8s.io';
+  const version = 'v1beta2';
+  const Metal3MachineTemplate = makeCustomResourceClass({
+    apiInfo: [{ group, version }],
+    kind: 'Metal3MachineTemplate',
+    pluralName: 'metal3machinetemplates',
+    singularName: 'Metal3MachineTemplate',
+    isNamespaced: true,
+  });
+
+  // Links the Name column to the detail route; the resource's name and
+  // namespace are passed as route params.
+  return class extendedMetal3MachineTemplateClass extends Metal3MachineTemplate {
+    static get detailsRoute() {
+      return 'metal3machinetemplate-detail';
+    }
+  };
+}
+
+/** List view for Metal3MachineTemplate resources, guarded by CRD presence. */
+export function Metal3MachineTemplates() {
+  return (
+    <CRDGuard
+      crdName="metal3machinetemplates.infrastructure.cluster.x-k8s.io"
+      resourceLabel="Metal3 Machine Template"
+    >
+      <ResourceListView
+        title="Metal3 Machine Templates"
+        resourceClass={metal3MachineTemplateClass()}
+        columns={[
+          'name',
+          'namespace',
+          {
+            // Whether machines stamped from this template reuse the same node.
+            id: 'nodeReuse',
+            label: 'Node Reuse',
+            getValue: (t: KubeObject) => (t.jsonData.spec?.nodeReuse ? 'Yes' : 'No'),
+          },
+          {
+            // The blueprint's image, taken from the embedded machine spec.
+            id: 'image',
+            label: 'Image',
+            getValue: (t: KubeObject) => t.jsonData.spec?.template?.spec?.image?.url || '-',
+          },
+          'age',
+        ]}
+      />
+    </CRDGuard>
+  );
+}

--- a/metal3/src/Metal3MachineTemplate/hostSelector.test.ts
+++ b/metal3/src/Metal3MachineTemplate/hostSelector.test.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { formatHostSelector } from './hostSelector';
+
+describe('formatHostSelector', () => {
+  it('returns "-" when the selector is absent', () => {
+    expect(formatHostSelector(undefined)).toBe('-');
+  });
+
+  it('returns "-" for an empty selector', () => {
+    expect(formatHostSelector({})).toBe('-');
+  });
+
+  it('formats matchLabels as key=value pairs', () => {
+    expect(formatHostSelector({ matchLabels: { 'node-role': 'control-plane', zone: 'a' } })).toBe(
+      'node-role=control-plane, zone=a'
+    );
+  });
+
+  it('sorts matchLabels by key for stable output', () => {
+    expect(formatHostSelector({ matchLabels: { zone: 'a', app: 'web' } })).toBe('app=web, zone=a');
+  });
+
+  it('formats matchExpressions that carry values with a bracketed list', () => {
+    expect(
+      formatHostSelector({
+        matchExpressions: [{ key: 'disk', operator: 'In', values: ['ssd', 'nvme'] }],
+      })
+    ).toBe('disk In [ssd, nvme]');
+  });
+
+  it('omits the bracketed list for value-less operators (Exists/DoesNotExist)', () => {
+    expect(formatHostSelector({ matchExpressions: [{ key: 'gpu', operator: 'Exists' }] })).toBe(
+      'gpu Exists'
+    );
+  });
+
+  it('keeps the bracketed list for value-taking operators even when values is empty', () => {
+    expect(
+      formatHostSelector({ matchExpressions: [{ key: 'disk', operator: 'In', values: [] }] })
+    ).toBe('disk In []');
+  });
+
+  it('combines matchLabels and matchExpressions', () => {
+    expect(
+      formatHostSelector({
+        matchLabels: { zone: 'a' },
+        matchExpressions: [{ key: 'gpu', operator: 'DoesNotExist' }],
+      })
+    ).toBe('zone=a, gpu DoesNotExist');
+  });
+});

--- a/metal3/src/Metal3MachineTemplate/hostSelector.ts
+++ b/metal3/src/Metal3MachineTemplate/hostSelector.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** A single matchExpressions entry of a HostSelector. */
+export interface HostSelectorRequirement {
+  key: string;
+  operator: string;
+  values?: string[];
+}
+
+/** The embedded machine spec's hostSelector: label match criteria for choosing a BareMetalHost. */
+export interface HostSelector {
+  matchLabels?: Record<string, string>;
+  matchExpressions?: HostSelectorRequirement[];
+}
+
+/**
+ * Formats a HostSelector into a readable one-line summary, joining matchLabels as
+ * `key=value` and matchExpressions as `key operator [values]`. Set-based operators
+ * such as `Exists`/`DoesNotExist` carry no values, so the bracketed list is dropped
+ * for them. Returns `'-'` when the selector is absent or empty (a template with no
+ * selector matches any host).
+ *
+ * @param hostSelector - The `spec.template.spec.hostSelector` value, if present.
+ * @returns The summary string, or `'-'` when there is nothing to show.
+ */
+export function formatHostSelector(hostSelector?: HostSelector): string {
+  if (!hostSelector) {
+    return '-';
+  }
+  const labels = hostSelector.matchLabels
+    ? Object.entries(hostSelector.matchLabels)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([key, value]) => `${key}=${value}`)
+    : [];
+  const expressions = (hostSelector.matchExpressions || []).map(expr => {
+    // Exists/DoesNotExist take no values, so drop the bracketed list for them;
+    // value-taking operators (In/NotIn) keep it, even when empty, so missing
+    // values stay visible rather than reading like a value-less operator.
+    const valueLess = expr.operator === 'Exists' || expr.operator === 'DoesNotExist';
+    return valueLess
+      ? `${expr.key} ${expr.operator}`
+      : `${expr.key} ${expr.operator} [${(expr.values || []).join(', ')}]`;
+  });
+  const parts = [...labels, ...expressions];
+  return parts.length ? parts.join(', ') : '-';
+}

--- a/metal3/src/index.tsx
+++ b/metal3/src/index.tsx
@@ -17,7 +17,13 @@
 import { registerRoute, registerSidebarEntry } from '@kinvolk/headlamp-plugin/lib';
 import { BareMetalHostDetail } from './BareMetalHost/Details';
 import { BareMetalHosts } from './BareMetalHost/List';
+import { Metal3MachineDetail } from './Metal3Machine/Details';
+import { Metal3Machines } from './Metal3Machine/List';
+import { Metal3MachineTemplateDetail } from './Metal3MachineTemplate/Details';
+import { Metal3MachineTemplates } from './Metal3MachineTemplate/List';
 
+// Parent Metal3 group. Its url points at the first child's list so the group
+// header is itself navigable.
 registerSidebarEntry({
   parent: null,
   name: 'metal3',
@@ -26,10 +32,17 @@ registerSidebarEntry({
   url: '/metal3/baremetalhosts',
 });
 
+registerSidebarEntry({
+  parent: 'metal3',
+  name: 'baremetalhosts',
+  label: 'Bare Metal Hosts',
+  url: '/metal3/baremetalhosts',
+});
+
 // List route. Marked exact so it does not also match the detail path below.
 registerRoute({
   path: '/metal3/baremetalhosts',
-  sidebar: 'metal3',
+  sidebar: 'baremetalhosts',
   component: BareMetalHosts,
   name: 'baremetalhosts-list',
   exact: true,
@@ -39,7 +52,51 @@ registerRoute({
 // are populated from the resource's metadata.
 registerRoute({
   path: '/metal3/baremetalhosts/:namespace/:name',
-  sidebar: 'metal3',
+  sidebar: 'baremetalhosts',
   component: () => <BareMetalHostDetail />,
   name: 'baremetalhost-detail',
+});
+
+registerSidebarEntry({
+  parent: 'metal3',
+  name: 'metal3machines',
+  label: 'Metal3 Machines',
+  url: '/metal3/metal3machines',
+});
+
+registerRoute({
+  path: '/metal3/metal3machines',
+  sidebar: 'metal3machines',
+  component: Metal3Machines,
+  name: 'metal3machines-list',
+  exact: true,
+});
+
+registerRoute({
+  path: '/metal3/metal3machines/:namespace/:name',
+  sidebar: 'metal3machines',
+  component: () => <Metal3MachineDetail />,
+  name: 'metal3machine-detail',
+});
+
+registerSidebarEntry({
+  parent: 'metal3',
+  name: 'metal3machinetemplates',
+  label: 'Metal3 Machine Templates',
+  url: '/metal3/metal3machinetemplates',
+});
+
+registerRoute({
+  path: '/metal3/metal3machinetemplates',
+  sidebar: 'metal3machinetemplates',
+  component: Metal3MachineTemplates,
+  name: 'metal3machinetemplates-list',
+  exact: true,
+});
+
+registerRoute({
+  path: '/metal3/metal3machinetemplates/:namespace/:name',
+  sidebar: 'metal3machinetemplates',
+  component: () => <Metal3MachineTemplateDetail />,
+  name: 'metal3machinetemplate-detail',
 });

--- a/metal3/test-files/metal3machine.yaml
+++ b/metal3/test-files/metal3machine.yaml
@@ -1,0 +1,45 @@
+# Sample Metal3Machine and Metal3MachineTemplate for trying out the Metal3 plugin locally.
+#
+#   kubectl apply -f metal3/test-files/metal3machine.yaml
+#
+# They appear under Metal3 > Metal3 Machines and Metal3 > Metal3 Machine Templates.
+# A Metal3Machine is the CAPM3 infra object bound to a BareMetalHost; a
+# Metal3MachineTemplate is the blueprint machines are stamped from. The provisioned
+# status is set by the CAPM3 controller as it reconciles; without a controller
+# running they still list, with an empty status. The annotation ties the machine to
+# the sample-host from baremetalhost.yaml.
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: Metal3Machine
+metadata:
+  name: sample-machine
+  namespace: default
+  labels:
+    cluster.x-k8s.io/cluster-name: sample-cluster
+  annotations:
+    metal3.io/BareMetalHost: default/sample-host
+spec:
+  image:
+    url: http://192.168.1.5/ubuntu-22.04.img
+    checksum: http://192.168.1.5/ubuntu-22.04.img.sha256sum
+  providerID: metal3://default/sample-host/sample-machine
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: Metal3MachineTemplate
+metadata:
+  name: sample-machinetemplate
+  namespace: default
+  labels:
+    cluster.x-k8s.io/cluster-name: sample-cluster
+spec:
+  nodeReuse: false
+  template:
+    spec:
+      automatedCleaningMode: metadata
+      hostSelector:
+        matchLabels:
+          node-role: control-plane
+      image:
+        url: http://192.168.1.5/ubuntu-22.04.img
+        checksum: http://192.168.1.5/ubuntu-22.04.img.sha256sum
+      dataTemplate:
+        name: sample-metadata


### PR DESCRIPTION
## Summary

Continues the Metal3 plugin. Adds Metal3Machine and Metal3MachineTemplate to the Metal3 section, the CAPM3 resources that back Cluster API machines on bare metal. More resources and a map view to follow.

## Included

- Metal3Machine list view with provisioned state, provider ID, and cluster columns, and a detail view that adds the image and the BareMetalHost it is bound to.
- Metal3MachineTemplate list view with node reuse and image, and a detail view that adds automated cleaning mode and data template.
- The Metal3 sidebar is now a group, with a Bare Metal Hosts entry alongside the two new ones.

## How to test

- A cluster with the Metal3 and CAPM3 CRDs installed.
- cd metal3 && npm install && npm start, then run Headlamp.
- Apply the sample objects: kubectl apply -f metal3/test-files/metal3machine.yaml.
- Open the Metal3 section: the machines and templates list, and clicking one opens the detail view.

## Snapshots

<img width="1912" height="796" alt="image" src="https://github.com/user-attachments/assets/9d867fb9-c5e1-4b66-8ea3-8df349caa9ed" />

Metal3Machine list. The CAPM3 infrastructure objects backing Cluster API Machines, showing provisioned state, provider ID, and owning cluster.

<img width="1896" height="536" alt="image" src="https://github.com/user-attachments/assets/d78ef8dc-19c8-4b4c-af33-f5d83478aa40" />

Metal3MachineTemplate list. The blueprints Metal3Machines are stamped from, showing node reuse and image.

<img width="1878" height="1028" alt="image" src="https://github.com/user-attachments/assets/1a1d1697-6175-466b-ad4b-702ca3ed19f4" />

Metal3MachineTemplate detail. The blueprint's node reuse, image, automated cleaning mode, and data template.