### PR TITLE
fix(strimzi): prevent null-pointer crash when listing topics or users on v1-only clusters

### DIFF
--- a/strimzi/package-lock.json
+++ b/strimzi/package-lock.json
@@ -138,6 +138,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -545,6 +546,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -568,6 +570,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -636,6 +639,7 @@
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -682,6 +686,7 @@
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1960,6 +1965,7 @@
       "integrity": "sha512-fe0rz9WJQ5t2iaLfdbDc9T80GJy0AeO453q8C3YCilnGozvOyCG5t+EZtg7j7D88+c3FipfP/x+wzGnh1xp8ZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
         "@typescript-eslint/scope-manager": "8.47.0",
@@ -2039,6 +2045,7 @@
       "integrity": "sha512-lJi3PfxVmo0AkEY93ecfN+r8SofEqZNGByvHAI3GBLrvt1Cw6H5k1IM02nSzu0RfUafr2EvFSw0wAsZgubNplQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.47.0",
         "@typescript-eslint/types": "8.47.0",
@@ -2211,6 +2218,7 @@
       "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2331,6 +2339,7 @@
       "integrity": "sha512-1s0vEZj5XFXDMmz3Arl/R7IncFqJ+WQ95LDp1roHWGDE2oCO3IS4/hmiOv1/8SD9r6B7tv9GLiqVZYHo+6PkTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.9"
       },
@@ -2400,6 +2409,7 @@
       "integrity": "sha512-bbH/HaJZpFtXGvWg3TsBWG4eyt3gah3E7nCNU8GLyRjVoWcA91Vm/T+sjHfUcwgJSw9iLtucfHBoq+qW/T30aA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@mui/core-downloads-tracker": "^5.18.0",
@@ -2508,6 +2518,7 @@
       "integrity": "sha512-ojZGVcRWqWhu557cdO3pWHloIGJdzVtxs3rk0F9L+x55LsUjcMUVkEhiF7E4TMxZoF9MmIHGGs0ZX3FDLAf0Xw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@mui/private-theming": "^5.17.1",
@@ -2595,6 +2606,7 @@
       "integrity": "sha512-wJ3tsqk/y6dp+mXGtT9czciAMEO5Zr3IIAHg9x6IL0Eqanqy0N3chbmQQZv3iq0m2qUpQDLvZ4utZBUTJdjNzw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.25.7",
         "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0",
@@ -3864,6 +3876,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.25"
@@ -4198,6 +4211,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -4719,6 +4733,7 @@
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -4730,6 +4745,7 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -4886,6 +4902,7 @@
       "integrity": "sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.5.1",
         "@typescript-eslint/scope-manager": "6.21.0",
@@ -4922,6 +4939,7 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -5495,7 +5513,8 @@
       "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
       "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
@@ -5549,6 +5568,7 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5595,6 +5615,7 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -6452,6 +6473,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -7371,7 +7393,8 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/d3-array": {
       "version": "3.2.4",
@@ -7480,6 +7503,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -8333,6 +8357,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -8411,6 +8436,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -8467,6 +8493,7 @@
       "integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -8530,6 +8557,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -8647,6 +8675,7 @@
       "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "aria-query": "^5.3.2",
         "array-includes": "^3.1.8",
@@ -8711,6 +8740,7 @@
       "integrity": "sha512-v501SSMOWv8gerHkk+IIQBkcGRGrO2nfybfj5pLxuJNFTPxxA3PSryhXTK+9pNbtkggheDdsC0E9Q8CuPk6JKA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -8744,6 +8774,7 @@
       "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -8822,6 +8853,7 @@
       "integrity": "sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "eslint": ">=5.0.0"
       }
@@ -8832,6 +8864,7 @@
       "integrity": "sha512-ZFBmXMGBYfHttdRtOG9nFFpmUvMtbHSjsKrS20vdWdbfiVYsO3yA2SGYy9i9XmZJDfMGBflZGBCm70SEnFQtOA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@typescript-eslint/eslint-plugin": "^8.0.0-0 || ^7.0.0 || ^6.0.0 || ^5.0.0",
         "eslint": "^9.0.0 || ^8.0.0"
@@ -10592,6 +10625,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.2"
       }
@@ -11834,6 +11868,7 @@
       "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.0.1",
         "data-urls": "^5.0.0",
@@ -11875,6 +11910,7 @@
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -13123,7 +13159,8 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
       "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -13139,6 +13176,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bundled-es-modules/cookie": "^2.0.0",
         "@bundled-es-modules/statuses": "^1.0.1",
@@ -14285,6 +14323,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -14394,6 +14433,7 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -14741,6 +14781,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -14785,6 +14826,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -14890,6 +14932,7 @@
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -15201,7 +15244,8 @@
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -15628,6 +15672,7 @@
       "integrity": "sha512-nc72Wgq62I7rtDV4izT5/aaS0zxy3kttkinf9586ApknY3jZO9NYsmtc24fUckA0X7Q2v+ML4a15pdUlV5V/jA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.9"
       },
@@ -15838,6 +15883,7 @@
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -16320,6 +16366,7 @@
       "integrity": "sha512-6rME2tww6PFhm96iG2Xx44yzwLDWBiDWy+kJ2ub6x90werSTOiuo+tZJ94BgCfFutR0tEfLRIq59s+Zg6YyChA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@testing-library/jest-dom": "^6.6.3",
@@ -17510,6 +17557,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17975,6 +18023,7 @@
       "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -18134,6 +18183,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -18300,6 +18350,7 @@
       "integrity": "sha512-v7RhXaJbpMlV0D7hC7lb2EbnxkoeUqf9qhKr6lozx3Q48pmFrqqNRmZFUEGmi7pSwm6fCQ2H1IjvCkHqdpVdjQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "^1.0.8",
         "@types/json-schema": "^7.0.15",
@@ -18829,6 +18880,7 @@
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/strimzi/src/components/KafkaTopicList.tsx
+++ b/strimzi/src/components/KafkaTopicList.tsx
@@ -14,6 +14,7 @@ import { useStrimziApiVersions } from '../hooks/useStrimziApiVersions';
 import { StrimziNotInstalledMessage } from './StrimziNotInstalledMessage';
 import { Toast, ToastMessage } from './Toast';
 import { TopicFormModal, type TopicFormData } from './TopicFormModal';
+import { getAvailableNamespaces, getFilteredClusterNames } from '../utils/clusterHelpers';
 
 export function KafkaTopicList() {
   const theme = useTheme();
@@ -40,15 +41,11 @@ export function KafkaTopicList() {
   const [loading, setLoading] = React.useState(false);
 
   const availableNamespacesForCreate = React.useMemo(() => {
-    return [...new Set(kafkaClusters.map(k => k.metadata.namespace))].sort();
+    return getAvailableNamespaces(kafkaClusters);
   }, [kafkaClusters]);
 
   const filteredClusterNames = React.useMemo(() => {
-    if (!formData.namespace) return [];
-    return kafkaClusters
-      .filter(k => k.metadata.namespace === formData.namespace)
-      .map(k => k.metadata.name)
-      .sort();
+    return getFilteredClusterNames(kafkaClusters, formData.namespace);
   }, [kafkaClusters, formData.namespace]);
 
   const handleCreate = async () => {
@@ -183,13 +180,8 @@ export function KafkaTopicList() {
 
   const openCreateDialog = () => {
     const firstNs = availableNamespacesForCreate[0] ?? '';
-    const firstCluster =
-      firstNs && kafkaClusters.length > 0
-        ? kafkaClusters
-            .filter(k => k.metadata.namespace === firstNs)
-            .map(k => k.metadata.name)
-            .sort()[0] ?? ''
-        : '';
+    const clustersInNs = getFilteredClusterNames(kafkaClusters, firstNs);
+    const firstCluster = clustersInNs[0] ?? '';
     setFormData({
       name: '',
       namespace: firstNs,
@@ -278,7 +270,7 @@ export function KafkaTopicList() {
         loading={loading}
         formData={formData}
         setFormData={setFormData}
-        kafkaClusters={kafkaClusters}
+        kafkaClusters={kafkaClusters || []}
         availableNamespacesForCreate={availableNamespacesForCreate}
         filteredClusterNames={filteredClusterNames}
         onCancel={() => {

--- a/strimzi/src/components/KafkaUserList.tsx
+++ b/strimzi/src/components/KafkaUserList.tsx
@@ -15,6 +15,7 @@ import { StrimziNotInstalledMessage } from './StrimziNotInstalledMessage';
 import { SecureSecretDisplay } from './SecureSecretDisplay';
 import { Toast, ToastMessage } from './Toast';
 import { KafkaUserCreateFormModal, type UserFormData } from './KafkaUserCreateFormModal';
+import { getAvailableNamespaces, getFilteredClusterNames } from '../utils/clusterHelpers';
 
 export function KafkaUserList() {
   const theme = useTheme();
@@ -43,15 +44,11 @@ export function KafkaUserList() {
   const [loading, setLoading] = React.useState(false);
 
   const availableNamespacesForCreate = React.useMemo(() => {
-    return [...new Set(kafkaClusters.map(k => k.metadata.namespace))].sort();
+    return getAvailableNamespaces(kafkaClusters);
   }, [kafkaClusters]);
 
   const filteredClusterNames = React.useMemo(() => {
-    if (!formData.namespace) return [];
-    return kafkaClusters
-      .filter(k => k.metadata.namespace === formData.namespace)
-      .map(k => k.metadata.name)
-      .sort();
+    return getFilteredClusterNames(kafkaClusters, formData.namespace);
   }, [kafkaClusters, formData.namespace]);
 
   const fetchUserSecret = async (user: KafkaUserInterface) => {
@@ -174,13 +171,8 @@ export function KafkaUserList() {
 
   const openCreateDialog = () => {
     const firstNs = availableNamespacesForCreate[0] ?? '';
-    const firstCluster =
-      firstNs && kafkaClusters.length > 0
-        ? kafkaClusters
-            .filter(k => k.metadata.namespace === firstNs)
-            .map(k => k.metadata.name)
-            .sort()[0] ?? ''
-        : '';
+    const clustersInNs = getFilteredClusterNames(kafkaClusters, firstNs);
+    const firstCluster = clustersInNs[0] ?? '';
     setFormData({
       name: '',
       namespace: firstNs,
@@ -293,7 +285,7 @@ export function KafkaUserList() {
         loading={loading}
         formData={formData}
         setFormData={setFormData}
-        kafkaClusters={kafkaClusters}
+        kafkaClusters={kafkaClusters || []}
         availableNamespacesForCreate={availableNamespacesForCreate}
         filteredClusterNames={filteredClusterNames}
         onCancel={() => {

--- a/strimzi/src/utils/clusterHelpers.test.ts
+++ b/strimzi/src/utils/clusterHelpers.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { getAvailableNamespaces, getFilteredClusterNames, type ClusterLike } from './clusterHelpers';
+
+describe('clusterHelpers', () => {
+  describe('getAvailableNamespaces', () => {
+    it('returns empty array when clusters list is null or undefined', () => {
+      expect(getAvailableNamespaces(null)).toEqual([]);
+      expect(getAvailableNamespaces(undefined)).toEqual([]);
+    });
+
+    it('returns empty array when clusters list is empty', () => {
+      expect(getAvailableNamespaces([])).toEqual([]);
+    });
+
+    it('extracts, deduplicates, and sorts namespaces', () => {
+      const mockClusters: ClusterLike[] = [
+        { metadata: { name: 'c1', namespace: 'prod' } },
+        { metadata: { name: 'c2', namespace: 'dev' } },
+        { metadata: { name: 'c3', namespace: 'prod' } },
+        { metadata: { name: 'c4', namespace: 'staging' } },
+      ];
+
+      expect(getAvailableNamespaces(mockClusters)).toEqual(['dev', 'prod', 'staging']);
+    });
+
+    it('ignores empty, missing, or non-string namespaces', () => {
+      const mockClusters: ClusterLike[] = [
+        { metadata: { name: 'c1', namespace: '' } },
+        { metadata: { name: 'c2', namespace: undefined } },
+        { metadata: { name: 'c3', namespace: 'prod' } },
+      ];
+
+      expect(getAvailableNamespaces(mockClusters)).toEqual(['prod']);
+    });
+  });
+
+  describe('getFilteredClusterNames', () => {
+    it('returns empty array when clusters list is null, undefined, or empty', () => {
+      expect(getFilteredClusterNames(null, 'default')).toEqual([]);
+      expect(getFilteredClusterNames(undefined, 'default')).toEqual([]);
+      expect(getFilteredClusterNames([], 'default')).toEqual([]);
+    });
+
+    it('returns empty array when namespace is null, undefined, or empty', () => {
+      const mockClusters: ClusterLike[] = [{ metadata: { name: 'c1', namespace: 'prod' } }];
+      expect(getFilteredClusterNames(mockClusters, null)).toEqual([]);
+      expect(getFilteredClusterNames(mockClusters, undefined)).toEqual([]);
+      expect(getFilteredClusterNames(mockClusters, '')).toEqual([]);
+    });
+
+    it('filters clusters by namespace and returns sorted names', () => {
+      const mockClusters: ClusterLike[] = [
+        { metadata: { name: 'cluster-z', namespace: 'prod' } },
+        { metadata: { name: 'cluster-a', namespace: 'prod' } },
+        { metadata: { name: 'cluster-b', namespace: 'dev' } },
+      ];
+
+      expect(getFilteredClusterNames(mockClusters, 'prod')).toEqual(['cluster-a', 'cluster-z']);
+      expect(getFilteredClusterNames(mockClusters, 'dev')).toEqual(['cluster-b']);
+      expect(getFilteredClusterNames(mockClusters, 'nonexistent')).toEqual([]);
+    });
+
+    it('ignores empty or missing names', () => {
+      const mockClusters: ClusterLike[] = [
+        { metadata: { name: '', namespace: 'prod' } },
+        { metadata: { name: 'c2', namespace: 'prod' } },
+      ];
+
+      expect(getFilteredClusterNames(mockClusters, 'prod')).toEqual(['c2']);
+    });
+  });
+});

--- a/strimzi/src/utils/clusterHelpers.ts
+++ b/strimzi/src/utils/clusterHelpers.ts
@@ -1,0 +1,34 @@
+export interface ClusterLike {
+  metadata: {
+    name: string;
+    namespace?: string;
+  };
+}
+
+/**
+ * Extracts and sorts unique namespaces from a list of Kafka clusters.
+ * Safely handles null/undefined inputs.
+ */
+export function getAvailableNamespaces(clusters: ClusterLike[] | null | undefined): string[] {
+  if (!clusters) return [];
+  const namespaces = clusters
+    .map(k => k.metadata.namespace)
+    .filter((ns): ns is string => typeof ns === 'string' && ns !== '');
+  return [...new Set(namespaces)].sort();
+}
+
+/**
+ * Filters Kafka clusters by namespace and returns their sorted names.
+ * Safely handles null/undefined inputs.
+ */
+export function getFilteredClusterNames(
+  clusters: ClusterLike[] | null | undefined,
+  namespace: string | null | undefined
+): string[] {
+  if (!clusters || !namespace) return [];
+  return clusters
+    .filter(k => k.metadata.namespace === namespace)
+    .map(k => k.metadata.name)
+    .filter((name): name is string => typeof name === 'string' && name !== '')
+    .sort();
+}


### PR DESCRIPTION
### Overview
This PR resolves issue #839 ("strimzi: support v1 resources"), which causes the Strimzi plugin to crash immediately on modern Kubernetes environments running Strimzi 1.0+.

---

### The Problem
Strimzi v1.0.0 promoted all custom resources to `v1` and retired the `v1beta2` API group. 

In `KafkaTopicList.tsx` and `KafkaUserList.tsx`, the component queries the cluster using `KafkaClass.useList({})` to retrieve cluster names/namespaces. 
* While the API version discovery probe (`useStrimziApiVersions`) is resolving in flight, the components default to querying the `v1beta2` endpoint.
* On a `v1`-only cluster, this request returns a 404 error, and `useList` returns `null` for `kafkaClusters` while loading/handling the error.
* The components immediately call `.map()` and `.filter()` in `useMemo` hooks (like `availableNamespacesForCreate` and `filteredClusterNames`), and `.length` in `openCreateDialog` without guarding against `null`.
* This causes Headlamp to throw `TypeError: Cannot read properties of null` and crash the UI before the version probe completes.

---

### Technical Solution
Instead of writing inline fallback statements directly inside the components, I decoupled the namespace and cluster name retrieval logic into a clean, testable utility module:

1. **Created `utils/clusterHelpers.ts`**:
   * **`getAvailableNamespaces`**: Extracts, deduplicates, and sorts unique namespaces from cluster lists.
   * **`getFilteredClusterNames`**: Filters clusters by namespace and returns sorted names.
   * Both functions explicitly check for and safely handle `null`/`undefined`/empty arrays, returning `[]` rather than throwing.
2. **Integrated Helpers**:
   * Refactored `KafkaTopicList.tsx` and `KafkaUserList.tsx` to use these helpers inside `useMemo` hooks and when opening dialogs.
   * Passed `kafkaClusters={kafkaClusters || []}` to the modal components to guarantee prop type safety inside form modals.
3. **Added Unit Tests (`utils/clusterHelpers.test.ts`)**:
   * Added test coverage for these helper functions verifying edge cases (including null inputs, missing values, duplicates, and sorting logic).

---

### Verification and Quality Checks
I ran the full validation pipeline locally inside the `strimzi` plugin directory:
* **Unit Tests**: All 73 tests passed successfully (`npx vitest run --globals`).
* **Type Safety**: Verified zero TypeScript errors (`npx tsc --noEmit`).
* **Linting**: Verified zero ESLint errors or warnings (`npx eslint src --ext .ts,.tsx`).
* **Production Build**: Bundled successfully (`npx headlamp-plugin build`).