### PR TITLE
kmesh: components: Implement Authorization Policy viewer

### DIFF
--- a/kmesh/src/components/daemon/AuthzPolicies.tsx
+++ b/kmesh/src/components/daemon/AuthzPolicies.tsx
@@ -1,0 +1,147 @@
+import { SectionBox, SimpleTable } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import {
+  Box,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  Typography,
+} from '@mui/material';
+import { useState } from 'react';
+import { useKmeshDaemonPods } from '../../hooks/useKmeshDaemonPods';
+import type { DaemonAuthorizationPolicy } from '../../types/daemonApi';
+import { KMESH_NAMESPACE } from '../../utils/kmeshDaemonApi';
+import { useAuthzPolicies } from './useAuthzPolicies';
+
+export default function AuthzPolicies() {
+  const { readyPod, loading: podsLoading, error: podError } = useKmeshDaemonPods();
+  const podName = readyPod?.name ?? null;
+
+  const { status, data: policies, error: apiError } = useAuthzPolicies(KMESH_NAMESPACE, podName);
+  const [selectedPolicy, setSelectedPolicy] = useState<DaemonAuthorizationPolicy | null>(null);
+
+  if (podsLoading) {
+    return (
+      <SectionBox title="Authorization Policies active in KMesh">
+        <Box display="flex" justifyContent="center" p={4}>
+          <CircularProgress />
+        </Box>
+      </SectionBox>
+    );
+  }
+
+  if (podError) {
+    return (
+      <SectionBox title="Authorization Policies active in KMesh">
+        <Typography color="error">Error locating Kmesh daemon pod: {podError}</Typography>
+      </SectionBox>
+    );
+  }
+
+  if (!readyPod) {
+    return (
+      <SectionBox title="Authorization Policies active in KMesh">
+        <Typography variant="body2" color="textSecondary">
+          No Running+Ready Kmesh daemon pod found. Ensure the kmesh-daemon DaemonSet is healthy.
+        </Typography>
+      </SectionBox>
+    );
+  }
+
+  if (status === 'loading') {
+    return (
+      <SectionBox title="Authorization Policies active in KMesh">
+        <Box display="flex" justifyContent="center" p={4}>
+          <CircularProgress />
+        </Box>
+      </SectionBox>
+    );
+  }
+
+  if (status === 'error' || apiError) {
+    const isKernelNativeMode =
+      /\b400\b/.test(apiError ?? '') || /Bad Request/i.test(apiError ?? '');
+    return (
+      <SectionBox title="Authorization Policies active in KMesh">
+        {isKernelNativeMode ? (
+          <Box p={2}>
+            <Typography color="error">
+              Kmesh is currently running in <strong>kernel-native (ADS) mode</strong>. Authorization
+              policies are only available in <strong>dual-engine (workload) mode</strong>.
+            </Typography>
+          </Box>
+        ) : (
+          <Typography color="error">
+            Error fetching authorization policies from daemon ({podName}):{' '}
+            {apiError ?? 'Unknown error'}
+          </Typography>
+        )}
+      </SectionBox>
+    );
+  }
+
+  return (
+    <>
+      <SectionBox title="Authorization Policies active in KMesh">
+        <SimpleTable
+          data={policies ?? []}
+          columns={[
+            {
+              label: 'Policy Name',
+              getter: (p: DaemonAuthorizationPolicy) => p.name ?? '-',
+              sort: (p: DaemonAuthorizationPolicy) => p.name ?? '',
+            },
+            {
+              label: 'Namespace',
+              getter: (p: DaemonAuthorizationPolicy) => p.namespace ?? '-',
+              sort: (p: DaemonAuthorizationPolicy) => p.namespace ?? '',
+            },
+            {
+              label: 'Scope',
+              getter: (p: DaemonAuthorizationPolicy) => p.scope ?? '-',
+              sort: (p: DaemonAuthorizationPolicy) => p.scope ?? '',
+            },
+            {
+              label: 'Action',
+              getter: (p: DaemonAuthorizationPolicy) => p.action ?? '-',
+              sort: (p: DaemonAuthorizationPolicy) => p.action ?? '',
+            },
+            {
+              label: 'Rules',
+              getter: (p: DaemonAuthorizationPolicy) => (
+                <Button size="small" variant="outlined" onClick={() => setSelectedPolicy(p)}>
+                  View Rules ({(p.rules ?? []).length})
+                </Button>
+              ),
+            },
+          ]}
+          emptyMessage="No Authorization Policies found."
+        />
+      </SectionBox>
+
+      <Dialog
+        open={!!selectedPolicy}
+        onClose={() => setSelectedPolicy(null)}
+        maxWidth="md"
+        fullWidth
+      >
+        <DialogTitle>Rules for {selectedPolicy?.name}</DialogTitle>
+        <DialogContent>
+          <Box
+            component="pre"
+            sx={{
+              backgroundColor: 'background.default',
+              p: 2,
+              borderRadius: 1,
+              overflowX: 'auto',
+              fontSize: '0.85rem',
+            }}
+          >
+            {selectedPolicy ? JSON.stringify(selectedPolicy.rules, null, 2) : ''}
+          </Box>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/kmesh/src/components/daemon/useAuthzPolicies.ts
+++ b/kmesh/src/components/daemon/useAuthzPolicies.ts
@@ -1,0 +1,28 @@
+/**
+ * useAuthzPolicies — fetches and slices the authorization policy list from
+ * the Kmesh workload config dump endpoint.
+ *
+ * Returns 400 (error state) if the daemon is in kernel-native mode —
+ * the component shows a graceful fallback in that case.
+ *
+ * @example
+ * ```tsx
+ * const { status, data: policies } = useAuthzPolicies('kmesh-system', readyPod?.name ?? null);
+ * ```
+ */
+
+import { useWorkloadConfigDump } from '../../hooks/useDaemonRequest';
+import type { DaemonAuthorizationPolicy, DaemonRequestState } from '../../types/daemonApi';
+
+export function useAuthzPolicies(
+  namespace: string,
+  podName: string | null
+): DaemonRequestState<DaemonAuthorizationPolicy[]> {
+  const raw = useWorkloadConfigDump(namespace, podName);
+
+  return {
+    status: raw.status,
+    error: raw.error,
+    data: raw.status === 'success' ? raw.data?.policies ?? [] : null,
+  };
+}

--- a/kmesh/src/index.test.ts
+++ b/kmesh/src/index.test.ts
@@ -17,4 +17,9 @@ describe('Kmesh Routes', () => {
     expect(kmeshRoutePaths.observability).toBe('/kmesh/observability');
     expect(kmeshRouteNames.observability).toBe('kmesh-observability');
   });
+
+  it('should define the authz policies route correctly', () => {
+    expect(kmeshRoutePaths.authzPolicies).toBe('/kmesh/authz-policies');
+    expect(kmeshRouteNames.authzPolicies).toBe('kmesh-authz-policies');
+  });
 });

--- a/kmesh/src/index.tsx
+++ b/kmesh/src/index.tsx
@@ -1,5 +1,6 @@
 import { registerRoute, registerSidebarEntry } from '@kinvolk/headlamp-plugin/lib';
 import type { ComponentType } from 'react';
+import AuthzPolicies from './components/daemon/AuthzPolicies';
 import HealthDashboard from './components/daemon/HealthDashboard';
 import ObservabilityPanel from './components/daemon/ObservabilityPanel';
 import XdsConfigDump from './components/daemon/XdsConfigDump';
@@ -135,4 +136,20 @@ registerRoute({
   name: kmeshRouteNames.observability,
   exact: true,
   component: () => <ObservabilityPanel />,
+});
+
+// Authz Policies Viewer
+registerSidebarEntry({
+  parent: 'kmesh',
+  name: 'kmesh-authz-policies',
+  label: 'Auth Policies',
+  url: kmeshRoutePaths.authzPolicies,
+});
+
+registerRoute({
+  path: kmeshRoutePaths.authzPolicies,
+  sidebar: 'kmesh-authz-policies',
+  name: kmeshRouteNames.authzPolicies,
+  exact: true,
+  component: () => <AuthzPolicies />,
 });

--- a/kmesh/src/utils/kmeshRoutes.ts
+++ b/kmesh/src/utils/kmeshRoutes.ts
@@ -8,6 +8,7 @@ export const kmeshRouteNames = {
   xdsConfigDump: 'kmesh-xds-config-dump',
   healthDashboard: 'kmesh-health-dashboard',
   observability: 'kmesh-observability',
+  authzPolicies: 'kmesh-authz-policies',
 } as const;
 
 /**
@@ -21,4 +22,5 @@ export const kmeshRoutePaths = {
   xdsConfigDump: '/kmesh/xds-config',
   healthDashboard: '/kmesh/health',
   observability: '/kmesh/observability',
+  authzPolicies: '/kmesh/authz-policies',
 } as const;


### PR DESCRIPTION
## Description
This PR implements the **Authorization Policy Viewer** (Section 11.7) for the Kmesh Headlamp plugin. It introduces a new read-only dashboard to view security policies active in the daemon when running in workload / dual-engine mode.

### Changes Included
- **New API Hook (`useAuthzPolicies`)**: Extracts the `policies[]` array directly from the `/debug/config_dump/dual-engine` config dump endpoint.
- **AuthzPolicies Component**: Renders a `SimpleTable` detailing active policies, including their `Name`, `Namespace`, `Scope`, and `Action` (e.g., ALLOW/DENY).
- **Rules Inspector (Dialog)**: Replaced a bulky inline JSON view with a clean "View Rules" button. Clicking this opens a Material-UI Dialog displaying the raw evaluated `rules` (from `security.proto`) in a formatted JSON block.
- **Routing**: Registered a new sidebar entry under Kmesh (`Auth Policies`) and mapped it to the `/kmesh/authz-policies` route.