### PR TITLE
metal3: Add Metal3Remediation and Metal3RemediationTemplate views

### DIFF
--- a/metal3/src/Metal3Remediation/Details.tsx
+++ b/metal3/src/Metal3Remediation/Details.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DetailsGrid } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { useParams } from 'react-router-dom';
+import { CRDGuard } from '../common/CRDGuard';
+import { metal3RemediationClass } from './List';
+
+/**
+ * Detail view for a single Metal3Remediation.
+ *
+ * A Metal3Remediation drives the repair of an unhealthy machine, usually by
+ * rebooting or reprovisioning the host, according to its strategy. `DetailsGrid`
+ * renders the standard metadata and Events; the `extraInfo` callback surfaces the
+ * strategy and retry state.
+ *
+ * @param props.name - Remediation name; falls back to the `:name` route param.
+ * @param props.namespace - Remediation namespace; falls back to the `:namespace` route param.
+ */
+export function Metal3RemediationDetail(props: { name?: string; namespace?: string }) {
+  const params = useParams<{ name: string; namespace: string }>();
+  const { name = params.name, namespace = params.namespace } = props;
+
+  return (
+    <CRDGuard
+      crdName="metal3remediations.infrastructure.cluster.x-k8s.io"
+      resourceLabel="Metal3 Remediation"
+    >
+      <DetailsGrid
+        resourceType={metal3RemediationClass()}
+        name={name}
+        namespace={namespace}
+        withEvents
+        extraInfo={(item: any) =>
+          item && [
+            {
+              name: 'Phase',
+              value: item.jsonData.status?.phase || '-',
+            },
+            {
+              name: 'Strategy',
+              value: item.jsonData.spec?.strategy?.type || '-',
+            },
+            {
+              name: 'Retry Limit',
+              value:
+                item.jsonData.spec?.strategy?.retryLimit === undefined
+                  ? '-'
+                  : String(item.jsonData.spec.strategy.retryLimit),
+            },
+            {
+              name: 'Retry Count',
+              value: String(item.jsonData.status?.retryCount ?? 0),
+            },
+            {
+              name: 'Last Remediated',
+              value: item.jsonData.status?.lastRemediated || '-',
+            },
+          ]
+        }
+      />
+    </CRDGuard>
+  );
+}

--- a/metal3/src/Metal3Remediation/Details.tsx
+++ b/metal3/src/Metal3Remediation/Details.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The Kubernetes Authors
+ * Copyright 2026 The Kubernetes Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metal3/src/Metal3Remediation/List.tsx
+++ b/metal3/src/Metal3Remediation/List.tsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ResourceListView } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import type { KubeObject } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import { makeCustomResourceClass } from '@kinvolk/headlamp-plugin/lib/lib/k8s/crd';
+import { CRDGuard } from '../common/CRDGuard';
+
+/** Defines the Metal3Remediation custom resource (group/version/kind) for the plugin. */
+export function metal3RemediationClass() {
+  const group = 'infrastructure.cluster.x-k8s.io';
+  const version = 'v1beta2';
+  const Metal3Remediation = makeCustomResourceClass({
+    apiInfo: [{ group, version }],
+    kind: 'Metal3Remediation',
+    pluralName: 'metal3remediations',
+    singularName: 'Metal3Remediation',
+    isNamespaced: true,
+  });
+
+  return class extendedMetal3RemediationClass extends Metal3Remediation {
+    static get detailsRoute() {
+      return 'metal3remediation-detail';
+    }
+  };
+}
+
+/** List view for Metal3Remediation resources, guarded by CRD presence. */
+export function Metal3Remediations() {
+  return (
+    <CRDGuard
+      crdName="metal3remediations.infrastructure.cluster.x-k8s.io"
+      resourceLabel="Metal3 Remediation"
+    >
+      <ResourceListView
+        title="Metal3 Remediations"
+        resourceClass={metal3RemediationClass()}
+        columns={[
+          'name',
+          'namespace',
+          {
+            id: 'phase',
+            label: 'Phase',
+            getValue: (r: KubeObject) => r.jsonData.status?.phase || '-',
+          },
+          {
+            id: 'strategy',
+            label: 'Strategy',
+            getValue: (r: KubeObject) => r.jsonData.spec?.strategy?.type || '-',
+          },
+          {
+            // Retry progress as count / limit.
+            id: 'retry',
+            label: 'Retries',
+            getValue: (r: KubeObject) => {
+              const count = r.jsonData.status?.retryCount ?? 0;
+              const limit = r.jsonData.spec?.strategy?.retryLimit;
+              return limit === undefined ? String(count) : `${count} / ${limit}`;
+            },
+          },
+          'age',
+        ]}
+      />
+    </CRDGuard>
+  );
+}

--- a/metal3/src/Metal3Remediation/List.tsx
+++ b/metal3/src/Metal3Remediation/List.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The Kubernetes Authors
+ * Copyright 2026 The Kubernetes Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metal3/src/Metal3RemediationTemplate/Details.tsx
+++ b/metal3/src/Metal3RemediationTemplate/Details.tsx
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DetailsGrid } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { useParams } from 'react-router-dom';
+import { CRDGuard } from '../common/CRDGuard';
+import { metal3RemediationTemplateClass } from './List';
+
+/**
+ * Detail view for a single Metal3RemediationTemplate.
+ *
+ * A Metal3RemediationTemplate is a blueprint that defines the remediation
+ * strategy Metal3Remediations are stamped from; its `spec.template.spec` is the
+ * embedded remediation spec. `DetailsGrid` renders the standard metadata and
+ * Events; the `extraInfo` callback surfaces the strategy.
+ *
+ * @param props.name - Template name; falls back to the `:name` route param.
+ * @param props.namespace - Template namespace; falls back to the `:namespace` route param.
+ */
+export function Metal3RemediationTemplateDetail(props: { name?: string; namespace?: string }) {
+  const params = useParams<{ name: string; namespace: string }>();
+  const { name = params.name, namespace = params.namespace } = props;
+
+  return (
+    <CRDGuard
+      crdName="metal3remediationtemplates.infrastructure.cluster.x-k8s.io"
+      resourceLabel="Metal3 Remediation Template"
+    >
+      <DetailsGrid
+        resourceType={metal3RemediationTemplateClass()}
+        name={name}
+        namespace={namespace}
+        withEvents
+        extraInfo={(item: any) => {
+          const strategy = item?.jsonData.spec?.template?.spec?.strategy;
+          return (
+            item && [
+              {
+                name: 'Strategy',
+                value: strategy?.type || '-',
+              },
+              {
+                name: 'Retry Limit',
+                value: strategy?.retryLimit === undefined ? '-' : String(strategy.retryLimit),
+              },
+            ]
+          );
+        }}
+      />
+    </CRDGuard>
+  );
+}

--- a/metal3/src/Metal3RemediationTemplate/Details.tsx
+++ b/metal3/src/Metal3RemediationTemplate/Details.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The Kubernetes Authors
+ * Copyright 2026 The Kubernetes Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metal3/src/Metal3RemediationTemplate/List.tsx
+++ b/metal3/src/Metal3RemediationTemplate/List.tsx
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ResourceListView } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import type { KubeObject } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import { makeCustomResourceClass } from '@kinvolk/headlamp-plugin/lib/lib/k8s/crd';
+import { CRDGuard } from '../common/CRDGuard';
+
+/** Defines the Metal3RemediationTemplate custom resource (group/version/kind) for the plugin. */
+export function metal3RemediationTemplateClass() {
+  const group = 'infrastructure.cluster.x-k8s.io';
+  const version = 'v1beta2';
+  const Metal3RemediationTemplate = makeCustomResourceClass({
+    apiInfo: [{ group, version }],
+    kind: 'Metal3RemediationTemplate',
+    pluralName: 'metal3remediationtemplates',
+    singularName: 'Metal3RemediationTemplate',
+    isNamespaced: true,
+  });
+
+  return class extendedMetal3RemediationTemplateClass extends Metal3RemediationTemplate {
+    static get detailsRoute() {
+      return 'metal3remediationtemplate-detail';
+    }
+  };
+}
+
+/** List view for Metal3RemediationTemplate resources, guarded by CRD presence. */
+export function Metal3RemediationTemplates() {
+  return (
+    <CRDGuard
+      crdName="metal3remediationtemplates.infrastructure.cluster.x-k8s.io"
+      resourceLabel="Metal3 Remediation Template"
+    >
+      <ResourceListView
+        title="Metal3 Remediation Templates"
+        resourceClass={metal3RemediationTemplateClass()}
+        columns={[
+          'name',
+          'namespace',
+          {
+            // Remediation strategy from the embedded remediation spec.
+            id: 'strategy',
+            label: 'Strategy',
+            getValue: (t: KubeObject) => t.jsonData.spec?.template?.spec?.strategy?.type || '-',
+          },
+          'age',
+        ]}
+      />
+    </CRDGuard>
+  );
+}

--- a/metal3/src/Metal3RemediationTemplate/List.tsx
+++ b/metal3/src/Metal3RemediationTemplate/List.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The Kubernetes Authors
+ * Copyright 2026 The Kubernetes Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metal3/src/index.tsx
+++ b/metal3/src/index.tsx
@@ -36,6 +36,10 @@ import { Metal3MachineDetail } from './Metal3Machine/Details';
 import { Metal3Machines } from './Metal3Machine/List';
 import { Metal3MachineTemplateDetail } from './Metal3MachineTemplate/Details';
 import { Metal3MachineTemplates } from './Metal3MachineTemplate/List';
+import { Metal3RemediationDetail } from './Metal3Remediation/Details';
+import { Metal3Remediations } from './Metal3Remediation/List';
+import { Metal3RemediationTemplateDetail } from './Metal3RemediationTemplate/Details';
+import { Metal3RemediationTemplates } from './Metal3RemediationTemplate/List';
 
 // Parent Metal3 group. Its url points at the first child's list so the group
 // header is itself navigable.
@@ -224,6 +228,50 @@ registerRoute({
   sidebar: 'metal3datatemplates',
   component: () => <Metal3DataTemplateDetail />,
   name: 'metal3datatemplate-detail',
+});
+
+registerSidebarEntry({
+  parent: 'metal3',
+  name: 'metal3remediations',
+  label: 'Metal3 Remediations',
+  url: '/metal3/metal3remediations',
+});
+
+registerRoute({
+  path: '/metal3/metal3remediations',
+  sidebar: 'metal3remediations',
+  component: Metal3Remediations,
+  name: 'metal3remediations-list',
+  exact: true,
+});
+
+registerRoute({
+  path: '/metal3/metal3remediations/:namespace/:name',
+  sidebar: 'metal3remediations',
+  component: () => <Metal3RemediationDetail />,
+  name: 'metal3remediation-detail',
+});
+
+registerSidebarEntry({
+  parent: 'metal3',
+  name: 'metal3remediationtemplates',
+  label: 'Metal3 Remediation Templates',
+  url: '/metal3/metal3remediationtemplates',
+});
+
+registerRoute({
+  path: '/metal3/metal3remediationtemplates',
+  sidebar: 'metal3remediationtemplates',
+  component: Metal3RemediationTemplates,
+  name: 'metal3remediationtemplates-list',
+  exact: true,
+});
+
+registerRoute({
+  path: '/metal3/metal3remediationtemplates/:namespace/:name',
+  sidebar: 'metal3remediationtemplates',
+  component: () => <Metal3RemediationTemplateDetail />,
+  name: 'metal3remediationtemplate-detail',
 });
 
 // Power on/off action on the BareMetalHost detail view. Toggles spec.online.

--- a/metal3/test-files/metal3remediation.yaml
+++ b/metal3/test-files/metal3remediation.yaml
@@ -1,0 +1,29 @@
+# Sample Metal3Remediation and Metal3RemediationTemplate for trying out the plugin locally.
+#
+#   kubectl apply -f metal3/test-files/metal3remediation.yaml
+#
+# They appear under Metal3 > Metal3 Remediations and Metal3 Remediation Templates.
+# A Metal3RemediationTemplate is the blueprint remediations are stamped from; a
+# Metal3Remediation drives the repair of an unhealthy machine per its strategy.
+# The phase and retry count are set by the CAPM3 controller as it reconciles.
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: Metal3RemediationTemplate
+metadata:
+  name: sample-remediationtemplate
+  namespace: default
+spec:
+  template:
+    spec:
+      strategy:
+        type: Reboot
+        retryLimit: 3
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: Metal3Remediation
+metadata:
+  name: sample-remediation
+  namespace: default
+spec:
+  strategy:
+    type: Reboot
+    retryLimit: 3


### PR DESCRIPTION
## Summary

Adds Metal3Remediation and Metal3RemediationTemplate to the Metal3 section, the CAPM3 resources that drive repair of an unhealthy machine according to a strategy, and the blueprint those are stamped from. This finishes the CAPM3 resource views; the map view and mutating actions come next.

## Included

- Metal3Remediation list and detail views with phase, strategy, and retry progress.
- Metal3RemediationTemplate list and detail views with the strategy.
- The Metal3 sidebar group extended with the two new entries.

## How to test

- A cluster with the Metal3 and CAPM3 CRDs installed.
- cd metal3 && npm install && npm start, then run Headlamp.
- Apply the sample: kubectl apply -f metal3/test-files/metal3remediation.yaml.
- Open the Metal3 section: the remediations and remediation templates list, and clicking one opens the detail view.
