### PR TITLE
metal3: Link BareMetalHost and Metal3Machine details to each other

### DIFF
--- a/metal3/src/BareMetalHost/Details.tsx
+++ b/metal3/src/BareMetalHost/Details.tsx
@@ -15,6 +15,7 @@
  */
 
 import { DetailsGrid } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { Link } from '@kinvolk/headlamp-plugin/lib/components/common';
 import { useParams } from 'react-router-dom';
 import { CRDGuard } from '../common/CRDGuard';
 import { bareMetalHostClass } from './List';
@@ -57,9 +58,25 @@ export function BareMetalHostDetail(props: { name?: string; namespace?: string }
             },
             {
               name: 'Consumer',
-              value: item.jsonData.spec?.consumerRef
-                ? `${item.jsonData.spec.consumerRef.name} (${item.jsonData.spec.consumerRef.kind})`
-                : '-',
+              value: (() => {
+                const ref = item.jsonData.spec?.consumerRef;
+                if (!ref) {
+                  return '-';
+                }
+                const label = `${ref.name} (${ref.kind})`;
+                // Link to the Metal3Machine detail when the consumer is one; other
+                // consumer kinds fall back to plain text.
+                return ref.kind === 'Metal3Machine' ? (
+                  <Link
+                    routeName="metal3machine-detail"
+                    params={{ namespace: ref.namespace || namespace, name: ref.name }}
+                  >
+                    {label}
+                  </Link>
+                ) : (
+                  label
+                );
+              })(),
             },
             {
               name: 'Power State',

--- a/metal3/src/Metal3Machine/Details.tsx
+++ b/metal3/src/Metal3Machine/Details.tsx
@@ -15,15 +15,14 @@
  */
 
 import { DetailsGrid } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { Link } from '@kinvolk/headlamp-plugin/lib/components/common';
 import { useParams } from 'react-router-dom';
 import { CRDGuard } from '../common/CRDGuard';
+import { HOST_ANNOTATION, parseHostAnnotation } from './hostAnnotation';
 import { metal3MachineClass } from './List';
 
 /** Label Cluster API stamps on a Metal3Machine to record its owning cluster. */
 const CLUSTER_NAME_LABEL = 'cluster.x-k8s.io/cluster-name';
-
-/** Annotation that links a Metal3Machine back to the BareMetalHost it claimed. */
-const HOST_ANNOTATION = 'metal3.io/BareMetalHost';
 
 /**
  * Detail view for a single Metal3Machine.
@@ -75,7 +74,22 @@ export function Metal3MachineDetail(props: { name?: string; namespace?: string }
             },
             {
               name: 'BareMetalHost',
-              value: item.jsonData.metadata?.annotations?.[HOST_ANNOTATION] || '-',
+              value: (() => {
+                const raw = item.jsonData.metadata?.annotations?.[HOST_ANNOTATION];
+                const host = parseHostAnnotation(raw);
+                // Link to the host's detail when the annotation is a well-formed
+                // namespace/name; otherwise fall back to the raw value or "-".
+                return host ? (
+                  <Link
+                    routeName="baremetalhost-detail"
+                    params={{ namespace: host.namespace, name: host.name }}
+                  >
+                    {host.name}
+                  </Link>
+                ) : (
+                  raw || '-'
+                );
+              })(),
             },
           ]
         }

--- a/metal3/src/Metal3Machine/hostAnnotation.test.ts
+++ b/metal3/src/Metal3Machine/hostAnnotation.test.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { parseHostAnnotation } from './hostAnnotation';
+
+describe('parseHostAnnotation', () => {
+  it('returns null when the value is absent', () => {
+    expect(parseHostAnnotation(undefined)).toBeNull();
+    expect(parseHostAnnotation('')).toBeNull();
+  });
+
+  it('parses a namespace/name pair', () => {
+    expect(parseHostAnnotation('metal3/host-03-degraded')).toEqual({
+      namespace: 'metal3',
+      name: 'host-03-degraded',
+    });
+  });
+
+  it('returns null when the namespace or name is missing', () => {
+    expect(parseHostAnnotation('host-03-degraded')).toBeNull();
+    expect(parseHostAnnotation('metal3/')).toBeNull();
+    expect(parseHostAnnotation('/host-03-degraded')).toBeNull();
+  });
+
+  it('returns null when there are extra path segments', () => {
+    expect(parseHostAnnotation('a/b/c')).toBeNull();
+  });
+});

--- a/metal3/src/Metal3Machine/hostAnnotation.ts
+++ b/metal3/src/Metal3Machine/hostAnnotation.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Annotation the provider writes on a Metal3Machine to record the BareMetalHost it claimed. */
+export const HOST_ANNOTATION = 'metal3.io/BareMetalHost';
+
+/**
+ * Parses the `metal3.io/BareMetalHost` annotation, which stores the claimed host as
+ * `"namespace/name"`, into its parts. Returns `null` when the value is absent or is
+ * not a well-formed `namespace/name` pair, so callers can fall back to plain text.
+ *
+ * @param value - The raw annotation value, if present.
+ * @returns `{ namespace, name }`, or `null` when it cannot be parsed.
+ */
+export function parseHostAnnotation(value?: string): { namespace: string; name: string } | null {
+  if (!value) {
+    return null;
+  }
+  const [namespace, name, ...rest] = value.split('/');
+  if (!namespace || !name || rest.length > 0) {
+    return null;
+  }
+  return { namespace, name };
+}


### PR DESCRIPTION
## Summary

Makes the link between a BareMetalHost and its Metal3Machine clickable in the detail views. A host is consumed by a machine, and the machine records which host it claimed, so this lets you click straight from one to the other instead of copying a name and searching for it. First piece of the resource chain.

## Included

- On the BareMetalHost detail, the Consumer field links to its Metal3Machine when the consumer is one; other consumer kinds stay plain text.
- On the Metal3Machine detail, the BareMetalHost field links to the host it claimed, read from the metal3.io/BareMetalHost annotation.
- A small parseHostAnnotation helper with unit tests for the "namespace/name" parsing.

## How to test

- A cluster with the Metal3 and CAPM3 CRDs installed, a host with a consumerRef pointing at a Metal3Machine, and that machine carrying the metal3.io/BareMetalHost annotation.
- cd metal3 && npm install && npm start, then run Headlamp.
- Open a BareMetalHost that has a consumer, click the Consumer link to reach its Metal3Machine, then click that machine's BareMetalHost link back.
