### PR TITLE
Kmesh : Implement xDS Config Dump Viewer

### DIFF
--- a/kmesh/src/components/daemon/XdsConfigDump.tsx
+++ b/kmesh/src/components/daemon/XdsConfigDump.tsx
@@ -1,0 +1,309 @@
+/**
+ * XdsConfigDump — xDS Config Dump viewer for the Kmesh daemon (kernel-native / ADS mode).
+ *
+ * Surfaces the three main xDS resource types from GET /debug/config_dump/kernel-native:
+ *   • Clusters  — upstream service definitions (api/v2/cluster/cluster.pb.go)
+ *   • Listeners — inbound/outbound listener configs (api/v2/listener/listener.pb.go)
+ *   • Routes    — virtual-host and route-match rules (api/v2/route/route.pb.go)
+ *
+ * The daemon serialises these via protojson.Format() — so each array element is a
+ * RAW proto object, with no versionInfo/lastUpdated envelope.
+ *
+ * The endpoint returns HTTP 400 when the daemon runs in dual-engine / workload mode.
+ *
+ * @see src/hooks/useDaemonRequest.ts  — useXdsClusters / useXdsListeners / useXdsRoutes
+ * @see src/types/daemonApi.ts         — XdsCluster, XdsListener, XdsRouteConfiguration
+ * @see src/utils/kmeshDaemonProxy.ts  — deduplication (one HTTP call for all three tabs)
+ */
+
+import {
+  SectionBox,
+  SimpleTable,
+  StatusLabel,
+} from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { Box, CircularProgress, Tab, Tabs, Typography } from '@mui/material';
+import { type ReactNode, useState } from 'react';
+import { useXdsClusters, useXdsListeners, useXdsRoutes } from '../../hooks/useDaemonRequest';
+import { useKmeshDaemonPods } from '../../hooks/useKmeshDaemonPods';
+import type { XdsCluster, XdsListener, XdsRouteConfiguration } from '../../types/daemonApi';
+import { KMESH_NAMESPACE } from '../../utils/kmeshDaemonApi';
+
+const PAGE_TITLE = 'Kmesh xDS Config Dump';
+
+// ---------------------------------------------------------------------------
+// Helper — convert IPv4 stored as uint32 → "a.b.c.d"
+// api/v2/core/address.pb.go stores the address as a raw uint32 (network byte order).
+// ---------------------------------------------------------------------------
+
+/**
+ * Converts a uint32 IPv4 address (as emitted by protojson) to a dotted-decimal string.
+ * Returns '-' when the value is absent.
+ */
+function formatIpv4Uint32(ipv4?: number): string {
+  if (ipv4 === undefined || ipv4 === null) return '-';
+  return [(ipv4 >>> 24) & 0xff, (ipv4 >>> 16) & 0xff, (ipv4 >>> 8) & 0xff, ipv4 & 0xff].join('.');
+}
+
+function renderApiStatus(apiStatus?: string): ReactNode {
+  const s = apiStatus ?? '';
+  return s ? <StatusLabel status={s === 'OK' ? 'success' : 'warning'}>{s}</StatusLabel> : '-';
+}
+
+// ---------------------------------------------------------------------------
+// Tab content panels — each uses SimpleTable exactly like HealthDashboard
+// ---------------------------------------------------------------------------
+
+/**
+ * Clusters tab — shows CDS dynamic cluster resources.
+ *
+ * Columns sourced from api/v2/cluster/cluster.pb.go:
+ *   GetName(), GetConnectTimeout(), GetLbPolicy(), GetApiStatus()
+ */
+function ClustersPanel({ clusters }: { clusters: XdsCluster[] }) {
+  return (
+    <SimpleTable
+      data={clusters}
+      columns={[
+        {
+          label: 'Name',
+          getter: (c: XdsCluster) => c.name ?? '-',
+          sort: true,
+        },
+        {
+          label: 'LB Policy',
+          getter: (c: XdsCluster) => c.lbPolicy ?? '-',
+          sort: true,
+        },
+        {
+          label: 'Connect Timeout (s)',
+          getter: (c: XdsCluster) => (c.connectTimeout !== undefined ? c.connectTimeout : '-'),
+          sort: (c: XdsCluster) => c.connectTimeout ?? -1,
+        },
+        {
+          label: 'API Status',
+          getter: (c: XdsCluster) => renderApiStatus(c.apiStatus),
+          sort: (c: XdsCluster) => c.apiStatus ?? '',
+        },
+      ]}
+      emptyMessage="No dynamic cluster configs found."
+    />
+  );
+}
+
+/**
+ * Listeners tab — shows LDS dynamic listener resources.
+ *
+ * Columns sourced from api/v2/listener/listener.pb.go and api/v2/core/address.pb.go:
+ *   GetName(), GetAddress().GetIpv4(), GetAddress().GetPort(), GetFilterChains()
+ */
+function ListenersPanel({ listeners }: { listeners: XdsListener[] }) {
+  return (
+    <SimpleTable
+      data={listeners}
+      columns={[
+        {
+          label: 'Name',
+          getter: (l: XdsListener) => l.name ?? '-',
+          sort: true,
+        },
+        {
+          label: 'Address',
+          getter: (l: XdsListener) => {
+            const ip = formatIpv4Uint32(l.address?.ipv4);
+            const port = l.address?.port;
+            return ip !== '-' && port !== undefined ? `${ip}:${port}` : '-';
+          },
+          sort: true,
+        },
+        {
+          label: 'Filter Chains',
+          getter: (l: XdsListener) => l.filterChains?.length ?? 0,
+          sort: true,
+        },
+        {
+          label: 'API Status',
+          getter: (l: XdsListener) => renderApiStatus(l.apiStatus),
+          sort: (l: XdsListener) => l.apiStatus ?? '',
+        },
+      ]}
+      emptyMessage="No dynamic listener configs found."
+    />
+  );
+}
+
+/**
+ * Routes tab — shows RDS dynamic route configurations.
+ *
+ * Columns sourced from api/v2/route/route.pb.go and route_components.pb.go:
+ *   GetName(), GetVirtualHosts(), VirtualHost.GetRoutes()
+ */
+function RoutesPanel({ routes }: { routes: XdsRouteConfiguration[] }) {
+  return (
+    <SimpleTable
+      data={routes}
+      columns={[
+        {
+          label: 'Name',
+          getter: (r: XdsRouteConfiguration) => r.name ?? '-',
+          sort: true,
+        },
+        {
+          label: 'Virtual Hosts',
+          getter: (r: XdsRouteConfiguration) => r.virtualHosts?.length ?? 0,
+          sort: true,
+        },
+        {
+          label: 'Total Routes',
+          getter: (r: XdsRouteConfiguration) =>
+            (r.virtualHosts ?? []).reduce((sum, vh) => sum + (vh.routes?.length ?? 0), 0),
+          sort: true,
+        },
+        {
+          label: 'API Status',
+          getter: (r: XdsRouteConfiguration) => renderApiStatus(r.apiStatus),
+          sort: (r: XdsRouteConfiguration) => r.apiStatus ?? '',
+        },
+      ]}
+      emptyMessage="No dynamic route configs found."
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Loading / error guard shared by all three tabs
+// ---------------------------------------------------------------------------
+
+interface XdsResourcePanelProps<T> {
+  status: 'idle' | 'loading' | 'success' | 'error';
+  data: T[] | null;
+  error: string | null;
+  children: (data: T[]) => ReactNode;
+}
+
+/**
+ * Renders a spinner while loading, a typed error on failure,
+ * or delegates to the tab-specific content component on success.
+ */
+function XdsResourcePanel<T>({ status, data, error, children }: XdsResourcePanelProps<T>) {
+  if (status === 'idle' || status === 'loading') {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
+        <CircularProgress size={28} />
+      </Box>
+    );
+  }
+
+  if (status === 'error') {
+    // HTTP 400 means the daemon is in workload mode — surface a clear message.
+    const isModeMismatch = /\b400\b/.test(error ?? '') || /Bad Request/i.test(error ?? '');
+    return (
+      <Typography color="error" variant="body2" sx={{ p: 2 }}>
+        {isModeMismatch
+          ? 'The Kmesh daemon is running in dual-engine / workload mode. ' +
+            'The xDS config dump is only available in kernel-native (ADS) mode.'
+          : `Error fetching xDS config dump: ${error}`}
+      </Typography>
+    );
+  }
+
+  return <>{children(data ?? [])}</>;
+}
+
+// ---------------------------------------------------------------------------
+// Tab type
+// ---------------------------------------------------------------------------
+
+type XdsTab = 'clusters' | 'listeners' | 'routes';
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+/**
+ * xDS Config Dump viewer page for Kmesh.
+ *
+ * Displays a tabbed interface (Clusters / Listeners / Routes) backed by the
+ * kernel-native config dump endpoint.  All three tabs share one HTTP round-trip
+ * thanks to the deduplication layer in kmeshDaemonProxy.ts.
+ */
+export default function XdsConfigDump() {
+  const [activeTab, setActiveTab] = useState<XdsTab>('clusters');
+
+  const { readyPod, loading: podsLoading, error: podsError } = useKmeshDaemonPods();
+  const podName = readyPod?.name ?? null;
+
+  // All three hooks call the same endpoint; the dedup layer ensures
+  // only one actual HTTP request is made regardless of tab switches.
+  const clusters = useXdsClusters(KMESH_NAMESPACE, podName);
+  const listeners = useXdsListeners(KMESH_NAMESPACE, podName);
+  const routes = useXdsRoutes(KMESH_NAMESPACE, podName);
+
+  if (podsLoading) {
+    return (
+      <SectionBox title={PAGE_TITLE}>
+        <CircularProgress />
+      </SectionBox>
+    );
+  }
+
+  if (podsError) {
+    return (
+      <SectionBox title={PAGE_TITLE}>
+        <Typography color="error">Error loading pods: {podsError}</Typography>
+      </SectionBox>
+    );
+  }
+
+  if (!readyPod) {
+    return (
+      <SectionBox title={PAGE_TITLE}>
+        <Typography variant="body2" color="textSecondary">
+          No Running+Ready Kmesh daemon pod found. Ensure the kmesh-daemon DaemonSet is healthy.
+        </Typography>
+      </SectionBox>
+    );
+  }
+
+  /** Tab label with live count badge once data is loaded. */
+  function tabLabel(id: XdsTab): string {
+    if (id === 'clusters' && clusters.status === 'success')
+      return `Clusters (${clusters.data?.length ?? 0})`;
+    if (id === 'listeners' && listeners.status === 'success')
+      return `Listeners (${listeners.data?.length ?? 0})`;
+    if (id === 'routes' && routes.status === 'success')
+      return `Routes (${routes.data?.length ?? 0})`;
+    return id.charAt(0).toUpperCase() + id.slice(1);
+  }
+
+  return (
+    <SectionBox title={PAGE_TITLE}>
+      <Tabs
+        value={activeTab}
+        onChange={(_e, v: XdsTab) => setActiveTab(v)}
+        sx={{ borderBottom: 1, borderColor: 'divider', mb: 1 }}
+      >
+        <Tab value="clusters" label={tabLabel('clusters')} />
+        <Tab value="listeners" label={tabLabel('listeners')} />
+        <Tab value="routes" label={tabLabel('routes')} />
+      </Tabs>
+
+      {activeTab === 'clusters' && (
+        <XdsResourcePanel<XdsCluster> {...clusters}>
+          {data => <ClustersPanel clusters={data} />}
+        </XdsResourcePanel>
+      )}
+
+      {activeTab === 'listeners' && (
+        <XdsResourcePanel<XdsListener> {...listeners}>
+          {data => <ListenersPanel listeners={data} />}
+        </XdsResourcePanel>
+      )}
+
+      {activeTab === 'routes' && (
+        <XdsResourcePanel<XdsRouteConfiguration> {...routes}>
+          {data => <RoutesPanel routes={data} />}
+        </XdsResourcePanel>
+      )}
+    </SectionBox>
+  );
+}

--- a/kmesh/src/hooks/useDaemonRequest.ts
+++ b/kmesh/src/hooks/useDaemonRequest.ts
@@ -208,17 +208,16 @@ export function useKmeshLoggerLevel(namespace: string, podName: string | null, l
  * const { status, data: clusters, error } = useXdsClusters('kmesh-system', readyPod?.name ?? null);
  * ```
  */
-export function useXdsClusters(namespace: string, podName: string | null) {
+export function useXdsClusters(
+  namespace: string,
+  podName: string | null
+): DaemonRequestState<XdsCluster[]> {
   const raw = useDaemonRequest<ConfigDump>(namespace, podName, DAEMON_ENDPOINTS.CONFIG_DUMP_ADS);
 
-  // Project only the clusters array so callers don't have to drill into dynamicResources.
-  const data: XdsCluster[] | null =
-    raw.status === 'success' ? raw.data?.dynamicResources?.clusterConfigs ?? [] : null;
-
-  return { ...raw, data } as {
-    status: typeof raw.status;
-    data: XdsCluster[] | null;
-    error: string | null;
+  return {
+    status: raw.status,
+    error: raw.error,
+    data: raw.status === 'success' ? raw.data?.dynamicResources?.clusterConfigs ?? [] : null,
   };
 }
 
@@ -232,16 +231,16 @@ export function useXdsClusters(namespace: string, podName: string | null) {
  * const { status, data: listeners } = useXdsListeners('kmesh-system', readyPod?.name ?? null);
  * ```
  */
-export function useXdsListeners(namespace: string, podName: string | null) {
+export function useXdsListeners(
+  namespace: string,
+  podName: string | null
+): DaemonRequestState<XdsListener[]> {
   const raw = useDaemonRequest<ConfigDump>(namespace, podName, DAEMON_ENDPOINTS.CONFIG_DUMP_ADS);
 
-  const data: XdsListener[] | null =
-    raw.status === 'success' ? raw.data?.dynamicResources?.listenerConfigs ?? [] : null;
-
-  return { ...raw, data } as {
-    status: typeof raw.status;
-    data: XdsListener[] | null;
-    error: string | null;
+  return {
+    status: raw.status,
+    error: raw.error,
+    data: raw.status === 'success' ? raw.data?.dynamicResources?.listenerConfigs ?? [] : null,
   };
 }
 
@@ -255,15 +254,15 @@ export function useXdsListeners(namespace: string, podName: string | null) {
  * const { status, data: routes } = useXdsRoutes('kmesh-system', readyPod?.name ?? null);
  * ```
  */
-export function useXdsRoutes(namespace: string, podName: string | null) {
+export function useXdsRoutes(
+  namespace: string,
+  podName: string | null
+): DaemonRequestState<XdsRouteConfiguration[]> {
   const raw = useDaemonRequest<ConfigDump>(namespace, podName, DAEMON_ENDPOINTS.CONFIG_DUMP_ADS);
 
-  const data: XdsRouteConfiguration[] | null =
-    raw.status === 'success' ? raw.data?.dynamicResources?.routeConfigs ?? [] : null;
-
-  return { ...raw, data } as {
-    status: typeof raw.status;
-    data: XdsRouteConfiguration[] | null;
-    error: string | null;
+  return {
+    status: raw.status,
+    error: raw.error,
+    data: raw.status === 'success' ? raw.data?.dynamicResources?.routeConfigs ?? [] : null,
   };
 }

--- a/kmesh/src/hooks/useDaemonRequest.ts
+++ b/kmesh/src/hooks/useDaemonRequest.ts
@@ -34,6 +34,9 @@ import type {
   LoggerInfo,
   WorkloadBpfDump,
   WorkloadDump,
+  XdsCluster,
+  XdsListener,
+  XdsRouteConfiguration,
 } from '../types/daemonApi';
 import { DAEMON_ENDPOINTS, type DaemonEndpoint } from '../utils/kmeshDaemonApi';
 import {
@@ -183,4 +186,84 @@ export function useKmeshLoggerLevel(namespace: string, podName: string | null, l
   return useDaemonRequest<LoggerInfo>(namespace, podName, DAEMON_ENDPOINTS.LOGGERS, {
     queryParams: { name: loggerName },
   });
+}
+
+// ---------------------------------------------------------------------------
+// xDS Config Dump convenience hooks (kernel-native / ADS mode)
+//
+// The full ADS config dump (`useAdsConfigDump`) is a large payload. These
+// three specialised hooks slice out the resource type callers actually need,
+// avoiding prop-drilling `data?.dynamicResources?.clusterConfigs` everywhere.
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetches the full ADS config dump and returns only the dynamic cluster list.
+ *
+ * Returns 400 (error state) if the daemon is in dual-engine / workload mode
+ * — the component should show a graceful fallback in that case.
+ *
+ * @example
+ * ```tsx
+ * const { readyPod } = useKmeshDaemonPods();
+ * const { status, data: clusters, error } = useXdsClusters('kmesh-system', readyPod?.name ?? null);
+ * ```
+ */
+export function useXdsClusters(namespace: string, podName: string | null) {
+  const raw = useDaemonRequest<ConfigDump>(namespace, podName, DAEMON_ENDPOINTS.CONFIG_DUMP_ADS);
+
+  // Project only the clusters array so callers don't have to drill into dynamicResources.
+  const data: XdsCluster[] | null =
+    raw.status === 'success' ? raw.data?.dynamicResources?.clusterConfigs ?? [] : null;
+
+  return { ...raw, data } as {
+    status: typeof raw.status;
+    data: XdsCluster[] | null;
+    error: string | null;
+  };
+}
+
+/**
+ * Fetches the full ADS config dump and returns only the dynamic listener list.
+ *
+ * Returns 400 (error state) if the daemon is in dual-engine / workload mode.
+ *
+ * @example
+ * ```tsx
+ * const { status, data: listeners } = useXdsListeners('kmesh-system', readyPod?.name ?? null);
+ * ```
+ */
+export function useXdsListeners(namespace: string, podName: string | null) {
+  const raw = useDaemonRequest<ConfigDump>(namespace, podName, DAEMON_ENDPOINTS.CONFIG_DUMP_ADS);
+
+  const data: XdsListener[] | null =
+    raw.status === 'success' ? raw.data?.dynamicResources?.listenerConfigs ?? [] : null;
+
+  return { ...raw, data } as {
+    status: typeof raw.status;
+    data: XdsListener[] | null;
+    error: string | null;
+  };
+}
+
+/**
+ * Fetches the full ADS config dump and returns only the dynamic route list.
+ *
+ * Returns 400 (error state) if the daemon is in dual-engine / workload mode.
+ *
+ * @example
+ * ```tsx
+ * const { status, data: routes } = useXdsRoutes('kmesh-system', readyPod?.name ?? null);
+ * ```
+ */
+export function useXdsRoutes(namespace: string, podName: string | null) {
+  const raw = useDaemonRequest<ConfigDump>(namespace, podName, DAEMON_ENDPOINTS.CONFIG_DUMP_ADS);
+
+  const data: XdsRouteConfiguration[] | null =
+    raw.status === 'success' ? raw.data?.dynamicResources?.routeConfigs ?? [] : null;
+
+  return { ...raw, data } as {
+    status: typeof raw.status;
+    data: XdsRouteConfiguration[] | null;
+    error: string | null;
+  };
 }

--- a/kmesh/src/index.test.ts
+++ b/kmesh/src/index.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it } from 'vitest';
-import { kmeshRoutePaths } from './utils/kmeshRoutes';
+import { kmeshRouteNames, kmeshRoutePaths } from './utils/kmeshRoutes';
 
 describe('Kmesh Routes', () => {
   it('should define waypoint routes correctly', () => {
     expect(kmeshRoutePaths.waypointsList).toBe('/kmesh/waypoints');
     expect(kmeshRoutePaths.waypointDetail).toBe('/kmesh/waypoints/:namespace/:name');
+  });
+
+  it('should define the xDS config dump route correctly', () => {
+    expect(kmeshRoutePaths.xdsConfigDump).toBe('/kmesh/xds-config');
+    expect(kmeshRouteNames.xdsConfigDump).toBe('kmesh-xds-config-dump');
   });
 });

--- a/kmesh/src/index.tsx
+++ b/kmesh/src/index.tsx
@@ -1,5 +1,6 @@
 import { registerRoute, registerSidebarEntry } from '@kinvolk/headlamp-plugin/lib';
 import type { ComponentType } from 'react';
+import XdsConfigDump from './components/daemon/XdsConfigDump';
 import WaypointDetail from './components/waypoints/Detail';
 import WaypointList from './components/waypoints/List';
 import { kmeshRouteNames, kmeshRoutePaths } from './utils/kmeshRoutes';
@@ -85,3 +86,19 @@ const kmeshResources: KmeshResourceRegistration[] = [
 ];
 
 kmeshResources.forEach(registerKmeshResource);
+
+// xDS Config Dump viewer (Single Route — tabs are internal to the component)
+registerSidebarEntry({
+  parent: 'kmesh',
+  name: 'kmesh-xds-config',
+  label: 'xDS Config Dump',
+  url: kmeshRoutePaths.xdsConfigDump,
+});
+
+registerRoute({
+  path: kmeshRoutePaths.xdsConfigDump,
+  sidebar: 'kmesh-xds-config',
+  name: kmeshRouteNames.xdsConfigDump,
+  exact: true,
+  component: () => <XdsConfigDump />,
+});

--- a/kmesh/src/types/daemonApi.ts
+++ b/kmesh/src/types/daemonApi.ts
@@ -253,18 +253,112 @@ export interface WorkloadBpfDump {
 
 // ---------------------------------------------------------------------------
 // /debug/config_dump/kernel-native  (ADS / kernel-native mode)
+//
+// The daemon serialises its internal xDS cache using protojson.Format() on
+// Kmesh-specific proto types defined in api/v2/admin/config_dump.proto.
+//
+// Key fact: clusterConfigs / listenerConfigs / routeConfigs are arrays of
+// RAW proto objects — there is NO envelope wrapper with versionInfo /
+// lastUpdated.  Each element is directly a Cluster, Listener, or
+// RouteConfiguration proto serialised to proto-JSON.
+//
+// Field names below are derived from the actual Go proto getters in:
+//   api/v2/cluster/cluster.pb.go        → Cluster: name, connectTimeout, lbPolicy, apiStatus
+//   api/v2/listener/listener.pb.go      → Listener: name, address, filterChains, apiStatus
+//   api/v2/core/address.pb.go           → SocketAddress: ipv4 (uint32), port, protocol
+//   api/v2/route/route.pb.go            → RouteConfiguration: name, virtualHosts, apiStatus
+//   api/v2/route/route_components.pb.go → VirtualHost: name, domains, routes
 // ---------------------------------------------------------------------------
 
-/** Opaque xDS resource — proto-JSON encoded */
-export type XdsResource = Record<string, unknown>;
+/**
+ * A single Cluster proto entry from GET /debug/config_dump/kernel-native.
+ *
+ * Serialised via protojson.Format() from api/v2/cluster/cluster.pb.go.
+ *
+ * Note: connectTimeout is a uint32 (seconds), NOT an Envoy duration string.
+ */
+export interface XdsCluster {
+  /** Cluster name */
+  name?: string;
+  /** Connection timeout in seconds (uint32 proto field) */
+  connectTimeout?: number;
+  /** Load-balancing policy enum string (e.g. "ROUND_ROBIN") */
+  lbPolicy?: string;
+  /** Internal API reconciliation status */
+  apiStatus?: string;
+  /** Remaining proto fields — opaque catch-all */
+  [key: string]: unknown;
+}
 
+/**
+ * SocketAddress proto from api/v2/core/address.pb.go.
+ *
+ * Note: the IPv4 address is stored as a raw uint32 (network byte order),
+ * NOT a dotted-decimal string.  Use a helper to render it as "a.b.c.d:port".
+ */
+export interface XdsSocketAddress {
+  /** IPv4 address encoded as uint32 */
+  ipv4?: number;
+  /** Port number */
+  port?: number;
+  /** Protocol enum string ("TCP" / "UDP") */
+  protocol?: string;
+}
+
+/**
+ * A single Listener proto entry from GET /debug/config_dump/kernel-native.
+ * Serialised via protojson.Format() from api/v2/listener/listener.pb.go.
+ */
+export interface XdsListener {
+  /** Listener name */
+  name?: string;
+  /** Bound address (IPv4 uint32 + port) */
+  address?: XdsSocketAddress;
+  /** Filter chains (opaque proto objects) */
+  filterChains?: Record<string, unknown>[];
+  /** Internal API reconciliation status */
+  apiStatus?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * VirtualHost proto from api/v2/route/route_components.pb.go.
+ */
+export interface XdsVirtualHost {
+  /** Virtual host name */
+  name?: string;
+  /** Domain patterns this virtual host responds to */
+  domains?: string[];
+  /** Route entries (opaque proto objects) */
+  routes?: Record<string, unknown>[];
+  [key: string]: unknown;
+}
+
+/**
+ * A single RouteConfiguration proto entry from GET /debug/config_dump/kernel-native.
+ * Serialised via protojson.Format() from api/v2/route/route.pb.go.
+ */
+export interface XdsRouteConfiguration {
+  /** RouteConfiguration name */
+  name?: string;
+  /** List of virtual hosts */
+  virtualHosts?: XdsVirtualHost[];
+  /** Internal API reconciliation status */
+  apiStatus?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Dynamic resources section of GET /debug/config_dump/kernel-native.
+ * Each array holds raw proto objects — no envelope wrapping.
+ */
 export interface ConfigResources {
-  /** Dump of all dynamic cluster configurations */
-  clusterConfigs?: XdsResource[];
-  /** Dump of all dynamic listener configurations */
-  listenerConfigs?: XdsResource[];
-  /** Dump of all dynamic route configurations */
-  routeConfigs?: XdsResource[];
+  /** Raw Cluster proto objects (api/v2/cluster/cluster.pb.go) */
+  clusterConfigs?: XdsCluster[];
+  /** Raw Listener proto objects (api/v2/listener/listener.pb.go) */
+  listenerConfigs?: XdsListener[];
+  /** Raw RouteConfiguration proto objects (api/v2/route/route.pb.go) */
+  routeConfigs?: XdsRouteConfiguration[];
 }
 
 /** Response shape for GET /debug/config_dump/kernel-native */

--- a/kmesh/src/utils/kmeshRoutes.ts
+++ b/kmesh/src/utils/kmeshRoutes.ts
@@ -4,6 +4,8 @@
 export const kmeshRouteNames = {
   waypointsList: 'kmesh-waypoints-list',
   waypointDetail: 'kmesh-waypoint-detail',
+  /** xDS Config Dump viewer (kernel-native / ADS mode) */
+  xdsConfigDump: 'kmesh-xds-config-dump',
 } as const;
 
 /**
@@ -12,4 +14,7 @@ export const kmeshRouteNames = {
 export const kmeshRoutePaths = {
   waypointsList: '/kmesh/waypoints',
   waypointDetail: '/kmesh/waypoints/:namespace/:name',
+  /** xDS Config Dump viewer — surfaces clusters, listeners, and routes from
+   *  the kernel-native (ADS) daemon config dump endpoint. */
+  xdsConfigDump: '/kmesh/xds-config',
 } as const;


### PR DESCRIPTION
## Description
This PR implements the **xDS Config Dump Viewer** for the Kmesh Headlamp plugin. It introduces a comprehensive dashboard that surfaces the internal state of the Kmesh daemon operating in kernel-native (ADS) mode. 

By utilizing the `/debug/config_dump/kernel-native` API endpoint on the Kmesh daemon, this feature provides deep observability into dynamic Envoy-style resources (Clusters, Listeners, Routes), significantly aiding in debugging traffic routing and mesh policies.

## Key Changes

### 1. Strict TypeScript Interfaces (`daemonApi.ts`)
- Replaced opaque `unknown` records with strict TypeScript definitions representing Kmesh's internal protobuf structures (`XdsCluster`, `XdsListener`, `XdsRouteConfiguration`).
- Extracted exact field mappings directly from Kmesh's Go source (`api/v2/cluster/cluster.pb.go`, `api/v2/listener/listener.pb.go`, etc.).
- Accounted for Kmesh-specific serialization quirks (e.g., `connectTimeout` being represented as an integer of seconds rather than an Envoy duration string, and IPs serialized as raw big-endian `uint32` values).

### 2. Dedicated Data Retrieval Hooks (`useDaemonRequest.ts`)
- Implemented `useXdsClusters`, `useXdsListeners`, and `useXdsRoutes` convenience hooks.
- **Optimization:** These hooks leverage our existing `daemonRequestDeduped` network layer. Even though three separate hooks request data for three separate tabs, the deduplication engine seamlessly coalesces them into a **single HTTP request** to the K8s API server/pod proxy.

### 3. UI Component Implementation (`XdsConfigDump.tsx`)
- Developed a tabbed interface (Clusters, Listeners, Routes) built on top of Headlamp's standard `SectionBox` and `SimpleTable` components for UI consistency.
- Implemented inline formatting helpers (e.g., parsing raw `uint32` network byte order into readable dotted-decimal IPv4 strings).
- **Graceful Degradation:** Added robust error handling that detects when the daemon is running in "dual-engine/workload" mode (which returns HTTP 400 for ADS endpoints) and displays a clear, user-friendly mode-mismatch message instead of a generic error stack.

### 4. Routing & Registration
- Registered the `/kmesh/xds-config` route and added the "xDS Config Dump" entry to the Headlamp sidebar.
- Added corresponding unit tests in `index.test.ts` to ensure route definitions remain intact.

## Screenshots
<img width="1489" height="661" alt="image" src="https://github.com/user-attachments/assets/cd0a827a-d5d0-4ffc-8c30-d5db437f30c8" />

