### PR TITLE
strimzi: Fix crash when the Kafka cluster list is still loading

### DIFF
--- a/strimzi/CHANGELOG.md
+++ b/strimzi/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- Crash on the Kafka Topics and Users pages when the Kafka cluster list was still loading
+
 ## [0.3.9] - 2026-03-07
 
 ### Added

--- a/strimzi/src/components/KafkaTopicList.tsx
+++ b/strimzi/src/components/KafkaTopicList.tsx
@@ -10,6 +10,7 @@ import {
 import { Kafka, KafkaV1, KafkaTopic, KafkaTopicV1 } from '../resources';
 import type { KafkaTopicInterface } from '../resources';
 import { getErrorMessage } from '../utils/errors';
+import { clusterNamespaces, clusterNamesInNamespace } from '../utils/clusters';
 import { useStrimziApiVersions } from '../hooks/useStrimziApiVersions';
 import { StrimziNotInstalledMessage } from './StrimziNotInstalledMessage';
 import { Toast, ToastMessage } from './Toast';
@@ -23,7 +24,9 @@ export function KafkaTopicList() {
   const kafkaApiPath = `/apis/kafka.strimzi.io/${kafkaVersion}`;
 
   // All hooks must be called before any early return (Rules of Hooks).
-  const { items: kafkaClusters } = KafkaClass.useList({});
+  // useList returns null while loading, so normalise to an array up front.
+  const { items } = KafkaClass.useList({});
+  const kafkaClusters = items ?? [];
   const [toast, setToast] = React.useState<ToastMessage | null>(null);
   const [showCreateDialog, setShowCreateDialog] = React.useState(false);
   const [showEditDialog, setShowEditDialog] = React.useState(false);
@@ -39,17 +42,15 @@ export function KafkaTopicList() {
   });
   const [loading, setLoading] = React.useState(false);
 
-  const availableNamespacesForCreate = React.useMemo(() => {
-    return [...new Set(kafkaClusters.map(k => k.metadata.namespace))].sort();
-  }, [kafkaClusters]);
+  const availableNamespacesForCreate = React.useMemo(
+    () => clusterNamespaces(kafkaClusters),
+    [kafkaClusters]
+  );
 
-  const filteredClusterNames = React.useMemo(() => {
-    if (!formData.namespace) return [];
-    return kafkaClusters
-      .filter(k => k.metadata.namespace === formData.namespace)
-      .map(k => k.metadata.name)
-      .sort();
-  }, [kafkaClusters, formData.namespace]);
+  const filteredClusterNames = React.useMemo(
+    () => clusterNamesInNamespace(kafkaClusters, formData.namespace),
+    [kafkaClusters, formData.namespace]
+  );
 
   const handleCreate = async () => {
     setLoading(true);
@@ -183,13 +184,7 @@ export function KafkaTopicList() {
 
   const openCreateDialog = () => {
     const firstNs = availableNamespacesForCreate[0] ?? '';
-    const firstCluster =
-      firstNs && kafkaClusters.length > 0
-        ? kafkaClusters
-            .filter(k => k.metadata.namespace === firstNs)
-            .map(k => k.metadata.name)
-            .sort()[0] ?? ''
-        : '';
+    const firstCluster = clusterNamesInNamespace(kafkaClusters, firstNs)[0] ?? '';
     setFormData({
       name: '',
       namespace: firstNs,

--- a/strimzi/src/components/KafkaUserCreateFormModal.tsx
+++ b/strimzi/src/components/KafkaUserCreateFormModal.tsx
@@ -3,6 +3,7 @@ import { Button } from '@mui/material';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import { useThemeColors } from '../utils/theme';
+import type { KafkaClusterRef } from '../utils/clusters';
 
 /** Single ACL rule attached to a KafkaUser. */
 export interface UserFormAcl {
@@ -36,8 +37,6 @@ export interface UserFormData {
   /** ACL rules (only used when authorizationType is 'simple'). */
   acls: UserFormAcl[];
 }
-
-export type KafkaClusterRef = { metadata: { namespace?: string; name: string } };
 
 export interface KafkaUserCreateFormModalProps {
   open: boolean;

--- a/strimzi/src/components/KafkaUserList.tsx
+++ b/strimzi/src/components/KafkaUserList.tsx
@@ -10,6 +10,7 @@ import {
 import { Kafka, KafkaV1, KafkaUser, KafkaUserV1 } from '../resources';
 import type { CreateKafkaUserPayload, KafkaUserInterface } from '../resources';
 import { getErrorMessage } from '../utils/errors';
+import { clusterNamespaces, clusterNamesInNamespace } from '../utils/clusters';
 import { useStrimziApiVersions } from '../hooks/useStrimziApiVersions';
 import { StrimziNotInstalledMessage } from './StrimziNotInstalledMessage';
 import { SecureSecretDisplay } from './SecureSecretDisplay';
@@ -24,7 +25,9 @@ export function KafkaUserList() {
   const kafkaApiPath = `/apis/kafka.strimzi.io/${kafkaVersion}`;
 
   // All hooks must be called before any early return (Rules of Hooks).
-  const { items: kafkaClusters } = KafkaClass.useList({});
+  // useList returns null while loading, so normalise to an array up front.
+  const { items } = KafkaClass.useList({});
+  const kafkaClusters = items ?? [];
   const [toast, setToast] = React.useState<ToastMessage | null>(null);
   const [showCreateDialog, setShowCreateDialog] = React.useState(false);
   const [showDeleteDialog, setShowDeleteDialog] = React.useState(false);
@@ -42,17 +45,15 @@ export function KafkaUserList() {
   });
   const [loading, setLoading] = React.useState(false);
 
-  const availableNamespacesForCreate = React.useMemo(() => {
-    return [...new Set(kafkaClusters.map(k => k.metadata.namespace))].sort();
-  }, [kafkaClusters]);
+  const availableNamespacesForCreate = React.useMemo(
+    () => clusterNamespaces(kafkaClusters),
+    [kafkaClusters]
+  );
 
-  const filteredClusterNames = React.useMemo(() => {
-    if (!formData.namespace) return [];
-    return kafkaClusters
-      .filter(k => k.metadata.namespace === formData.namespace)
-      .map(k => k.metadata.name)
-      .sort();
-  }, [kafkaClusters, formData.namespace]);
+  const filteredClusterNames = React.useMemo(
+    () => clusterNamesInNamespace(kafkaClusters, formData.namespace),
+    [kafkaClusters, formData.namespace]
+  );
 
   const fetchUserSecret = async (user: KafkaUserInterface) => {
     try {
@@ -174,13 +175,7 @@ export function KafkaUserList() {
 
   const openCreateDialog = () => {
     const firstNs = availableNamespacesForCreate[0] ?? '';
-    const firstCluster =
-      firstNs && kafkaClusters.length > 0
-        ? kafkaClusters
-            .filter(k => k.metadata.namespace === firstNs)
-            .map(k => k.metadata.name)
-            .sort()[0] ?? ''
-        : '';
+    const firstCluster = clusterNamesInNamespace(kafkaClusters, firstNs)[0] ?? '';
     setFormData({
       name: '',
       namespace: firstNs,

--- a/strimzi/src/components/TopicFormModal.tsx
+++ b/strimzi/src/components/TopicFormModal.tsx
@@ -3,6 +3,7 @@ import { Button } from '@mui/material';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import { useThemeColors } from '../utils/theme';
+import type { KafkaClusterRef } from '../utils/clusters';
 
 /** Form state for creating or editing a KafkaTopic resource. */
 export interface TopicFormData {
@@ -23,8 +24,6 @@ export interface TopicFormData {
   /** Optional minimum number of in-sync replicas (min.insync.replicas). */
   minInSyncReplicas?: number;
 }
-
-export type KafkaClusterRef = { metadata: { namespace?: string; name: string } };
 
 export interface TopicFormModalProps {
   open: boolean;

--- a/strimzi/src/utils/clusters.test.ts
+++ b/strimzi/src/utils/clusters.test.ts
@@ -1,0 +1,35 @@
+import { clusterNamespaces, clusterNamesInNamespace, KafkaClusterRef } from './clusters';
+
+const clusters: KafkaClusterRef[] = [
+  { metadata: { namespace: 'prod', name: 'orders' } },
+  { metadata: { namespace: 'prod', name: 'billing' } },
+  { metadata: { namespace: 'dev', name: 'sandbox' } },
+];
+
+describe('clusterNamespaces', () => {
+  it('returns unique namespaces sorted alphabetically', () => {
+    expect(clusterNamespaces(clusters)).toEqual(['dev', 'prod']);
+  });
+
+  it('returns an empty array when the list is still loading (null)', () => {
+    expect(clusterNamespaces(null)).toEqual([]);
+  });
+
+  it('ignores clusters without a namespace', () => {
+    expect(clusterNamespaces([{ metadata: { name: 'orphan' } }])).toEqual([]);
+  });
+});
+
+describe('clusterNamesInNamespace', () => {
+  it('returns sorted cluster names within the namespace', () => {
+    expect(clusterNamesInNamespace(clusters, 'prod')).toEqual(['billing', 'orders']);
+  });
+
+  it('returns an empty array when the list is still loading (null)', () => {
+    expect(clusterNamesInNamespace(null, 'prod')).toEqual([]);
+  });
+
+  it('returns an empty array when no namespace is selected', () => {
+    expect(clusterNamesInNamespace(clusters, '')).toEqual([]);
+  });
+});

--- a/strimzi/src/utils/clusters.ts
+++ b/strimzi/src/utils/clusters.ts
@@ -1,0 +1,24 @@
+export type KafkaClusterRef = { metadata: { namespace?: string; name: string } };
+
+// useList returns null while the query is loading, so every caller must
+// tolerate a null cluster list.
+
+/** Unique, sorted namespaces that contain at least one Kafka cluster. */
+export function clusterNamespaces(clusters: KafkaClusterRef[] | null): string[] {
+  const namespaces = (clusters ?? [])
+    .map(cluster => cluster.metadata.namespace)
+    .filter((namespace): namespace is string => Boolean(namespace));
+  return [...new Set(namespaces)].sort();
+}
+
+/** Sorted names of the Kafka clusters that live in the given namespace. */
+export function clusterNamesInNamespace(
+  clusters: KafkaClusterRef[] | null,
+  namespace: string
+): string[] {
+  if (!namespace) return [];
+  return (clusters ?? [])
+    .filter(cluster => cluster.metadata.namespace === namespace)
+    .map(cluster => cluster.metadata.name)
+    .sort();
+}


### PR DESCRIPTION
## Problem

Opening the **Kafka Topics** or **Kafka Users** page throws
`Cannot read properties of null (reading 'map')` and blanks the page.
It is reliably reproducible on a cluster that has no topics or users (the
lists render before the Kafka cluster list has resolved).

`KubeObject.useList().items` is typed `Array<T> | null` and is `null` while
the query is loading, but both list components mapped over it directly to
build the create-dialog namespace/cluster dropdowns.

## Fix

- Normalise the cluster list to an array at the `useList` call site.
- Extract the dropdown derivations into null-tolerant helpers
  (`clusterNamespaces`, `clusterNamesInNamespace`) with unit tests covering
  the null/loading case, so the crash cannot silently regress.
- De-duplicate the shared `KafkaClusterRef` type into `utils`.

It's a small, self-contained change, and the null handling is covered by
unit tests. `tsc`, `eslint`, `prettier` and the full test suite (71 tests)
pass.

## Note

This is a focused, standalone fix for the crash only. #850 also touches this
null crash, but bundles it with a v1-resources rework that has since landed
on `main` separately, and appears stale.
