### PR TITLE
kueue: Add LocalQueue views

### DIFF
--- a/kueue/README.md
+++ b/kueue/README.md
@@ -6,26 +6,29 @@ See the [Kueue getting started guide](https://kueue.sigs.k8s.io/docs/getting-sta
 
 ## Current Scope
 
-This plugin currently reads Kueue `ClusterQueue` and `ResourceFlavor` resources from the Kubernetes API and displays them in basic list and detail pages. It registers a Kueue sidebar section with entries for both resources.
+This plugin currently reads Kueue `ClusterQueue`, `LocalQueue`, and `ResourceFlavor` resources from the Kubernetes API and displays them in basic list and detail pages. It registers a Kueue sidebar section with entries for these resources.
 
-Kueue resources such as `LocalQueue`, `Workload`, and additional queueing views will be added in later PRs.
+Kueue resources such as `Workload` and additional queueing views will be added in later PRs.
 
 ## Prerequisites
 
 Kueue CRDs must be installed in the cluster before the plugin can list resources. See the [Kueue installation guide](https://kueue.sigs.k8s.io/docs/getting-started/installation/) for installation instructions.
 
-You can check for the `ClusterQueue` and `ResourceFlavor` CRDs and resources with:
+You can check for the `ClusterQueue`, `LocalQueue`, and `ResourceFlavor` CRDs and resources with:
 
 ```bash
 kubectl get crd clusterqueues.kueue.x-k8s.io
+kubectl get crd localqueues.kueue.x-k8s.io
 kubectl get crd resourceflavors.kueue.x-k8s.io
 kubectl get clusterqueues
+kubectl get localqueues -A
+kubectl get localqueue <name> -n <namespace> -o yaml
 kubectl get resourceflavors
 ```
 
 ## Test Files
 
-Sample `ClusterQueue` and `ResourceFlavor` manifests are available in `test-files/deploy/`.
+Sample `ClusterQueue`, `LocalQueue`, and `ResourceFlavor` manifests are available in `test-files/deploy/`.
 
 Apply them to a cluster with Kueue installed:
 
@@ -34,9 +37,10 @@ kubectl apply -f test-files/deploy/resourceflavor-default.yaml
 kubectl apply -f test-files/deploy/resourceflavor-spot.yaml
 kubectl apply -f test-files/deploy/resourceflavor-topology.yaml
 kubectl apply -f test-files/deploy/clusterqueue-team-a.yaml
+kubectl apply -f test-files/deploy/localqueue-team-a.yaml
 ```
 
-After applying the examples, open `Kueue` > `ClusterQueues` or `Kueue` > `ResourceFlavors` in Headlamp.
+After applying the examples, open `Kueue` > `ClusterQueues`, `Kueue` > `LocalQueues`, or `Kueue` > `ResourceFlavors` in Headlamp.
 
 ## Development
 

--- a/kueue/src/components/common/KueueAdminResourceAccess.tsx
+++ b/kueue/src/components/common/KueueAdminResourceAccess.tsx
@@ -8,12 +8,14 @@ import { KubeObjectClass } from '@kinvolk/headlamp-plugin/lib/lib/k8s/KubeObject
 import { ReactNode, useState } from 'react';
 
 interface KueueAdminResourceAccessProps {
-  /** Kueue admin resource class to check access for. */
+  /** Kueue resource class to check access for. */
   resourceClass: KubeObjectClass;
   /** Human-readable resource name shown in loading and denied messages. */
   resourceLabel: string;
   /** Kubernetes verb to verify before rendering the page. */
   verb: 'get' | 'list';
+  /** Optional sentence describing the resource scope in denied messages. */
+  accessDescription?: string;
   /** Page content to render after the user is authorized. */
   children: ReactNode;
 }
@@ -22,6 +24,7 @@ export default function KueueAdminResourceAccess({
   resourceClass,
   resourceLabel,
   verb,
+  accessDescription = `Kueue ${resourceLabel} are cluster-scoped admin resources.`,
   children,
 }: KueueAdminResourceAccessProps) {
   const [allowed, setAllowed] = useState<boolean | null>(null);
@@ -32,7 +35,7 @@ export default function KueueAdminResourceAccess({
       {allowed === false && (
         <SectionBox title={`Kueue ${resourceLabel}`}>
           <EmptyContent color="text.secondary">
-            {`Kueue ${resourceLabel} are cluster-scoped admin resources. Your current Kubernetes credentials are not authorized to ${
+            {`${accessDescription} Your current Kubernetes credentials are not authorized to ${
               verb === 'get' ? 'view' : 'list'
             } this page.`}
           </EmptyContent>

--- a/kueue/src/components/localqueues/Detail.tsx
+++ b/kueue/src/components/localqueues/Detail.tsx
@@ -1,0 +1,89 @@
+import {
+  ConditionsSection,
+  DetailsGrid,
+  Link,
+} from '@kinvolk/headlamp-plugin/lib/components/common';
+import { useParams } from 'react-router-dom';
+import { LocalQueue } from '../../resources/localQueue';
+import { kueueRouteNames } from '../../utils/kueueRoutes';
+import KueueAdminResourceAccess from '../common/KueueAdminResourceAccess';
+
+/** Render a ClusterQueue reference as a detail-page link. */
+function renderClusterQueueLink(localQueue: LocalQueue) {
+  const clusterQueueName = localQueue.clusterQueueName;
+
+  if (!clusterQueueName) {
+    return '-';
+  }
+
+  return (
+    <Link routeName={kueueRouteNames.clusterQueueDetail} params={{ name: clusterQueueName }}>
+      {clusterQueueName}
+    </Link>
+  );
+}
+
+/** Build the standard Headlamp conditions section for LocalQueue status. */
+function getConditionsSection(localQueue: LocalQueue) {
+  if (!localQueue.conditions.length) {
+    return null;
+  }
+
+  return {
+    id: 'conditions',
+    section: <ConditionsSection resource={localQueue.jsonData} />,
+  };
+}
+
+export default function LocalQueueDetail() {
+  const { namespace, name } = useParams<{ namespace: string; name: string }>();
+
+  return (
+    <KueueAdminResourceAccess
+      resourceClass={LocalQueue}
+      resourceLabel="LocalQueues"
+      verb="get"
+      accessDescription="Kueue LocalQueues are namespaced user queue resources."
+    >
+      <DetailsGrid
+        resourceType={LocalQueue}
+        name={name}
+        namespace={namespace}
+        withEvents
+        extraInfo={localQueue =>
+          localQueue
+            ? [
+                {
+                  name: 'ClusterQueue',
+                  value: renderClusterQueueLink(localQueue),
+                },
+                {
+                  name: 'Stop Policy',
+                  value: localQueue.stopPolicyDisplay,
+                },
+                {
+                  name: 'Pending Workloads',
+                  value: localQueue.pendingWorkloads,
+                },
+                {
+                  name: 'Admitted Workloads',
+                  value: localQueue.admittedWorkloads,
+                },
+                {
+                  name: 'Reserving Workloads',
+                  value: localQueue.reservingWorkloads,
+                },
+                {
+                  name: 'Status',
+                  value: localQueue.statusDisplay,
+                },
+              ]
+            : []
+        }
+        extraSections={localQueue =>
+          localQueue ? [getConditionsSection(localQueue)].filter(Boolean) : []
+        }
+      />
+    </KueueAdminResourceAccess>
+  );
+}

--- a/kueue/src/components/localqueues/List.tsx
+++ b/kueue/src/components/localqueues/List.tsx
@@ -1,0 +1,55 @@
+import { ResourceListView } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { ClusterQueue } from '../../resources/clusterQueue';
+import { LocalQueue } from '../../resources/localQueue';
+import KueueAdminResourceAccess from '../common/KueueAdminResourceAccess';
+
+export default function LocalQueueList() {
+  return (
+    <KueueAdminResourceAccess
+      resourceClass={LocalQueue}
+      resourceLabel="LocalQueues"
+      verb="list"
+      accessDescription="Kueue LocalQueues are namespaced user queue resources."
+    >
+      <ResourceListView
+        title="Kueue LocalQueues"
+        resourceClass={LocalQueue}
+        columns={[
+          'name',
+          'namespace',
+          {
+            id: 'clusterQueue',
+            label: ClusterQueue.kind,
+            getValue: (localQueue: LocalQueue) => localQueue.clusterQueueDisplay,
+          },
+          {
+            id: 'stopPolicy',
+            label: 'Stop Policy',
+            getValue: (localQueue: LocalQueue) => localQueue.stopPolicyDisplay,
+          },
+          {
+            id: 'pendingWorkloads',
+            label: 'Pending Workloads',
+            getValue: (localQueue: LocalQueue) => localQueue.pendingWorkloads,
+          },
+          {
+            id: 'admittedWorkloads',
+            label: 'Admitted Workloads',
+            getValue: (localQueue: LocalQueue) => localQueue.admittedWorkloads,
+          },
+          {
+            id: 'reservingWorkloads',
+            label: 'Reserving Workloads',
+            getValue: (localQueue: LocalQueue) => localQueue.reservingWorkloads,
+          },
+          {
+            id: 'status',
+            label: 'Status',
+            getValue: (localQueue: LocalQueue) => localQueue.statusDisplay,
+          },
+          'age',
+        ]}
+      />
+    </KueueAdminResourceAccess>
+  );
+}

--- a/kueue/src/index.tsx
+++ b/kueue/src/index.tsx
@@ -1,6 +1,8 @@
 import { registerRoute, registerSidebarEntry } from '@kinvolk/headlamp-plugin/lib';
 import ClusterQueueDetail from './components/clusterqueues/Detail';
 import ClusterQueueList from './components/clusterqueues/List';
+import LocalQueueDetail from './components/localqueues/Detail';
+import LocalQueueList from './components/localqueues/List';
 import ResourceFlavorDetail from './components/resourceflavors/Detail';
 import ResourceFlavorList from './components/resourceflavors/List';
 import { kueueRouteNames, kueueRoutePaths } from './utils/kueueRoutes';
@@ -18,6 +20,13 @@ registerSidebarEntry({
   name: 'kueue-clusterqueues',
   label: 'ClusterQueues',
   url: kueueRoutePaths.clusterQueuesList,
+});
+
+registerSidebarEntry({
+  parent: 'kueue',
+  name: 'kueue-localqueues',
+  label: 'LocalQueues',
+  url: kueueRoutePaths.localQueuesList,
 });
 
 registerSidebarEntry({
@@ -41,6 +50,22 @@ registerRoute({
   name: kueueRouteNames.clusterQueueDetail,
   exact: true,
   component: () => <ClusterQueueDetail />,
+});
+
+registerRoute({
+  path: kueueRoutePaths.localQueuesList,
+  sidebar: 'kueue-localqueues',
+  name: kueueRouteNames.localQueuesList,
+  exact: true,
+  component: () => <LocalQueueList />,
+});
+
+registerRoute({
+  path: kueueRoutePaths.localQueueDetail,
+  sidebar: 'kueue-localqueues',
+  name: kueueRouteNames.localQueueDetail,
+  exact: true,
+  component: () => <LocalQueueDetail />,
 });
 
 registerRoute({

--- a/kueue/src/resources/localQueue.test.ts
+++ b/kueue/src/resources/localQueue.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { kueueRoutePaths } from '../utils/kueueRoutes';
+import {
+  getLocalQueueDetailRouteParams,
+  renderClusterQueueName,
+  renderLocalQueueStatus,
+  renderStopPolicy,
+  renderWorkloadCount,
+} from './localQueueFormatters';
+
+describe('LocalQueue formatters', () => {
+  it('formats cluster queue and stop policy values', () => {
+    expect(renderClusterQueueName('team-a')).toBe('team-a');
+    expect(renderClusterQueueName()).toBe('-');
+    expect(renderStopPolicy('Hold')).toBe('Hold');
+    expect(renderStopPolicy()).toBe('-');
+  });
+
+  it('preserves explicit zero workload counts', () => {
+    expect(renderWorkloadCount(0)).toBe(0);
+    expect(renderWorkloadCount(3)).toBe(3);
+    expect(renderWorkloadCount()).toBe(0);
+  });
+
+  it('derives a readable status from the Active condition', () => {
+    expect(renderLocalQueueStatus({ type: 'Active', status: 'True' })).toBe('Active');
+    expect(renderLocalQueueStatus({ type: 'Active', status: 'False' })).toBe('Inactive');
+    expect(renderLocalQueueStatus({ type: 'Active', status: 'Unknown' })).toBe('Unknown');
+    expect(renderLocalQueueStatus()).toBe('Unknown');
+  });
+
+  it('builds namespaced detail route params', () => {
+    expect(kueueRoutePaths.localQueueDetail).toBe('/kueue/localqueues/:namespace/:name');
+    expect(getLocalQueueDetailRouteParams('team-a', 'team-a-queue')).toEqual({
+      namespace: 'team-a',
+      name: 'team-a-queue',
+    });
+  });
+
+  it('handles missing values without producing undefined display output', () => {
+    expect(renderClusterQueueName(undefined)).toBe('-');
+    expect(renderStopPolicy(undefined)).toBe('-');
+    expect(renderWorkloadCount(undefined)).toBe(0);
+    expect(renderLocalQueueStatus(undefined)).toBe('Unknown');
+    expect(getLocalQueueDetailRouteParams(undefined, undefined)).toEqual({
+      namespace: '',
+      name: '',
+    });
+  });
+});

--- a/kueue/src/resources/localQueue.ts
+++ b/kueue/src/resources/localQueue.ts
@@ -1,0 +1,266 @@
+import { KubeObject, KubeObjectInterface } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import { kueueApiVersions } from '../utils/kueueApi';
+import { kueueRoutePaths } from '../utils/kueueRoutes';
+import type { FairSharing, KueueCondition, ResourceQuantity, StopPolicy } from './clusterQueue';
+import {
+  getLocalQueueDetailRouteParams,
+  renderClusterQueueName,
+  renderLocalQueueStatus,
+  renderStopPolicy,
+  renderWorkloadCount,
+} from './localQueueFormatters';
+
+const LOCAL_QUEUE_API_DOCS = 'https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#localqueue';
+const LOCAL_QUEUE_SPEC_DOCS =
+  'https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#localqueuespec';
+const LOCAL_QUEUE_STATUS_DOCS =
+  'https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#localqueuestatus';
+
+/**
+ * Desired state of a Kueue LocalQueue.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#localqueuespec
+ */
+export interface LocalQueueSpec {
+  /**
+   * ClusterQueue that backs this LocalQueue.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#localqueuespec
+   */
+  clusterQueue?: string;
+  /**
+   * Policy controlling whether new reservations are made for this LocalQueue.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#localqueuespec
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#stoppolicy
+   */
+  stopPolicy?: StopPolicy;
+  /**
+   * FairSharing settings used when AdmissionFairSharing is enabled.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#localqueuespec
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#fairsharing
+   */
+  fairSharing?: FairSharing;
+}
+
+/**
+ * Per-resource quota usage for a LocalQueue ResourceFlavor.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#localqueueresourceusage
+ */
+export interface LocalQueueResourceUsage {
+  /**
+   * Resource name, such as `cpu`, `memory`, or an extended resource.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#localqueueresourceusage
+   */
+  name: string;
+  /**
+   * Total quantity of used quota.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#localqueueresourceusage
+   */
+  total?: ResourceQuantity;
+}
+
+/**
+ * LocalQueue quota usage grouped by ResourceFlavor.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#localqueueflavorusage
+ */
+export interface LocalQueueFlavorUsage {
+  /**
+   * ResourceFlavor name.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#localqueueflavorusage
+   */
+  name: string;
+  /**
+   * Resource usage values reported under this flavor.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#localqueueflavorusage
+   */
+  resources?: LocalQueueResourceUsage[];
+}
+
+/**
+ * FairSharing consumption details for a LocalQueue.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#localqueueadmissionfairsharingstatus
+ */
+export interface LocalQueueAdmissionFairSharingStatus {
+  /**
+   * Aggregated usage of resources over time with a decaying function applied.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#localqueueadmissionfairsharingstatus
+   */
+  consumedResources?: Record<string, ResourceQuantity>;
+  /**
+   * Time when fair sharing resource consumption was updated.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#localqueueadmissionfairsharingstatus
+   */
+  lastUpdate?: string;
+}
+
+/**
+ * Current FairSharing state reported by Kueue for a LocalQueue.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#localqueuefairsharingstatus
+ */
+export interface LocalQueueFairSharingStatus {
+  /**
+   * Weighted share calculated for this LocalQueue.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#localqueuefairsharingstatus
+   */
+  weightedShare: number;
+  /**
+   * Admission FairSharing status details.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#localqueuefairsharingstatus
+   */
+  admissionFairSharingStatus?: LocalQueueAdmissionFairSharingStatus;
+}
+
+/**
+ * Observed state of a Kueue LocalQueue.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#localqueuestatus
+ */
+export interface LocalQueueStatus {
+  /**
+   * Latest observations of LocalQueue state.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#localqueuestatus
+   */
+  conditions?: KueueCondition[];
+  /**
+   * Number of workloads waiting to be admitted.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#localqueuestatus
+   */
+  pendingWorkloads?: number;
+  /**
+   * Number of workloads currently reserving quota.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#localqueuestatus
+   */
+  reservingWorkloads?: number;
+  /**
+   * Number of admitted workloads that have not finished yet.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#localqueuestatus
+   */
+  admittedWorkloads?: number;
+  /**
+   * Reserved quotas currently used by workloads assigned to this LocalQueue.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#localqueuestatus
+   */
+  flavorsReservation?: LocalQueueFlavorUsage[];
+  /**
+   * Used quotas currently used by workloads assigned to this LocalQueue.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#localqueuestatus
+   */
+  flavorsUsage?: LocalQueueFlavorUsage[];
+  /**
+   * Current FairSharing state.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#localqueuestatus
+   */
+  fairSharing?: LocalQueueFairSharingStatus;
+}
+
+/**
+ * Kubernetes LocalQueue object returned by the Kueue API.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#localqueue
+ */
+export interface KubeLocalQueue extends KubeObjectInterface {
+  /**
+   * Kubernetes object metadata for the LocalQueue.
+   *
+   * @see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#objectmeta-v1-meta
+   */
+  metadata: KubeObjectInterface['metadata'];
+  /**
+   * LocalQueue desired state.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#localqueuespec
+   */
+  spec?: LocalQueueSpec;
+  /**
+   * LocalQueue observed state.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#localqueuestatus
+   */
+  status?: LocalQueueStatus;
+}
+
+export class LocalQueue extends KubeObject<KubeLocalQueue> {
+  static kind = 'LocalQueue';
+  static apiName = 'localqueues';
+  static apiVersion = kueueApiVersions;
+  static isNamespaced = true;
+
+  static get detailsRoute() {
+    return kueueRoutePaths.localQueueDetail;
+  }
+
+  get spec(): LocalQueueSpec {
+    return this.jsonData.spec ?? {};
+  }
+
+  get status(): LocalQueueStatus {
+    return this.jsonData.status ?? {};
+  }
+
+  get clusterQueueName() {
+    return this.spec.clusterQueue;
+  }
+
+  get clusterQueueDisplay() {
+    return renderClusterQueueName(this.clusterQueueName);
+  }
+
+  get stopPolicy() {
+    return this.spec.stopPolicy;
+  }
+
+  get stopPolicyDisplay() {
+    return renderStopPolicy(this.stopPolicy);
+  }
+
+  get pendingWorkloads() {
+    return renderWorkloadCount(this.status.pendingWorkloads);
+  }
+
+  get admittedWorkloads() {
+    return renderWorkloadCount(this.status.admittedWorkloads);
+  }
+
+  get reservingWorkloads() {
+    return renderWorkloadCount(this.status.reservingWorkloads);
+  }
+
+  get conditions() {
+    return this.status.conditions || [];
+  }
+
+  get activeCondition() {
+    return this.conditions.find(condition => condition.type === 'Active');
+  }
+
+  get statusDisplay() {
+    return renderLocalQueueStatus(this.activeCondition);
+  }
+
+  get detailRouteParams() {
+    return getLocalQueueDetailRouteParams(this.metadata.namespace, this.metadata.name);
+  }
+}
+
+export { LOCAL_QUEUE_API_DOCS, LOCAL_QUEUE_SPEC_DOCS, LOCAL_QUEUE_STATUS_DOCS };

--- a/kueue/src/resources/localQueueFormatters.ts
+++ b/kueue/src/resources/localQueueFormatters.ts
@@ -1,7 +1,10 @@
 import type { KueueCondition } from './clusterQueue';
 
 /** Minimal LocalQueue condition shape needed to summarize queue readiness. */
-export type LocalQueueConditionLike = Pick<KueueCondition, 'type' | 'status' | 'reason' | 'message'>;
+export type LocalQueueConditionLike = Pick<
+  KueueCondition,
+  'type' | 'status' | 'reason' | 'message'
+>;
 
 /** Render the ClusterQueue reference for LocalQueue list and detail views. */
 export function renderClusterQueueName(clusterQueue?: string) {

--- a/kueue/src/resources/localQueueFormatters.ts
+++ b/kueue/src/resources/localQueueFormatters.ts
@@ -1,0 +1,44 @@
+import type { KueueCondition } from './clusterQueue';
+
+/** Minimal LocalQueue condition shape needed to summarize queue readiness. */
+export type LocalQueueConditionLike = Pick<KueueCondition, 'type' | 'status' | 'reason' | 'message'>;
+
+/** Render the ClusterQueue reference for LocalQueue list and detail views. */
+export function renderClusterQueueName(clusterQueue?: string) {
+  return clusterQueue || '-';
+}
+
+/** Render the LocalQueue stop policy, falling back when the API omits the field. */
+export function renderStopPolicy(stopPolicy?: string) {
+  return stopPolicy || '-';
+}
+
+/** Render a workload count while preserving explicit zero values. */
+export function renderWorkloadCount(count?: number) {
+  return count ?? 0;
+}
+
+/** Render the user-facing LocalQueue status from its Active condition. */
+export function renderLocalQueueStatus(activeCondition?: LocalQueueConditionLike) {
+  if (!activeCondition) {
+    return 'Unknown';
+  }
+
+  if (activeCondition.status === 'True') {
+    return 'Active';
+  }
+
+  if (activeCondition.status === 'False') {
+    return 'Inactive';
+  }
+
+  return 'Unknown';
+}
+
+/** Build route params for a namespaced LocalQueue detail link. */
+export function getLocalQueueDetailRouteParams(namespace?: string, name?: string) {
+  return {
+    namespace: namespace || '',
+    name: name || '',
+  };
+}

--- a/kueue/src/utils/kueueRoutes.ts
+++ b/kueue/src/utils/kueueRoutes.ts
@@ -1,6 +1,8 @@
 export const kueueRouteNames = {
   clusterQueuesList: 'kueue-clusterqueues-list',
   clusterQueueDetail: 'kueue-clusterqueue-detail',
+  localQueuesList: 'kueue-localqueues-list',
+  localQueueDetail: 'kueue-localqueue-detail',
   resourceFlavorsList: 'kueue-resourceflavors-list',
   resourceFlavorDetail: 'kueue-resourceflavor-detail',
 } as const;
@@ -8,6 +10,8 @@ export const kueueRouteNames = {
 export const kueueRoutePaths = {
   clusterQueuesList: '/kueue/clusterqueues',
   clusterQueueDetail: '/kueue/clusterqueues/:name',
+  localQueuesList: '/kueue/localqueues',
+  localQueueDetail: '/kueue/localqueues/:namespace/:name',
   resourceFlavorsList: '/kueue/resourceflavors',
   resourceFlavorDetail: '/kueue/resourceflavors/:name',
 } as const;

--- a/kueue/test-files/deploy/localqueue-team-a.yaml
+++ b/kueue/test-files/deploy/localqueue-team-a.yaml
@@ -1,0 +1,7 @@
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: LocalQueue
+metadata:
+  name: team-a-queue
+  namespace: default
+spec:
+  clusterQueue: team-a


### PR DESCRIPTION
## Summary

Adds Kueue `LocalQueue` support to the Headlamp Kueue plugin.

## Changes

- Add typed `LocalQueue` resource model for the v1beta2 Kueue API
- Add LocalQueue list and detail views
- Register LocalQueue sidebar entry and routes
- Add readable display helpers and focused tests
- Add sample LocalQueue manifest
- Update Kueue README with LocalQueue support and test commands

## Testing

- `CI=1 npm test`
- `npm run tsc`
- `npm run lint`
- `npm run build`