### PR TITLE
feat(kueue): implement ClusterQueue, LocalQueue, and Workload views with active controls

### DIFF
--- a/kueue/package-lock.json
+++ b/kueue/package-lock.json
@@ -122,6 +122,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -515,6 +516,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -538,6 +540,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -606,6 +609,7 @@
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -652,6 +656,7 @@
       "integrity": "sha512-XxfOnXFffatap2IyCeJyNov3kiDQWoR08gPUQxvbL7fxKryGBKUZUkG6Hz48DZwVrJSVh9sJboyV1Ds4OW6SgA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1947,6 +1952,7 @@
       "integrity": "sha512-v501SSMOWv8gerHkk+IIQBkcGRGrO2nfybfj5pLxuJNFTPxxA3PSryhXTK+9pNbtkggheDdsC0E9Q8CuPk6JKA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -1980,6 +1986,7 @@
       "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -2153,6 +2160,7 @@
       "integrity": "sha512-heL4S+EawrP61xMXBm59QH6HODsu0gxtZi5JtnXF2r+rghzyU/3Uftlt1ij8rmJh+cFdKTQug1L9KkZB5JgpMQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.9"
       },
@@ -2222,6 +2230,7 @@
       "integrity": "sha512-eSXQVCMKU2xc7EcTxe/X/rC9QsV2jUe8eLM3MUCPYbo6V52eCE436akRIvELq/AqZpxx2bwkq7HC0cRhLB+yaw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@mui/core-downloads-tracker": "^5.16.14",
@@ -2329,6 +2338,7 @@
       "integrity": "sha512-KBxMwCb8mSIABnKvoGbvM33XHyT+sN0BzEBG+rsSc0lLQGzs7127KWkCA6/H8h6LZ00XpBEME5MAj8mZLiQ1tw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@mui/private-theming": "^5.16.14",
@@ -2416,6 +2426,7 @@
       "integrity": "sha512-igfKTPC4ZVCmS5j/NXcXBtj/hHseQHzRpCpIB1PMnJGhMdRYXnz8qZz5XhlNBKlzJVXkGu6Uil+obZpCLNj1xg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.25.7",
         "@mui/utils": "^5.16.6 || ^6.0.0",
@@ -3731,6 +3742,7 @@
       "integrity": "sha512-Qd8eBPkUFL4eAONgGjycZXj1jFCBW8Fd+xF0PzdTlBCWQIV1xnUT7B93wUANtW3KGjl3TRcOyxwSx/u/jyKw/Q==",
       "dev": true,
       "hasInstallScript": true,
+      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.25"
@@ -4053,6 +4065,7 @@
       "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -4520,6 +4533,7 @@
       "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -4531,6 +4545,7 @@
       "integrity": "sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -4663,6 +4678,7 @@
       "integrity": "sha512-cLr1J6pe56zjKYajK6SSSre6nl1Gj6xDp1TY0trpgPzjVbgDwd09v2Ws37LABxzkicmUjhEeg/fAUjPJJB1v5Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
         "@typescript-eslint/scope-manager": "8.26.0",
@@ -4693,6 +4709,7 @@
       "integrity": "sha512-mNtXP9LTVBy14ZF3o7JG69gRPBK/2QWtQd0j0oH26HcY/foyJJau6pNUez7QrM5UHnSvwlQcJXKsk0I99B9pOA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.26.0",
         "@typescript-eslint/types": "8.26.0",
@@ -5256,7 +5273,8 @@
       "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
       "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
@@ -5307,6 +5325,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5352,6 +5371,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -6176,6 +6196,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -7075,7 +7096,8 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/d3-array": {
       "version": "3.2.4",
@@ -7190,6 +7212,7 @@
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -8013,6 +8036,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -8090,6 +8114,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -8146,6 +8171,7 @@
       "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -8209,6 +8235,7 @@
       "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -8326,6 +8353,7 @@
       "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "aria-query": "^5.3.2",
         "array-includes": "^3.1.8",
@@ -8390,7 +8418,6 @@
       "integrity": "sha512-EsTAnj9fLVr/GZleBLFbj/sSuXeWmp1eXIN60ceYnZveqEaUCyW4X+Vh4WTdUhCkW4xutXYqTXCUSyqD4rB75w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -8438,7 +8465,6 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -8450,7 +8476,6 @@
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "esutils": "^2.0.2"
       },
@@ -8464,7 +8489,6 @@
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -8478,7 +8502,6 @@
       "integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
@@ -8497,7 +8520,6 @@
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -8508,6 +8530,7 @@
       "integrity": "sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "eslint": ">=5.0.0"
       }
@@ -8518,6 +8541,7 @@
       "integrity": "sha512-YptD6IzQjDardkl0POxnnRBhU1OEePMV0nd6siHaRBbd+lyh6NAhFEobiznKU7kTsSsDeSD62Pe7kAM1b7dAZQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@typescript-eslint/eslint-plugin": "^8.0.0-0 || ^7.0.0 || ^6.0.0 || ^5.0.0",
         "eslint": "^9.0.0 || ^8.0.0"
@@ -10186,6 +10210,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.2"
       }
@@ -11173,6 +11198,7 @@
       "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.0.1",
         "data-urls": "^5.0.0",
@@ -11214,6 +11240,7 @@
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -12449,7 +12476,8 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
       "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -12465,6 +12493,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bundled-es-modules/cookie": "^2.0.0",
         "@bundled-es-modules/statuses": "^1.0.1",
@@ -13446,6 +13475,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.8",
         "picocolors": "^1.1.1",
@@ -13549,6 +13579,7 @@
       "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -13893,6 +13924,7 @@
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -13936,6 +13968,7 @@
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -14036,6 +14069,7 @@
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -14340,7 +14374,8 @@
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -14739,6 +14774,7 @@
       "integrity": "sha512-nF5XYqWWp9hx/LrpC8sZvvvmq0TeTjQgaZHYmAgwysT9nh8sWnZhBnM8ZyVbbJFIQBLwHDNoMqsBZBbUo4U8sQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.6"
       },
@@ -14956,6 +14992,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -15379,6 +15416,7 @@
       "integrity": "sha512-6rME2tww6PFhm96iG2Xx44yzwLDWBiDWy+kJ2ub6x90werSTOiuo+tZJ94BgCfFutR0tEfLRIq59s+Zg6YyChA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@testing-library/jest-dom": "^6.6.3",
@@ -16536,6 +16574,7 @@
       "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16996,6 +17035,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -17154,6 +17194,7 @@
       "integrity": "sha512-dfqAsNqRGUc8hB9OVR2P0w8PZPEckti2+5rdZip0WIz9WW0MnImJ8XiR61QhqLa92EQzKP2uPkzenKOAHyEIbA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "3.0.8",
         "@vitest/mocker": "3.0.8",
@@ -17373,6 +17414,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.103.0.tgz",
       "integrity": "sha512-HU1JOuV1OavsZ+mfigY0j8d1TgQgbZ6M+J75zDkpEAwYeXjWSqrGJtgnPblJjd/mAyTNQ7ygw0MiKOn6etz8yw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -17891,6 +17933,7 @@
       "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/kueue/src/components/clusterqueues/Detail.tsx
+++ b/kueue/src/components/clusterqueues/Detail.tsx
@@ -1,0 +1,97 @@
+import { DetailsGrid } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { SectionBox } from '@kinvolk/headlamp-plugin/lib/components/common';
+import { Table, TableBody, TableCell, TableHead, TableRow, Typography } from '@mui/material';
+import { useParams } from 'react-router-dom';
+import { ClusterQueue } from '../../resources/clusterQueue';
+
+export default function ClusterQueueDetail() {
+  const { name } = useParams<{ name: string }>();
+
+  return (
+    <DetailsGrid
+      resourceType={ClusterQueue}
+      name={name}
+      withEvents
+      extraInfo={cq =>
+        cq
+          ? [
+              {
+                name: 'Cohort',
+                value: cq.cohort,
+              },
+              {
+                name: 'Queueing Strategy',
+                value: cq.queueingStrategy,
+              },
+              {
+                name: 'Pending Workloads',
+                value: cq.pendingWorkloads,
+              },
+              {
+                name: 'Admitted Workloads',
+                value: cq.admittedWorkloads,
+              },
+            ]
+          : []
+      }
+      extraSections={cq =>
+        cq
+          ? [
+              {
+                id: 'kueue-clusterqueue-resource-groups',
+                section: (
+                  <SectionBox title="Resource Groups">
+                    {cq.resourceGroups.length === 0 ? (
+                      <Typography variant="body2">No resource groups defined.</Typography>
+                    ) : (
+                      cq.resourceGroups.map((rg, groupIndex) => (
+                        <div key={groupIndex} style={{ marginBottom: '20px' }}>
+                          <Typography variant="subtitle1" fontWeight="bold" gutterBottom>
+                            Resource Group {groupIndex + 1} (Resources: {rg.coveredResources?.join(', ') || '-'})
+                          </Typography>
+                          <Table size="small">
+                            <TableHead>
+                              <TableRow>
+                                <TableCell>Flavor Name</TableCell>
+                                <TableCell>Resource</TableCell>
+                                <TableCell>Nominal Quota</TableCell>
+                                <TableCell>Borrowing Limit</TableCell>
+                                <TableCell>Lending Limit</TableCell>
+                              </TableRow>
+                            </TableHead>
+                            <TableBody>
+                              {rg.flavors?.flatMap(flavor =>
+                                flavor.resources?.map((resource, resIndex) => (
+                                  <TableRow key={`${flavor.name}-${resource.name}`}>
+                                    {resIndex === 0 && (
+                                      <TableCell rowSpan={flavor.resources.length} style={{ verticalAlign: 'top' }}>
+                                        <Typography variant="body2" fontWeight="bold">
+                                          {flavor.name}
+                                        </Typography>
+                                      </TableCell>
+                                    )}
+                                    <TableCell>{resource.name}</TableCell>
+                                    <TableCell>{resource.nominalQuota}</TableCell>
+                                    <TableCell>{resource.borrowingLimit ?? '-'}</TableCell>
+                                    <TableCell>{resource.lendingLimit ?? '-'}</TableCell>
+                                  </TableRow>
+                                ))
+                              ) || (
+                                <TableRow>
+                                  <TableCell colSpan={5}>No flavors configured</TableCell>
+                                </TableRow>
+                              )}
+                            </TableBody>
+                          </Table>
+                        </div>
+                      ))
+                    )}
+                  </SectionBox>
+                ),
+              },
+            ]
+          : []
+      }
+    />
+  );
+}

--- a/kueue/src/components/clusterqueues/List.tsx
+++ b/kueue/src/components/clusterqueues/List.tsx
@@ -1,0 +1,45 @@
+import { ResourceListView, StatusLabel } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { ClusterQueue } from '../../resources/clusterQueue';
+
+export default function ClusterQueueList() {
+  return (
+    <ResourceListView
+      title="ClusterQueues"
+      resourceClass={ClusterQueue}
+      columns={[
+        'name',
+        {
+          id: 'cohort',
+          label: 'Cohort',
+          getValue: (cq: ClusterQueue) => cq.cohort,
+        },
+        {
+          id: 'queueingStrategy',
+          label: 'Queueing Strategy',
+          getValue: (cq: ClusterQueue) => cq.queueingStrategy,
+        },
+        {
+          id: 'pendingWorkloads',
+          label: 'Pending Workloads',
+          getValue: (cq: ClusterQueue) => cq.pendingWorkloads,
+        },
+        {
+          id: 'admittedWorkloads',
+          label: 'Admitted Workloads',
+          getValue: (cq: ClusterQueue) => cq.admittedWorkloads,
+        },
+        {
+          id: 'status',
+          label: 'Status',
+          getValue: (cq: ClusterQueue) => cq.statusMessage,
+          render: (cq: ClusterQueue) => (
+            <StatusLabel status={cq.isActive ? 'success' : 'error'}>
+              {cq.statusMessage}
+            </StatusLabel>
+          ),
+        },
+        'age',
+      ]}
+    />
+  );
+}

--- a/kueue/src/components/localqueues/Detail.tsx
+++ b/kueue/src/components/localqueues/Detail.tsx
@@ -1,0 +1,45 @@
+import { DetailsGrid, Link } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { useParams } from 'react-router-dom';
+import { LocalQueue } from '../../resources/localQueue';
+import { kueueRouteNames } from '../../utils/kueueRoutes';
+
+export default function LocalQueueDetail() {
+  const { name, namespace } = useParams<{ name: string; namespace: string }>();
+
+  return (
+    <DetailsGrid
+      resourceType={LocalQueue}
+      name={name}
+      namespace={namespace}
+      withEvents
+      extraInfo={lq =>
+        lq
+          ? [
+              {
+                name: 'ClusterQueue',
+                value: lq.clusterQueue && lq.clusterQueue !== '-' ? (
+                  <Link routeName={kueueRouteNames.clusterQueueDetail} params={{ name: lq.clusterQueue }}>
+                    {lq.clusterQueue}
+                  </Link>
+                ) : (
+                  '-'
+                ),
+              },
+              {
+                name: 'Pending Workloads',
+                value: lq.pendingWorkloads,
+              },
+              {
+                name: 'Admitted Workloads',
+                value: lq.admittedWorkloads,
+              },
+              {
+                name: 'Status',
+                value: lq.statusMessage,
+              },
+            ]
+          : []
+      }
+    />
+  );
+}

--- a/kueue/src/components/localqueues/List.tsx
+++ b/kueue/src/components/localqueues/List.tsx
@@ -1,0 +1,51 @@
+import { Link, ResourceListView, StatusLabel } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { LocalQueue } from '../../resources/localQueue';
+import { kueueRouteNames } from '../../utils/kueueRoutes';
+
+export default function LocalQueueList() {
+  return (
+    <ResourceListView
+      title="LocalQueues"
+      resourceClass={LocalQueue}
+      columns={[
+        'name',
+        'namespace',
+        {
+          id: 'clusterQueue',
+          label: 'ClusterQueue',
+          getValue: (lq: LocalQueue) => lq.clusterQueue,
+          render: (lq: LocalQueue) => (
+            lq.clusterQueue && lq.clusterQueue !== '-' ? (
+              <Link routeName={kueueRouteNames.clusterQueueDetail} params={{ name: lq.clusterQueue }}>
+                {lq.clusterQueue}
+              </Link>
+            ) : (
+              '-'
+            )
+          ),
+        },
+        {
+          id: 'pendingWorkloads',
+          label: 'Pending Workloads',
+          getValue: (lq: LocalQueue) => lq.pendingWorkloads,
+        },
+        {
+          id: 'admittedWorkloads',
+          label: 'Admitted Workloads',
+          getValue: (lq: LocalQueue) => lq.admittedWorkloads,
+        },
+        {
+          id: 'status',
+          label: 'Status',
+          getValue: (lq: LocalQueue) => lq.statusMessage,
+          render: (lq: LocalQueue) => (
+            <StatusLabel status={lq.isActive ? 'success' : 'error'}>
+              {lq.statusMessage}
+            </StatusLabel>
+          ),
+        },
+        'age',
+      ]}
+    />
+  );
+}

--- a/kueue/src/components/workloads/Detail.tsx
+++ b/kueue/src/components/workloads/Detail.tsx
@@ -1,0 +1,196 @@
+import { DetailsGrid, Link } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { ActionButton, SectionBox } from '@kinvolk/headlamp-plugin/lib/components/common';
+import { Table, TableBody, TableCell, TableHead, TableRow, Typography } from '@mui/material';
+import { useSnackbar } from 'notistack';
+import { useParams } from 'react-router-dom';
+import { Workload } from '../../resources/workload';
+import { kueueRouteNames } from '../../utils/kueueRoutes';
+
+export default function WorkloadDetail() {
+  const { name, namespace } = useParams<{ name: string; namespace: string }>();
+  const { enqueueSnackbar } = useSnackbar();
+
+  const handleActiveToggle = async (wl: Workload, nextActiveState: boolean) => {
+    try {
+      await wl.patch({
+        spec: {
+          active: nextActiveState,
+        },
+      });
+      const actionName = nextActiveState ? 'resumed' : 'suspended';
+      enqueueSnackbar(`Successfully ${actionName} workload ${wl.metadata.name}`, {
+        variant: 'success',
+      });
+    } catch (err: any) {
+      enqueueSnackbar(`Failed to update workload state: ${err.message || err}`, {
+        variant: 'error',
+      });
+    }
+  };
+
+  return (
+    <DetailsGrid
+      resourceType={Workload}
+      name={name}
+      namespace={namespace}
+      withEvents
+      actions={wl => {
+        if (!wl) return [];
+        return [
+          wl.isActive ? (
+            <ActionButton
+              key="suspend"
+              description="Suspend"
+              icon="mdi:pause"
+              onClick={() => handleActiveToggle(wl, false)}
+            />
+          ) : (
+            <ActionButton
+              key="resume"
+              description="Resume"
+              icon="mdi:play"
+              onClick={() => handleActiveToggle(wl, true)}
+            />
+          ),
+        ];
+      }}
+      extraInfo={wl =>
+        wl
+          ? [
+              {
+                name: 'LocalQueue',
+                value: wl.queueName && wl.queueName !== '-' ? (
+                  <Link
+                    routeName={kueueRouteNames.localQueueDetail}
+                    params={{ name: wl.queueName, namespace: wl.metadata.namespace }}
+                  >
+                    {wl.queueName}
+                  </Link>
+                ) : (
+                  '-'
+                ),
+              },
+              {
+                name: 'Priority',
+                value: wl.priority,
+              },
+              {
+                name: 'Priority Class',
+                value: wl.priorityClassName,
+              },
+              {
+                name: 'Active',
+                value: wl.isActive ? 'Yes' : 'No',
+              },
+              {
+                name: 'Status',
+                value: wl.statusMessage,
+              },
+            ]
+          : []
+      }
+      extraSections={wl =>
+        wl
+          ? [
+              {
+                id: 'kueue-workload-podsets',
+                section: (
+                  <SectionBox title="Pod Sets">
+                    {wl.podSets.length === 0 ? (
+                      <Typography variant="body2">No pod sets defined.</Typography>
+                    ) : (
+                      <Table size="small">
+                        <TableHead>
+                          <TableRow>
+                            <TableCell>Name</TableCell>
+                            <TableCell>Count</TableCell>
+                            <TableCell>Containers & Resource Requests</TableCell>
+                          </TableRow>
+                        </TableHead>
+                        <TableBody>
+                          {wl.podSets.map((podSet, idx) => (
+                            <TableRow key={`${podSet.name}-${idx}`}>
+                              <TableCell style={{ fontWeight: 'bold' }}>{podSet.name}</TableCell>
+                              <TableCell>{podSet.count}</TableCell>
+                              <TableCell>
+                                {podSet.template?.spec?.containers?.map((c, cIdx) => (
+                                  <div key={`${c.name}-${cIdx}`} style={{ marginBottom: '4px' }}>
+                                    <Typography variant="body2" component="span" fontWeight="bold">
+                                      {c.name}
+                                    </Typography>
+                                    {c.image && ` (${c.image})`}
+                                    {c.resources?.requests && (
+                                      <div style={{ paddingLeft: '8px', color: 'gray', fontSize: '0.85rem' }}>
+                                        Requests: {Object.entries(c.resources.requests)
+                                          .map(([key, val]) => `${key}: ${val}`)
+                                          .join(', ')}
+                                      </div>
+                                    )}
+                                  </div>
+                                ))}
+                              </TableCell>
+                            </TableRow>
+                          ))}
+                        </TableBody>
+                      </Table>
+                    )}
+                  </SectionBox>
+                ),
+              },
+              ...(wl.admission
+                ? [
+                    {
+                      id: 'kueue-workload-admission',
+                      section: (
+                        <SectionBox title="Admission Details">
+                          <Table size="small">
+                            <TableBody>
+                              <TableRow>
+                                <TableCell style={{ fontWeight: 'bold', width: '200px' }}>
+                                  Admitted ClusterQueue
+                                </TableCell>
+                                <TableCell>
+                                  <Link
+                                    routeName={kueueRouteNames.clusterQueueDetail}
+                                    params={{ name: wl.admission.clusterQueue }}
+                                  >
+                                    {wl.admission.clusterQueue}
+                                  </Link>
+                                </TableCell>
+                              </TableRow>
+                              {wl.admission.podSetFlavors && wl.admission.podSetFlavors.length > 0 && (
+                                <TableRow>
+                                  <TableCell style={{ fontWeight: 'bold' }}>
+                                    Assigned Flavors
+                                  </TableCell>
+                                  <TableCell>
+                                    {wl.admission.podSetFlavors.map((psf, fIdx) => (
+                                      <div key={`${psf.name}-${fIdx}`} style={{ marginBottom: '4px' }}>
+                                        <Typography variant="body2" component="span" fontWeight="bold">
+                                          {psf.name}
+                                        </Typography>
+                                        {psf.flavors && (
+                                          <span style={{ color: 'gray', marginLeft: '8px' }}>
+                                            ({Object.entries(psf.flavors)
+                                              .map(([res, flav]) => `${res} -> ${flav}`)
+                                              .join(', ')})
+                                          </span>
+                                        )}
+                                      </div>
+                                    ))}
+                                  </TableCell>
+                                </TableRow>
+                              )}
+                            </TableBody>
+                          </Table>
+                        </SectionBox>
+                      ),
+                    },
+                  ]
+                : []),
+            ]
+          : []
+      }
+    />
+  );
+}

--- a/kueue/src/components/workloads/List.tsx
+++ b/kueue/src/components/workloads/List.tsx
@@ -1,0 +1,77 @@
+import { Link, ResourceListView, StatusLabel } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { Workload } from '../../resources/workload';
+import { kueueRouteNames } from '../../utils/kueueRoutes';
+
+function getWorkloadStatusSeverity(status: string): 'success' | 'warning' | 'error' | 'info' | '' {
+  if (status === 'Admitted' || status === 'Finished') {
+    return 'success';
+  }
+  if (status.startsWith('Evicted')) {
+    return 'warning';
+  }
+  if (status === 'Pending') {
+    return 'info';
+  }
+  return '';
+}
+
+export default function WorkloadList() {
+  return (
+    <ResourceListView
+      title="Workloads"
+      resourceClass={Workload}
+      columns={[
+        'name',
+        'namespace',
+        {
+          id: 'queueName',
+          label: 'LocalQueue',
+          getValue: (wl: Workload) => wl.queueName,
+          render: (wl: Workload) => (
+            wl.queueName && wl.queueName !== '-' ? (
+              <Link
+                routeName={kueueRouteNames.localQueueDetail}
+                params={{ name: wl.queueName, namespace: wl.metadata.namespace }}
+              >
+                {wl.queueName}
+              </Link>
+            ) : (
+              '-'
+            )
+          ),
+        },
+        {
+          id: 'priority',
+          label: 'Priority',
+          getValue: (wl: Workload) => wl.priority,
+        },
+        {
+          id: 'priorityClassName',
+          label: 'Priority Class',
+          getValue: (wl: Workload) => wl.priorityClassName,
+        },
+        {
+          id: 'status',
+          label: 'Status',
+          getValue: (wl: Workload) => wl.statusMessage,
+          render: (wl: Workload) => (
+            <StatusLabel status={getWorkloadStatusSeverity(wl.statusMessage)}>
+              {wl.statusMessage}
+            </StatusLabel>
+          ),
+        },
+        {
+          id: 'active',
+          label: 'Active',
+          getValue: (wl: Workload) => (wl.isActive ? 'Yes' : 'No'),
+          render: (wl: Workload) => (
+            <StatusLabel status={wl.isActive ? 'success' : 'error'}>
+              {wl.isActive ? 'Yes' : 'No'}
+            </StatusLabel>
+          ),
+        },
+        'age',
+      ]}
+    />
+  );
+}

--- a/kueue/src/index.tsx
+++ b/kueue/src/index.tsx
@@ -1,14 +1,43 @@
 import { registerRoute, registerSidebarEntry } from '@kinvolk/headlamp-plugin/lib';
+import ClusterQueueDetail from './components/clusterqueues/Detail';
+import ClusterQueueList from './components/clusterqueues/List';
+import LocalQueueDetail from './components/localqueues/Detail';
+import LocalQueueList from './components/localqueues/List';
 import ResourceFlavorDetail from './components/resourceflavors/Detail';
 import ResourceFlavorList from './components/resourceflavors/List';
+import WorkloadDetail from './components/workloads/Detail';
+import WorkloadList from './components/workloads/List';
 import { kueueRouteNames, kueueRoutePaths } from './utils/kueueRoutes';
 
+// Main Sidebar Entry
 registerSidebarEntry({
   parent: null,
   name: 'kueue',
   label: 'Kueue',
   icon: 'mdi:queue-first-in-last-out',
-  url: kueueRoutePaths.resourceFlavorsList,
+  url: kueueRoutePaths.clusterQueuesList,
+});
+
+// Sidebar Sub-entries
+registerSidebarEntry({
+  parent: 'kueue',
+  name: 'kueue-clusterqueues',
+  label: 'ClusterQueues',
+  url: kueueRoutePaths.clusterQueuesList,
+});
+
+registerSidebarEntry({
+  parent: 'kueue',
+  name: 'kueue-localqueues',
+  label: 'LocalQueues',
+  url: kueueRoutePaths.localQueuesList,
+});
+
+registerSidebarEntry({
+  parent: 'kueue',
+  name: 'kueue-workloads',
+  label: 'Workloads',
+  url: kueueRoutePaths.workloadsList,
 });
 
 registerSidebarEntry({
@@ -18,6 +47,58 @@ registerSidebarEntry({
   url: kueueRoutePaths.resourceFlavorsList,
 });
 
+// ClusterQueue Routes
+registerRoute({
+  path: kueueRoutePaths.clusterQueuesList,
+  sidebar: 'kueue-clusterqueues',
+  name: kueueRouteNames.clusterQueuesList,
+  exact: true,
+  component: () => <ClusterQueueList />,
+});
+
+registerRoute({
+  path: kueueRoutePaths.clusterQueueDetail,
+  sidebar: 'kueue-clusterqueues',
+  name: kueueRouteNames.clusterQueueDetail,
+  exact: true,
+  component: () => <ClusterQueueDetail />,
+});
+
+// LocalQueue Routes
+registerRoute({
+  path: kueueRoutePaths.localQueuesList,
+  sidebar: 'kueue-localqueues',
+  name: kueueRouteNames.localQueuesList,
+  exact: true,
+  component: () => <LocalQueueList />,
+});
+
+registerRoute({
+  path: kueueRoutePaths.localQueueDetail,
+  sidebar: 'kueue-localqueues',
+  name: kueueRouteNames.localQueueDetail,
+  exact: true,
+  component: () => <LocalQueueDetail />,
+});
+
+// Workload Routes
+registerRoute({
+  path: kueueRoutePaths.workloadsList,
+  sidebar: 'kueue-workloads',
+  name: kueueRouteNames.workloadsList,
+  exact: true,
+  component: () => <WorkloadList />,
+});
+
+registerRoute({
+  path: kueueRoutePaths.workloadDetail,
+  sidebar: 'kueue-workloads',
+  name: kueueRouteNames.workloadDetail,
+  exact: true,
+  component: () => <WorkloadDetail />,
+});
+
+// ResourceFlavor Routes
 registerRoute({
   path: kueueRoutePaths.resourceFlavorsList,
   sidebar: 'kueue-resourceflavors',
@@ -33,3 +114,4 @@ registerRoute({
   exact: true,
   component: () => <ResourceFlavorDetail />,
 });
+

--- a/kueue/src/resources/clusterQueue.test.ts
+++ b/kueue/src/resources/clusterQueue.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@kinvolk/headlamp-plugin/lib/k8s/cluster', () => ({
+  KubeObject: class KubeObject {
+    jsonData: any;
+    constructor(jsonData: any) {
+      this.jsonData = jsonData;
+    }
+  },
+}));
+
+import { ClusterQueue } from './clusterQueue';
+
+describe('ClusterQueue KubeObject', () => {
+  it('correctly extracts spec and status properties', () => {
+    const rawCQ = {
+      metadata: { name: 'test-cq' },
+      spec: {
+        cohort: 'test-cohort',
+        queueingStrategy: 'BestEffort' as const,
+        resourceGroups: [
+          {
+            coveredResources: ['cpu'],
+            flavors: [
+              {
+                name: 'default',
+                resources: [{ name: 'cpu', nominalQuota: '10' }],
+              },
+            ],
+          },
+        ],
+      },
+      status: {
+        pendingWorkloads: 5,
+        admittedWorkloads: 2,
+        conditions: [
+          {
+            type: 'Active',
+            status: 'True' as const,
+          },
+        ],
+      },
+    };
+
+    const cq = new ClusterQueue(rawCQ as any);
+
+    expect(cq.cohort).toBe('test-cohort');
+    expect(cq.queueingStrategy).toBe('BestEffort');
+    expect(cq.pendingWorkloads).toBe(5);
+    expect(cq.admittedWorkloads).toBe(2);
+    expect(cq.isActive).toBe(true);
+    expect(cq.statusMessage).toBe('Active');
+    expect(cq.resourceGroups).toHaveLength(1);
+    expect(cq.resourceGroups[0].coveredResources).toEqual(['cpu']);
+  });
+
+  it('handles default empty values gracefully', () => {
+    const cq = new ClusterQueue({ metadata: { name: 'empty-cq' } } as any);
+
+    expect(cq.cohort).toBe('-');
+    expect(cq.queueingStrategy).toBe('Strict');
+    expect(cq.pendingWorkloads).toBe(0);
+    expect(cq.admittedWorkloads).toBe(0);
+    expect(cq.isActive).toBe(false);
+    expect(cq.statusMessage).toBe('Unknown');
+    expect(cq.resourceGroups).toEqual([]);
+  });
+
+  it('renders inactive status message with reason', () => {
+    const rawCQ = {
+      metadata: { name: 'inactive-cq' },
+      status: {
+        conditions: [
+          {
+            type: 'Active',
+            status: 'False' as const,
+            reason: 'FlavorNotFound',
+          },
+        ],
+      },
+    };
+    const cq = new ClusterQueue(rawCQ as any);
+
+    expect(cq.isActive).toBe(false);
+    expect(cq.statusMessage).toBe('Inactive (FlavorNotFound)');
+  });
+});

--- a/kueue/src/resources/clusterQueue.ts
+++ b/kueue/src/resources/clusterQueue.ts
@@ -1,0 +1,115 @@
+import { KubeObject, KubeObjectInterface } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import { kueueApiVersions } from '../utils/kueueApi';
+import { kueueRoutePaths } from '../utils/kueueRoutes';
+
+export interface ClusterQueueResourceQuota {
+  name: string;
+  nominalQuota: string;
+  borrowingLimit?: string;
+  lendingLimit?: string;
+}
+
+export interface ClusterQueueFlavor {
+  name: string;
+  resources: ClusterQueueResourceQuota[];
+}
+
+export interface ClusterQueueResourceGroup {
+  coveredResources: string[];
+  flavors: ClusterQueueFlavor[];
+}
+
+export interface ClusterQueuePreemption {
+  reclaimWithinCohort?: 'Never' | 'Any' | 'LowerPriority';
+  withinClusterQueue?: 'Never' | 'Block' | 'LowerPriority';
+}
+
+export interface ClusterQueueSpec {
+  cohort?: string;
+  queueingStrategy?: 'Strict' | 'BestEffort';
+  namespaceSelector?: {
+    matchLabels?: Record<string, string>;
+    matchExpressions?: Array<{
+      key: string;
+      operator: string;
+      values?: string[];
+    }>;
+  };
+  resourceGroups?: ClusterQueueResourceGroup[];
+  preemption?: ClusterQueuePreemption;
+}
+
+export interface ClusterQueueCondition {
+  type: string;
+  status: 'True' | 'False' | 'Unknown';
+  reason?: string;
+  message?: string;
+  lastTransitionTime?: string;
+}
+
+export interface ClusterQueueStatus {
+  pendingWorkloads?: number;
+  admittedWorkloads?: number;
+  conditions?: ClusterQueueCondition[];
+}
+
+export interface KubeClusterQueue extends KubeObjectInterface {
+  spec?: ClusterQueueSpec;
+  status?: ClusterQueueStatus;
+}
+
+export class ClusterQueue extends KubeObject<KubeClusterQueue> {
+  static kind = 'ClusterQueue';
+  static apiName = 'clusterqueues';
+  static apiVersion = kueueApiVersions;
+  static isNamespaced = false;
+
+  static get detailsRoute() {
+    return kueueRoutePaths.clusterQueueDetail;
+  }
+
+  get spec(): ClusterQueueSpec {
+    return this.jsonData.spec ?? {};
+  }
+
+  get status(): ClusterQueueStatus {
+    return this.jsonData.status ?? {};
+  }
+
+  get cohort(): string {
+    return this.spec.cohort ?? '-';
+  }
+
+  get queueingStrategy(): string {
+    return this.spec.queueingStrategy ?? 'Strict';
+  }
+
+  get pendingWorkloads(): number {
+    return this.status.pendingWorkloads ?? 0;
+  }
+
+  get admittedWorkloads(): number {
+    return this.status.admittedWorkloads ?? 0;
+  }
+
+  get conditions(): ClusterQueueCondition[] {
+    return this.status.conditions ?? [];
+  }
+
+  get isActive(): boolean {
+    const activeCond = this.conditions.find(c => c.type === 'Active');
+    return activeCond?.status === 'True';
+  }
+
+  get statusMessage(): string {
+    const activeCond = this.conditions.find(c => c.type === 'Active');
+    if (!activeCond) {
+      return 'Unknown';
+    }
+    return activeCond.status === 'True' ? 'Active' : `Inactive (${activeCond.reason ?? 'Unknown reason'})`;
+  }
+
+  get resourceGroups(): ClusterQueueResourceGroup[] {
+    return this.spec.resourceGroups ?? [];
+  }
+}

--- a/kueue/src/resources/localQueue.test.ts
+++ b/kueue/src/resources/localQueue.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@kinvolk/headlamp-plugin/lib/k8s/cluster', () => ({
+  KubeObject: class KubeObject {
+    jsonData: any;
+    constructor(jsonData: any) {
+      this.jsonData = jsonData;
+    }
+  },
+}));
+
+import { LocalQueue } from './localQueue';
+
+describe('LocalQueue KubeObject', () => {
+  it('correctly extracts properties', () => {
+    const rawLQ = {
+      metadata: { name: 'test-lq', namespace: 'default' },
+      spec: {
+        clusterQueue: 'test-cq',
+      },
+      status: {
+        pendingWorkloads: 3,
+        admittedWorkloads: 1,
+        conditions: [
+          {
+            type: 'Active',
+            status: 'True' as const,
+          },
+        ],
+      },
+    };
+
+    const lq = new LocalQueue(rawLQ as any);
+
+    expect(lq.clusterQueue).toBe('test-cq');
+    expect(lq.pendingWorkloads).toBe(3);
+    expect(lq.admittedWorkloads).toBe(1);
+    expect(lq.isActive).toBe(true);
+    expect(lq.statusMessage).toBe('Active');
+  });
+
+  it('handles default empty values gracefully', () => {
+    const lq = new LocalQueue({ metadata: { name: 'empty-lq' } } as any);
+
+    expect(lq.clusterQueue).toBe('-');
+    expect(lq.pendingWorkloads).toBe(0);
+    expect(lq.admittedWorkloads).toBe(0);
+    expect(lq.isActive).toBe(false);
+    expect(lq.statusMessage).toBe('Unknown');
+  });
+});

--- a/kueue/src/resources/localQueue.ts
+++ b/kueue/src/resources/localQueue.ts
@@ -1,0 +1,83 @@
+import { KubeObject, KubeObjectInterface } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import { kueueApiVersions } from '../utils/kueueApi';
+import { kueueRoutePaths } from '../utils/kueueRoutes';
+
+export interface LocalQueueSpec {
+  clusterQueue?: string;
+}
+
+export interface LocalQueueCondition {
+  type: string;
+  status: 'True' | 'False' | 'Unknown';
+  reason?: string;
+  message?: string;
+  lastTransitionTime?: string;
+}
+
+export interface LocalQueueFlavorUsage {
+  name: string;
+  resources: Array<{
+    name: string;
+    total: string;
+  }>;
+}
+
+export interface LocalQueueStatus {
+  pendingWorkloads?: number;
+  admittedWorkloads?: number;
+  conditions?: LocalQueueCondition[];
+  flavorUsage?: LocalQueueFlavorUsage[];
+}
+
+export interface KubeLocalQueue extends KubeObjectInterface {
+  spec?: LocalQueueSpec;
+  status?: LocalQueueStatus;
+}
+
+export class LocalQueue extends KubeObject<KubeLocalQueue> {
+  static kind = 'LocalQueue';
+  static apiName = 'localqueues';
+  static apiVersion = kueueApiVersions;
+  static isNamespaced = true;
+
+  static get detailsRoute() {
+    return kueueRoutePaths.localQueueDetail;
+  }
+
+  get spec(): LocalQueueSpec {
+    return this.jsonData.spec ?? {};
+  }
+
+  get status(): LocalQueueStatus {
+    return this.jsonData.status ?? {};
+  }
+
+  get clusterQueue(): string {
+    return this.spec.clusterQueue ?? '-';
+  }
+
+  get pendingWorkloads(): number {
+    return this.status.pendingWorkloads ?? 0;
+  }
+
+  get admittedWorkloads(): number {
+    return this.status.admittedWorkloads ?? 0;
+  }
+
+  get conditions(): LocalQueueCondition[] {
+    return this.status.conditions ?? [];
+  }
+
+  get isActive(): boolean {
+    const activeCond = this.conditions.find(c => c.type === 'Active');
+    return activeCond?.status === 'True';
+  }
+
+  get statusMessage(): string {
+    const activeCond = this.conditions.find(c => c.type === 'Active');
+    if (!activeCond) {
+      return 'Unknown';
+    }
+    return activeCond.status === 'True' ? 'Active' : `Inactive (${activeCond.reason ?? 'Unknown reason'})`;
+  }
+}

--- a/kueue/src/resources/workload.test.ts
+++ b/kueue/src/resources/workload.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@kinvolk/headlamp-plugin/lib/k8s/cluster', () => ({
+  KubeObject: class KubeObject {
+    jsonData: any;
+    constructor(jsonData: any) {
+      this.jsonData = jsonData;
+    }
+  },
+}));
+
+import { Workload } from './workload';
+
+describe('Workload KubeObject', () => {
+  it('correctly extracts properties', () => {
+    const rawWorkload = {
+      metadata: { name: 'test-wl', namespace: 'default' },
+      spec: {
+        active: true,
+        queueName: 'test-lq',
+        priority: 100,
+        priorityClassName: 'high-priority',
+        podSets: [
+          {
+            count: 2,
+            name: 'main',
+            template: {
+              spec: {
+                containers: [{ name: 'web', image: 'nginx' }],
+              },
+            },
+          },
+        ],
+      },
+      status: {
+        conditions: [
+          {
+            type: 'Admitted',
+            status: 'True' as const,
+          },
+        ],
+        admission: {
+          clusterQueue: 'test-cq',
+          podSetFlavors: [
+            {
+              name: 'main',
+              flavors: { cpu: 'default' },
+            },
+          ],
+        },
+      },
+    };
+
+    const wl = new Workload(rawWorkload as any);
+
+    expect(wl.queueName).toBe('test-lq');
+    expect(wl.priority).toBe(100);
+    expect(wl.priorityClassName).toBe('high-priority');
+    expect(wl.isActive).toBe(true);
+    expect(wl.statusMessage).toBe('Admitted');
+    expect(wl.podSets).toHaveLength(1);
+    expect(wl.admission?.clusterQueue).toBe('test-cq');
+  });
+
+  it('handles default empty values gracefully', () => {
+    const wl = new Workload({ metadata: { name: 'empty-wl' } } as any);
+
+    expect(wl.queueName).toBe('-');
+    expect(wl.priority).toBe(0);
+    expect(wl.priorityClassName).toBe('-');
+    expect(wl.isActive).toBe(true); // defaults to true
+    expect(wl.statusMessage).toBe('Pending');
+    expect(wl.podSets).toEqual([]);
+    expect(wl.admission).toBeUndefined();
+  });
+
+  it('returns Finished status message when Finished condition is True', () => {
+    const rawWorkload = {
+      metadata: { name: 'finished-wl' },
+      status: {
+        conditions: [
+          { type: 'Admitted', status: 'True' as const },
+          { type: 'Finished', status: 'True' as const },
+        ],
+      },
+    };
+    const wl = new Workload(rawWorkload as any);
+    expect(wl.statusMessage).toBe('Finished');
+  });
+
+  it('returns Evicted status message when Evicted condition is True', () => {
+    const rawWorkload = {
+      metadata: { name: 'evicted-wl' },
+      status: {
+        conditions: [{ type: 'Evicted', status: 'True' as const, reason: 'Preempted' }],
+      },
+    };
+    const wl = new Workload(rawWorkload as any);
+    expect(wl.statusMessage).toBe('Evicted (Preempted)');
+  });
+});

--- a/kueue/src/resources/workload.ts
+++ b/kueue/src/resources/workload.ts
@@ -1,0 +1,137 @@
+import { KubeObject, KubeObjectInterface } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import { kueueApiVersions } from '../utils/kueueApi';
+import { kueueRoutePaths } from '../utils/kueueRoutes';
+
+export interface PodSetFlavor {
+  [key: string]: string;
+}
+
+export interface PodSetResource {
+  name: string;
+  requests?: Record<string, string>;
+}
+
+export interface PodSet {
+  count: number;
+  name: string;
+  template: {
+    spec: {
+      containers: Array<{
+        name: string;
+        image?: string;
+        resources?: {
+          requests?: Record<string, string>;
+          limits?: Record<string, string>;
+        };
+      }>;
+      initContainers?: Array<{
+        name: string;
+        image?: string;
+        resources?: {
+          requests?: Record<string, string>;
+          limits?: Record<string, string>;
+        };
+      }>;
+    };
+  };
+}
+
+export interface WorkloadSpec {
+  active?: boolean;
+  queueName?: string;
+  podSets?: PodSet[];
+  priorityClassName?: string;
+  priority?: number;
+}
+
+export interface WorkloadCondition {
+  type: string;
+  status: 'True' | 'False' | 'Unknown';
+  reason?: string;
+  message?: string;
+  lastTransitionTime?: string;
+}
+
+export interface Admission {
+  clusterQueue: string;
+  podSetFlavors?: Array<{
+    name: string;
+    flavors?: Record<string, string>;
+  }>;
+}
+
+export interface WorkloadStatus {
+  conditions?: WorkloadCondition[];
+  admission?: Admission;
+}
+
+export interface KubeWorkload extends KubeObjectInterface {
+  spec?: WorkloadSpec;
+  status?: WorkloadStatus;
+}
+
+export class Workload extends KubeObject<KubeWorkload> {
+  static kind = 'Workload';
+  static apiName = 'workloads';
+  static apiVersion = kueueApiVersions;
+  static isNamespaced = true;
+
+  static get detailsRoute() {
+    return kueueRoutePaths.workloadDetail;
+  }
+
+  get spec(): WorkloadSpec {
+    return this.jsonData.spec ?? {};
+  }
+
+  get status(): WorkloadStatus {
+    return this.jsonData.status ?? {};
+  }
+
+  get queueName(): string {
+    return this.spec.queueName ?? '-';
+  }
+
+  get priority(): number {
+    return this.spec.priority ?? 0;
+  }
+
+  get priorityClassName(): string {
+    return this.spec.priorityClassName ?? '-';
+  }
+
+  get isActive(): boolean {
+    return this.spec.active !== false; // defaults to true if omitted
+  }
+
+  get conditions(): WorkloadCondition[] {
+    return this.status.conditions ?? [];
+  }
+
+  get admission(): Admission | undefined {
+    return this.status.admission;
+  }
+
+  get statusMessage(): string {
+    const finishedCond = this.conditions.find(c => c.type === 'Finished');
+    if (finishedCond?.status === 'True') {
+      return 'Finished';
+    }
+
+    const admittedCond = this.conditions.find(c => c.type === 'Admitted');
+    if (admittedCond?.status === 'True') {
+      return 'Admitted';
+    }
+
+    const evictedCond = this.conditions.find(c => c.type === 'Evicted');
+    if (evictedCond?.status === 'True') {
+      return `Evicted (${evictedCond.reason ?? 'Unknown'})`;
+    }
+
+    return 'Pending';
+  }
+
+  get podSets(): PodSet[] {
+    return this.spec.podSets ?? [];
+  }
+}

--- a/kueue/src/utils/kueueRoutes.ts
+++ b/kueue/src/utils/kueueRoutes.ts
@@ -1,9 +1,21 @@
 export const kueueRouteNames = {
   resourceFlavorsList: 'kueue-resourceflavors-list',
   resourceFlavorDetail: 'kueue-resourceflavor-detail',
+  clusterQueuesList: 'kueue-clusterqueues-list',
+  clusterQueueDetail: 'kueue-clusterqueue-detail',
+  localQueuesList: 'kueue-localqueues-list',
+  localQueueDetail: 'kueue-localqueue-detail',
+  workloadsList: 'kueue-workloads-list',
+  workloadDetail: 'kueue-workload-detail',
 } as const;
 
 export const kueueRoutePaths = {
   resourceFlavorsList: '/kueue/resourceflavors',
   resourceFlavorDetail: '/kueue/resourceflavors/:name',
+  clusterQueuesList: '/kueue/clusterqueues',
+  clusterQueueDetail: '/kueue/clusterqueues/:name',
+  localQueuesList: '/kueue/localqueues',
+  localQueueDetail: '/kueue/localqueues/:namespace/:name',
+  workloadsList: '/kueue/workloads',
+  workloadDetail: '/kueue/workloads/:namespace/:name',
 } as const;


### PR DESCRIPTION
### Overview
This Pull Request builds out full dashboard support and lifecycle controls for **Kueue** in Headlamp. 

Currently, the Kueue plugin is in a skeleton phase—it only supports listing and viewing `ResourceFlavor` resources. While that's a helpful starting point, it doesn't give operators or cluster users visibility into active queues, waiting workloads, or resource pressure. Since Kueue is a primary scheduler for batch jobs and AI/ML workloads (specifically GPU-bound training), bringing queue and workload visibility directly into the UI is critical for cluster operators.

With this PR, I have added complete support for the remaining core Kueue resources: `ClusterQueue`, `LocalQueue`, and `Workload`. This turns the plugin into a fully functional queueing dashboard.

---

### What's Changed

#### 1. API Models (`KubeObject` wrappers)
I created standard, type-safe API resource wrappers that map exactly to the Kueue `v1beta1`/`v1beta2` specs:
* **`ClusterQueue`**: Parses resource group quotas, cohort details, scheduling strategies, and active pending/admitted workload counts.
* **`LocalQueue`**: Maps namespaced queues and handles associations to cluster-scoped `ClusterQueues`.
* **`Workload`**: Exposes pod specs, resource requests, priority levels, priority classes, and admission choices (including allocated flavors per pod set).

#### 2. UI Components & Navigational Flows
* **ClusterQueue List & Detail Pages**:
  * The list view displays cohorts, strategies, active counts, and status badges.
  * The details view features a custom, clean **Resource Groups** table. This map aggregates nominal resource quotas, borrowing limits, and lending limits grouped by flavor so operators can see resource allocations at a glance.
* **LocalQueue List & Detail Pages**:
  * Lists and details feature direct deep links to the associated ClusterQueue for quick navigation.
* **Workload List & Detail Pages**:
  * Lists display workload statuses (Admitted, Finished, Evicted, Pending) with color-coded severity labels.
  * Detail views showcase **Pod Sets** (complete with container image tags and specific resource requests) and **Admission Details** (showing which ClusterQueue scheduled the workload and the specific resource flavors assigned).
* **Lifecycle Actions (Suspend/Resume)**:
  * Integrated **Suspend** and **Resume** buttons directly into the Workload details view. These buttons dynamically patch the `.spec.active` field on the workload, giving administrators an easy, interactive way to halt or requeue workloads directly from the Headlamp interface.

#### 3. Routing & Sidebar Registrations
* Configured the main `Kueue` sidebar menu to expand and list sub-routes for **ClusterQueues**, **LocalQueues**, **Workloads**, and **ResourceFlavors**, following the default navigation layout of the other plugins.

---

### Verification and Quality Checks

I've tested the code thoroughly to ensure it meets the Headlamp repository standards:

1. **Unit Testing (`vitest`)**:
   * Added unit test suites under `src/resources/*.test.ts` for all three new resource classes.
   * Mocked the `KubeObject` constructor to verify properties, state defaults, and condition logic (e.g., precedence mapping from `Finished` -> `Admitted` -> `Evicted`).
   * **Result**: All 11 tests passed successfully:
     ```bash
     ✓ src/resources/localQueue.test.ts (2 tests)
     ✓ src/resources/clusterQueue.test.ts (3 tests)
     ✓ src/resources/workload.test.ts (4 tests)
     ✓ src/utils/kueueApi.test.ts (2 tests)
     ```
2. **Type Safety (`tsc`)**:
   * Re-ran type checking (`npx tsc --noEmit`) to verify zero TypeScript errors.
3. **Linting Check (`eslint`)**:
   * Ran ESLint on all modified/new files. Checked out with **0 warnings and 0 errors**.
4. **Bundling (`vite`)**:
   * Executed `npm run build` to verify production compilation. It generates a clean `dist/main.js` (15.28 kB).

---

### How to Test
1. Make sure you have the Kueue CRDs installed in your Kubernetes cluster (`clusterqueues.kueue.x-k8s.io`, `localqueues.kueue.x-k8s.io`, and `workloads.kueue.x-k8s.io`).
2. Run `npm start` in the `kueue` subdirectory to start the dev server.
3. Open Headlamp and navigate to the **Kueue** sidebar item.
4. Apply some sample Kueue resources (e.g., `ClusterQueue`, `LocalQueue`, and a `Workload` job).
5. Verify that:
   * Queues and workloads load and link together properly.
   * The resource group grid in the ClusterQueue details accurately represents quotas.
   * The Suspend/Resume toggle actions successfully update the workload active spec.