### PR TITLE
metal3: Add a Map view for the Machine to BareMetalHost chain

### DIFF
--- a/metal3/src/index.tsx
+++ b/metal3/src/index.tsx
@@ -16,6 +16,7 @@
 
 import {
   registerDetailsViewHeaderAction,
+  registerMapSource,
   registerRoute,
   registerSidebarEntry,
 } from '@kinvolk/headlamp-plugin/lib';
@@ -24,6 +25,7 @@ import { BareMetalHostDetail } from './BareMetalHost/Details';
 import { BareMetalHosts } from './BareMetalHost/List';
 import { PowerActionButton } from './BareMetalHost/PowerActionButton';
 import { RebootActionButton } from './BareMetalHost/RebootActionButton';
+import { metal3Source } from './mapView';
 import { Metal3ClusterDetail } from './Metal3Cluster/Details';
 import { Metal3Clusters } from './Metal3Cluster/List';
 import { Metal3ClusterTemplateDetail } from './Metal3ClusterTemplate/Details';
@@ -275,6 +277,9 @@ registerRoute({
   component: () => <Metal3RemediationTemplateDetail />,
   name: 'metal3remediationtemplate-detail',
 });
+// Map source. Draws the Metal3Machine to BareMetalHost link and the Cluster API
+// Machine to Metal3Machine link, neither of which Headlamp derives on its own.
+registerMapSource(metal3Source);
 
 // Power on/off action on the BareMetalHost detail view. Toggles spec.online.
 registerDetailsViewHeaderAction(PowerActionButton);

--- a/metal3/src/index.tsx
+++ b/metal3/src/index.tsx
@@ -16,12 +16,14 @@
 
 import {
   registerDetailsViewHeaderAction,
+  registerMapSource,
   registerRoute,
   registerSidebarEntry,
 } from '@kinvolk/headlamp-plugin/lib';
 import { BareMetalHostDetail } from './BareMetalHost/Details';
 import { BareMetalHosts } from './BareMetalHost/List';
 import { PowerActionButton } from './BareMetalHost/PowerActionButton';
+import { metal3Source } from './mapView';
 import { Metal3ClusterDetail } from './Metal3Cluster/Details';
 import { Metal3Clusters } from './Metal3Cluster/List';
 import { Metal3ClusterTemplateDetail } from './Metal3ClusterTemplate/Details';
@@ -225,6 +227,10 @@ registerRoute({
   component: () => <Metal3DataTemplateDetail />,
   name: 'metal3datatemplate-detail',
 });
+
+// Map source. Draws the Metal3Machine to BareMetalHost link and the Cluster API
+// Machine to Metal3Machine link, neither of which Headlamp derives on its own.
+registerMapSource(metal3Source);
 
 // Power on/off action on the BareMetalHost detail view. Toggles spec.online.
 registerDetailsViewHeaderAction(PowerActionButton);

--- a/metal3/src/mapEdges.test.ts
+++ b/metal3/src/mapEdges.test.ts
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { KubeObject } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import { describe, expect, it } from 'vitest';
+import { findHostEdges, findOwnerMachineEdges } from './mapEdges';
+import { HOST_ANNOTATION } from './Metal3Machine/hostAnnotation';
+
+/** Builds a minimal Metal3Machine-shaped object carrying the host annotation. */
+function machine(uid: string, hostRef?: string): KubeObject {
+  return {
+    metadata: { uid },
+    jsonData: {
+      metadata: { uid, annotations: hostRef ? { [HOST_ANNOTATION]: hostRef } : {} },
+    },
+  } as unknown as KubeObject;
+}
+
+/** Builds a minimal BareMetalHost-shaped object. */
+function host(uid: string, namespace: string, name: string): KubeObject {
+  return {
+    metadata: { uid },
+    jsonData: { metadata: { uid, namespace, name } },
+  } as unknown as KubeObject;
+}
+
+/** Builds a Metal3Machine-shaped object carrying an ownerReference. */
+function ownedMachine(
+  uid: string,
+  owner?: { kind: string; apiVersion: string; uid: string }
+): KubeObject {
+  return {
+    metadata: { uid },
+    jsonData: {
+      metadata: {
+        uid,
+        ownerReferences: owner
+          ? [{ kind: owner.kind, apiVersion: owner.apiVersion, uid: owner.uid, name: 'owner' }]
+          : [],
+      },
+    },
+  } as unknown as KubeObject;
+}
+
+describe('findHostEdges', () => {
+  it('links a machine to the host named in its annotation', () => {
+    const machines = [machine('m1', 'metal3/host-01')];
+    const hosts = [host('h1', 'metal3', 'host-01')];
+    expect(findHostEdges(machines, hosts)).toEqual([{ id: 'm1-h1', source: 'm1', target: 'h1' }]);
+  });
+
+  it('ignores a machine with no host annotation', () => {
+    expect(findHostEdges([machine('m1')], [host('h1', 'metal3', 'host-01')])).toEqual([]);
+  });
+
+  it('ignores a machine whose annotation names a host that is not present', () => {
+    const machines = [machine('m1', 'metal3/missing')];
+    const hosts = [host('h1', 'metal3', 'host-01')];
+    expect(findHostEdges(machines, hosts)).toEqual([]);
+  });
+
+  it('matches on namespace as well as name', () => {
+    const machines = [machine('m1', 'other-ns/host-01')];
+    const hosts = [host('h1', 'metal3', 'host-01')];
+    expect(findHostEdges(machines, hosts)).toEqual([]);
+  });
+
+  it('builds one edge per linked machine', () => {
+    const machines = [machine('m1', 'metal3/host-01'), machine('m2', 'metal3/host-02')];
+    const hosts = [host('h1', 'metal3', 'host-01'), host('h2', 'metal3', 'host-02')];
+    expect(findHostEdges(machines, hosts)).toEqual([
+      { id: 'm1-h1', source: 'm1', target: 'h1' },
+      { id: 'm2-h2', source: 'm2', target: 'h2' },
+    ]);
+  });
+});
+
+describe('findOwnerMachineEdges', () => {
+  it('links a Metal3Machine to the Cluster API Machine that owns it', () => {
+    const machines = [
+      ownedMachine('m1', { kind: 'Machine', apiVersion: 'cluster.x-k8s.io/v1beta1', uid: 'cap1' }),
+    ];
+    expect(findOwnerMachineEdges(machines)).toEqual([
+      { id: 'cap1-m1', source: 'cap1', target: 'm1' },
+    ]);
+  });
+
+  it('ignores a Metal3Machine with no ownerReferences', () => {
+    expect(findOwnerMachineEdges([ownedMachine('m1')])).toEqual([]);
+  });
+
+  it('ignores an owner that is not a Machine', () => {
+    const machines = [
+      ownedMachine('m1', { kind: 'Cluster', apiVersion: 'cluster.x-k8s.io/v1beta1', uid: 'c1' }),
+    ];
+    expect(findOwnerMachineEdges(machines)).toEqual([]);
+  });
+
+  it('ignores a Machine owner from a different API group', () => {
+    const machines = [
+      ownedMachine('m1', { kind: 'Machine', apiVersion: 'other.example.com/v1', uid: 'x1' }),
+    ];
+    expect(findOwnerMachineEdges(machines)).toEqual([]);
+  });
+
+  it('accepts any served Cluster API version', () => {
+    const machines = [
+      ownedMachine('m1', { kind: 'Machine', apiVersion: 'cluster.x-k8s.io/v1beta2', uid: 'cap1' }),
+    ];
+    expect(findOwnerMachineEdges(machines)).toEqual([
+      { id: 'cap1-m1', source: 'cap1', target: 'm1' },
+    ]);
+  });
+});

--- a/metal3/src/mapEdges.test.ts
+++ b/metal3/src/mapEdges.test.ts
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2026 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { KubeObject } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import { describe, expect, it } from 'vitest';
+import { findHostEdges, findOwnerMachineEdges } from './mapEdges';
+import { HOST_ANNOTATION } from './Metal3Machine/hostAnnotation';
+
+/** Builds a minimal Metal3Machine-shaped object carrying the host annotation. */
+function machine(uid: string, hostRef?: string): KubeObject {
+  return {
+    metadata: { uid },
+    jsonData: {
+      metadata: { uid, annotations: hostRef ? { [HOST_ANNOTATION]: hostRef } : {} },
+    },
+  } as unknown as KubeObject;
+}
+
+/** Builds a minimal BareMetalHost-shaped object. */
+function host(uid: string, namespace: string, name: string): KubeObject {
+  return {
+    metadata: { uid },
+    jsonData: { metadata: { uid, namespace, name } },
+  } as unknown as KubeObject;
+}
+
+/** Builds a Metal3Machine-shaped object carrying an ownerReference. */
+function ownedMachine(
+  uid: string,
+  owner?: { kind: string; apiVersion: string; uid: string }
+): KubeObject {
+  return {
+    metadata: { uid },
+    jsonData: {
+      metadata: {
+        uid,
+        ownerReferences: owner
+          ? [{ kind: owner.kind, apiVersion: owner.apiVersion, uid: owner.uid, name: 'owner' }]
+          : [],
+      },
+    },
+  } as unknown as KubeObject;
+}
+
+describe('findHostEdges', () => {
+  it('links a machine to the host named in its annotation', () => {
+    const machines = [machine('m1', 'metal3/host-01')];
+    const hosts = [host('h1', 'metal3', 'host-01')];
+    expect(findHostEdges(machines, hosts)).toEqual([{ id: 'm1-h1', source: 'm1', target: 'h1' }]);
+  });
+
+  it('ignores a machine with no host annotation', () => {
+    expect(findHostEdges([machine('m1')], [host('h1', 'metal3', 'host-01')])).toEqual([]);
+  });
+
+  it('ignores a machine whose annotation names a host that is not present', () => {
+    const machines = [machine('m1', 'metal3/missing')];
+    const hosts = [host('h1', 'metal3', 'host-01')];
+    expect(findHostEdges(machines, hosts)).toEqual([]);
+  });
+
+  it('matches on namespace as well as name', () => {
+    const machines = [machine('m1', 'other-ns/host-01')];
+    const hosts = [host('h1', 'metal3', 'host-01')];
+    expect(findHostEdges(machines, hosts)).toEqual([]);
+  });
+
+  it('builds one edge per linked machine', () => {
+    const machines = [machine('m1', 'metal3/host-01'), machine('m2', 'metal3/host-02')];
+    const hosts = [host('h1', 'metal3', 'host-01'), host('h2', 'metal3', 'host-02')];
+    expect(findHostEdges(machines, hosts)).toEqual([
+      { id: 'm1-h1', source: 'm1', target: 'h1' },
+      { id: 'm2-h2', source: 'm2', target: 'h2' },
+    ]);
+  });
+});
+
+describe('findOwnerMachineEdges', () => {
+  it('links a Metal3Machine to the Cluster API Machine that owns it', () => {
+    const machines = [
+      ownedMachine('m1', { kind: 'Machine', apiVersion: 'cluster.x-k8s.io/v1beta1', uid: 'cap1' }),
+    ];
+    expect(findOwnerMachineEdges(machines)).toEqual([
+      { id: 'cap1-m1', source: 'cap1', target: 'm1' },
+    ]);
+  });
+
+  it('ignores a Metal3Machine with no ownerReferences', () => {
+    expect(findOwnerMachineEdges([ownedMachine('m1')])).toEqual([]);
+  });
+
+  it('ignores an owner that is not a Machine', () => {
+    const machines = [
+      ownedMachine('m1', { kind: 'Cluster', apiVersion: 'cluster.x-k8s.io/v1beta1', uid: 'c1' }),
+    ];
+    expect(findOwnerMachineEdges(machines)).toEqual([]);
+  });
+
+  it('ignores a Machine owner from a different API group', () => {
+    const machines = [
+      ownedMachine('m1', { kind: 'Machine', apiVersion: 'other.example.com/v1', uid: 'x1' }),
+    ];
+    expect(findOwnerMachineEdges(machines)).toEqual([]);
+  });
+
+  it('accepts any served Cluster API version', () => {
+    const machines = [
+      ownedMachine('m1', { kind: 'Machine', apiVersion: 'cluster.x-k8s.io/v1beta2', uid: 'cap1' }),
+    ];
+    expect(findOwnerMachineEdges(machines)).toEqual([
+      { id: 'cap1-m1', source: 'cap1', target: 'm1' },
+    ]);
+  });
+});

--- a/metal3/src/mapEdges.ts
+++ b/metal3/src/mapEdges.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { KubeObject } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import { HOST_ANNOTATION, parseHostAnnotation } from './Metal3Machine/hostAnnotation';
+
+/** A single edge in the map: `source` and `target` are node uids. */
+export interface GraphEdge {
+  id: string;
+  source: string;
+  target: string;
+}
+
+/**
+ * Builds the Metal3Machine → BareMetalHost edges from each machine's
+ * `metal3.io/BareMetalHost` annotation. This is the one link in the chain Headlamp
+ * cannot derive on its own: it is a consumerRef/annotation pair, not an
+ * ownerReference, so the default map leaves the machine and its host disconnected.
+ *
+ * @param machines - The Metal3Machine list.
+ * @param hosts - The BareMetalHost list, used to resolve each annotation to a host.
+ * @returns One edge per machine that names a host present in the list.
+ */
+export function findHostEdges(machines: KubeObject[], hosts: KubeObject[]): GraphEdge[] {
+  const edges: GraphEdge[] = [];
+  machines.forEach(machine => {
+    const ref = parseHostAnnotation(machine.jsonData.metadata?.annotations?.[HOST_ANNOTATION]);
+    if (!ref) {
+      return;
+    }
+    const host = hosts.find(
+      h =>
+        h.jsonData.metadata?.namespace === ref.namespace && h.jsonData.metadata?.name === ref.name
+    );
+    if (host) {
+      edges.push({
+        id: `${machine.metadata.uid}-${host.metadata.uid}`,
+        source: machine.metadata.uid,
+        target: host.metadata.uid,
+      });
+    }
+  });
+  return edges;
+}
+
+/** API group and kind of the Cluster API Machine that owns a Metal3Machine. */
+const MACHINE_OWNER_GROUP = 'cluster.x-k8s.io';
+const MACHINE_OWNER_KIND = 'Machine';
+
+/**
+ * Builds the Cluster API Machine → Metal3Machine edges from each Metal3Machine's
+ * ownerReference back to its Machine. Cluster API sets this controller reference
+ * when a Machine claims its infrastructure. Neither the cluster-api plugin nor
+ * Headlamp's core draws it, because each only links resources it owns and this
+ * reference spans the two, so the Metal3 plugin emits it here to close the
+ * Machine → Metal3Machine → BareMetalHost chain in the Map. The edge targets the
+ * Machine's uid, so it merges onto the node the cluster-api plugin contributes.
+ *
+ * @param machines - The Metal3Machine list.
+ * @returns One edge per Metal3Machine owned by a Cluster API Machine.
+ */
+export function findOwnerMachineEdges(machines: KubeObject[]): GraphEdge[] {
+  const edges: GraphEdge[] = [];
+  machines.forEach(machine => {
+    const owners = machine.jsonData.metadata?.ownerReferences ?? [];
+    owners.forEach(owner => {
+      const group = owner.apiVersion?.split('/')[0];
+      if (owner.kind !== MACHINE_OWNER_KIND || group !== MACHINE_OWNER_GROUP || !owner.uid) {
+        return;
+      }
+      edges.push({
+        id: `${owner.uid}-${machine.metadata.uid}`,
+        source: owner.uid,
+        target: machine.metadata.uid,
+      });
+    });
+  });
+  return edges;
+}

--- a/metal3/src/mapEdges.ts
+++ b/metal3/src/mapEdges.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { KubeObject } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import { HOST_ANNOTATION, parseHostAnnotation } from './Metal3Machine/hostAnnotation';
+
+/** A single edge in the map: `source` and `target` are node uids. */
+export interface GraphEdge {
+  id: string;
+  source: string;
+  target: string;
+}
+
+/**
+ * Builds the Metal3Machine → BareMetalHost edges from each machine's
+ * `metal3.io/BareMetalHost` annotation. This is the one link in the chain Headlamp
+ * cannot derive on its own: it is a consumerRef/annotation pair, not an
+ * ownerReference, so the default map leaves the machine and its host disconnected.
+ *
+ * @param machines - The Metal3Machine list.
+ * @param hosts - The BareMetalHost list, used to resolve each annotation to a host.
+ * @returns One edge per machine that names a host present in the list.
+ */
+export function findHostEdges(machines: KubeObject[], hosts: KubeObject[]): GraphEdge[] {
+  const edges: GraphEdge[] = [];
+  machines.forEach(machine => {
+    const ref = parseHostAnnotation(machine.jsonData.metadata?.annotations?.[HOST_ANNOTATION]);
+    if (!ref) {
+      return;
+    }
+    const host = hosts.find(
+      h =>
+        h.jsonData.metadata?.namespace === ref.namespace && h.jsonData.metadata?.name === ref.name
+    );
+    if (host) {
+      edges.push({
+        id: `${machine.metadata.uid}-${host.metadata.uid}`,
+        source: machine.metadata.uid,
+        target: host.metadata.uid,
+      });
+    }
+  });
+  return edges;
+}
+
+/** API group and kind of the Cluster API Machine that owns a Metal3Machine. */
+const MACHINE_OWNER_GROUP = 'cluster.x-k8s.io';
+const MACHINE_OWNER_KIND = 'Machine';
+
+/**
+ * Builds the Cluster API Machine → Metal3Machine edges from each Metal3Machine's
+ * ownerReference back to its Machine. Cluster API sets this controller reference
+ * when a Machine claims its infrastructure. Neither the cluster-api plugin nor
+ * Headlamp's core draws it, because each only links resources it owns and this
+ * reference spans the two, so the Metal3 plugin emits it here to close the
+ * Machine → Metal3Machine → BareMetalHost chain in the Map. The edge targets the
+ * Machine's uid, so it merges onto the node the cluster-api plugin contributes.
+ *
+ * @param machines - The Metal3Machine list.
+ * @returns One edge per Metal3Machine owned by a Cluster API Machine.
+ */
+export function findOwnerMachineEdges(machines: KubeObject[]): GraphEdge[] {
+  const edges: GraphEdge[] = [];
+  machines.forEach(machine => {
+    const owners = machine.jsonData.metadata?.ownerReferences ?? [];
+    owners.forEach(owner => {
+      const group = owner.apiVersion?.split('/')[0];
+      if (owner.kind !== MACHINE_OWNER_KIND || group !== MACHINE_OWNER_GROUP || !owner.uid) {
+        return;
+      }
+      edges.push({
+        id: `${owner.uid}-${machine.metadata.uid}`,
+        source: owner.uid,
+        target: machine.metadata.uid,
+      });
+    });
+  });
+  return edges;
+}

--- a/metal3/src/mapView.tsx
+++ b/metal3/src/mapView.tsx
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { KubeObject } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import CustomResourceDefinition from '@kinvolk/headlamp-plugin/lib/k8s/crd';
+import { useMemo } from 'react';
+import { bareMetalHostClass } from './BareMetalHost/List';
+import { findHostEdges, findOwnerMachineEdges } from './mapEdges';
+import { metal3MachineClass } from './Metal3Machine/List';
+
+/** CRD names used to detect whether each resource type exists in the cluster. */
+const BAREMETALHOST_CRD = 'baremetalhosts.metal3.io';
+const METAL3MACHINE_CRD = 'metal3machines.infrastructure.cluster.x-k8s.io';
+
+/** Map source contributing the BareMetalHost nodes. */
+const bareMetalHostSource = {
+  id: 'metal3-baremetalhosts',
+  label: 'Bare Metal Hosts',
+  useData() {
+    const [crd, crdError] = CustomResourceDefinition.useGet(BAREMETALHOST_CRD);
+    const [hosts] = bareMetalHostClass().useList();
+    return useMemo(() => {
+      // CRD absent or unreadable: contribute nothing rather than loading forever.
+      if (crdError) {
+        return { nodes: [] };
+      }
+      // Still detecting the CRD, or the list has not loaded yet.
+      if (!crd || !hosts) {
+        return null;
+      }
+      return {
+        nodes: hosts.map((host: KubeObject) => ({ id: host.metadata.uid, kubeObject: host })),
+      };
+    }, [crd, crdError, hosts]);
+  },
+};
+
+/** Map source contributing the Metal3Machine nodes and their edges down to the hosts. */
+const metal3MachineSource = {
+  id: 'metal3-machines',
+  label: 'Metal3 Machines',
+  useData() {
+    const [crd, crdError] = CustomResourceDefinition.useGet(METAL3MACHINE_CRD);
+    const [machines] = metal3MachineClass().useList();
+    const [hosts] = bareMetalHostClass().useList();
+    return useMemo(() => {
+      // On a bare-metal-only cluster the Metal3Machine CRD is absent: contribute
+      // nothing rather than leaving the source loading forever.
+      if (crdError) {
+        return { nodes: [] };
+      }
+      // Still detecting the CRD, or the list has not loaded yet.
+      if (!crd || !machines) {
+        return null;
+      }
+      return {
+        nodes: machines.map((machine: KubeObject) => ({
+          id: machine.metadata.uid,
+          kubeObject: machine,
+        })),
+        edges: [...findHostEdges(machines, hosts || []), ...findOwnerMachineEdges(machines)],
+      };
+    }, [crd, crdError, machines, hosts]);
+  },
+};
+
+/**
+ * Aggregated Metal3 map source. It draws the Metal3Machine → BareMetalHost link so
+ * the Machine → Metal3Machine → BareMetalHost chain is connected in the Map view;
+ * the Cluster → Machine half is drawn by the cluster-api plugin when it is installed.
+ */
+export const metal3Source = {
+  id: 'metal3',
+  label: 'Metal3',
+  sources: [metal3MachineSource, bareMetalHostSource],
+};

--- a/metal3/src/mapView.tsx
+++ b/metal3/src/mapView.tsx
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2026 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Link, NameValueTable, SectionBox } from '@kinvolk/headlamp-plugin/lib/components/common';
+import type { KubeObject } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import CustomResourceDefinition from '@kinvolk/headlamp-plugin/lib/k8s/crd';
+import { useMemo } from 'react';
+import { HostStatusLabel } from './BareMetalHost/HostStatusLabel';
+import { bareMetalHostClass } from './BareMetalHost/List';
+import { findHostEdges, findOwnerMachineEdges } from './mapEdges';
+import { metal3MachineClass } from './Metal3Machine/List';
+
+/** CRD names used to detect whether each resource type exists in the cluster. */
+const BAREMETALHOST_CRD = 'baremetalhosts.metal3.io';
+const METAL3MACHINE_CRD = 'metal3machines.infrastructure.cluster.x-k8s.io';
+
+/**
+ * Read-only panel shown when a node is clicked in the Map. Headlamp has no built-in
+ * view for these custom kinds, so each node supplies its own via `detailsComponent`;
+ * without it the side panel is empty. The Map is a read-only visualization, so this
+ * shows a summary and a link to the full detail rather than the detail's own actions.
+ */
+function HostNodeDetails({ node }: { node: { kubeObject?: KubeObject } }) {
+  const host = node.kubeObject;
+  if (!host) {
+    return null;
+  }
+  const spec = host.jsonData.spec ?? {};
+  const ref = spec.consumerRef;
+  return (
+    <SectionBox title={`BareMetalHost: ${host.metadata.name}`}>
+      <NameValueTable
+        rows={[
+          { name: 'Namespace', value: host.metadata.namespace },
+          { name: 'Status', value: <HostStatusLabel host={host} /> },
+          {
+            name: 'Provisioning State',
+            value: host.jsonData.status?.provisioning?.state || 'Unknown',
+          },
+          { name: 'Consumer', value: ref?.name ? `${ref.name} (${ref.kind})` : '-' },
+          { name: 'Online', value: String(spec.online ?? false) },
+        ]}
+      />
+      <Link
+        routeName="baremetalhost-detail"
+        params={{ namespace: host.metadata.namespace, name: host.metadata.name }}
+      >
+        Open details
+      </Link>
+    </SectionBox>
+  );
+}
+
+function Metal3MachineNodeDetails({ node }: { node: { kubeObject?: KubeObject } }) {
+  const machine = node.kubeObject;
+  if (!machine) {
+    return null;
+  }
+  return (
+    <SectionBox title={`Metal3Machine: ${machine.metadata.name}`}>
+      <NameValueTable
+        rows={[
+          { name: 'Namespace', value: machine.metadata.namespace },
+          { name: 'Provider ID', value: machine.jsonData.spec?.providerID || '-' },
+        ]}
+      />
+      <Link
+        routeName="metal3machine-detail"
+        params={{ namespace: machine.metadata.namespace, name: machine.metadata.name }}
+      >
+        Open details
+      </Link>
+    </SectionBox>
+  );
+}
+
+/** Map source contributing the BareMetalHost nodes. */
+const bareMetalHostSource = {
+  id: 'metal3-baremetalhosts',
+  label: 'Bare Metal Hosts',
+  useData() {
+    const [crd, crdError] = CustomResourceDefinition.useGet(BAREMETALHOST_CRD);
+    const [hosts] = bareMetalHostClass().useList();
+    return useMemo(() => {
+      // CRD absent or unreadable: contribute nothing rather than loading forever.
+      if (crdError) {
+        return { nodes: [] };
+      }
+      // Still detecting the CRD, or the list has not loaded yet.
+      if (!crd || !hosts) {
+        return null;
+      }
+      return {
+        nodes: hosts.map((host: KubeObject) => ({
+          id: host.metadata.uid,
+          kubeObject: host,
+          detailsComponent: HostNodeDetails,
+        })),
+      };
+    }, [crd, crdError, hosts]);
+  },
+};
+
+/** Map source contributing the Metal3Machine nodes and their edges down to the hosts. */
+const metal3MachineSource = {
+  id: 'metal3-machines',
+  label: 'Metal3 Machines',
+  useData() {
+    const [crd, crdError] = CustomResourceDefinition.useGet(METAL3MACHINE_CRD);
+    const [machines] = metal3MachineClass().useList();
+    const [hosts] = bareMetalHostClass().useList();
+    return useMemo(() => {
+      // On a bare-metal-only cluster the Metal3Machine CRD is absent: contribute
+      // nothing rather than leaving the source loading forever.
+      if (crdError) {
+        return { nodes: [] };
+      }
+      // Still detecting the CRD, or the list has not loaded yet.
+      if (!crd || !machines) {
+        return null;
+      }
+      return {
+        nodes: machines.map((machine: KubeObject) => ({
+          id: machine.metadata.uid,
+          kubeObject: machine,
+          detailsComponent: Metal3MachineNodeDetails,
+        })),
+        edges: [...findHostEdges(machines, hosts || []), ...findOwnerMachineEdges(machines)],
+      };
+    }, [crd, crdError, machines, hosts]);
+  },
+};
+
+/**
+ * Aggregated Metal3 map source. It draws the Metal3Machine → BareMetalHost link so
+ * the Machine → Metal3Machine → BareMetalHost chain is connected in the Map view;
+ * the Cluster → Machine half is drawn by the cluster-api plugin when it is installed.
+ */
+export const metal3Source = {
+  id: 'metal3',
+  label: 'Metal3',
+  sources: [metal3MachineSource, bareMetalHostSource],
+};


### PR DESCRIPTION
This adds the Map view for the Metal3 plugin. It registers a custom GraphSource
that draws the links Headlamp cannot work out on its own.

There are two such links. The first is Metal3Machine to BareMetalHost. A
Metal3Machine records the host it claimed in the `metal3.io/BareMetalHost`
annotation, not as an ownerReference, so Headlamp does not draw it. The second
is the Cluster API Machine to Metal3Machine. The Metal3Machine has an
ownerReference back to its Machine, but the cluster-api plugin only links
Cluster API resources to each other and this plugin only links Metal3 resources,
so that reference falls between the two and neither draws it. This source emits
both edges.

The full chain is Cluster → Machine → Metal3Machine → BareMetalHost. The top
half, Cluster to Machine, is drawn by the cluster-api plugin, so seeing the whole
chain needs that plugin installed. Without it, the Map still shows the
Metal3Machines and BareMetalHosts and the link between them.

On a cluster that runs the bare metal operator without Cluster API, the
Metal3Machine CRD is absent. The source checks for the CRD and contributes
nothing when it is missing, so the Map does not hang and still shows the hosts.

The edge builders are pure functions in `mapEdges.ts` with unit tests in
`mapEdges.test.ts`.

Stacked on #902, which adds the annotation helper this reuses.

## Screenshots

_Full chain, Cluster → Machine → Metal3Machine → BareMetalHost:_
<img width="1950" height="1058" alt="image" src="https://github.com/user-attachments/assets/b46a971c-7a43-493f-b07b-ef2f6ff30e87" />


_The Metal3Machine → BareMetalHost link on its own:_
<img width="1498" height="590" alt="image" src="https://github.com/user-attachments/assets/6dcdc437-68d5-44ed-9d67-f978ce810334" />

