### PR TITLE
tinkerbell: Align UI with v0.23 lab data

### DIFF
--- a/tinkerbell/src/components/hardware/Detail.tsx
+++ b/tinkerbell/src/components/hardware/Detail.tsx
@@ -12,8 +12,92 @@ import {
   fallback,
   renderRecordSection,
   renderTextSection,
-  statusValue,
+  renderUnknownValue,
 } from '../common/detailHelpers';
+import { getHardwareAgentID } from './helpers';
+
+/** Controller-reported block device details from the agent attributes annotation. */
+interface AgentBlockDevice {
+  /** Block device name reported by the operating system. */
+  name?: string;
+  /** Storage controller type, when detected. */
+  controllerType?: string;
+  /** Drive type reported by the agent. */
+  driveType?: string;
+  /** Device size reported by the agent. */
+  size?: string;
+  /** Device model reported by the agent. */
+  model?: string;
+  /** Device serial number reported by the agent. */
+  serialNumber?: string;
+}
+
+/** Controller-reported network interface details from the agent attributes annotation. */
+interface AgentNetworkInterface {
+  /** Network interface name reported by the operating system. */
+  name?: string;
+  /** MAC address reported by the agent. */
+  mac?: string;
+  /** Link speed reported by the agent. */
+  speed?: string;
+}
+
+/** Parsed hardware facts collected by the Tinkerbell agent. */
+interface HardwareAgentAttributes {
+  /** CPU information reported by the agent. */
+  cpu?: {
+    /** Number of physical or logical cores reported by the agent. */
+    totalCores?: number;
+    /** Number of total CPU threads reported by the agent. */
+    totalThreads?: number;
+  };
+  /** Memory information reported by the agent. */
+  memory?: {
+    /** Total memory reported by the agent. */
+    total?: string;
+    /** Usable memory reported by the agent. */
+    usable?: string;
+  };
+  /** Block devices observed on the hardware. */
+  blockDevices?: AgentBlockDevice[];
+  /** Network interfaces observed on the hardware. */
+  networkInterfaces?: AgentNetworkInterface[];
+  /** Product or chassis details reported by the agent. */
+  product?: Record<string, unknown>;
+  /** BIOS details reported by the agent. */
+  bios?: Record<string, unknown>;
+  /** Baseboard details reported by the agent. */
+  baseboard?: Record<string, unknown>;
+}
+
+/**
+ * Parses controller-reported hardware attributes from annotations.
+ *
+ * @param item - Hardware resource to inspect.
+ * @returns Parsed agent attributes or undefined when absent.
+ */
+function getAgentAttributes(item: Hardware): HardwareAgentAttributes | undefined {
+  const attributes = item.metadata.annotations?.['tinkerbell.org/agent-attributes'];
+  if (!attributes) {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(attributes) as HardwareAgentAttributes;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Checks whether a record has data worth rendering.
+ *
+ * @param value - Optional object value.
+ * @returns True when the object has at least one key.
+ */
+function hasRecord(value: Record<string, unknown> | undefined): boolean {
+  return !!value && Object.keys(value).length > 0;
+}
 
 /**
  * Renders the Tinkerbell Hardware detail view.
@@ -31,100 +115,162 @@ export function HardwareDetail() {
       withEvents
       extraInfo={item =>
         item
-          ? [
-              { name: 'Status', value: statusValue(item.status?.state) },
-              { name: 'Agent ID', value: fallback(item.spec?.agentID) },
-              {
-                name: 'Auto Enrollment',
-                value: booleanValue(item.spec?.auto?.enrollmentEnabled),
-              },
-              { name: 'BMC Ref', value: fallback(item.spec?.bmcRef?.name) },
-              { name: 'CPU', value: fallback(item.spec?.resources?.cpu) },
-              { name: 'Memory', value: fallback(item.spec?.resources?.memory) },
-              { name: 'Storage', value: fallback(item.spec?.resources?.storage) },
-              { name: 'Tink Version', value: fallback(item.spec?.tinkVersion) },
-            ]
+          ? (() => {
+              const attributes = getAgentAttributes(item);
+
+              return [
+                { name: 'Agent ID', value: getHardwareAgentID(item) },
+                { name: 'Hostname', value: fallback(item.spec?.metadata?.instance?.hostname) },
+                {
+                  name: 'Primary IP',
+                  value: fallback(item.spec?.interfaces?.[0]?.dhcp?.ip?.address),
+                },
+                { name: 'Primary MAC', value: fallback(item.spec?.interfaces?.[0]?.dhcp?.mac) },
+                {
+                  name: 'Auto Enrollment',
+                  value: booleanValue(item.spec?.auto?.enrollmentEnabled),
+                },
+                { name: 'CPU Cores', value: fallback(attributes?.cpu?.totalCores) },
+                {
+                  name: 'Memory',
+                  value: fallback(attributes?.memory?.usable ?? attributes?.memory?.total),
+                },
+              ];
+            })()
           : []
       }
-      extraSections={item =>
-        item
-          ? [
-              {
-                id: 'tinkerbell.hardware-interfaces',
-                section: (
-                  <SectionBox title="Interfaces">
-                    <SimpleTable
-                      columns={[
-                        { label: 'MAC', getter: row => fallback(row.dhcp?.mac) },
-                        { label: 'Hostname', getter: row => fallback(row.dhcp?.hostname) },
-                        { label: 'IP Address', getter: row => fallback(row.dhcp?.ip?.address) },
-                        { label: 'Gateway', getter: row => fallback(row.dhcp?.ip?.gateway) },
-                        { label: 'Netmask', getter: row => fallback(row.dhcp?.ip?.netmask) },
-                        { label: 'Arch', getter: row => fallback(row.dhcp?.arch) },
-                        { label: 'UEFI', getter: row => booleanValue(row.dhcp?.uefi) },
-                        { label: 'PXE', getter: row => booleanValue(row.netboot?.allowPXE) },
-                        {
-                          label: 'Workflow Boot',
-                          getter: row => booleanValue(row.netboot?.allowWorkflow),
-                        },
-                      ]}
-                      data={item.spec?.interfaces ?? []}
-                    />
-                  </SectionBox>
-                ),
-              },
-              {
-                id: 'tinkerbell.hardware-disks',
-                section: (
-                  <SectionBox title="Disks">
-                    <SimpleTable
-                      columns={[
-                        { label: 'Device', getter: row => fallback(row.device) },
-                        { label: 'Wipe Table', getter: row => booleanValue(row.wipeTable) },
-                      ]}
-                      data={item.spec?.disks ?? []}
-                    />
-                  </SectionBox>
-                ),
-              },
-              {
-                id: 'tinkerbell.hardware-bmc-ref',
-                section: (
-                  <SectionBox title="BMC Reference">
-                    <NameValueTable
-                      rows={[
-                        { name: 'Name', value: fallback(item.spec?.bmcRef?.name) },
-                        { name: 'Namespace', value: fallback(item.spec?.bmcRef?.namespace) },
-                        { name: 'Kind', value: fallback(item.spec?.bmcRef?.kind) },
-                        { name: 'API Group', value: fallback(item.spec?.bmcRef?.apiGroup) },
-                      ]}
-                    />
-                  </SectionBox>
-                ),
-              },
-              {
-                id: 'tinkerbell.hardware-conditions',
-                section: <ConditionsSection resource={item.jsonData} />,
-              },
-              {
-                id: 'tinkerbell.hardware-metadata',
-                section: renderRecordSection('Hardware Metadata', item.spec?.metadata),
-              },
-              {
-                id: 'tinkerbell.hardware-references',
-                section: renderRecordSection('References', item.spec?.references),
-              },
-              {
-                id: 'tinkerbell.hardware-user-data',
-                section: renderTextSection('User Data', item.spec?.userData),
-              },
-              {
-                id: 'tinkerbell.hardware-vendor-data',
-                section: renderTextSection('Vendor Data', item.spec?.vendorData),
-              },
-            ]
-          : []
-      }
+      extraSections={item => {
+        if (!item) {
+          return [];
+        }
+
+        const attributes = getAgentAttributes(item);
+
+        return [
+          {
+            id: 'tinkerbell.hardware-interfaces',
+            section: (
+              <SectionBox title="Interfaces">
+                <SimpleTable
+                  columns={[
+                    { label: 'MAC', getter: row => fallback(row.dhcp?.mac) },
+                    { label: 'Hostname', getter: row => fallback(row.dhcp?.hostname) },
+                    { label: 'IP Address', getter: row => fallback(row.dhcp?.ip?.address) },
+                    { label: 'Gateway', getter: row => fallback(row.dhcp?.ip?.gateway) },
+                    { label: 'Netmask', getter: row => fallback(row.dhcp?.ip?.netmask) },
+                    { label: 'Arch', getter: row => fallback(row.dhcp?.arch) },
+                    { label: 'UEFI', getter: row => booleanValue(row.dhcp?.uefi) },
+                    { label: 'PXE', getter: row => booleanValue(row.netboot?.allowPXE) },
+                    {
+                      label: 'Workflow Boot',
+                      getter: row => booleanValue(row.netboot?.allowWorkflow),
+                    },
+                  ]}
+                  data={item.spec?.interfaces ?? []}
+                />
+              </SectionBox>
+            ),
+          },
+          {
+            id: 'tinkerbell.hardware-disks',
+            section: (
+              <SectionBox title="Disks">
+                <SimpleTable
+                  columns={[
+                    { label: 'Device', getter: row => fallback(row.device) },
+                    { label: 'Wipe Table', getter: row => booleanValue(row.wipeTable) },
+                  ]}
+                  data={item.spec?.disks ?? []}
+                />
+              </SectionBox>
+            ),
+          },
+          item.spec?.bmcRef && {
+            id: 'tinkerbell.hardware-bmc-ref',
+            section: (
+              <SectionBox title="BMC Reference">
+                <NameValueTable
+                  rows={[
+                    { name: 'Name', value: fallback(item.spec?.bmcRef?.name) },
+                    { name: 'Namespace', value: fallback(item.spec?.bmcRef?.namespace) },
+                    { name: 'Kind', value: fallback(item.spec?.bmcRef?.kind) },
+                    { name: 'API Group', value: fallback(item.spec?.bmcRef?.apiGroup) },
+                  ]}
+                />
+              </SectionBox>
+            ),
+          },
+          {
+            id: 'tinkerbell.hardware-conditions',
+            section: <ConditionsSection resource={item.jsonData} />,
+          },
+          {
+            id: 'tinkerbell.hardware-metadata',
+            section: renderRecordSection('Hardware Metadata', item.spec?.metadata),
+          },
+          attributes && {
+            id: 'tinkerbell.hardware-agent-summary',
+            section: (
+              <SectionBox title="Observed Agent Attributes">
+                <NameValueTable
+                  rows={[
+                    { name: 'CPU Cores', value: fallback(attributes.cpu?.totalCores) },
+                    { name: 'CPU Threads', value: fallback(attributes.cpu?.totalThreads) },
+                    { name: 'Memory Total', value: fallback(attributes.memory?.total) },
+                    { name: 'Memory Usable', value: fallback(attributes.memory?.usable) },
+                    { name: 'Product', value: renderUnknownValue(attributes.product) },
+                    { name: 'BIOS', value: renderUnknownValue(attributes.bios) },
+                  ]}
+                />
+              </SectionBox>
+            ),
+          },
+          attributes?.networkInterfaces?.length && {
+            id: 'tinkerbell.hardware-agent-network-interfaces',
+            section: (
+              <SectionBox title="Observed Network Interfaces">
+                <SimpleTable
+                  columns={[
+                    { label: 'Name', getter: row => fallback(row.name) },
+                    { label: 'MAC', getter: row => fallback(row.mac) },
+                    { label: 'Speed', getter: row => fallback(row.speed) },
+                  ]}
+                  data={attributes.networkInterfaces}
+                />
+              </SectionBox>
+            ),
+          },
+          attributes?.blockDevices?.length && {
+            id: 'tinkerbell.hardware-agent-block-devices',
+            section: (
+              <SectionBox title="Observed Block Devices">
+                <SimpleTable
+                  columns={[
+                    { label: 'Name', getter: row => fallback(row.name) },
+                    { label: 'Size', getter: row => fallback(row.size) },
+                    { label: 'Type', getter: row => fallback(row.driveType) },
+                    { label: 'Controller', getter: row => fallback(row.controllerType) },
+                    { label: 'Model', getter: row => fallback(row.model) },
+                  ]}
+                  data={attributes.blockDevices}
+                />
+              </SectionBox>
+            ),
+          },
+          hasRecord(item.spec?.references) && {
+            id: 'tinkerbell.hardware-references',
+            section: renderRecordSection('References', item.spec?.references),
+          },
+          item.spec?.userData && {
+            id: 'tinkerbell.hardware-user-data',
+            section: renderTextSection('User Data', item.spec?.userData),
+          },
+          item.spec?.vendorData && {
+            id: 'tinkerbell.hardware-vendor-data',
+            section: renderTextSection('Vendor Data', item.spec?.vendorData),
+          },
+        ].filter(Boolean);
+      }}
     />
   );
 }

--- a/tinkerbell/src/components/hardware/List.tsx
+++ b/tinkerbell/src/components/hardware/List.tsx
@@ -10,27 +10,23 @@ import {
   fallback,
   getFirstDefined,
   renderFallback,
-  renderStatus,
 } from '../common/listHelpers';
+import { getHardwareAgentID } from './helpers';
 
 /**
  * Renders the Tinkerbell Hardware list view.
+ *
+ * @returns Hardware list view with network and provisioning columns.
  */
 export function HardwareList() {
   const columns: (ColumnType | ResourceTableColumn<Hardware>)[] = [
     'name',
     'namespace',
     {
-      id: 'status',
-      label: 'Status',
-      getValue: item => fallback(item.status?.state),
-      render: item => renderStatus(item.status?.state),
-    },
-    {
       id: 'agentID',
       label: 'Agent ID',
-      getValue: item => fallback(item.spec?.agentID),
-      render: item => renderFallback(item.spec?.agentID),
+      getValue: item => getHardwareAgentID(item),
+      render: item => renderFallback(getHardwareAgentID(item)),
     },
     {
       id: 'mac',

--- a/tinkerbell/src/components/hardware/helpers.ts
+++ b/tinkerbell/src/components/hardware/helpers.ts
@@ -1,0 +1,18 @@
+import { Hardware } from '../../resources/hardware';
+import { fallback, getFirstDefined } from '../common/listHelpers';
+
+/**
+ * Gets the best machine identifier available on a Hardware object.
+ *
+ * @param item - Hardware resource to inspect.
+ * @returns Agent, instance, or interface identifier.
+ */
+export function getHardwareAgentID(item: Hardware): string {
+  return fallback(
+    getFirstDefined(
+      item.spec?.agentID,
+      item.spec?.metadata?.instance?.id,
+      item.spec?.interfaces?.[0]?.dhcp?.mac
+    )
+  );
+}

--- a/tinkerbell/src/components/templates/Detail.tsx
+++ b/tinkerbell/src/components/templates/Detail.tsx
@@ -5,9 +5,8 @@ import {
   SimpleTable,
 } from '@kinvolk/headlamp-plugin/lib/components/common';
 import { useParams } from 'react-router-dom';
-import { normalizeState } from '../../resources/common';
 import { Template } from '../../resources/template';
-import { fallback, renderTextSection, statusValue } from '../common/detailHelpers';
+import { fallback, renderTextSection } from '../common/detailHelpers';
 
 /** Parsed summary for one task in a Tinkerbell template. */
 interface ParsedTemplateTask {
@@ -27,6 +26,10 @@ interface ParsedTemplateAction {
   taskName: string;
   /** Action name from the template data. */
   name: string;
+  /** Alternative action names controlled by template conditionals. */
+  alternatives?: string[];
+  /** Template conditional expression that chooses the alternatives. */
+  condition?: string;
   /** Container image used by the action, when present. */
   image?: string;
   /** Action timeout value, when present. */
@@ -43,6 +46,186 @@ interface ParsedTemplate {
   tasks: ParsedTemplateTask[];
   /** Parsed action summaries across all tasks. */
   actions: ParsedTemplateAction[];
+}
+
+/** Parsed template control-flow marker. */
+interface TemplateMarker {
+  /** Marker keyword such as if, else, or end. */
+  keyword: 'if' | 'else' | 'end';
+  /** Marker expression following the keyword, when present. */
+  expression?: string;
+}
+
+/**
+ * Gets an action name from a template line.
+ *
+ * @param line - One line from `spec.data`.
+ * @returns Parsed action name or undefined.
+ */
+function getActionName(line: string): string | undefined {
+  return line.match(/^\s*-\s+name:\s*"?([^"]+)"?/)?.[1];
+}
+
+/**
+ * Gets a Go template control-flow marker from a line.
+ *
+ * @param line - One line from `spec.data`.
+ * @returns Parsed marker or undefined.
+ */
+function getTemplateMarker(line: string): TemplateMarker | undefined {
+  const match = line.match(/^\s*\{\{-?\s*(if|else|end)\b(.*?)\s*-?}}\s*$/);
+  if (!match) {
+    return undefined;
+  }
+
+  return {
+    keyword: match[1] as TemplateMarker['keyword'],
+    expression: match[2]?.trim(),
+  };
+}
+
+/**
+ * Finds the end of a simple Go template conditional block.
+ *
+ * @param lines - Task lines to search.
+ * @param startIndex - Index of the opening `if` marker.
+ * @returns Indexes for the optional `else` marker and required `end` marker.
+ */
+function findConditionalBounds(
+  lines: string[],
+  startIndex: number
+): { elseIndex?: number; endIndex?: number } {
+  let depth = 0;
+  let elseIndex: number | undefined;
+
+  for (let index = startIndex; index < lines.length; index++) {
+    const marker = getTemplateMarker(lines[index]);
+    if (!marker) {
+      continue;
+    }
+
+    if (marker.keyword === 'if') {
+      depth += 1;
+      continue;
+    }
+
+    if (marker.keyword === 'else' && depth === 1) {
+      elseIndex = index;
+      continue;
+    }
+
+    if (marker.keyword === 'end') {
+      depth -= 1;
+      if (depth === 0) {
+        return { elseIndex, endIndex: index };
+      }
+    }
+  }
+
+  return { elseIndex };
+}
+
+/**
+ * Finds the first action name between two indexes.
+ *
+ * @param lines - Task lines to search.
+ * @param startIndex - Inclusive start index.
+ * @param endIndex - Exclusive end index.
+ * @returns Parsed action name or undefined.
+ */
+function findActionNameBetween(
+  lines: string[],
+  startIndex: number,
+  endIndex: number | undefined
+): string | undefined {
+  for (const line of lines.slice(startIndex, endIndex)) {
+    const actionName = getActionName(line);
+    if (actionName) {
+      return actionName;
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Reads common action details near an action definition.
+ *
+ * @param lines - Lines that belong to the action.
+ * @returns Image and timeout summary fields.
+ */
+function getActionDetails(lines: string[]): Pick<ParsedTemplateAction, 'image' | 'timeout'> {
+  return {
+    image: lines
+      .find(nextLine => /^\s*image:\s*/.test(nextLine))
+      ?.split(/image:\s*/)[1]
+      ?.trim(),
+    timeout: lines
+      .find(nextLine => /^\s*timeout:\s*/.test(nextLine))
+      ?.split(/timeout:\s*/)[1]
+      ?.trim(),
+  };
+}
+
+/**
+ * Parses action rows from one template task.
+ *
+ * Conditional action alternatives are shown as one executable action slot
+ * because only one branch is rendered into a Workflow.
+ *
+ * @param taskName - Name of the parent task.
+ * @param taskLines - Lines that belong to the task.
+ * @returns Parsed action rows.
+ */
+function parseTaskActions(taskName: string, taskLines: string[]): ParsedTemplateAction[] {
+  const actions: ParsedTemplateAction[] = [];
+
+  for (let lineIndex = 1; lineIndex < taskLines.length; lineIndex++) {
+    const marker = getTemplateMarker(taskLines[lineIndex]);
+
+    if (marker?.keyword === 'if') {
+      const { elseIndex, endIndex } = findConditionalBounds(taskLines, lineIndex);
+      if (endIndex) {
+        const firstBranchName = findActionNameBetween(
+          taskLines,
+          lineIndex + 1,
+          elseIndex ?? endIndex
+        );
+        const secondBranchName =
+          elseIndex !== undefined
+            ? findActionNameBetween(taskLines, elseIndex + 1, endIndex)
+            : undefined;
+        const alternatives = [firstBranchName, secondBranchName].filter(Boolean) as string[];
+
+        if (alternatives.length > 0) {
+          actions.push({
+            taskName,
+            name: alternatives.join(' / '),
+            alternatives,
+            condition: marker.expression,
+            ...getActionDetails(taskLines.slice(lineIndex, endIndex + 10)),
+          });
+        }
+
+        lineIndex = endIndex;
+      }
+
+      continue;
+    }
+
+    const actionName = getActionName(taskLines[lineIndex]);
+    if (!actionName) {
+      continue;
+    }
+
+    actions.push({
+      taskName,
+      name: actionName,
+      ...getActionDetails(taskLines.slice(lineIndex, lineIndex + 8)),
+    });
+  }
+
+  return actions;
 }
 
 /**
@@ -104,7 +287,7 @@ function parseTemplateData(data: string | undefined): ParsedTemplate {
     return {
       name: task.name,
       worker,
-      actionCount: taskLines.filter(line => /^\s*-\s+name:/.test(line)).length - 1,
+      actionCount: parseTaskActions(task.name, taskLines).length,
       volumeCount: taskLines.filter(line => /^\s*-\s+[^:]+:[^/]*\//.test(line)).length,
     };
   });
@@ -113,28 +296,7 @@ function parseTemplateData(data: string | undefined): ParsedTemplate {
     const nextTask = topLevelTasks[index + 1];
     const taskLines = lines.slice(task.lineIndex, nextTask?.lineIndex);
 
-    return taskLines.reduce<ParsedTemplateAction[]>((actions, line, lineIndex) => {
-      const actionName = line.match(/^\s*-\s+name:\s*"?([^"]+)"?/)?.[1];
-      if (!actionName || lineIndex === 0) {
-        return actions;
-      }
-
-      const followingLines = taskLines.slice(lineIndex, lineIndex + 8);
-      actions.push({
-        taskName: task.name,
-        name: actionName,
-        image: followingLines
-          .find(nextLine => /^\s*image:\s*/.test(nextLine))
-          ?.split(/image:\s*/)[1]
-          ?.trim(),
-        timeout: followingLines
-          .find(nextLine => /^\s*timeout:\s*/.test(nextLine))
-          ?.split(/timeout:\s*/)[1]
-          ?.trim(),
-      });
-
-      return actions;
-    }, []);
+    return parseTaskActions(task.name, taskLines);
   });
 
   return { name: templateName, globalTimeout, tasks, actions };
@@ -159,11 +321,10 @@ export function TemplateDetail() {
 
         return item
           ? [
-              { name: 'Status', value: statusValue(normalizeState(item.status?.state)) },
               { name: 'Template Name', value: fallback(parsedTemplate.name) },
               { name: 'Global Timeout', value: fallback(parsedTemplate.globalTimeout) },
               { name: 'Tasks', value: fallback(parsedTemplate.tasks.length) },
-              { name: 'Actions', value: fallback(parsedTemplate.actions.length) },
+              { name: 'Action Slots', value: fallback(parsedTemplate.actions.length) },
               { name: 'Template Data Size', value: fallback(`${item.data?.length ?? 0} chars`) },
             ]
           : [];
@@ -182,7 +343,7 @@ export function TemplateDetail() {
                         { name: 'Name', value: fallback(parsedTemplate.name) },
                         { name: 'Global Timeout', value: fallback(parsedTemplate.globalTimeout) },
                         { name: 'Tasks', value: fallback(parsedTemplate.tasks.length) },
-                        { name: 'Actions', value: fallback(parsedTemplate.actions.length) },
+                        { name: 'Action Slots', value: fallback(parsedTemplate.actions.length) },
                       ]}
                     />
                   </SectionBox>
@@ -196,7 +357,7 @@ export function TemplateDetail() {
                       columns={[
                         { label: 'Name', getter: row => row.name },
                         { label: 'Worker', getter: row => fallback(row.worker) },
-                        { label: 'Actions', getter: row => fallback(row.actionCount) },
+                        { label: 'Action Slots', getter: row => fallback(row.actionCount) },
                         { label: 'Volumes', getter: row => fallback(row.volumeCount) },
                       ]}
                       data={parsedTemplate.tasks}
@@ -212,6 +373,12 @@ export function TemplateDetail() {
                       columns={[
                         { label: 'Task', getter: row => row.taskName },
                         { label: 'Action', getter: row => row.name },
+                        {
+                          label: 'Type',
+                          getter: row =>
+                            fallback(row.alternatives?.length ? 'Conditional' : 'Direct'),
+                        },
+                        { label: 'Condition', getter: row => fallback(row.condition) },
                         { label: 'Image', getter: row => fallback(row.image) },
                         { label: 'Timeout', getter: row => fallback(row.timeout) },
                       ]}

--- a/tinkerbell/src/components/templates/List.tsx
+++ b/tinkerbell/src/components/templates/List.tsx
@@ -3,9 +3,8 @@ import {
   ResourceListView,
   type ResourceTableColumn,
 } from '@kinvolk/headlamp-plugin/lib/components/common';
-import { normalizeState } from '../../resources/common';
 import { Template } from '../../resources/template';
-import { fallback, renderStatus } from '../common/listHelpers';
+import { fallback } from '../common/listHelpers';
 
 /**
  * Counts top-level task steps from a Tinkerbell template body.
@@ -53,12 +52,6 @@ export function TemplateList() {
   const columns: (ColumnType | ResourceTableColumn<Template>)[] = [
     'name',
     'namespace',
-    {
-      id: 'status',
-      label: 'Status',
-      getValue: item => normalizeState(item.status?.state),
-      render: item => renderStatus(normalizeState(item.status?.state)),
-    },
     {
       id: 'steps',
       label: 'Steps',

--- a/tinkerbell/src/components/workflows/Detail.tsx
+++ b/tinkerbell/src/components/workflows/Detail.tsx
@@ -7,8 +7,43 @@ import {
 } from '@kinvolk/headlamp-plugin/lib/components/common';
 import { useParams } from 'react-router-dom';
 import { normalizeState } from '../../resources/common';
-import { Workflow } from '../../resources/workflow';
+import { Workflow, WorkflowActionStatus, WorkflowTaskStatus } from '../../resources/workflow';
 import { booleanValue, fallback, renderRecordSection, statusValue } from '../common/detailHelpers';
+
+/**
+ * Gets a task state from its actions when the task has no direct state field.
+ *
+ * @param task - Workflow task status entry.
+ * @returns Normalized task state.
+ */
+function getTaskState(task: WorkflowTaskStatus): string {
+  if (task.state) {
+    return normalizeState(task.state);
+  }
+
+  const actionStates = task.actions?.map(action => action.state).filter(Boolean) ?? [];
+  if (actionStates.some(state => state === 'RUNNING')) {
+    return normalizeState('RUNNING');
+  }
+  if (actionStates.some(state => state === 'FAILED')) {
+    return normalizeState('FAILED');
+  }
+  if (actionStates.length && actionStates.every(state => state === 'SUCCESS')) {
+    return normalizeState('SUCCESS');
+  }
+
+  return normalizeState(undefined);
+}
+
+/**
+ * Gets the preferred start timestamp for a workflow action.
+ *
+ * @param action - Workflow action status entry.
+ * @returns Start timestamp or fallback.
+ */
+function getActionStart(action: WorkflowActionStatus): string {
+  return fallback(action.executionStart ?? action.startedAt);
+}
 
 /**
  * Renders the Tinkerbell Workflow detail view.
@@ -29,7 +64,9 @@ export function WorkflowDetail() {
           ? [
               {
                 name: 'Status',
-                value: statusValue(normalizeState(item.status?.state ?? item.status?.currentState)),
+                value: statusValue(
+                  normalizeState(item.status?.state ?? item.status?.currentState?.state)
+                ),
               },
               { name: 'Hardware', value: fallback(item.spec?.hardwareRef) },
               { name: 'Template', value: fallback(item.spec?.templateRef) },
@@ -37,8 +74,8 @@ export function WorkflowDetail() {
               { name: 'Agent ID', value: fallback(item.status?.agentID) },
               { name: 'Global Timeout', value: fallback(item.status?.globalTimeout) },
               {
-                name: 'Execution Stop',
-                value: booleanValue(item.status?.globalExecutionStop),
+                name: 'Global Execution Stop',
+                value: fallback(item.status?.globalExecutionStop),
               },
             ]
           : []
@@ -66,20 +103,24 @@ export function WorkflowDetail() {
                     <NameValueTable
                       rows={[
                         {
-                          name: 'Spec Netboot',
-                          value: booleanValue(item.spec?.bootOptions?.netboot),
+                          name: 'Toggle Netboot',
+                          value: booleanValue(item.spec?.bootOptions?.toggleAllowNetboot),
                         },
                         {
                           name: 'Spec ISO Boot',
                           value: booleanValue(item.spec?.bootOptions?.isoboot),
                         },
                         {
-                          name: 'Status Netboot',
+                          name: 'Netboot Enabled',
                           value: booleanValue(item.status?.bootOptions?.netboot),
                         },
                         {
-                          name: 'Status ISO Boot',
-                          value: booleanValue(item.status?.bootOptions?.isoboot),
+                          name: 'AllowNetboot Toggled True',
+                          value: booleanValue(item.status?.bootOptions?.allowNetboot?.toggledTrue),
+                        },
+                        {
+                          name: 'AllowNetboot Toggled False',
+                          value: booleanValue(item.status?.bootOptions?.allowNetboot?.toggledFalse),
                         },
                       ]}
                     />
@@ -99,13 +140,21 @@ export function WorkflowDetail() {
                         { name: 'State', value: statusValue(normalizeState(item.status?.state)) },
                         {
                           name: 'Current State',
-                          value: statusValue(normalizeState(item.status?.currentState)),
+                          value: statusValue(normalizeState(item.status?.currentState?.state)),
+                        },
+                        {
+                          name: 'Current Task',
+                          value: fallback(item.status?.currentState?.taskName),
+                        },
+                        {
+                          name: 'Current Action',
+                          value: fallback(item.status?.currentState?.actionName),
                         },
                         { name: 'Agent ID', value: fallback(item.status?.agentID) },
                         { name: 'Global Timeout', value: fallback(item.status?.globalTimeout) },
                         {
                           name: 'Global Execution Stop',
-                          value: booleanValue(item.status?.globalExecutionStop),
+                          value: fallback(item.status?.globalExecutionStop),
                         },
                       ]}
                     />
@@ -119,7 +168,7 @@ export function WorkflowDetail() {
                     <SimpleTable
                       columns={[
                         { label: 'Name', getter: row => fallback(row.name) },
-                        { label: 'State', getter: row => statusValue(normalizeState(row.state)) },
+                        { label: 'State', getter: row => statusValue(getTaskState(row)) },
                         { label: 'Actions', getter: row => fallback(row.actions?.length) },
                       ]}
                       data={item.status?.tasks ?? []}
@@ -137,8 +186,12 @@ export function WorkflowDetail() {
                         { label: 'Action', getter: row => fallback(row.name) },
                         { label: 'State', getter: row => statusValue(normalizeState(row.state)) },
                         { label: 'Message', getter: row => fallback(row.message) },
-                        { label: 'Started', getter: row => fallback(row.startedAt) },
-                        { label: 'Seconds', getter: row => fallback(row.seconds) },
+                        { label: 'Started', getter: row => getActionStart(row) },
+                        { label: 'Stopped', getter: row => fallback(row.executionStop) },
+                        {
+                          label: 'Duration',
+                          getter: row => fallback(row.executionDuration ?? row.seconds),
+                        },
                       ]}
                       data={
                         item.status?.tasks?.flatMap(task =>

--- a/tinkerbell/src/components/workflows/List.tsx
+++ b/tinkerbell/src/components/workflows/List.tsx
@@ -4,17 +4,44 @@ import {
   type ResourceTableColumn,
 } from '@kinvolk/headlamp-plugin/lib/components/common';
 import { normalizeState } from '../../resources/common';
-import { Workflow } from '../../resources/workflow';
-import {
-  booleanLabel,
-  countLabel,
-  fallback,
-  getFirstDefined,
-  renderStatus,
-} from '../common/listHelpers';
+import { Workflow, WorkflowTaskStatus } from '../../resources/workflow';
+import { booleanLabel, countLabel, fallback, renderStatus } from '../common/listHelpers';
+
+/**
+ * Gets a user-facing workflow state from the current v0.23.0 status shape.
+ *
+ * @param item - Workflow resource to inspect.
+ * @returns Normalized workflow state.
+ */
+function getWorkflowState(item: Workflow): string {
+  return normalizeState(item.status?.state ?? item.status?.currentState?.state);
+}
+
+/**
+ * Gets the best currently relevant action name for a workflow.
+ *
+ * @param item - Workflow resource to inspect.
+ * @returns Current action, latest action, or fallback.
+ */
+function getCurrentAction(item: Workflow): string {
+  const actions = item.status?.tasks?.flatMap(task => task.actions ?? []) ?? [];
+  return fallback(item.status?.currentState?.actionName ?? actions.at(-1)?.name);
+}
+
+/**
+ * Gets a task count label using workflow status tasks.
+ *
+ * @param tasks - Workflow task status entries.
+ * @returns Count label for workflow tasks.
+ */
+function getTaskCount(tasks: WorkflowTaskStatus[] | undefined) {
+  return countLabel(tasks?.length, 'task');
+}
 
 /**
  * Renders the Tinkerbell Workflow list view.
+ *
+ * @returns Workflow list view with live provisioning summary columns.
  */
 export function WorkflowList() {
   const columns: (ColumnType | ResourceTableColumn<Workflow>)[] = [
@@ -23,12 +50,8 @@ export function WorkflowList() {
     {
       id: 'status',
       label: 'Status',
-      getValue: item =>
-        normalizeState(getFirstDefined(item.status?.state, item.status?.currentState)),
-      render: item =>
-        renderStatus(
-          normalizeState(getFirstDefined(item.status?.state, item.status?.currentState))
-        ),
+      getValue: item => getWorkflowState(item),
+      render: item => renderStatus(getWorkflowState(item)),
     },
     {
       id: 'hardware',
@@ -48,15 +71,12 @@ export function WorkflowList() {
     {
       id: 'tasks',
       label: 'Tasks',
-      getValue: item => countLabel(item.status?.tasks?.length, 'task'),
+      getValue: item => getTaskCount(item.status?.tasks),
     },
     {
       id: 'lastAction',
-      label: 'Last Action',
-      getValue: item => {
-        const actions = item.status?.tasks?.flatMap(task => task.actions ?? []) ?? [];
-        return fallback(actions.at(-1)?.name ?? item.status?.currentState);
-      },
+      label: 'Current Action',
+      getValue: item => getCurrentAction(item),
     },
     'age',
   ];

--- a/tinkerbell/src/resources/common.test.ts
+++ b/tinkerbell/src/resources/common.test.ts
@@ -5,6 +5,10 @@ describe('normalizeState', () => {
     expect(normalizeState(undefined)).toBe('Unknown');
   });
 
+  it('returns Unknown when state is not a string', () => {
+    expect(normalizeState({ state: 'SUCCESS' })).toBe('Unknown');
+  });
+
   it('humanizes Tinkerbell workflow state constants', () => {
     expect(normalizeState('STATE_RUNNING')).toBe('Running');
     expect(normalizeState('STATE_TIMED_OUT')).toBe('Timed Out');

--- a/tinkerbell/src/resources/common.ts
+++ b/tinkerbell/src/resources/common.ts
@@ -82,8 +82,8 @@ export interface NamespacedObjectReference {
  * @param state - Raw state value from a Tinkerbell resource.
  * @returns A human-readable state label, or "Unknown" when absent.
  */
-export function normalizeState(state: string | undefined): string {
-  if (!state) {
+export function normalizeState(state: unknown): string {
+  if (typeof state !== 'string' || !state) {
     return 'Unknown';
   }
 

--- a/tinkerbell/src/resources/workflow.ts
+++ b/tinkerbell/src/resources/workflow.ts
@@ -10,6 +10,18 @@ export const WORKFLOW_CRD_NAME = 'workflows.tinkerbell.org';
  * @see https://github.com/tinkerbell/tinkerbell/blob/v0.23.0/crd/bases/tinkerbell.org_workflows.yaml
  */
 export interface WorkflowBootOptions {
+  /** Whether workflow creation should toggle hardware netboot on. */
+  toggleAllowNetboot?: boolean;
+
+  /** Observed allowNetboot toggle status. */
+  allowNetboot?: {
+    /** Whether allowNetboot was toggled to false. */
+    toggledFalse?: boolean;
+
+    /** Whether allowNetboot was toggled to true. */
+    toggledTrue?: boolean;
+  };
+
   /** Whether ISO boot is enabled. */
   isoboot?: boolean;
 
@@ -53,6 +65,15 @@ export interface WorkflowActionStatus {
   /** Action start timestamp. */
   startedAt?: string;
 
+  /** Action start timestamp reported by v0.23.0 workflows. */
+  executionStart?: string;
+
+  /** Action stop timestamp reported by v0.23.0 workflows. */
+  executionStop?: string;
+
+  /** Human-readable execution duration reported by v0.23.0 workflows. */
+  executionDuration?: string;
+
   /** Number of seconds spent executing this action. */
   seconds?: number;
 
@@ -87,10 +108,28 @@ export interface WorkflowStatus {
   conditions?: TinkerbellCondition[];
 
   /** Current state reported by the workflow engine. */
-  currentState?: string;
+  currentState?: {
+    /** Current action identifier. */
+    actionID?: string;
 
-  /** Whether a global execution stop has been requested. */
-  globalExecutionStop?: boolean;
+    /** Current action name. */
+    actionName?: string;
+
+    /** Agent identifier currently running the workflow. */
+    agentID?: string;
+
+    /** Current action state. */
+    state?: string;
+
+    /** Current task identifier. */
+    taskID?: string;
+
+    /** Current task name. */
+    taskName?: string;
+  };
+
+  /** Time when global execution stops or stopped. */
+  globalExecutionStop?: string;
 
   /** Workflow timeout in seconds. */
   globalTimeout?: number;


### PR DESCRIPTION
## Summary

This PR updates the Tinkerbell plugin UI based on testing against a real
Tinkerbell v0.23.0 Vagrant/VirtualBox lab.

The changes focus on the core Hardware, Template, and Workflow CRDs.

## Changes

- Update Workflow list/detail views to handle the v0.23.0 status shape.
- Fix Workflow detail rendering when `status.currentState` is an object.
- Use v0.23.0 action timing fields like `executionStart`,
  `executionStop`, and `executionDuration`.
- Remove misleading status fields from Hardware and Template views.
- Improve Hardware detail display using observed agent attributes.
- Improve Template action summaries for simple conditional alternatives,
  such as `reboot into os` / `kexec into os`.