### PR TITLE
metal3: Add Metal3Data, Metal3DataClaim, and Metal3DataTemplate views

### DIFF
--- a/metal3/src/Metal3Data/Details.tsx
+++ b/metal3/src/Metal3Data/Details.tsx
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DetailsGrid } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { useParams } from 'react-router-dom';
+import { CRDGuard } from '../common/CRDGuard';
+import { metal3DataClass } from './List';
+
+/**
+ * Detail view for a single Metal3Data.
+ *
+ * A Metal3Data is the rendered per-node metadata and network data produced for a
+ * machine from a Metal3DataTemplate. `DetailsGrid` renders the standard metadata
+ * and Events; the `extraInfo` callback surfaces the rendered-data fields.
+ *
+ * @param props.name - Data name; falls back to the `:name` route param.
+ * @param props.namespace - Data namespace; falls back to the `:namespace` route param.
+ */
+export function Metal3DataDetail(props: { name?: string; namespace?: string }) {
+  const params = useParams<{ name: string; namespace: string }>();
+  const { name = params.name, namespace = params.namespace } = props;
+
+  return (
+    <CRDGuard crdName="metal3datas.infrastructure.cluster.x-k8s.io" resourceLabel="Metal3 Data">
+      <DetailsGrid
+        resourceType={metal3DataClass()}
+        name={name}
+        namespace={namespace}
+        withEvents
+        extraInfo={(item: any) =>
+          item && [
+            {
+              name: 'Ready',
+              value:
+                item.jsonData.status?.ready === undefined
+                  ? 'Unknown'
+                  : item.jsonData.status.ready
+                  ? 'Yes'
+                  : 'No',
+            },
+            {
+              name: 'Index',
+              value:
+                item.jsonData.spec?.index === undefined ? '-' : String(item.jsonData.spec.index),
+            },
+            {
+              name: 'Template',
+              value: item.jsonData.spec?.template?.name || '-',
+            },
+            {
+              name: 'Claim',
+              value: item.jsonData.spec?.claim?.name || '-',
+            },
+            {
+              name: 'Error',
+              value: item.jsonData.status?.errorMessage || '-',
+            },
+          ]
+        }
+      />
+    </CRDGuard>
+  );
+}

--- a/metal3/src/Metal3Data/List.tsx
+++ b/metal3/src/Metal3Data/List.tsx
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ResourceListView } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { StatusLabel } from '@kinvolk/headlamp-plugin/lib/components/common';
+import type { KubeObject } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import { makeCustomResourceClass } from '@kinvolk/headlamp-plugin/lib/lib/k8s/crd';
+import { CRDGuard } from '../common/CRDGuard';
+
+/** Defines the Metal3Data custom resource (group/version/kind) for the plugin. */
+export function metal3DataClass() {
+  const group = 'infrastructure.cluster.x-k8s.io';
+  const version = 'v1beta2';
+  const Metal3Data = makeCustomResourceClass({
+    apiInfo: [{ group, version }],
+    kind: 'Metal3Data',
+    pluralName: 'metal3datas',
+    singularName: 'Metal3Data',
+    isNamespaced: true,
+  });
+
+  return class extendedMetal3DataClass extends Metal3Data {
+    static get detailsRoute() {
+      return 'metal3data-detail';
+    }
+  };
+}
+
+/** List view for Metal3Data resources, guarded by CRD presence. */
+export function Metal3Datas() {
+  return (
+    <CRDGuard crdName="metal3datas.infrastructure.cluster.x-k8s.io" resourceLabel="Metal3 Data">
+      <ResourceListView
+        title="Metal3 Data"
+        resourceClass={metal3DataClass()}
+        columns={[
+          'name',
+          'namespace',
+          {
+            id: 'ready',
+            label: 'Ready',
+            // An absent status.ready (no controller yet) is Unknown, which is
+            // distinct from an explicit false.
+            getValue: (d: KubeObject) => {
+              const ready = d.jsonData.status?.ready;
+              return ready === undefined ? 'Unknown' : ready ? 'Yes' : 'No';
+            },
+            render: (d: KubeObject) => {
+              const ready = d.jsonData.status?.ready;
+              const label = ready === undefined ? 'Unknown' : ready ? 'Yes' : 'No';
+              // Yes is a success; an explicit No is a warning; Unknown stays neutral.
+              const status = ready === true ? 'success' : ready === false ? 'warning' : '';
+              return <StatusLabel status={status}>{label}</StatusLabel>;
+            },
+          },
+          {
+            id: 'index',
+            label: 'Index',
+            getValue: (d: KubeObject) =>
+              d.jsonData.spec?.index === undefined ? '-' : String(d.jsonData.spec.index),
+          },
+          'age',
+        ]}
+      />
+    </CRDGuard>
+  );
+}

--- a/metal3/src/Metal3DataClaim/Details.tsx
+++ b/metal3/src/Metal3DataClaim/Details.tsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DetailsGrid } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { useParams } from 'react-router-dom';
+import { CRDGuard } from '../common/CRDGuard';
+import { metal3DataClaimClass } from './List';
+
+/**
+ * Detail view for a single Metal3DataClaim.
+ *
+ * A Metal3DataClaim requests rendered data from a Metal3DataTemplate, the same
+ * way a storage claim asks for a volume; its status carries the resulting
+ * Metal3Data. `DetailsGrid` renders the standard metadata and Events; the
+ * `extraInfo` callback surfaces the claim fields.
+ *
+ * @param props.name - Claim name; falls back to the `:name` route param.
+ * @param props.namespace - Claim namespace; falls back to the `:namespace` route param.
+ */
+export function Metal3DataClaimDetail(props: { name?: string; namespace?: string }) {
+  const params = useParams<{ name: string; namespace: string }>();
+  const { name = params.name, namespace = params.namespace } = props;
+
+  return (
+    <CRDGuard
+      crdName="metal3dataclaims.infrastructure.cluster.x-k8s.io"
+      resourceLabel="Metal3 Data Claim"
+    >
+      <DetailsGrid
+        resourceType={metal3DataClaimClass()}
+        name={name}
+        namespace={namespace}
+        withEvents
+        extraInfo={(item: any) =>
+          item && [
+            {
+              name: 'Template',
+              value: item.jsonData.spec?.template?.name || '-',
+            },
+            {
+              name: 'Rendered Data',
+              value: item.jsonData.status?.renderedData?.name || '-',
+            },
+            {
+              name: 'Error',
+              value: item.jsonData.status?.errorMessage || '-',
+            },
+          ]
+        }
+      />
+    </CRDGuard>
+  );
+}

--- a/metal3/src/Metal3DataClaim/List.tsx
+++ b/metal3/src/Metal3DataClaim/List.tsx
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ResourceListView } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import type { KubeObject } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import { makeCustomResourceClass } from '@kinvolk/headlamp-plugin/lib/lib/k8s/crd';
+import { CRDGuard } from '../common/CRDGuard';
+
+/** Defines the Metal3DataClaim custom resource (group/version/kind) for the plugin. */
+export function metal3DataClaimClass() {
+  const group = 'infrastructure.cluster.x-k8s.io';
+  const version = 'v1beta2';
+  const Metal3DataClaim = makeCustomResourceClass({
+    apiInfo: [{ group, version }],
+    kind: 'Metal3DataClaim',
+    pluralName: 'metal3dataclaims',
+    singularName: 'Metal3DataClaim',
+    isNamespaced: true,
+  });
+
+  return class extendedMetal3DataClaimClass extends Metal3DataClaim {
+    static get detailsRoute() {
+      return 'metal3dataclaim-detail';
+    }
+  };
+}
+
+/** List view for Metal3DataClaim resources, guarded by CRD presence. */
+export function Metal3DataClaims() {
+  return (
+    <CRDGuard
+      crdName="metal3dataclaims.infrastructure.cluster.x-k8s.io"
+      resourceLabel="Metal3 Data Claim"
+    >
+      <ResourceListView
+        title="Metal3 Data Claims"
+        resourceClass={metal3DataClaimClass()}
+        columns={[
+          'name',
+          'namespace',
+          {
+            // The Metal3Data this claim was bound to, once rendered.
+            id: 'renderedData',
+            label: 'Rendered Data',
+            getValue: (c: KubeObject) => c.jsonData.status?.renderedData?.name || '-',
+          },
+          'age',
+        ]}
+      />
+    </CRDGuard>
+  );
+}

--- a/metal3/src/Metal3DataTemplate/Details.tsx
+++ b/metal3/src/Metal3DataTemplate/Details.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DetailsGrid } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { useParams } from 'react-router-dom';
+import { CRDGuard } from '../common/CRDGuard';
+import { metal3DataTemplateClass } from './List';
+
+/**
+ * Detail view for a single Metal3DataTemplate.
+ *
+ * A Metal3DataTemplate defines the pattern for a node's metadata and network
+ * data, with placeholders filled in per host. `DetailsGrid` renders the standard
+ * metadata and Events; the `extraInfo` callback surfaces the template fields.
+ *
+ * @param props.name - Template name; falls back to the `:name` route param.
+ * @param props.namespace - Template namespace; falls back to the `:namespace` route param.
+ */
+export function Metal3DataTemplateDetail(props: { name?: string; namespace?: string }) {
+  const params = useParams<{ name: string; namespace: string }>();
+  const { name = params.name, namespace = params.namespace } = props;
+
+  return (
+    <CRDGuard
+      crdName="metal3datatemplates.infrastructure.cluster.x-k8s.io"
+      resourceLabel="Metal3 Data Template"
+    >
+      <DetailsGrid
+        resourceType={metal3DataTemplateClass()}
+        name={name}
+        namespace={namespace}
+        withEvents
+        extraInfo={(item: any) =>
+          item && [
+            {
+              name: 'Cluster',
+              value: item.jsonData.spec?.clusterName || '-',
+            },
+            {
+              name: 'Metadata Entries',
+              value: String(
+                item.jsonData.spec?.metaData ? Object.keys(item.jsonData.spec.metaData).length : 0
+              ),
+            },
+          ]
+        }
+      />
+    </CRDGuard>
+  );
+}

--- a/metal3/src/Metal3DataTemplate/List.tsx
+++ b/metal3/src/Metal3DataTemplate/List.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ResourceListView } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import type { KubeObject } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import { makeCustomResourceClass } from '@kinvolk/headlamp-plugin/lib/lib/k8s/crd';
+import { CRDGuard } from '../common/CRDGuard';
+
+/** Defines the Metal3DataTemplate custom resource (group/version/kind) for the plugin. */
+export function metal3DataTemplateClass() {
+  const group = 'infrastructure.cluster.x-k8s.io';
+  const version = 'v1beta2';
+  const Metal3DataTemplate = makeCustomResourceClass({
+    apiInfo: [{ group, version }],
+    kind: 'Metal3DataTemplate',
+    pluralName: 'metal3datatemplates',
+    singularName: 'Metal3DataTemplate',
+    isNamespaced: true,
+  });
+
+  return class extendedMetal3DataTemplateClass extends Metal3DataTemplate {
+    static get detailsRoute() {
+      return 'metal3datatemplate-detail';
+    }
+  };
+}
+
+/** List view for Metal3DataTemplate resources, guarded by CRD presence. */
+export function Metal3DataTemplates() {
+  return (
+    <CRDGuard
+      crdName="metal3datatemplates.infrastructure.cluster.x-k8s.io"
+      resourceLabel="Metal3 Data Template"
+    >
+      <ResourceListView
+        title="Metal3 Data Templates"
+        resourceClass={metal3DataTemplateClass()}
+        columns={[
+          'name',
+          'namespace',
+          {
+            id: 'cluster',
+            label: 'Cluster',
+            getValue: (t: KubeObject) => t.jsonData.spec?.clusterName || '-',
+          },
+          'age',
+        ]}
+      />
+    </CRDGuard>
+  );
+}

--- a/metal3/src/index.tsx
+++ b/metal3/src/index.tsx
@@ -26,6 +26,12 @@ import { Metal3ClusterDetail } from './Metal3Cluster/Details';
 import { Metal3Clusters } from './Metal3Cluster/List';
 import { Metal3ClusterTemplateDetail } from './Metal3ClusterTemplate/Details';
 import { Metal3ClusterTemplates } from './Metal3ClusterTemplate/List';
+import { Metal3DataDetail } from './Metal3Data/Details';
+import { Metal3Datas } from './Metal3Data/List';
+import { Metal3DataClaimDetail } from './Metal3DataClaim/Details';
+import { Metal3DataClaims } from './Metal3DataClaim/List';
+import { Metal3DataTemplateDetail } from './Metal3DataTemplate/Details';
+import { Metal3DataTemplates } from './Metal3DataTemplate/List';
 import { Metal3MachineDetail } from './Metal3Machine/Details';
 import { Metal3Machines } from './Metal3Machine/List';
 import { Metal3MachineTemplateDetail } from './Metal3MachineTemplate/Details';
@@ -152,6 +158,72 @@ registerRoute({
   sidebar: 'metal3clustertemplates',
   component: () => <Metal3ClusterTemplateDetail />,
   name: 'metal3clustertemplate-detail',
+});
+
+registerSidebarEntry({
+  parent: 'metal3',
+  name: 'metal3datas',
+  label: 'Metal3 Data',
+  url: '/metal3/metal3datas',
+});
+
+registerRoute({
+  path: '/metal3/metal3datas',
+  sidebar: 'metal3datas',
+  component: Metal3Datas,
+  name: 'metal3datas-list',
+  exact: true,
+});
+
+registerRoute({
+  path: '/metal3/metal3datas/:namespace/:name',
+  sidebar: 'metal3datas',
+  component: () => <Metal3DataDetail />,
+  name: 'metal3data-detail',
+});
+
+registerSidebarEntry({
+  parent: 'metal3',
+  name: 'metal3dataclaims',
+  label: 'Metal3 Data Claims',
+  url: '/metal3/metal3dataclaims',
+});
+
+registerRoute({
+  path: '/metal3/metal3dataclaims',
+  sidebar: 'metal3dataclaims',
+  component: Metal3DataClaims,
+  name: 'metal3dataclaims-list',
+  exact: true,
+});
+
+registerRoute({
+  path: '/metal3/metal3dataclaims/:namespace/:name',
+  sidebar: 'metal3dataclaims',
+  component: () => <Metal3DataClaimDetail />,
+  name: 'metal3dataclaim-detail',
+});
+
+registerSidebarEntry({
+  parent: 'metal3',
+  name: 'metal3datatemplates',
+  label: 'Metal3 Data Templates',
+  url: '/metal3/metal3datatemplates',
+});
+
+registerRoute({
+  path: '/metal3/metal3datatemplates',
+  sidebar: 'metal3datatemplates',
+  component: Metal3DataTemplates,
+  name: 'metal3datatemplates-list',
+  exact: true,
+});
+
+registerRoute({
+  path: '/metal3/metal3datatemplates/:namespace/:name',
+  sidebar: 'metal3datatemplates',
+  component: () => <Metal3DataTemplateDetail />,
+  name: 'metal3datatemplate-detail',
 });
 
 // Power on/off action on the BareMetalHost detail view. Toggles spec.online.

--- a/metal3/test-files/metal3data.yaml
+++ b/metal3/test-files/metal3data.yaml
@@ -1,0 +1,39 @@
+# Sample Metal3DataTemplate, Metal3DataClaim, and Metal3Data for trying out the plugin locally.
+#
+#   kubectl apply -f metal3/test-files/metal3data.yaml
+#
+# They appear under Metal3 > Metal3 Data, Metal3 Data Claims, and Metal3 Data Templates.
+# A Metal3DataTemplate is the pattern for a node's metadata and network data; a
+# Metal3DataClaim requests rendered data from it; a Metal3Data is the rendered
+# result. The Ready flag and renderedData ref are set by the CAPM3 controller as it
+# reconciles; without a controller running they still list, Ready shown as Unknown.
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: Metal3DataTemplate
+metadata:
+  name: sample-datatemplate
+  namespace: default
+  labels:
+    cluster.x-k8s.io/cluster-name: sample-cluster
+spec:
+  clusterName: sample-cluster
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: Metal3DataClaim
+metadata:
+  name: sample-dataclaim
+  namespace: default
+spec:
+  template:
+    name: sample-datatemplate
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: Metal3Data
+metadata:
+  name: sample-data
+  namespace: default
+spec:
+  index: 0
+  template:
+    name: sample-datatemplate
+  claim:
+    name: sample-dataclaim


### PR DESCRIPTION
Stacked on #899 (which is stacked on #892).

## Summary

Continues the Metal3 plugin. Adds Metal3Data, Metal3DataClaim, and Metal3DataTemplate to the Metal3 section, the CAPM3 resources that render and hand out per-node metadata and network data on bare metal. More resources and a map view to follow.

## Included

- Metal3Data list and detail views with Ready state, index, template and claim links, and error.
- Metal3DataClaim list and detail views with the rendered-data reference.
- Metal3DataTemplate list and detail views with cluster name and metadata.
- The Metal3 sidebar group extended with the three new entries.

## How to test

- A cluster with the Metal3 and CAPM3 CRDs installed.
- cd metal3 && npm install && npm start, then run Headlamp.
- Apply the sample: kubectl apply -f metal3/test-files/metal3data.yaml.
- Open the Metal3 section: the data, data claims, and data templates lists, and clicking one opens the detail view.
