### PR TITLE
argocd: Add CRD guard, RBAC-aware actions, AppProject views, and enhanced Application detail

### DIFF
--- a/argocd/README.md
+++ b/argocd/README.md
@@ -4,6 +4,30 @@ This is a Headlamp plugin created for the LFX Mentorship project to integrate Ar
 
 To learn more about Argo CD, see the [Argo CD Getting Started Guide](https://argo-cd.readthedocs.io/en/stable/getting_started/).
 
+## Features
+
+- **Application List View** — Lists all Argo CD `Application` resources in the cluster with columns for project, source repo, target revision, sync status, and health status (rendered as color-coded badges).
+- **Application Detail View** — Displays detailed metadata for a single Application: project, source, destination, sync status, health status, and Kubernetes events.
+- **Sync Action** — Triggers a sync by patching the Application's `.operation` field via the Kubernetes API. The Argo CD application-controller picks this up exactly as it would from the Argo CD UI.
+- **Refresh Action** — Requests a refresh by setting the `argocd.argoproj.io/refresh` annotation (supports `normal` and `hard` refresh types).
+- **Argo CD Sidebar Icon** — Registers the official Argo CD octopus logo as an offline Iconify icon (CSP-safe, no external fetch).
+
+### Why the Kubernetes API instead of the Argo CD REST API?
+
+Headlamp routes all plugin API calls through the Kubernetes apiserver service proxy. The apiserver consumes the `Authorization: Bearer` header for its own auth, so the Argo CD session token can never reach `argocd-server`. The browser also strips the `Cookie` header (a forbidden header in fetch). This makes the Argo CD REST API unreachable from a Headlamp plugin.
+
+Instead, this plugin drives Argo CD the **Kubernetes-native way** — by writing directly to the `Application` custom resource. No Argo CD API token is needed; only standard Kubernetes RBAC permissions apply.
+
+### Behavioral differences from the Argo CD UI
+
+| Behavior | Argo CD UI | This plugin |
+|---|---|---|
+| **Auth** | Argo CD session token (JWT or cookie) | Kubernetes RBAC (same kubeconfig as Headlamp) |
+| **Sync** | REST API `POST /api/v1/applications/{name}/sync` | K8s PATCH on `.operation.sync` field |
+| **Refresh** | REST API `GET` with `?refresh=normal` | K8s PATCH setting `argocd.argoproj.io/refresh` annotation |
+| **Refresh annotation cleanup** | Controller removes the annotation after reconciliation | Same — the controller handles cleanup |
+| **`.operation` field cleanup** | Controller clears `.operation` and writes `.status.operationState` | Same — this is controller-managed |
+
 ## Prerequisites
 
 - Node.js (v20.11.1 or later)
@@ -11,12 +35,22 @@ To learn more about Argo CD, see the [Argo CD Getting Started Guide](https://arg
 - Headlamp running locally (desktop or in-cluster)
 - A local Kubernetes cluster with Argo CD installed
 
-## Goal
+## Required RBAC Permissions
 
-Extend the Projects view to include Argo CD context per project, showing associated Applications with:
-- Sync Status
-- Health Status
-- Current Revision
+The user's Kubernetes role must allow `patch` on `applications.argoproj.io` in the namespace where Argo CD Applications live (usually `argocd`). Example ClusterRole:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: argocd-headlamp-plugin
+rules:
+  - apiGroups: ["argoproj.io"]
+    resources: ["applications"]
+    verbs: ["get", "list", "watch", "patch"]
+```
+
+If the user lacks `patch` permission, the plugin shows a clear error message explaining which RBAC permission is missing.
 
 ## Development
 

--- a/argocd/package-lock.json
+++ b/argocd/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@headlamp-k8s/plugin-argocd",
-  "version": "0.1.0",
+  "name": "@headlamp-k8s/argocd",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@headlamp-k8s/plugin-argocd",
-      "version": "0.1.0",
+      "name": "@headlamp-k8s/argocd",
+      "version": "0.2.0",
       "devDependencies": {
         "@kinvolk/headlamp-plugin": "^0.14.0"
       }

--- a/argocd/package.json
+++ b/argocd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@headlamp-k8s/argocd",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Headlamp plugin for Argo CD GitOps Application Management",
   "author": "Joshna Waikar",
   "scripts": {

--- a/argocd/src/api/argoClient.test.ts
+++ b/argocd/src/api/argoClient.test.ts
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockRequest } = vi.hoisted(() => ({
+  mockRequest: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock('@kinvolk/headlamp-plugin/lib', () => ({
+  ApiProxy: { request: mockRequest },
+  K8s: {
+    cluster: {
+      KubeObject: class KubeObject {
+        jsonData: any;
+        constructor(jsonData: any) {
+          this.jsonData = jsonData;
+        }
+      },
+    },
+  },
+}));
+
+import { refreshApplication, syncApplication } from './argoClient';
+
+describe('argoClient', () => {
+  beforeEach(() => {
+    mockRequest.mockReset().mockResolvedValue({});
+  });
+
+  it('syncApplication sends a merge-patch with .operation.sync', async () => {
+    await syncApplication('guestbook', 'argocd');
+
+    expect(mockRequest).toHaveBeenCalledWith(
+      '/apis/argoproj.io/v1alpha1/namespaces/argocd/applications/guestbook',
+      {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/merge-patch+json' },
+        body: JSON.stringify({
+          operation: {
+            initiatedBy: { username: 'headlamp' },
+            sync: {},
+          },
+        }),
+      }
+    );
+  });
+
+  it('syncApplication accepts a custom revision', async () => {
+    await syncApplication('guestbook', 'argocd', 'main');
+
+    expect(mockRequest).toHaveBeenCalledWith(
+      '/apis/argoproj.io/v1alpha1/namespaces/argocd/applications/guestbook',
+      expect.objectContaining({
+        body: JSON.stringify({
+          operation: {
+            initiatedBy: { username: 'headlamp' },
+            sync: { revision: 'main' },
+          },
+        }),
+      })
+    );
+  });
+
+  it('refreshApplication sends a merge-patch with the refresh annotation', async () => {
+    await refreshApplication('guestbook', 'argocd');
+
+    expect(mockRequest).toHaveBeenCalledWith(
+      '/apis/argoproj.io/v1alpha1/namespaces/argocd/applications/guestbook',
+      {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/merge-patch+json' },
+        body: JSON.stringify({
+          metadata: {
+            annotations: { 'argocd.argoproj.io/refresh': 'normal' },
+          },
+        }),
+      }
+    );
+  });
+
+  it('refreshApplication supports hard refresh', async () => {
+    await refreshApplication('guestbook', 'argocd', 'hard');
+
+    expect(mockRequest).toHaveBeenCalledWith(
+      '/apis/argoproj.io/v1alpha1/namespaces/argocd/applications/guestbook',
+      expect.objectContaining({
+        body: JSON.stringify({
+          metadata: {
+            annotations: { 'argocd.argoproj.io/refresh': 'hard' },
+          },
+        }),
+      })
+    );
+  });
+
+  it('throws a user-friendly RBAC error on 403 Error', async () => {
+    mockRequest.mockRejectedValueOnce(new Error('403 Forbidden'));
+
+    await expect(syncApplication('guestbook', 'argocd')).rejects.toThrow(
+      /Permission denied.*RBAC.*"argocd" namespace/
+    );
+  });
+
+  it('throws a user-friendly RBAC error on { status: 403 } object', async () => {
+    mockRequest.mockRejectedValueOnce({ status: 403, message: 'Forbidden' });
+
+    await expect(syncApplication('guestbook', 'argocd')).rejects.toThrow(
+      /Permission denied.*RBAC.*"argocd" namespace/
+    );
+  });
+
+  it('re-throws non-403 errors unchanged', async () => {
+    mockRequest.mockRejectedValueOnce(new Error('network timeout'));
+
+    await expect(refreshApplication('guestbook', 'argocd')).rejects.toThrow('network timeout');
+  });
+
+  it('does not false-positive on errors with 403 in message but a different status', async () => {
+    mockRequest.mockRejectedValueOnce({ status: 500, message: 'upstream returned 403' });
+
+    await expect(syncApplication('guestbook', 'argocd')).rejects.not.toThrow(/Permission denied/);
+  });
+});

--- a/argocd/src/api/argoClient.ts
+++ b/argocd/src/api/argoClient.ts
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ApiProxy } from '@kinvolk/headlamp-plugin/lib';
+import { argocdApiVersion } from '../resources/application';
+
+const request = ApiProxy.request;
+
+// Why not the Argo CD REST API?
+// -----------------------------
+// The Argo CD REST API cannot be reached from the plugin: Headlamp routes all
+// calls through the Kubernetes apiserver service proxy, which strips the
+// `Authorization: Bearer` header (consumed for its own auth) and the browser
+// strips the `Cookie` header (a forbidden header). So the Argo CD session token
+// can never reach argocd-server. Instead we drive Argo CD the Kubernetes-native
+// way, by writing to the Application custom resource directly — no Argo CD auth
+// needed, just the cluster RBAC the user already has.
+
+const APPLICATIONS_API_ROOT = `/apis/${argocdApiVersion}`;
+
+/** Builds the K8s API path for a single Application custom resource. */
+function applicationPath(name: string, namespace: string): string {
+  return `${APPLICATIONS_API_ROOT}/namespaces/${namespace}/applications/${name}`;
+}
+
+/**
+ * Sends a JSON merge-patch to an Application custom resource via the Kubernetes API.
+ *
+ * @param name - The name of the Argo CD Application to patch.
+ * @param namespace - The namespace where the Application is deployed.
+ * @param patch - The JSON merge-patch object to apply to the Application.
+ * @returns A promise resolving to the API response from the Kubernetes server.
+ */
+async function mergePatchApplication(name: string, namespace: string, patch: object) {
+  try {
+    return await request(applicationPath(name, namespace), {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/merge-patch+json',
+      },
+      body: JSON.stringify(patch),
+    });
+  } catch (err: unknown) {
+    const errObj = typeof err === 'object' && err !== null ? (err as Record<string, unknown>) : {};
+    const status = errObj.status ?? errObj.statusCode;
+    const message =
+      err instanceof Error ? err.message : errObj.message ? String(errObj.message) : String(err);
+
+    // Prefer the structured status code; only fall back to message matching
+    // when the error has no status property, to avoid false positives.
+    const isForbidden = status === 403 || (status === undefined && message.includes('403'));
+
+    if (isForbidden) {
+      throw new Error(
+        `Permission denied: your Kubernetes RBAC role does not allow patching Application ` +
+          `resources in the "${namespace}" namespace. ` +
+          'Ask your cluster admin to grant you patch access to applications.argoproj.io.'
+      );
+    }
+
+    throw err instanceof Error ? err : new Error(message);
+  }
+}
+
+/**
+ * Triggers a sync of an Argo CD Application by setting its `.operation` field.
+ *
+ * The Argo CD application-controller watches this field and runs the sync, just
+ * as it does when the Argo CD UI or CLI initiates one — no Argo CD API auth required.
+ *
+ * When {@link revision} is omitted the `revision` key is left out of the patch
+ * so the controller falls back to `spec.source.targetRevision`, matching the
+ * behaviour of the Argo CD UI.
+ *
+ * @param name - The Application resource name.
+ * @param namespace - The namespace the Application lives in (usually "argocd").
+ * @param revision - Optional Git revision to sync to. When omitted the
+ *   controller resolves the app's configured `targetRevision`.
+ */
+export function syncApplication(name: string, namespace: string, revision?: string) {
+  const sync: Record<string, string> = {};
+  if (revision !== undefined) {
+    sync.revision = revision;
+  }
+  return mergePatchApplication(name, namespace, {
+    operation: {
+      initiatedBy: { username: 'headlamp' },
+      sync,
+    },
+  });
+}
+
+/**
+ * Requests a refresh of an Argo CD Application by setting the refresh annotation.
+ *
+ * The controller reconciles the app against its source when it sees this annotation.
+ *
+ * @param name - The Application resource name.
+ * @param namespace - The namespace the Application lives in (usually "argocd").
+ * @param type - The refresh type: "normal" (default) or "hard".
+ */
+export function refreshApplication(
+  name: string,
+  namespace: string,
+  type: 'normal' | 'hard' = 'normal'
+) {
+  return mergePatchApplication(name, namespace, {
+    metadata: {
+      annotations: {
+        'argocd.argoproj.io/refresh': type,
+      },
+    },
+  });
+}

--- a/argocd/src/components/applications/Detail.tsx
+++ b/argocd/src/components/applications/Detail.tsx
@@ -1,0 +1,258 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  ActionButton,
+  AuthVisible,
+  DetailsGrid,
+  NameValueTable,
+  SectionBox,
+  SimpleTable,
+  StatusLabel,
+} from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { ConditionsTable } from '@kinvolk/headlamp-plugin/lib/components/common';
+import { useParams } from 'react-router-dom';
+import { refreshApplication, syncApplication } from '../../api/argoClient';
+import { useArgoOperation } from '../../hooks/useArgoOperation';
+import { ArgoApplication, ManagedResource } from '../../resources/application';
+import { getHealthStatus, getSyncStatus } from './statusHelpers';
+
+/**
+ * Renders the detail view for an Argo CD Application.
+ *
+ * @param props - The component properties.
+ * @param props.namespace - The namespace of the Argo CD Application. If omitted, parsed from route params.
+ * @param props.name - The name of the Argo CD Application. If omitted, parsed from route params.
+ * @returns The application detail view component.
+ */
+export default function ApplicationDetail(props: { namespace?: string; name?: string }) {
+  const params = useParams<{ namespace: string; name: string }>();
+  const { namespace = params.namespace, name = params.name } = props;
+  const sync = useArgoOperation(syncApplication, 'Sync');
+  const refresh = useArgoOperation(refreshApplication, 'Refresh');
+  const anyLoading = sync.isLoading || refresh.isLoading;
+
+  return (
+    <DetailsGrid
+      resourceType={ArgoApplication}
+      name={name}
+      namespace={namespace}
+      withEvents
+      actions={(app: ArgoApplication) =>
+        app
+          ? [
+              {
+                id: 'argocd-sync',
+                action: (
+                  <AuthVisible item={app} authVerb="patch">
+                    <ActionButton
+                      description={sync.isLoading ? 'Syncing…' : 'Sync'}
+                      icon={sync.isLoading ? 'mdi:loading' : 'mdi:sync'}
+                      onClick={() => sync.execute(app.metadata.name, app.metadata.namespace)}
+                      iconButtonProps={{ disabled: anyLoading }}
+                    />
+                  </AuthVisible>
+                ),
+              },
+              {
+                id: 'argocd-refresh',
+                action: (
+                  <AuthVisible item={app} authVerb="patch">
+                    <ActionButton
+                      description={refresh.isLoading ? 'Refreshing…' : 'Refresh'}
+                      icon={refresh.isLoading ? 'mdi:loading' : 'mdi:refresh'}
+                      onClick={() => refresh.execute(app.metadata.name, app.metadata.namespace)}
+                      iconButtonProps={{ disabled: anyLoading }}
+                    />
+                  </AuthVisible>
+                ),
+              },
+            ]
+          : []
+      }
+      extraInfo={(app: ArgoApplication) =>
+        app
+          ? [
+              {
+                name: 'Project',
+                value: app.project,
+              },
+              ...(app.isMultiSource
+                ? app.sources.flatMap((src, i) => [
+                    { name: `Source ${i + 1} Repo`, value: src.repoURL },
+                    { name: `Source ${i + 1} Revision`, value: src.targetRevision ?? 'HEAD' },
+                    { name: `Source ${i + 1} Path`, value: src.path ?? src.chart ?? '-' },
+                  ])
+                : [
+                    { name: 'Source Repo', value: app.repoURL },
+                    { name: 'Target Revision', value: app.targetRevision },
+                    { name: 'Path', value: app.path || '-' },
+                  ]),
+              {
+                name: 'Destination',
+                value: `${app.destinationServer} / ${app.destinationNamespace}`,
+              },
+              {
+                name: 'Sync Status',
+                value: (
+                  <StatusLabel status={getSyncStatus(app.syncStatus)}>{app.syncStatus}</StatusLabel>
+                ),
+              },
+              {
+                name: 'Health Status',
+                value: (
+                  <StatusLabel status={getHealthStatus(app.healthStatus)}>
+                    {app.healthStatus}
+                  </StatusLabel>
+                ),
+              },
+            ]
+          : []
+      }
+      extraSections={(app: ArgoApplication) =>
+        app
+          ? [
+              getManagedResourcesSection(app),
+              getSyncPolicySection(app),
+              getConditionsSection(app),
+            ].filter(Boolean)
+          : []
+      }
+    />
+  );
+}
+
+/**
+ * Generates the extra section displaying the managed resources of the Application.
+ *
+ * @param app - The ArgoApplication instance.
+ * @returns A section box definition containing the managed resources table, or null if no resources exist.
+ */
+function getManagedResourcesSection(app: ArgoApplication) {
+  const resources = app.managedResources;
+  if (!resources.length) return null;
+
+  return {
+    id: 'managed-resources',
+    section: (
+      <SectionBox title="Managed Resources">
+        <SimpleTable
+          data={resources}
+          columns={[
+            {
+              label: 'Kind',
+              getter: (r: ManagedResource) => r.kind,
+              sort: true,
+            },
+            {
+              label: 'Name',
+              getter: (r: ManagedResource) => r.name,
+              sort: true,
+            },
+            {
+              label: 'Namespace',
+              getter: (r: ManagedResource) => r.namespace ?? '-',
+              sort: true,
+            },
+            {
+              label: 'Status',
+              getter: (r: ManagedResource) => r.status ?? '-',
+            },
+            {
+              label: 'Health',
+              getter: (r: ManagedResource) =>
+                r.health?.status ? (
+                  <StatusLabel status={getHealthStatus(r.health.status)}>
+                    {r.health.status}
+                  </StatusLabel>
+                ) : (
+                  '-'
+                ),
+              sort: (a: ManagedResource, b: ManagedResource) =>
+                (a.health?.status ?? '').localeCompare(b.health?.status ?? ''),
+            },
+          ]}
+        />
+      </SectionBox>
+    ),
+  };
+}
+
+/**
+ * Generates the extra section displaying the sync policy configuration of the Application.
+ *
+ * @param app - The ArgoApplication instance.
+ * @returns A section box definition containing the sync policy details, or null if no sync policy is defined.
+ */
+function getSyncPolicySection(app: ArgoApplication) {
+  const policy = app.syncPolicy;
+  if (!policy) return null;
+
+  const rows = [
+    { name: 'Automated', value: policy.automated ? 'Yes' : 'No' },
+    ...(policy.automated
+      ? [
+          { name: 'Self Heal', value: policy.automated.selfHeal ? 'Yes' : 'No' },
+          { name: 'Prune', value: policy.automated.prune ? 'Yes' : 'No' },
+        ]
+      : []),
+    ...(policy.retry
+      ? [
+          { name: 'Retry Limit', value: String(policy.retry.limit ?? '-') },
+          {
+            name: 'Retry Backoff',
+            value: policy.retry.backoff
+              ? `${policy.retry.backoff.duration ?? '-'} (max ${
+                  policy.retry.backoff.maxDuration ?? '-'
+                })`
+              : '-',
+          },
+        ]
+      : []),
+    ...(policy.syncOptions?.length
+      ? [{ name: 'Sync Options', value: policy.syncOptions.join(', ') }]
+      : []),
+  ];
+
+  return {
+    id: 'sync-policy',
+    section: (
+      <SectionBox title="Sync Policy">
+        <NameValueTable rows={rows} />
+      </SectionBox>
+    ),
+  };
+}
+
+/**
+ * Generates the extra section displaying the warning and error conditions of the Application.
+ *
+ * @param app - The ArgoApplication instance.
+ * @returns A section box definition containing the conditions table, or null if no conditions exist.
+ */
+function getConditionsSection(app: ArgoApplication) {
+  const conditions = app.conditions;
+  if (!conditions.length) return null;
+
+  return {
+    id: 'conditions',
+    section: (
+      <SectionBox title="Conditions">
+        <ConditionsTable resource={app.jsonData} />
+      </SectionBox>
+    ),
+  };
+}

--- a/argocd/src/components/applications/List.tsx
+++ b/argocd/src/components/applications/List.tsx
@@ -14,51 +14,16 @@
  * limitations under the License.
  */
 
-import { ResourceListView, StatusLabel } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import {
+  ActionButton,
+  AuthVisible,
+  ResourceListView,
+  StatusLabel,
+} from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { refreshApplication, syncApplication } from '../../api/argoClient';
+import { useArgoOperationMap } from '../../hooks/useArgoOperation';
 import { ArgoApplication } from '../../resources/application';
-
-/**
- * Maps an Argo CD health status string to a Headlamp StatusLabel severity.
- *
- * @param health - The health status string from the Application resource
- *   (e.g., "Healthy", "Degraded", "Progressing", "Suspended", "Missing").
- * @returns A StatusLabel status string: "success", "warning", "info", "error",
- *   or "" for unknown values.
- */
-function getHealthStatus(health: string): string {
-  switch (health.toLowerCase()) {
-    case 'healthy':
-      return 'success';
-    case 'suspended':
-      return 'warning';
-    case 'progressing':
-      return 'info';
-    case 'degraded':
-    case 'missing':
-      return 'error';
-    default:
-      return '';
-  }
-}
-
-/**
- * Maps an Argo CD sync status string to a Headlamp StatusLabel severity.
- *
- * @param sync - The sync status string from the Application resource
- *   (e.g., "Synced", "OutOfSync").
- * @returns A StatusLabel status string: "success", "warning",
- *   or "" for unknown values.
- */
-function getSyncStatus(sync: string): string {
-  switch (sync.toLowerCase()) {
-    case 'synced':
-      return 'success';
-    case 'outofsync':
-      return 'warning';
-    default:
-      return '';
-  }
-}
+import { getHealthStatus, getSyncStatus } from './statusHelpers';
 
 /**
  * Renders a table of all Argo CD Application resources in the current cluster.
@@ -71,10 +36,51 @@ function getSyncStatus(sync: string): string {
  * @returns The Application list view React element.
  */
 export default function ApplicationList() {
+  const sync = useArgoOperationMap(syncApplication, 'Sync');
+  const refresh = useArgoOperationMap(refreshApplication, 'Refresh');
+
   return (
     <ResourceListView
       title="Argo CD Applications"
       resourceClass={ArgoApplication}
+      actions={[
+        {
+          id: 'argocd-sync',
+          action: ({ item }: { item: ArgoApplication }) => {
+            const { name, namespace } = item.metadata;
+            const isLoadingSync = sync.isLoading(name, namespace);
+            const isLoadingAny = isLoadingSync || refresh.isLoading(name, namespace);
+            return (
+              <AuthVisible item={item} authVerb="patch">
+                <ActionButton
+                  description={isLoadingSync ? 'Syncing…' : 'Sync'}
+                  icon={isLoadingSync ? 'mdi:loading' : 'mdi:sync'}
+                  onClick={() => sync.execute(name, namespace)}
+                  iconButtonProps={{ disabled: isLoadingAny }}
+                />
+              </AuthVisible>
+            );
+          },
+        },
+        {
+          id: 'argocd-refresh',
+          action: ({ item }: { item: ArgoApplication }) => {
+            const { name, namespace } = item.metadata;
+            const isLoadingRefresh = refresh.isLoading(name, namespace);
+            const isLoadingAny = isLoadingRefresh || sync.isLoading(name, namespace);
+            return (
+              <AuthVisible item={item} authVerb="patch">
+                <ActionButton
+                  description={isLoadingRefresh ? 'Refreshing…' : 'Refresh'}
+                  icon={isLoadingRefresh ? 'mdi:loading' : 'mdi:refresh'}
+                  onClick={() => refresh.execute(name, namespace)}
+                  iconButtonProps={{ disabled: isLoadingAny }}
+                />
+              </AuthVisible>
+            );
+          },
+        },
+      ]}
       columns={[
         'name',
         'namespace',
@@ -86,7 +92,8 @@ export default function ApplicationList() {
         {
           id: 'source-repo',
           label: 'Source Repo',
-          getValue: (app: ArgoApplication) => app.repoURL,
+          getValue: (app: ArgoApplication) =>
+            app.isMultiSource ? `${app.sources.length} sources` : app.repoURL,
         },
         {
           id: 'target-revision',

--- a/argocd/src/components/applications/statusHelpers.ts
+++ b/argocd/src/components/applications/statusHelpers.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Maps an Argo CD health status string to a Headlamp StatusLabel severity.
+ *
+ * @param health - The health status string from the Application resource
+ *   (e.g., "Healthy", "Degraded", "Progressing", "Suspended", "Missing").
+ * @returns A StatusLabel status string: "success", "warning", "info", "error",
+ *   or "" for unknown values.
+ */
+export function getHealthStatus(health: string): string {
+  switch (health.toLowerCase()) {
+    case 'healthy':
+      return 'success';
+    case 'suspended':
+      return 'warning';
+    case 'progressing':
+      return 'info';
+    case 'degraded':
+    case 'missing':
+      return 'error';
+    default:
+      return '';
+  }
+}
+
+/**
+ * Maps an Argo CD sync status string to a Headlamp StatusLabel severity.
+ *
+ * @param sync - The sync status string from the Application resource
+ *   (e.g., "Synced", "OutOfSync").
+ * @returns A StatusLabel status string: "success", "warning",
+ *   or "" for unknown values.
+ */
+export function getSyncStatus(sync: string): string {
+  switch (sync.toLowerCase()) {
+    case 'synced':
+      return 'success';
+    case 'outofsync':
+      return 'warning';
+    default:
+      return '';
+  }
+}

--- a/argocd/src/components/appprojects/Detail.tsx
+++ b/argocd/src/components/appprojects/Detail.tsx
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  DetailsGrid,
+  NameValueTable,
+  SectionBox,
+  SimpleTable,
+} from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { useParams } from 'react-router-dom';
+import {
+  AppProjectDestination,
+  AppProjectRole,
+  ArgoAppProject,
+  GroupKind,
+} from '../../resources/appproject';
+
+export default function AppProjectDetail(props: { namespace?: string; name?: string }) {
+  const params = useParams<{ namespace: string; name: string }>();
+  const { namespace = params.namespace, name = params.name } = props;
+
+  return (
+    <DetailsGrid
+      resourceType={ArgoAppProject}
+      name={name}
+      namespace={namespace}
+      withEvents
+      extraInfo={(project: ArgoAppProject) =>
+        project
+          ? [
+              { name: 'Description', value: project.description || '-' },
+              { name: 'Source Repos', value: String(project.sourceRepos.length) },
+              { name: 'Destinations', value: String(project.destinations.length) },
+            ]
+          : []
+      }
+      extraSections={(project: ArgoAppProject) =>
+        project
+          ? [
+              getSourceReposSection(project),
+              getDestinationsSection(project),
+              getClusterResourceWhitelistSection(project),
+              getRolesSection(project),
+            ].filter(Boolean)
+          : []
+      }
+    />
+  );
+}
+
+function getSourceReposSection(project: ArgoAppProject) {
+  const repos = project.sourceRepos;
+  if (!repos.length) return null;
+
+  return {
+    id: 'source-repos',
+    section: (
+      <SectionBox title="Source Repositories">
+        <NameValueTable rows={repos.map((repo, i) => ({ name: `Repo ${i + 1}`, value: repo }))} />
+      </SectionBox>
+    ),
+  };
+}
+
+function getDestinationsSection(project: ArgoAppProject) {
+  const destinations = project.destinations;
+  if (!destinations.length) return null;
+
+  return {
+    id: 'destinations',
+    section: (
+      <SectionBox title="Destinations">
+        <SimpleTable
+          data={destinations}
+          columns={[
+            {
+              label: 'Server',
+              getter: (d: AppProjectDestination) => d.server ?? d.name ?? '-',
+            },
+            {
+              label: 'Namespace',
+              getter: (d: AppProjectDestination) => d.namespace ?? '*',
+            },
+          ]}
+        />
+      </SectionBox>
+    ),
+  };
+}
+
+function getClusterResourceWhitelistSection(project: ArgoAppProject) {
+  const whitelist = project.clusterResourceWhitelist;
+  if (!whitelist.length) return null;
+
+  return {
+    id: 'cluster-resource-whitelist',
+    section: (
+      <SectionBox title="Cluster Resource Whitelist">
+        <SimpleTable
+          data={whitelist}
+          columns={[
+            { label: 'Group', getter: (gk: GroupKind) => gk.group || '*' },
+            { label: 'Kind', getter: (gk: GroupKind) => gk.kind || '*' },
+          ]}
+        />
+      </SectionBox>
+    ),
+  };
+}
+
+function getRolesSection(project: ArgoAppProject) {
+  const roles = project.roles;
+  if (!roles.length) return null;
+
+  return {
+    id: 'roles',
+    section: (
+      <SectionBox title="Roles">
+        <SimpleTable
+          data={roles}
+          columns={[
+            { label: 'Name', getter: (r: AppProjectRole) => r.name },
+            { label: 'Description', getter: (r: AppProjectRole) => r.description ?? '-' },
+            {
+              label: 'Groups',
+              getter: (r: AppProjectRole) => r.groups?.join(', ') ?? '-',
+            },
+          ]}
+        />
+      </SectionBox>
+    ),
+  };
+}

--- a/argocd/src/components/appprojects/List.tsx
+++ b/argocd/src/components/appprojects/List.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ResourceListView } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { ArgoAppProject } from '../../resources/appproject';
+
+export default function AppProjectList() {
+  return (
+    <ResourceListView
+      title="Argo CD Projects"
+      resourceClass={ArgoAppProject}
+      columns={[
+        'name',
+        'namespace',
+        {
+          id: 'description',
+          label: 'Description',
+          getValue: (project: ArgoAppProject) => project.description || '-',
+        },
+        {
+          id: 'source-repos',
+          label: 'Source Repos',
+          getValue: (project: ArgoAppProject) => String(project.sourceRepos.length),
+        },
+        {
+          id: 'destinations',
+          label: 'Destinations',
+          getValue: (project: ArgoAppProject) => String(project.destinations.length),
+        },
+        'age',
+      ]}
+    />
+  );
+}

--- a/argocd/src/hooks/useArgoOperation.ts
+++ b/argocd/src/hooks/useArgoOperation.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useSnackbar } from 'notistack';
+import { useCallback, useRef, useState } from 'react';
+
+type OperationFn = (name: string, namespace: string) => Promise<unknown>;
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'object' && error !== null && 'message' in error) {
+    return String((error as { message: unknown }).message);
+  }
+  if (typeof error === 'string') return error;
+  return 'Unknown error';
+}
+
+/**
+ * Hook for a single Argo CD operation with loading state and snackbar feedback.
+ * Used by the Application detail view where one operation runs at a time.
+ */
+export function useArgoOperation(operationFn: OperationFn, operationLabel: string) {
+  const { enqueueSnackbar } = useSnackbar();
+  const [isLoading, setIsLoading] = useState(false);
+  const inFlightRef = useRef(false);
+
+  const execute = useCallback(
+    async (name: string, namespace: string) => {
+      if (isLoading) return;
+      if (inFlightRef.current) return;
+      inFlightRef.current = true;
+      setIsLoading(true);
+      try {
+        await operationFn(name, namespace);
+        enqueueSnackbar(`${operationLabel} triggered for ${name}`, { variant: 'success' });
+      } catch (error) {
+        enqueueSnackbar(
+          `Failed to ${operationLabel.toLowerCase()} ${name}: ${getErrorMessage(error)}`,
+          { variant: 'error' }
+        );
+      } finally {
+        inFlightRef.current = false;
+        setIsLoading(false);
+      }
+    },
+    [isLoading, operationFn, operationLabel, enqueueSnackbar]
+  );
+
+  return { execute, isLoading };
+}
+
+/**
+ * Hook for per-app Argo CD operations with independent loading states.
+ * Used by the Application list view where multiple apps can be operated on concurrently.
+ */
+export function useArgoOperationMap(operationFn: OperationFn, operationLabel: string) {
+  const { enqueueSnackbar } = useSnackbar();
+  const [loadingKeys, setLoadingKeys] = useState<Record<string, boolean>>({});
+  const inFlightKeys = useRef<Set<string>>(new Set());
+
+  const execute = useCallback(
+    async (name: string, namespace: string) => {
+      const key = `${namespace}/${name}`;
+      if (loadingKeys[key]) return;
+      if (inFlightKeys.current.has(key)) return;
+      inFlightKeys.current.add(key);
+      setLoadingKeys(prev => ({ ...prev, [key]: true }));
+      try {
+        await operationFn(name, namespace);
+        enqueueSnackbar(`${operationLabel} triggered for ${name}`, { variant: 'success' });
+      } catch (error) {
+        enqueueSnackbar(
+          `Failed to ${operationLabel.toLowerCase()} ${name}: ${getErrorMessage(error)}`,
+          { variant: 'error' }
+        );
+      } finally {
+        inFlightKeys.current.delete(key);
+        setLoadingKeys(prev => {
+          const next = { ...prev };
+          delete next[key];
+          return next;
+        });
+      }
+    },
+    [loadingKeys, operationFn, operationLabel, enqueueSnackbar]
+  );
+
+  const isLoading = useCallback(
+    (name: string, namespace: string) => !!loadingKeys[`${namespace}/${name}`],
+    [loadingKeys]
+  );
+
+  return { execute, isLoading };
+}

--- a/argocd/src/index.test.tsx
+++ b/argocd/src/index.test.tsx
@@ -14,16 +14,22 @@
  * limitations under the License.
  */
 
+import type * as React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
-const { mockRegisterRoute, mockRegisterSidebarEntry } = vi.hoisted(() => ({
-  mockRegisterRoute: vi.fn(),
-  mockRegisterSidebarEntry: vi.fn(),
-}));
+const { mockRegisterRoute, mockRegisterSidebarEntry, mockRegisterSidebarEntryFilter } = vi.hoisted(
+  () => ({
+    mockRegisterRoute: vi.fn(),
+    mockRegisterSidebarEntry: vi.fn(),
+    mockRegisterSidebarEntryFilter: vi.fn(),
+  })
+);
 
 vi.mock('@kinvolk/headlamp-plugin/lib', () => ({
   registerRoute: mockRegisterRoute,
   registerSidebarEntry: mockRegisterSidebarEntry,
+  registerSidebarEntryFilter: mockRegisterSidebarEntryFilter,
+  ApiProxy: { request: vi.fn() },
   K8s: {
     cluster: {
       KubeObject: class KubeObject {
@@ -33,12 +39,42 @@ vi.mock('@kinvolk/headlamp-plugin/lib', () => ({
         }
       },
     },
+    ResourceClasses: {
+      CustomResourceDefinition: {
+        apiList: vi.fn(() => vi.fn()),
+      },
+    },
+  },
+  Utils: {
+    getCluster: vi.fn(() => 'default'),
   },
 }));
 
 vi.mock('@kinvolk/headlamp-plugin/lib/CommonComponents', () => ({
+  ActionButton: () => null,
+  AuthVisible: ({ children }: { children: React.ReactNode }) => children,
+  DetailsGrid: () => null,
+  NameValueTable: () => null,
   ResourceListView: () => null,
+  SectionBox: () => null,
+  SimpleTable: () => null,
   StatusLabel: () => null,
+}));
+
+vi.mock('@kinvolk/headlamp-plugin/lib/components/common', () => ({
+  ConditionsTable: () => null,
+}));
+
+vi.mock('@iconify/react', () => ({
+  addIcon: vi.fn(),
+}));
+
+vi.mock('notistack', () => ({
+  useSnackbar: () => ({ enqueueSnackbar: vi.fn() }),
+}));
+
+vi.mock('react-router-dom', () => ({
+  useParams: () => ({ namespace: 'argocd', name: 'test-app' }),
 }));
 
 // Static import triggers the module's top-level registration calls.
@@ -46,7 +82,7 @@ vi.mock('@kinvolk/headlamp-plugin/lib/CommonComponents', () => ({
 import './index';
 
 describe('argocd plugin', () => {
-  it('should register the /argocd/applications route and sidebar entries', () => {
+  it('should register the application list and detail routes', () => {
     expect(mockRegisterRoute).toHaveBeenCalledWith(
       expect.objectContaining({
         path: '/argocd/applications',
@@ -56,11 +92,43 @@ describe('argocd plugin', () => {
       })
     );
 
+    expect(mockRegisterRoute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/argocd/applications/:namespace/:name',
+        name: 'argocd-application-detail',
+        sidebar: 'argocd-applications',
+        exact: true,
+      })
+    );
+  });
+
+  it('should register the AppProject list and detail routes', () => {
+    expect(mockRegisterRoute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/argocd/projects',
+        name: 'argocd-projects-list',
+        sidebar: 'argocd-projects',
+        exact: true,
+      })
+    );
+
+    expect(mockRegisterRoute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/argocd/projects/:namespace/:name',
+        name: 'argocd-project-detail',
+        sidebar: 'argocd-projects',
+        exact: true,
+      })
+    );
+  });
+
+  it('should register sidebar entries with the Argo CD icon', () => {
     expect(mockRegisterSidebarEntry).toHaveBeenCalledWith(
       expect.objectContaining({
         name: 'argocd',
         label: 'Argo CD',
         url: '/argocd/applications',
+        icon: 'simple-icons:argo',
         parent: null,
       })
     );
@@ -73,5 +141,18 @@ describe('argocd plugin', () => {
         parent: 'argocd',
       })
     );
+
+    expect(mockRegisterSidebarEntry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'argocd-projects',
+        label: 'Projects',
+        url: '/argocd/projects',
+        parent: 'argocd',
+      })
+    );
+  });
+
+  it('should register the CRD sidebar entry filter', () => {
+    expect(mockRegisterSidebarEntryFilter).toHaveBeenCalledWith(expect.any(Function));
   });
 });

--- a/argocd/src/index.tsx
+++ b/argocd/src/index.tsx
@@ -14,8 +14,79 @@
  * limitations under the License.
  */
 
-import { registerRoute, registerSidebarEntry } from '@kinvolk/headlamp-plugin/lib';
+import { addIcon } from '@iconify/react';
+import {
+  K8s,
+  registerRoute,
+  registerSidebarEntry,
+  registerSidebarEntryFilter,
+  Utils,
+} from '@kinvolk/headlamp-plugin/lib';
+import ApplicationDetail from './components/applications/Detail';
 import ApplicationList from './components/applications/List';
+import AppProjectDetail from './components/appprojects/Detail';
+import AppProjectList from './components/appprojects/List';
+
+// ---------------------------------------------------------------------------
+// CRD Detection Guard — hide Argo CD sidebar entries on clusters without
+// the argoproj.io CRDs installed. Follows the Flux plugin pattern.
+// ---------------------------------------------------------------------------
+const argoInstalledByCluster: Record<string, boolean> = {};
+const lastCheckedAt: Record<string, number> = {};
+const inFlight: Record<string, boolean> = {};
+const CHECK_TTL_MS = 30 * 1000;
+
+function checkArgoInstalled(cluster: string) {
+  const now = Date.now();
+  const fresh = now - (lastCheckedAt[cluster] ?? 0) < CHECK_TTL_MS;
+  if (inFlight[cluster] || fresh) {
+    return;
+  }
+  inFlight[cluster] = true;
+
+  const listFn = K8s.ResourceClasses.CustomResourceDefinition.apiList(
+    (crds: { jsonData: { metadata: { name: string } } }[]) => {
+      argoInstalledByCluster[cluster] = crds.some(crd =>
+        [
+          'applications.argoproj.io',
+          'appprojects.argoproj.io',
+          'applicationsets.argoproj.io',
+        ].includes(crd.jsonData?.metadata?.name)
+      );
+      lastCheckedAt[cluster] = Date.now();
+      inFlight[cluster] = false;
+    },
+    () => {
+      argoInstalledByCluster[cluster] = false;
+      lastCheckedAt[cluster] = Date.now();
+      inFlight[cluster] = false;
+    },
+    { cluster }
+  );
+  listFn();
+}
+
+registerSidebarEntryFilter(entry => {
+  if (entry.name !== 'argocd' && entry.parent !== 'argocd') {
+    return entry;
+  }
+
+  const cluster = Utils.getCluster() ?? '';
+  checkArgoInstalled(cluster);
+
+  if (argoInstalledByCluster[cluster] === false) {
+    return null;
+  }
+  return entry;
+});
+
+// Register the official Argo CD logo as an offline Iconify icon (CSP-safe:
+// no external fetch). Sourced from the Simple Icons "argo" glyph.
+addIcon('simple-icons:argo', {
+  body: '<path fill="currentColor" d="M12.581 0c.436.037.871.1 1.299.186 1.679.383 3.121 1.213 4.382 2.365 1.161 1.06 1.917 2.372 2.335 3.881.089.321.216.56.586.624.205.035.238.245.239.43.003.646.002 1.294.002 1.94l-.002 1.21c-.001.356-.116.479-.466.474-.211-.003-.293.119-.344.291-.146.489-.33.966-.552 1.426-.818 1.682-2.084 2.938-3.688 3.87-.077.045-.155.088-.233.131-.252.137-.258.146-.155.415.114.299.358.529.664.625.269.096.553.134.827.21a.672.672 0 0 1 .236.094c-.066.082-.156.067-.231.082-.36.073-.713.184-1.086.17a1.275 1.275 0 0 1-.438-.064c-.114-.045-.152-.006-.176.109a5.354 5.354 0 0 0-.084.92c-.015.617-.071 1.23-.112 1.844-.042.598-.018.651.558.842.281.094.563.187.842.286.069.024.15.038.192.117-.04.057-.098.035-.146.035-.493.003-.985.005-1.478.001-.524-.005-.806-.282-.845-.803-.055-.762-.12-1.524-.182-2.286a.947.947 0 0 0-.026-.12c-.079.455-.065.879-.084 1.298-.023.528-.008 1.057-.007 1.584 0 .27.086.388.335.483.359.135.711.295 1.114.262.141-.012.276.062.402.129.032.017.073.033.069.073-.004.043-.049.047-.084.045-.657-.019-1.317.065-1.972-.028-.323-.046-.533-.236-.631-.552-.094-.303-.114-.617-.137-.93-.046-.626-.078-1.253-.116-1.88a.222.222 0 0 0-.061-.171.282.282 0 0 0-.031.193c-.002.956-.002 1.911-.001 2.866 0 .388.123.575.494.708.481.172.976.298 1.47.423.11.028.225.047.242.192h-1.852c-.051-.01-.103-.022-.155-.03-.701-.1-1.001-.372-1.143-1.042l-.067-.331-.226-1.103c-.069.12-.118.25-.144.386-.083.399-.151.802-.243 1.2-.113.493-.444.763-.932.857l-.33.063H8.558c.057-.171.216-.185.355-.221.476-.127.96-.223 1.417-.409a.603.603 0 0 0 .397-.521c.058-.435.002-.865-.013-1.296a1.528 1.528 0 0 0-.078-.315.405.405 0 0 0-.071.207c-.026.296-.049.591-.075.886-.038.432-.273.716-.679.81a1.702 1.702 0 0 1-.37.045c-.557.003-1.115-.001-1.673-.005-.048 0-.109.019-.148-.065.178-.103.377-.168.582-.187a5.67 5.67 0 0 0 .939-.193c.42-.114.522-.249.512-.687-.023-.931-.091-1.86-.069-2.791.004-.184.001-.368.001-.551a2.387 2.387 0 0 0-.05.385 40.299 40.299 0 0 1-.186 2.623c-.052.513-.296.748-.804.805-.446.051-.889.002-1.332-.02-.108-.006-.234.012-.339-.064.043-.066.106-.07.16-.087.362-.115.725-.224 1.086-.344.246-.081.35-.235.355-.492a2.241 2.241 0 0 0-.003-.232 45.315 45.315 0 0 1-.105-2.149 5.487 5.487 0 0 0-.035-.478c-.024-.188-.131-.287-.295-.258-.505.092-.99-.006-1.473-.139-.059-.016-.134-.007-.178-.088a.986.986 0 0 1 .285-.09c.255-.052.507-.121.753-.208.312-.112.564-.347.695-.651.089-.203.056-.317-.112-.398-1.418-.683-2.512-1.73-3.391-3.017a8.152 8.152 0 0 1-1.123-2.447c-.067-.246-.156-.3-.383-.26-.306.053-.401.006-.535-.273v-3.49c.144-.303.205-.341.534-.329.235.01.247-.004.309-.242.396-1.508 1.082-2.861 2.171-3.988C6.9 1.42 8.523.631 10.34.203c.456-.108.922-.15 1.387-.203h.854Zm7.974 8.948a7.34 7.34 0 0 0-.048-.938 8.353 8.353 0 0 0-.099-.65c-.598-2.964-2.344-5.02-5.051-6.268-1.553-.715-3.21-.835-4.878-.511-3.248.633-5.396 2.583-6.539 5.652-.436 1.173-.495 2.406-.37 3.65.087.935.339 1.846.745 2.694.585 1.213 1.444 2.207 2.477 3.058.343.286.719.528 1.121.719.235.111.247.105.245-.146.006-.16.003-.32-.009-.48-.125-1.02-.142-2.045-.169-3.069a.392.392 0 0 0-.184-.353c-.385-.268-.713-.592-.921-1.019-.474-.97-.372-2.361.813-3.215.136-.097.217-.19.198-.373a1.724 1.724 0 0 1 .031-.442c.177-1.187.748-2.138 1.722-2.84.68-.492 1.442-.772 2.286-.782.483-.007.953.11 1.414.244 1.609.467 2.846 2.07 2.845 3.697a.64.64 0 0 0 .268.565c.463.371.821.83.943 1.426.22 1.077-.083 1.982-.979 2.634-.266.194-.347.406-.333.698.002.047 0 .095-.002.142l-.062 1.439c-.025.586-.138 1.165-.117 1.754.008.223.006.226.201.128a7.46 7.46 0 0 0 2.393-1.903c1.32-1.577 2.074-3.372 2.059-5.511ZM9.117 12.102c1.489.021 2.443-1.578 1.716-2.879a1.937 1.937 0 0 0-1.699-.991c-1.094-.004-1.954.822-1.958 1.881-.005 1.148.813 1.985 1.941 1.989Zm5.794 0c1.101.002 1.935-.823 1.935-1.917 0-1.091-.846-1.949-1.92-1.947-1.064.003-1.94.866-1.943 1.915-.003 1.105.831 1.948 1.928 1.949Zm-1.472 1.937c-.208.128-.407.277-.63.384-.536.257-1.063.257-1.579-.048-.158-.094-.308-.201-.464-.298-.047-.028-.092-.103-.15-.062-.044.03-.01.1-.001.151.037.179.064.362.082.544.027.565.293.992.742 1.31a.984.984 0 0 0 .791.186c.565-.119 1.025-.614 1.124-1.218.043-.266.005-.544.109-.803a.133.133 0 0 0-.024-.146Zm-8.78-4.92c-.012-1.102.143-2.055.54-2.961.633-1.443 1.642-2.553 2.98-3.374a.378.378 0 0 1 .459.067c.06.06.036.118.01.178a1.09 1.09 0 0 1-.48.51c-1.079.639-1.829 1.571-2.357 2.688a6.325 6.325 0 0 0-.618 2.986c.055 1.309.439 2.516 1.213 3.588.088.104.148.23.173.365.01.08.059.168-.031.228a.312.312 0 0 1-.288.041.502.502 0 0 1-.234-.185c-.72-.979-1.193-2.056-1.331-3.273-.036-.326-.004-.653-.036-.858ZM8.94 2.34a.373.373 0 0 1 .378-.382c.211.001.409.226.416.473.004.138-.309.39-.476.386-.189-.005-.318-.2-.318-.477Zm-.465 7.48a.609.609 0 0 1 .586-.631c.38-.003.671.271.675.633.004.356-.27.622-.639.621-.38-.002-.621-.241-.622-.623Zm6.496.623c-.381-.002-.625-.255-.621-.646a.635.635 0 0 1 .596-.613.656.656 0 0 1 .669.643c.001.354-.275.618-.644.616Z"/>',
+  width: 24,
+  height: 24,
+});
 
 registerRoute({
   path: '/argocd/applications',
@@ -25,12 +96,20 @@ registerRoute({
   component: () => <ApplicationList />,
 });
 
+registerRoute({
+  path: '/argocd/applications/:namespace/:name',
+  sidebar: 'argocd-applications',
+  name: 'argocd-application-detail',
+  exact: true,
+  component: () => <ApplicationDetail />,
+});
+
 registerSidebarEntry({
   parent: null,
   name: 'argocd',
   label: 'Argo CD',
   url: '/argocd/applications',
-  icon: 'mdi:application-cog',
+  icon: 'simple-icons:argo',
 });
 
 registerSidebarEntry({
@@ -38,4 +117,27 @@ registerSidebarEntry({
   name: 'argocd-applications',
   label: 'Applications',
   url: '/argocd/applications',
+});
+
+registerRoute({
+  path: '/argocd/projects',
+  sidebar: 'argocd-projects',
+  name: 'argocd-projects-list',
+  exact: true,
+  component: () => <AppProjectList />,
+});
+
+registerRoute({
+  path: '/argocd/projects/:namespace/:name',
+  sidebar: 'argocd-projects',
+  name: 'argocd-project-detail',
+  exact: true,
+  component: () => <AppProjectDetail />,
+});
+
+registerSidebarEntry({
+  parent: 'argocd',
+  name: 'argocd-projects',
+  label: 'Projects',
+  url: '/argocd/projects',
 });

--- a/argocd/src/resources/application.ts
+++ b/argocd/src/resources/application.ts
@@ -30,6 +30,14 @@ export const argocdApiGroup = 'argoproj.io';
 /** The full API version string for Argo CD Application resources. */
 export const argocdApiVersion = 'argoproj.io/v1alpha1';
 
+/** A single Git or Helm source configuration. */
+export interface SourceSpec {
+  repoURL: string;
+  targetRevision?: string;
+  path?: string;
+  chart?: string;
+}
+
 /**
  * Represents the desired state (spec) of an Argo CD Application.
  *
@@ -39,16 +47,9 @@ export interface ArgoApplicationSpec {
   /** The Argo CD project this application belongs to (e.g., "default"). */
   project: string;
   /** The Git or Helm source configuration for the application manifests. */
-  source: {
-    /** The URL of the Git repository or Helm chart repository. */
-    repoURL: string;
-    /** The Git branch, tag, or commit SHA to track (e.g., "HEAD", "main"). */
-    targetRevision?: string;
-    /** The directory path within the repository containing the manifests. */
-    path?: string;
-    /** The Helm chart name, if using a Helm chart source instead of a Git path. */
-    chart?: string;
-  };
+  source?: SourceSpec;
+  /** Multiple sources for multi-source Applications (Argo CD 2.6+). */
+  sources?: SourceSpec[];
   /** The target Kubernetes cluster and namespace for deployment. */
   destination: {
     /** The API server URL of the destination cluster. */
@@ -58,6 +59,41 @@ export interface ArgoApplicationSpec {
     /** The target namespace in the destination cluster. */
     namespace?: string;
   };
+  /** Sync policy controlling automated sync, pruning, self-heal, and retries. */
+  syncPolicy?: {
+    automated?: {
+      prune?: boolean;
+      selfHeal?: boolean;
+    };
+    retry?: {
+      limit?: number;
+      backoff?: {
+        duration?: string;
+        factor?: number;
+        maxDuration?: string;
+      };
+    };
+    syncOptions?: string[];
+  };
+}
+
+/** A Kubernetes resource managed by an Argo CD Application. */
+export interface ManagedResource {
+  group?: string;
+  version: string;
+  kind: string;
+  namespace?: string;
+  name: string;
+  status?: string;
+  health?: { status: string; message?: string };
+}
+
+/** A condition set by the Argo CD controller on an Application. */
+export interface ArgoCondition {
+  type: string;
+  message?: string;
+  lastTransitionTime?: string;
+  status?: string;
 }
 
 /**
@@ -79,6 +115,10 @@ export interface ArgoApplicationStatus {
     /** The sync status string (e.g., "Synced", "OutOfSync"). */
     status: string;
   };
+  /** Kubernetes resources managed by this Application. */
+  resources?: ManagedResource[];
+  /** Warning and error conditions set by the controller. */
+  conditions?: ArgoCondition[];
 }
 
 /**
@@ -108,7 +148,13 @@ export class ArgoApplication extends KubeObject<KubeArgoApplication> {
   static apiVersion = argocdApiVersion;
   static isNamespaced = true;
 
-  // No custom detailsRoute yet; rely on Headlamp defaults until a detail view is implemented.
+  /**
+   * Route the Application name links to. Must match the detail route
+   * registered in index.tsx, otherwise the link falls back to Home.
+   */
+  static get detailsRoute() {
+    return '/argocd/applications/:namespace/:name';
+  }
 
   /** Returns the application's desired state specification. */
   get spec(): ArgoApplicationSpec {
@@ -125,19 +171,30 @@ export class ArgoApplication extends KubeObject<KubeArgoApplication> {
     return this.spec.project || 'default';
   }
 
+  /** Returns all sources, normalizing single-source and multi-source apps. */
+  get sources(): SourceSpec[] {
+    return this.spec.sources ?? (this.spec.source ? [this.spec.source] : []);
+  }
+
+  /** Whether this is a multi-source Application (Argo CD 2.6+). */
+  get isMultiSource(): boolean {
+    return (this.spec.sources?.length ?? 0) > 1;
+  }
+
   /** Returns the Git or Helm repository URL for the application source. */
   get repoURL(): string {
-    return this.spec.source?.repoURL || '';
+    return this.spec.source?.repoURL || this.spec.sources?.[0]?.repoURL || '';
   }
 
   /** Returns the target Git revision (branch, tag, or SHA). Defaults to "HEAD". */
   get targetRevision(): string {
-    return this.spec.source?.targetRevision || 'HEAD';
+    return this.spec.source?.targetRevision || this.spec.sources?.[0]?.targetRevision || 'HEAD';
   }
 
   /** Returns the manifest path within the repository, or the Helm chart name. */
   get path(): string {
-    return this.spec.source?.path || this.spec.source?.chart || '';
+    const src = this.spec.source || this.spec.sources?.[0];
+    return src?.path || src?.chart || '';
   }
 
   /** Returns the destination cluster API server URL or cluster name. */
@@ -158,5 +215,20 @@ export class ArgoApplication extends KubeObject<KubeArgoApplication> {
   /** Returns the sync status string (e.g., "Synced", "OutOfSync"). Defaults to "Unknown". */
   get syncStatus(): string {
     return this.status?.sync?.status || 'Unknown';
+  }
+
+  /** Returns the sync policy configuration, or undefined if not set. */
+  get syncPolicy(): ArgoApplicationSpec['syncPolicy'] {
+    return this.spec.syncPolicy;
+  }
+
+  /** Returns the list of managed Kubernetes resources. */
+  get managedResources(): ManagedResource[] {
+    return this.status?.resources ?? [];
+  }
+
+  /** Returns the list of conditions set by the controller. */
+  get conditions(): ArgoCondition[] {
+    return this.status?.conditions ?? [];
   }
 }

--- a/argocd/src/resources/appproject.ts
+++ b/argocd/src/resources/appproject.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { K8s } from '@kinvolk/headlamp-plugin/lib';
+import { argocdApiVersion } from './application';
+
+const { KubeObject } = K8s.cluster;
+type KubeObjectInterface = K8s.cluster.KubeObjectInterface;
+
+export interface AppProjectDestination {
+  /** Server specifies the URL of the target cluster's Kubernetes control plane API. */
+  server?: string;
+  /** Name is an alternate way of specifying the target cluster by its symbolic name. */
+  name?: string;
+  /** Namespace specifies the target namespace on the destination cluster. */
+  namespace?: string;
+}
+
+export interface AppProjectRole {
+  /** Name is a project-unique name of the role. */
+  name: string;
+  /** Description is a human-readable description of the role. */
+  description?: string;
+  /** Policies stores a list of casbin formatted strings that define access policies for the role in the project. */
+  policies?: string[];
+  /** Groups are a list of OIDC group claims bound to this role. */
+  groups?: string[];
+}
+
+export interface GroupKind {
+  /** Group is the API group of the resource (e.g. "apps"). */
+  group: string;
+  /** Kind is the API kind of the resource (e.g. "Deployment"). */
+  kind: string;
+}
+
+export interface ArgoAppProjectSpec {
+  /** Description is a human-readable description of the project. */
+  description?: string;
+  /** SourceRepos contains a list of repository URLs which can be used for deployment in this project. */
+  sourceRepos?: string[];
+  /** Destinations contains a list of destinations (cluster/namespace) to which apps in this project can be deployed. */
+  destinations?: AppProjectDestination[];
+  /** ClusterResourceWhitelist contains a list of cluster-scoped resources allowed to be deployed in this project. */
+  clusterResourceWhitelist?: GroupKind[];
+  /** ClusterResourceBlacklist contains a list of cluster-scoped resources forbidden from being deployed in this project. */
+  clusterResourceBlacklist?: GroupKind[];
+  /** NamespaceResourceWhitelist contains a list of namespace-scoped resources allowed to be deployed in this project. */
+  namespaceResourceWhitelist?: GroupKind[];
+  /** NamespaceResourceBlacklist contains a list of namespace-scoped resources forbidden from being deployed in this project. */
+  namespaceResourceBlacklist?: GroupKind[];
+  /** Roles are user defined RBAC roles associated with this project. */
+  roles?: AppProjectRole[];
+}
+
+export interface KubeArgoAppProject extends KubeObjectInterface {
+  /** Spec represents the desired state of the AppProject. */
+  spec: ArgoAppProjectSpec;
+}
+
+/**
+ * Headlamp KubeObject wrapper for the Argo CD AppProject CRD.
+ *
+ * AppProjects define security boundaries — which Git repos, clusters,
+ * namespaces, and resource kinds an Application is allowed to use.
+ */
+export class ArgoAppProject extends KubeObject<KubeArgoAppProject> {
+  static kind = 'AppProject';
+  static apiName = 'appprojects';
+  static apiVersion = argocdApiVersion;
+  static isNamespaced = true;
+
+  static get detailsRoute() {
+    return '/argocd/projects/:namespace/:name';
+  }
+
+  get spec(): ArgoAppProjectSpec {
+    return this.jsonData.spec;
+  }
+
+  get description(): string {
+    return this.spec.description || '';
+  }
+
+  get sourceRepos(): string[] {
+    return this.spec.sourceRepos || [];
+  }
+
+  get destinations(): AppProjectDestination[] {
+    return this.spec.destinations || [];
+  }
+
+  get roles(): AppProjectRole[] {
+    return this.spec.roles || [];
+  }
+
+  get clusterResourceWhitelist(): GroupKind[] {
+    return this.spec.clusterResourceWhitelist || [];
+  }
+
+  get namespaceResourceWhitelist(): GroupKind[] {
+    return this.spec.namespaceResourceWhitelist || [];
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds a CRD detection guard, RBAC-aware Sync/Refresh buttons, enhanced Application detail sections, shared operation hooks, multi-source Application support, and AppProject list/detail views.

### Why CRD Detection Guard?
On clusters where Argo CD is not installed, the sidebar entries should not appear. This follows the exact same pattern used by the Flux plugin — a module-level cache with a 30s TTL checks for `argoproj.io` CRDs via `K8s.ResourceClasses.CustomResourceDefinition.apiList()`. If no CRDs are found, the sidebar children are hidden via `registerSidebarEntryFilter`.

### Why RBAC-aware buttons?
Previously, users without `patch` permission on `applications.argoproj.io` would see Sync/Refresh buttons but get 403 errors when clicking them. Now both buttons are wrapped with Headlamp's `AuthVisible` component — they only render when the user has `patch` permission. This is the same approach used by the Volcano and Kyverno plugins.

## Changes

### Added
- `src/hooks/useArgoOperation.ts` — Shared operation hook with loading state and snackbar feedback. `useArgoOperation` for the detail view (single loading state), `useArgoOperationMap` for the list view (per-app loading state keyed by `namespace/name`).
- `src/resources/appproject.ts` — `ArgoAppProject` KubeObject class for the AppProject CRD with typed getters for destinations, source repos, roles, and cluster resource whitelist.
- `src/components/appprojects/List.tsx` — AppProject list view using `ResourceListView` with columns for description, source repos count, and destinations count.
- `src/components/appprojects/Detail.tsx` — AppProject detail view using `DetailsGrid` with extra sections for Source Repositories, Destinations, Cluster Resource Whitelist, and Roles.
- `src/components/applications/Detail.tsx` — Application detail view with Managed Resources table, Sync Policy section, and Conditions table as `extraSections`.
- `src/components/applications/statusHelpers.ts` — Sync and health status to `StatusLabel` badge mapping.
- `src/api/argoClient.ts` — Kubernetes-native sync (merge-patch `.operation`) and refresh (annotation patch) functions.
- `src/api/argoClient.test.ts` — Unit tests for sync and refresh API functions (8 tests).

### Changed
- `src/resources/application.ts` — Extended with `SourceSpec`, `ManagedResource`, `ArgoCondition` interfaces, `syncPolicy` field, multi-source support (`spec.sources[]`), and convenience getters.
- `src/index.tsx` — Added CRD detection guard via `registerSidebarEntryFilter`, registered detail route, AppProject routes and sidebar entry, added official Argo CD logo icon via `addIcon()`.
- `src/components/applications/List.tsx` — Replaced inline handlers with `useArgoOperationMap` hook, wrapped action buttons with `AuthVisible`, shows "N sources" for multi-source apps.
- `src/index.test.tsx` — Updated mocks for `registerSidebarEntryFilter`, `Utils`, `K8s.ResourceClasses`, `AuthVisible`, `ConditionsTable`. Added assertions for AppProject routes, sidebar entry, and CRD filter registration.
- `README.md` — Updated with new features and RBAC permissions documentation.

## Steps to Test

1. Have a running Kubernetes cluster with Argo CD installed and Headlamp accessible.
2. Apply the mock CRD and test data if needed:
   ```
   kubectl apply -f test-files/deploy/crd.yaml
   ```
3. Navigate to **Argo CD → Applications** — verify Sync/Refresh buttons appear (or are hidden if user lacks patch permission).
4. Click into an Application — verify Managed Resources table, Sync Policy section, and Conditions table render.
5. Navigate to **Argo CD → Projects** — verify AppProject list and detail views.
6. On a cluster without Argo CD CRDs, verify the sidebar entries are hidden.