### PR TITLE
metal3: Add Metal3Cluster and Metal3ClusterTemplate views

### DIFF
--- a/metal3/src/Metal3Cluster/Details.tsx
+++ b/metal3/src/Metal3Cluster/Details.tsx
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DetailsGrid } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { useParams } from 'react-router-dom';
+import { CRDGuard } from '../common/CRDGuard';
+import { metal3ClusterClass } from './List';
+
+/** Label Cluster API stamps on a resource to record its owning cluster. */
+const CLUSTER_NAME_LABEL = 'cluster.x-k8s.io/cluster-name';
+
+/**
+ * Detail view for a single Metal3Cluster.
+ *
+ * A Metal3Cluster is the Metal3 (infrastructure) side of a Cluster API Cluster;
+ * it carries the control plane endpoint and reports whether the cluster
+ * infrastructure is provisioned. `DetailsGrid` renders the standard metadata and
+ * Events; the `extraInfo` callback surfaces the cluster-level fields.
+ *
+ * @param props.name - Cluster name; falls back to the `:name` route param.
+ * @param props.namespace - Cluster namespace; falls back to the `:namespace` route param.
+ */
+export function Metal3ClusterDetail(props: { name?: string; namespace?: string }) {
+  const params = useParams<{ name: string; namespace: string }>();
+  const { name = params.name, namespace = params.namespace } = props;
+
+  return (
+    <CRDGuard
+      crdName="metal3clusters.infrastructure.cluster.x-k8s.io"
+      resourceLabel="Metal3 Cluster"
+    >
+      <DetailsGrid
+        resourceType={metal3ClusterClass()}
+        name={name}
+        namespace={namespace}
+        withEvents
+        extraInfo={(item: any) =>
+          item && [
+            {
+              name: 'Provisioned',
+              value:
+                item.jsonData.status?.initialization?.provisioned === undefined
+                  ? 'Unknown'
+                  : item.jsonData.status.initialization.provisioned
+                  ? 'Yes'
+                  : 'No',
+            },
+            {
+              name: 'Control Plane Endpoint',
+              value: (() => {
+                const ep = item.jsonData.spec?.controlPlaneEndpoint;
+                return ep?.host
+                  ? typeof ep.port === 'number'
+                    ? `${ep.host}:${ep.port}`
+                    : ep.host
+                  : '-';
+              })(),
+            },
+            {
+              name: 'Cluster',
+              value: item.jsonData.metadata?.labels?.[CLUSTER_NAME_LABEL] || '-',
+            },
+            {
+              name: 'Cloud Provider Enabled',
+              value: (() => {
+                const enabled = item.jsonData.spec?.cloudProviderEnabled;
+                return enabled === undefined ? '-' : enabled ? 'Yes' : 'No';
+              })(),
+            },
+          ]
+        }
+      />
+    </CRDGuard>
+  );
+}

--- a/metal3/src/Metal3Cluster/List.tsx
+++ b/metal3/src/Metal3Cluster/List.tsx
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ResourceListView } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { StatusLabel } from '@kinvolk/headlamp-plugin/lib/components/common';
+import type { KubeObject } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import { makeCustomResourceClass } from '@kinvolk/headlamp-plugin/lib/lib/k8s/crd';
+import { CRDGuard } from '../common/CRDGuard';
+
+/** Label Cluster API stamps on a resource to record its owning cluster. */
+const CLUSTER_NAME_LABEL = 'cluster.x-k8s.io/cluster-name';
+
+/** Defines the Metal3Cluster custom resource (group/version/kind) for the plugin. */
+export function metal3ClusterClass() {
+  const group = 'infrastructure.cluster.x-k8s.io';
+  const version = 'v1beta2';
+  const Metal3Cluster = makeCustomResourceClass({
+    apiInfo: [{ group, version }],
+    kind: 'Metal3Cluster',
+    pluralName: 'metal3clusters',
+    singularName: 'Metal3Cluster',
+    isNamespaced: true,
+  });
+
+  // Links the Name column to the detail route.
+  return class extendedMetal3ClusterClass extends Metal3Cluster {
+    static get detailsRoute() {
+      return 'metal3cluster-detail';
+    }
+  };
+}
+
+/** List view for Metal3Cluster resources, guarded by CRD presence. */
+export function Metal3Clusters() {
+  return (
+    <CRDGuard
+      crdName="metal3clusters.infrastructure.cluster.x-k8s.io"
+      resourceLabel="Metal3 Cluster"
+    >
+      <ResourceListView
+        title="Metal3 Clusters"
+        resourceClass={metal3ClusterClass()}
+        columns={[
+          'name',
+          'namespace',
+          {
+            id: 'provisioned',
+            label: 'Provisioned',
+            // An absent status.initialization.provisioned (no controller yet) is
+            // Unknown, which is distinct from an explicit false.
+            getValue: (c: KubeObject) => {
+              const provisioned = c.jsonData.status?.initialization?.provisioned;
+              return provisioned === undefined ? 'Unknown' : provisioned ? 'Yes' : 'No';
+            },
+            render: (c: KubeObject) => {
+              const provisioned = c.jsonData.status?.initialization?.provisioned;
+              const label = provisioned === undefined ? 'Unknown' : provisioned ? 'Yes' : 'No';
+              // Yes is a success; an explicit No is a warning; Unknown stays neutral.
+              const status =
+                provisioned === true ? 'success' : provisioned === false ? 'warning' : '';
+              return <StatusLabel status={status}>{label}</StatusLabel>;
+            },
+          },
+          {
+            id: 'endpoint',
+            label: 'Control Plane Endpoint',
+            getValue: (c: KubeObject) => {
+              const ep = c.jsonData.spec?.controlPlaneEndpoint;
+              return ep?.host
+                ? typeof ep.port === 'number'
+                  ? `${ep.host}:${ep.port}`
+                  : ep.host
+                : '-';
+            },
+          },
+          {
+            id: 'cluster',
+            label: 'Cluster',
+            getValue: (c: KubeObject) => c.jsonData.metadata?.labels?.[CLUSTER_NAME_LABEL] || '-',
+          },
+          'age',
+        ]}
+      />
+    </CRDGuard>
+  );
+}

--- a/metal3/src/Metal3ClusterTemplate/Details.tsx
+++ b/metal3/src/Metal3ClusterTemplate/Details.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DetailsGrid } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { useParams } from 'react-router-dom';
+import { CRDGuard } from '../common/CRDGuard';
+import { metal3ClusterTemplateClass } from './List';
+
+/**
+ * Detail view for a single Metal3ClusterTemplate.
+ *
+ * A Metal3ClusterTemplate is a blueprint that Cluster API stamps Metal3Clusters
+ * from; its `spec.template.spec` is the embedded cluster spec. `DetailsGrid`
+ * renders the standard metadata and Events; the `extraInfo` callback surfaces the
+ * blueprint's key fields.
+ *
+ * @param props.name - Template name; falls back to the `:name` route param.
+ * @param props.namespace - Template namespace; falls back to the `:namespace` route param.
+ */
+export function Metal3ClusterTemplateDetail(props: { name?: string; namespace?: string }) {
+  const params = useParams<{ name: string; namespace: string }>();
+  const { name = params.name, namespace = params.namespace } = props;
+
+  return (
+    <CRDGuard
+      crdName="metal3clustertemplates.infrastructure.cluster.x-k8s.io"
+      resourceLabel="Metal3 Cluster Template"
+    >
+      <DetailsGrid
+        resourceType={metal3ClusterTemplateClass()}
+        name={name}
+        namespace={namespace}
+        withEvents
+        extraInfo={(item: any) =>
+          item && [
+            {
+              name: 'Cloud Provider Enabled',
+              value: (() => {
+                const enabled = item.jsonData.spec?.template?.spec?.cloudProviderEnabled;
+                return enabled === undefined ? '-' : enabled ? 'Yes' : 'No';
+              })(),
+            },
+          ]
+        }
+      />
+    </CRDGuard>
+  );
+}

--- a/metal3/src/Metal3ClusterTemplate/List.tsx
+++ b/metal3/src/Metal3ClusterTemplate/List.tsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ResourceListView } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import type { KubeObject } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import { makeCustomResourceClass } from '@kinvolk/headlamp-plugin/lib/lib/k8s/crd';
+import { CRDGuard } from '../common/CRDGuard';
+
+/** Defines the Metal3ClusterTemplate custom resource (group/version/kind) for the plugin. */
+export function metal3ClusterTemplateClass() {
+  const group = 'infrastructure.cluster.x-k8s.io';
+  const version = 'v1beta2';
+  const Metal3ClusterTemplate = makeCustomResourceClass({
+    apiInfo: [{ group, version }],
+    kind: 'Metal3ClusterTemplate',
+    pluralName: 'metal3clustertemplates',
+    singularName: 'Metal3ClusterTemplate',
+    isNamespaced: true,
+  });
+
+  return class extendedMetal3ClusterTemplateClass extends Metal3ClusterTemplate {
+    static get detailsRoute() {
+      return 'metal3clustertemplate-detail';
+    }
+  };
+}
+
+/** List view for Metal3ClusterTemplate resources, guarded by CRD presence. */
+export function Metal3ClusterTemplates() {
+  return (
+    <CRDGuard
+      crdName="metal3clustertemplates.infrastructure.cluster.x-k8s.io"
+      resourceLabel="Metal3 Cluster Template"
+    >
+      <ResourceListView
+        title="Metal3 Cluster Templates"
+        resourceClass={metal3ClusterTemplateClass()}
+        columns={[
+          'name',
+          'namespace',
+          {
+            // Cloud provider setting from the embedded cluster spec.
+            id: 'cloudProviderEnabled',
+            label: 'Cloud Provider Enabled',
+            getValue: (t: KubeObject) => {
+              const enabled = t.jsonData.spec?.template?.spec?.cloudProviderEnabled;
+              return enabled === undefined ? '-' : enabled ? 'Yes' : 'No';
+            },
+          },
+          'age',
+        ]}
+      />
+    </CRDGuard>
+  );
+}

--- a/metal3/src/index.tsx
+++ b/metal3/src/index.tsx
@@ -17,6 +17,10 @@
 import { registerRoute, registerSidebarEntry } from '@kinvolk/headlamp-plugin/lib';
 import { BareMetalHostDetail } from './BareMetalHost/Details';
 import { BareMetalHosts } from './BareMetalHost/List';
+import { Metal3ClusterDetail } from './Metal3Cluster/Details';
+import { Metal3Clusters } from './Metal3Cluster/List';
+import { Metal3ClusterTemplateDetail } from './Metal3ClusterTemplate/Details';
+import { Metal3ClusterTemplates } from './Metal3ClusterTemplate/List';
 import { Metal3MachineDetail } from './Metal3Machine/Details';
 import { Metal3Machines } from './Metal3Machine/List';
 import { Metal3MachineTemplateDetail } from './Metal3MachineTemplate/Details';
@@ -99,4 +103,48 @@ registerRoute({
   sidebar: 'metal3machinetemplates',
   component: () => <Metal3MachineTemplateDetail />,
   name: 'metal3machinetemplate-detail',
+});
+
+registerSidebarEntry({
+  parent: 'metal3',
+  name: 'metal3clusters',
+  label: 'Metal3 Clusters',
+  url: '/metal3/metal3clusters',
+});
+
+registerRoute({
+  path: '/metal3/metal3clusters',
+  sidebar: 'metal3clusters',
+  component: Metal3Clusters,
+  name: 'metal3clusters-list',
+  exact: true,
+});
+
+registerRoute({
+  path: '/metal3/metal3clusters/:namespace/:name',
+  sidebar: 'metal3clusters',
+  component: () => <Metal3ClusterDetail />,
+  name: 'metal3cluster-detail',
+});
+
+registerSidebarEntry({
+  parent: 'metal3',
+  name: 'metal3clustertemplates',
+  label: 'Metal3 Cluster Templates',
+  url: '/metal3/metal3clustertemplates',
+});
+
+registerRoute({
+  path: '/metal3/metal3clustertemplates',
+  sidebar: 'metal3clustertemplates',
+  component: Metal3ClusterTemplates,
+  name: 'metal3clustertemplates-list',
+  exact: true,
+});
+
+registerRoute({
+  path: '/metal3/metal3clustertemplates/:namespace/:name',
+  sidebar: 'metal3clustertemplates',
+  component: () => <Metal3ClusterTemplateDetail />,
+  name: 'metal3clustertemplate-detail',
 });

--- a/metal3/test-files/metal3cluster.yaml
+++ b/metal3/test-files/metal3cluster.yaml
@@ -1,0 +1,34 @@
+# Sample Metal3Cluster and Metal3ClusterTemplate for trying out the Metal3 plugin locally.
+#
+#   kubectl apply -f metal3/test-files/metal3cluster.yaml
+#
+# They appear under Metal3 > Metal3 Clusters and Metal3 > Metal3 Cluster Templates.
+# A Metal3Cluster is the Metal3 (infrastructure) side of a Cluster API Cluster and
+# carries the control plane endpoint; a Metal3ClusterTemplate is the blueprint
+# clusters are stamped from. The provisioned status is set by the CAPM3 controller
+# as it reconciles; without a controller running they still list, with an empty
+# status shown as Unknown.
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: Metal3Cluster
+metadata:
+  name: sample-cluster
+  namespace: default
+  labels:
+    cluster.x-k8s.io/cluster-name: sample-cluster
+spec:
+  controlPlaneEndpoint:
+    host: 192.168.1.100
+    port: 6443
+  cloudProviderEnabled: false
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: Metal3ClusterTemplate
+metadata:
+  name: sample-clustertemplate
+  namespace: default
+  labels:
+    cluster.x-k8s.io/cluster-name: sample-cluster
+spec:
+  template:
+    spec:
+      cloudProviderEnabled: false


### PR DESCRIPTION


## Summary

Continues the Metal3 plugin. Adds Metal3Cluster and Metal3ClusterTemplate to the Metal3 section, the CAPM3 resources for the cluster side of a Cluster API cluster on bare metal. More resources and a map view to follow.

## Included

- Metal3Cluster list and detail views with provisioned state, control plane endpoint, and cluster columns.
- Metal3ClusterTemplate list and detail views with the cloud provider setting.
- The Metal3 sidebar group extended with the two new entries.

## How to test

- A cluster with the Metal3 and CAPM3 CRDs installed.
- cd metal3 && npm install && npm start, then run Headlamp.
- Apply the sample: kubectl apply -f metal3/test-files/metal3cluster.yaml.
- Open the Metal3 section: the clusters and templates list, and clicking one opens the detail view.
