### PR TITLE
ai-assistant: improve cached skills and sidebar workflows

### DIFF
--- a/ai-assistant/packages/ai-common/src/skills/SkillManager.test.ts
+++ b/ai-assistant/packages/ai-common/src/skills/SkillManager.test.ts
@@ -17,10 +17,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { DEFAULT_SKILLS_CONFIG, SkillsConfig } from './config';
 import { getSkillIdentity } from './config';
+import type { ParsedSkill } from './parseSkill';
 import type { EmbeddingSkillRouter } from './routing/EmbeddingSkillRouter';
 import { DEFAULT_ROUTER_CONFIG } from './routing/KeywordSkillRouter';
 import { SkillFileSystem } from './SkillLoader';
-import { SkillManager } from './SkillManager';
+import { type SkillCache, SkillManager } from './SkillManager';
 
 /** Creates a mock filesystem for testing. */
 function createMockFs(files: Record<string, string | 'DIR'>): SkillFileSystem {
@@ -106,6 +107,30 @@ describe('SkillManager', () => {
       const skills2 = await manager.loadAllSkills(config);
       expect(skills1).toEqual(skills2);
     });
+
+    it('ignores persistent cache failures during loads and explicit reloads', async () => {
+      const fetchFiles = vi.fn(
+        async () => new Map([['SKILL.md', '---\nname: remote\ndescription: Remote\n---\nContent']])
+      );
+      const cache: SkillCache = {
+        get: vi.fn().mockRejectedValue(new Error('cache read failed')),
+        set: vi.fn().mockRejectedValue(new Error('cache write failed')),
+        delete: vi.fn().mockRejectedValue(new Error('cache delete failed')),
+      };
+      const remoteConfig: SkillsConfig = {
+        ...DEFAULT_SKILLS_CONFIG,
+        sources: [{ type: 'git', url: 'https://github.com/owner/repo', ref: 'v1', enabled: true }],
+      };
+      const cachedManager = new SkillManager(createMockFs({}), { fetchFiles });
+      cachedManager.setSkillCache(cache);
+
+      await expect(cachedManager.loadAllSkills(remoteConfig)).resolves.toHaveLength(1);
+      await expect(cachedManager.loadAllSkills(remoteConfig, true)).resolves.toHaveLength(1);
+      expect(fetchFiles).toHaveBeenCalledTimes(2);
+      expect(cache.get).toHaveBeenCalledTimes(1);
+      expect(cache.delete).toHaveBeenCalledTimes(1);
+      expect(cache.set).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('getEnabledSkills', () => {
@@ -180,12 +205,32 @@ describe('SkillManager', () => {
 
   describe('invalidateCache', () => {
     it('should force reload on next call', async () => {
-      await manager.loadAllSkills(config);
-      manager.invalidateCache();
+      const fs = createMockFs({
+        '/skills': 'DIR',
+        '/skills/SKILL.md': SKILL_1,
+        '/other-skills': 'DIR',
+        '/other-skills/SKILL.md': SKILL_2,
+      });
+      const readFile = vi.spyOn(fs, 'readFile');
+      const cachedManager = new SkillManager(fs);
+      const entries = new Map<string, ParsedSkill[]>();
+      const persistentCache: SkillCache = {
+        get: async key => entries.get(key) ?? null,
+        set: async (key, skills) => {
+          entries.set(key, skills);
+        },
+        delete: async key => {
+          entries.delete(key);
+        },
+      };
+      cachedManager.setSkillCache(persistentCache);
+      await cachedManager.loadAllSkills(config);
+      expect(readFile).toHaveBeenCalledTimes(2);
+      cachedManager.invalidateCache();
 
-      // After invalidation, skills should still load correctly
-      const skills = await manager.loadAllSkills(config);
+      const skills = await cachedManager.loadAllSkills(config);
       expect(skills).toHaveLength(2);
+      expect(readFile).toHaveBeenCalledTimes(4);
     });
   });
 
@@ -328,12 +373,83 @@ describe('SkillManager', () => {
       expect(result2.errors).toHaveLength(0); // Cached — no loading, no errors
     });
 
+    it('does not report persistent cache failures as source errors', async () => {
+      const fetchFiles = vi.fn(
+        async () => new Map([['SKILL.md', '---\nname: remote\ndescription: Remote\n---\nContent']])
+      );
+      const cache: SkillCache = {
+        get: vi.fn().mockRejectedValue(new Error('cache read failed')),
+        set: vi.fn().mockRejectedValue(new Error('cache write failed')),
+        delete: vi.fn().mockRejectedValue(new Error('cache delete failed')),
+      };
+      const remoteConfig: SkillsConfig = {
+        ...DEFAULT_SKILLS_CONFIG,
+        sources: [{ type: 'git', url: 'https://github.com/owner/repo', ref: 'v1', enabled: true }],
+      };
+      const cachedManager = new SkillManager(createMockFs({}), { fetchFiles });
+      cachedManager.setSkillCache(cache);
+
+      const first = await cachedManager.loadAllSkillsWithErrors(remoteConfig);
+      const reloaded = await cachedManager.loadAllSkillsWithErrors(remoteConfig, undefined, true);
+
+      expect(first).toMatchObject({ skills: [expect.any(Object)], errors: [] });
+      expect(reloaded).toMatchObject({ skills: [expect.any(Object)], errors: [] });
+      expect(fetchFiles).toHaveBeenCalledTimes(2);
+    });
+
     it('should reload after invalidateCache', async () => {
       await manager.loadAllSkillsWithErrors(config);
       manager.invalidateCache();
       const { skills, errors } = await manager.loadAllSkillsWithErrors(config);
       expect(skills).toHaveLength(2);
       expect(errors).toHaveLength(0);
+    });
+
+    it('shares downloaded skills across managers and bypasses them on explicit reload', async () => {
+      const fetchFiles = vi.fn(
+        async () => new Map([['SKILL.md', '---\nname: remote\ndescription: Remote\n---\nContent']])
+      );
+      const entries = new Map<string, ParsedSkill[]>();
+      const sharedCache: SkillCache = {
+        get: async key => entries.get(key) ?? null,
+        set: async (key, skills) => {
+          entries.set(key, skills);
+        },
+        delete: async key => {
+          entries.delete(key);
+        },
+      };
+      const remoteConfig: SkillsConfig = {
+        ...DEFAULT_SKILLS_CONFIG,
+        sources: [
+          {
+            type: 'git',
+            url: 'https://github.com/owner/repo',
+            ref: 'v1.0.0',
+            enabled: true,
+          },
+        ],
+      };
+      const firstManager = new SkillManager(createMockFs({}), { fetchFiles });
+      const secondManager = new SkillManager(createMockFs({}), { fetchFiles });
+      firstManager.setSkillCache(sharedCache);
+      secondManager.setSkillCache(sharedCache);
+
+      await firstManager.loadAllSkillsWithErrors(remoteConfig);
+      await secondManager.loadAllSkillsWithErrors(remoteConfig);
+      expect(fetchFiles).toHaveBeenCalledTimes(1);
+
+      await secondManager.loadAllSkillsWithErrors(remoteConfig, undefined, true);
+      expect(fetchFiles).toHaveBeenCalledTimes(2);
+
+      const limitedManager = new SkillManager(createMockFs({}), { fetchFiles });
+      limitedManager.setSkillCache(sharedCache);
+      const limited = await limitedManager.loadAllSkillsWithErrors({
+        ...remoteConfig,
+        maxSkillSizeBytes: 1,
+      });
+      expect(fetchFiles).toHaveBeenCalledTimes(3);
+      expect(limited.skills).toEqual([]);
     });
   });
 

--- a/ai-assistant/packages/ai-common/src/skills/SkillManager.ts
+++ b/ai-assistant/packages/ai-common/src/skills/SkillManager.ts
@@ -24,6 +24,16 @@ import {
 } from './routing/KeywordSkillRouter';
 import { SkillFileSystem, SkillHttpClient, SkillLoader, SkillZipExtractor } from './SkillLoader';
 
+/** Optional per-source cache shared across SkillManager instances. */
+export interface SkillCache {
+  /** Returns cached parsed skills, or null when the source is not cached. */
+  get(key: string): Promise<ParsedSkill[] | null>;
+  /** Stores parsed skills for a source. */
+  set(key: string, skills: ParsedSkill[]): Promise<void>;
+  /** Removes one source entry before an explicit reload. */
+  delete?(key: string): Promise<void>;
+}
+
 /** Per-source error reported during skill loading. */
 export interface SkillLoadError {
   /** URL or path of the source that failed to load. */
@@ -48,6 +58,7 @@ export class SkillManager {
   private lastLoadTimestamp: number = 0;
   private lastSourcesKey: string = '';
   private lastMaxSkillSizeBytes: number = 0;
+  private reloadRequired: boolean = false;
 
   /** Cache TTL in milliseconds (default: 1 hour). */
   private cacheTtlMs: number;
@@ -55,6 +66,7 @@ export class SkillManager {
   private fs: SkillFileSystem;
   private httpClient?: SkillHttpClient;
   private zipExtractor?: SkillZipExtractor;
+  private skillCache?: SkillCache;
 
   /**
    * Optional embedding router for semantic skill selection.
@@ -106,6 +118,54 @@ export class SkillManager {
     });
   }
 
+  /** Builds the persistent cache key for one source, including integrity constraints. */
+  private buildSourceCacheKey(
+    source: SkillsConfig['sources'][number],
+    maxSkillSizeBytes: number
+  ): string {
+    return JSON.stringify({
+      type: source.type,
+      url: source.url,
+      ref: source.ref ?? '',
+      path: source.path ?? '',
+      sha256: source.sha256 ?? '',
+      maxSkillSizeBytes,
+    });
+  }
+
+  /** Attaches a cache that can be shared by separately-created managers. */
+  setSkillCache(skillCache: SkillCache): void {
+    this.skillCache = skillCache;
+  }
+
+  /** Reads persistent skills as a best-effort cache lookup. */
+  private async getPersistedSkills(key: string): Promise<ParsedSkill[] | null> {
+    try {
+      return (await this.skillCache?.get(key)) ?? null;
+    } catch (error) {
+      console.warn(`Failed to read persistent skill cache for ${key}:`, error);
+      return null;
+    }
+  }
+
+  /** Writes persistent skills without affecting source loading on failure. */
+  private async setPersistedSkills(key: string, skills: ParsedSkill[]): Promise<void> {
+    try {
+      await this.skillCache?.set(key, skills);
+    } catch (error) {
+      console.warn(`Failed to write persistent skill cache for ${key}:`, error);
+    }
+  }
+
+  /** Deletes persistent skills without affecting explicit reload on failure. */
+  private async deletePersistedSkills(key: string): Promise<void> {
+    try {
+      await this.skillCache?.delete?.(key);
+    } catch (error) {
+      console.warn(`Failed to delete persistent skill cache for ${key}:`, error);
+    }
+  }
+
   /**
    * Loads all skills from the configured sources.
    *
@@ -116,9 +176,11 @@ export class SkillManager {
    * @param config - The current skills configuration.
    * @returns Array of all loaded skills (before filtering by enabled state).
    */
-  async loadAllSkills(config: SkillsConfig): Promise<ParsedSkill[]> {
+  async loadAllSkills(config: SkillsConfig, forceReload = false): Promise<ParsedSkill[]> {
     const now = Date.now();
     const sourcesKey = this.buildSourcesKey(config);
+    const reloadRequested = forceReload || this.reloadRequired;
+    this.reloadRequired = false;
 
     // Invalidate cache if sources have changed
     if (sourcesKey !== this.lastSourcesKey) {
@@ -126,7 +188,11 @@ export class SkillManager {
       this.lastSourcesKey = sourcesKey;
     }
 
-    if (this.cachedSkills.size > 0 && now - this.lastLoadTimestamp < this.cacheTtlMs) {
+    if (
+      !reloadRequested &&
+      this.cachedSkills.size > 0 &&
+      now - this.lastLoadTimestamp < this.cacheTtlMs
+    ) {
       return this.getAllCachedSkills();
     }
 
@@ -148,9 +214,19 @@ export class SkillManager {
       if (!source.enabled) continue;
 
       try {
-        const sourceKey = `${source.type}:${source.url}:${source.path || ''}`;
+        const sourceKey = this.buildSourceCacheKey(source, config.maxSkillSizeBytes);
+        if (reloadRequested) {
+          await this.deletePersistedSkills(sourceKey);
+        } else {
+          const cached = await this.getPersistedSkills(sourceKey);
+          if (cached !== null) {
+            this.cachedSkills.set(sourceKey, cached);
+            continue;
+          }
+        }
         const skills = await this.loader.loadFromSource(source);
         this.cachedSkills.set(sourceKey, skills);
+        await this.setPersistedSkills(sourceKey, skills);
       } catch (error) {
         loadFailed = true;
         console.warn(`Error loading skills from ${source.url}:`, error);
@@ -173,7 +249,8 @@ export class SkillManager {
    */
   async loadAllSkillsWithErrors(
     config: SkillsConfig,
-    onProgress?: (sourceUrl: string, progress: import('./SkillLoader').SkillLoadProgress) => void
+    onProgress?: (sourceUrl: string, progress: import('./SkillLoader').SkillLoadProgress) => void,
+    forceReload = false
   ): Promise<{
     /** Skills loaded successfully from enabled sources. */
     skills: ParsedSkill[];
@@ -183,13 +260,19 @@ export class SkillManager {
     const errors: SkillLoadError[] = [];
     const now = Date.now();
     const sourcesKey = this.buildSourcesKey(config);
+    const reloadRequested = forceReload || this.reloadRequired;
+    this.reloadRequired = false;
 
     if (sourcesKey !== this.lastSourcesKey) {
       this.cachedSkills.clear();
       this.lastSourcesKey = sourcesKey;
     }
 
-    if (this.cachedSkills.size > 0 && now - this.lastLoadTimestamp < this.cacheTtlMs) {
+    if (
+      !reloadRequested &&
+      this.cachedSkills.size > 0 &&
+      now - this.lastLoadTimestamp < this.cacheTtlMs
+    ) {
       return { skills: this.getAllCachedSkills(), errors };
     }
 
@@ -209,12 +292,22 @@ export class SkillManager {
       if (!source.enabled) continue;
 
       try {
-        const sourceKey = `${source.type}:${source.url}:${source.path || ''}`;
+        const sourceKey = this.buildSourceCacheKey(source, config.maxSkillSizeBytes);
+        if (reloadRequested) {
+          await this.deletePersistedSkills(sourceKey);
+        } else {
+          const cached = await this.getPersistedSkills(sourceKey);
+          if (cached !== null) {
+            this.cachedSkills.set(sourceKey, cached);
+            continue;
+          }
+        }
         const skills = await this.loader.loadFromSource(
           source,
           onProgress ? p => onProgress(source.url, p) : undefined
         );
         this.cachedSkills.set(sourceKey, skills);
+        await this.setPersistedSkills(sourceKey, skills);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         console.warn(`Error loading skills from ${source.url}:`, error);
@@ -368,6 +461,7 @@ export class SkillManager {
   invalidateCache(): void {
     this.cachedSkills.clear();
     this.lastLoadTimestamp = 0;
+    this.reloadRequired = true;
     if (this.embeddingRouter) {
       this.embeddingRouter.clearIndex();
     }

--- a/ai-assistant/packages/ai-common/src/skills/adapters/browser.test.ts
+++ b/ai-assistant/packages/ai-common/src/skills/adapters/browser.test.ts
@@ -483,6 +483,10 @@ function createMockIndexedDB() {
       makeRequest(() => {
         store.set(entry.key, entry);
       }),
+    delete: (key: string) =>
+      makeRequest(() => {
+        store.delete(key);
+      }),
     clear: () =>
       makeRequest(() => {
         store.clear();
@@ -555,6 +559,18 @@ describe('BrowserSkillCache', () => {
     expect(result).toBeNull();
   });
 
+  it('does not expire downloaded skills by default', async () => {
+    const cache = new BrowserSkillCache();
+    const skills = [makeParsedSkill('downloaded-skill')];
+    await cache.set('key1', skills);
+
+    const entry = mockIndexedDB._store.get('key1');
+    expect(entry).toBeDefined();
+    mockIndexedDB._store.set('key1', { ...entry!, cachedAt: 0 });
+
+    expect(await cache.get('key1')).toEqual(skills);
+  });
+
   it('returns null when the stored skills JSON is corrupt', async () => {
     mockIndexedDB._store.set('bad-key', {
       key: 'bad-key',
@@ -573,6 +589,16 @@ describe('BrowserSkillCache', () => {
     await cache.clear();
 
     expect(mockIndexedDB._store.size).toBe(0);
+  });
+
+  it('deletes one source entry', async () => {
+    const cache = new BrowserSkillCache();
+    await cache.set('a', []);
+    await cache.set('b', []);
+    await cache.delete('a');
+
+    expect(await cache.get('a')).toBeNull();
+    expect(await cache.get('b')).toEqual([]);
   });
 
   it('get returns null when IndexedDB is unavailable', async () => {

--- a/ai-assistant/packages/ai-common/src/skills/adapters/browser.ts
+++ b/ai-assistant/packages/ai-common/src/skills/adapters/browser.ts
@@ -399,9 +399,9 @@ export class BrowserSkillCache {
   /**
    * Creates an IndexedDB-backed skill cache.
    *
-   * @param cacheTtlMs - How long cached skills remain valid (default: 1 hour).
+   * @param cacheTtlMs - How long cached skills remain valid (default: no expiry).
    */
-  constructor(cacheTtlMs: number = 60 * 60 * 1000) {
+  constructor(cacheTtlMs: number = Number.POSITIVE_INFINITY) {
     this.cacheTtlMs = cacheTtlMs;
   }
 
@@ -460,6 +460,27 @@ export class BrowserSkillCache {
           cachedAt: Date.now(),
         };
         const request = store.put(entry);
+        request.onsuccess = () => resolve();
+        request.onerror = () => reject(request.error);
+      });
+    } catch {
+      // IndexedDB not available — skip silently
+    }
+  }
+
+  /**
+   * Removes cached skills for one source.
+   *
+   * @param key - Source cache key.
+   * @returns No value; IndexedDB failures are ignored.
+   */
+  async delete(key: string): Promise<void> {
+    try {
+      const db = await openSkillsDB();
+      return new Promise((resolve, reject) => {
+        const tx = db.transaction(STORE_NAME, 'readwrite');
+        const store = tx.objectStore(STORE_NAME);
+        const request = store.delete(key);
         request.onsuccess = () => resolve();
         request.onerror = () => reject(request.error);
       });

--- a/ai-assistant/packages/ai-common/src/skills/adapters/browser.ts
+++ b/ai-assistant/packages/ai-common/src/skills/adapters/browser.ts
@@ -386,8 +386,8 @@ function openSkillsDB(): Promise<IDBDatabase> {
  * IndexedDB-backed cache for parsed skills.
  *
  * Persists downloaded and parsed skills in the browser so they survive
- * page reloads. Each source is stored separately, keyed by
- * `{type}:{url}:{ref}:{path}`.
+ * page reloads. Each source is stored separately under an opaque key
+ * supplied by the caller.
  *
  * Falls back gracefully: if IndexedDB is unavailable (e.g. private
  * browsing in some browsers), all operations return null/resolve

--- a/ai-assistant/packages/ai-ui/src/components/assistant/AIChatContent/AIChatContent.tsx
+++ b/ai-assistant/packages/ai-ui/src/components/assistant/AIChatContent/AIChatContent.tsx
@@ -72,8 +72,10 @@ export default function AIChatContent({
     <Box
       sx={{
         height: '100%',
-        overflowY: 'auto',
-        overflowX: 'auto',
+        minHeight: 0,
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
         maxWidth: '100%',
         minWidth: 0,
         wordWrap: 'break-word',
@@ -92,16 +94,18 @@ export default function AIChatContent({
         </Alert>
       )}
 
-      <TextStreamSlot
-        history={history}
-        isLoading={isLoading}
-        apiError={apiError}
-        onOperationSuccess={onOperationSuccess}
-        onOperationFailure={onOperationFailure}
-        onYamlAction={onYamlAction}
-        onRetryTool={onRetryTool}
-        agentThinkingSteps={agentThinkingSteps}
-      />
+      <Box sx={{ flex: '1 1 0', minHeight: 0, overflow: 'hidden' }}>
+        <TextStreamSlot
+          history={history}
+          isLoading={isLoading}
+          apiError={apiError}
+          onOperationSuccess={onOperationSuccess}
+          onOperationFailure={onOperationFailure}
+          onYamlAction={onYamlAction}
+          onRetryTool={onRetryTool}
+          agentThinkingSteps={agentThinkingSteps}
+        />
+      </Box>
     </Box>
   );
 }

--- a/ai-assistant/packages/ai-ui/src/components/chat/TextStreamContainer/TextStreamContainer.test.tsx
+++ b/ai-assistant/packages/ai-ui/src/components/chat/TextStreamContainer/TextStreamContainer.test.tsx
@@ -101,6 +101,14 @@ it('renders Storybook conversation semantics and passes axe', async () => {
   await expect(runAxe()).resolves.toEqual([]);
 });
 
+it('contains overscroll within the conversation log', () => {
+  renderStream();
+
+  expect(
+    getComputedStyle(screen.getByRole('log', { name: 'Conversation messages' })).overscrollBehavior
+  ).toBe('contain');
+});
+
 it('filters hidden messages and extracts validated tool follow-up text', () => {
   const history: ConversationMessage[] = [
     { role: 'system', content: 'hidden system' },
@@ -431,17 +439,20 @@ it('forwards prompt width to content renderers', () => {
 
 it('shows and operates the scroll-to-bottom control when the user scrolls away', async () => {
   vi.useFakeTimers();
+  const scrollTo = vi.fn();
   renderStream();
   const log = screen.getByRole('log', { name: 'Conversation messages' });
   Object.defineProperties(log, {
     scrollHeight: { configurable: true, value: 1000 },
     clientHeight: { configurable: true, value: 200 },
     scrollTop: { configurable: true, writable: true, value: 0 },
+    scrollTo: { configurable: true, value: scrollTo },
   });
   fireEvent.scroll(log);
   const button = screen.getByRole('button', { name: 'scroll to bottom' });
   fireEvent.click(button);
   expect(screen.queryByRole('button', { name: 'scroll to bottom' })).toBeNull();
+  expect(scrollTo).toHaveBeenCalledWith({ top: 1000, behavior: 'smooth' });
   vi.runOnlyPendingTimers();
 });
 
@@ -533,32 +544,59 @@ it('keeps following a tall append when the user was previously at the bottom', (
 
 it('recognizes a new user message when conversations have equal user counts', () => {
   vi.useFakeTimers();
-  const scrollIntoView = vi.fn();
-  Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
-    configurable: true,
-    value: scrollIntoView,
-  });
+  const scrollTo = vi.fn();
   const props = {
     isLoading: false,
     apiError: null,
     ContentRendererSlot: Renderer,
   };
-  const { rerender } = render(
+  const { container, rerender } = render(
     <TextStreamContainer
       {...props}
       history={[{ role: 'user', content: 'first conversation', requestId: 'first' }]}
     />
   );
+  const log = screen.getByRole('log', { name: 'Conversation messages' });
+  Object.defineProperties(log, {
+    scrollHeight: { configurable: true, value: 1000 },
+    clientHeight: { configurable: true, value: 200 },
+    scrollTop: { configurable: true, writable: true, value: 100 },
+    scrollTo: { configurable: true, value: scrollTo },
+  });
+  log.getBoundingClientRect = () => ({
+    x: 0,
+    y: 0,
+    width: 300,
+    height: 200,
+    top: 0,
+    right: 300,
+    bottom: 200,
+    left: 0,
+    toJSON: () => ({}),
+  });
   vi.runOnlyPendingTimers();
-  scrollIntoView.mockClear();
+  scrollTo.mockClear();
   rerender(
     <TextStreamContainer
       {...props}
       history={[{ role: 'user', content: 'second conversation', requestId: 'second' }]}
     />
   );
+  const userMessage = container.querySelector('[data-message-index="0"]');
+  if (!(userMessage instanceof HTMLElement)) throw new Error('User message was not rendered');
+  userMessage.getBoundingClientRect = () => ({
+    x: 0,
+    y: 20,
+    width: 300,
+    height: 80,
+    top: 20,
+    right: 300,
+    bottom: 100,
+    left: 0,
+    toJSON: () => ({}),
+  });
   vi.runOnlyPendingTimers();
-  expect(scrollIntoView).toHaveBeenCalled();
+  expect(scrollTo).toHaveBeenCalledWith({ top: 120, behavior: 'smooth' });
 });
 
 it('ignores programmatic scroll events while following streamed appends', () => {

--- a/ai-assistant/packages/ai-ui/src/components/chat/TextStreamContainer/TextStreamContainer.tsx
+++ b/ai-assistant/packages/ai-ui/src/components/chat/TextStreamContainer/TextStreamContainer.tsx
@@ -120,6 +120,14 @@ function DefaultEditorDialogAdapter({
   );
 }
 
+function scrollElementTo(element: HTMLElement, top: number): void {
+  if (typeof element.scrollTo === 'function') {
+    element.scrollTo({ top, behavior: 'smooth' });
+  } else {
+    element.scrollTop = top;
+  }
+}
+
 const TextStreamContainer = React.memo(function TextStreamContainer({
   history,
   isLoading,
@@ -141,7 +149,6 @@ const TextStreamContainer = React.memo(function TextStreamContainer({
   const [isDelete, setIsDelete] = useState(false);
   const theme = useTheme();
   // Refs for controlling auto-scrolling
-  const messagesEndRef = useRef<HTMLDivElement>(null);
   const lastMessageRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const wasNearBottomRef = useRef(true);
@@ -187,13 +194,8 @@ const TextStreamContainer = React.memo(function TextStreamContainer({
   const scrollToBottom = useCallback(() => {
     wasNearBottomRef.current = true;
     markProgrammaticScroll();
-    if (messagesEndRef.current && typeof messagesEndRef.current.scrollIntoView === 'function') {
-      messagesEndRef.current.scrollIntoView({ behavior: 'smooth', block: 'start' });
-      // Hide the button immediately after clicking it
-      setShowScrollButton(false);
-    } else if (containerRef.current) {
-      // Fallback scrolling method if the ref isn't available
-      containerRef.current.scrollTop = containerRef.current.scrollHeight;
+    if (containerRef.current) {
+      scrollElementTo(containerRef.current, containerRef.current.scrollHeight);
       setShowScrollButton(false);
     }
   }, [markProgrammaticScroll]);
@@ -215,8 +217,8 @@ const TextStreamContainer = React.memo(function TextStreamContainer({
         // Count non-user messages after the last user message
         const nonUserMessagesAfterUser = history.length - 1 - lastUserMessageIndex;
 
-        if (nonUserMessagesAfterUser === 1) {
-          // Only one non-user message after user - show the user message
+        if (nonUserMessagesAfterUser <= 1) {
+          // Keep the latest user message visible while its response begins.
           const messageElements = container.querySelectorAll('[data-message-index]');
           const userMessageElement = Array.from(messageElements).find(
             el => el.getAttribute('data-message-index') === lastUserMessageIndex.toString()
@@ -236,17 +238,11 @@ const TextStreamContainer = React.memo(function TextStreamContainer({
               // If user message is larger than viewport, show the bottom of it
               const targetScrollPosition = messageTop + messageHeight - containerHeight;
               markProgrammaticScroll();
-              container.scrollTo({
-                top: Math.max(0, targetScrollPosition),
-                behavior: 'smooth',
-              });
+              scrollElementTo(container, Math.max(0, targetScrollPosition));
             } else {
               // Show the user message at the top of the viewport
               markProgrammaticScroll();
-              container.scrollTo({
-                top: Math.max(0, messageTop),
-                behavior: 'smooth',
-              });
+              scrollElementTo(container, Math.max(0, messageTop));
             }
           }
         } else {
@@ -259,10 +255,7 @@ const TextStreamContainer = React.memo(function TextStreamContainer({
 
             // Scroll to show half of the last message
             markProgrammaticScroll();
-            container.scrollTo({
-              top: messageTop,
-              behavior: 'smooth',
-            });
+            scrollElementTo(container, messageTop);
           }
         }
       } else {
@@ -304,10 +297,10 @@ const TextStreamContainer = React.memo(function TextStreamContainer({
     lastUserMessageKeyRef.current = latestUserMessageKey;
 
     if (hasNewUserMessage) {
-      // Always scroll to bottom when there's a new user message
+      // Keep the newly submitted user message visible at the top of the log.
       timeouts.push(
         setTimeout(() => {
-          scrollToBottom();
+          scrollToShowNewMessage();
         }, 100)
       );
     } else if (wasNearBottomRef.current) {
@@ -322,7 +315,7 @@ const TextStreamContainer = React.memo(function TextStreamContainer({
       setShowScrollButton(true);
     }
     return () => timeouts.forEach(clearTimeout);
-  }, [history, scrollToBottom, scrollToShowNewMessage]);
+  }, [history, scrollToShowNewMessage]);
 
   // Auto-scroll only when loading starts (not when it finishes)
   useEffect(() => {
@@ -575,6 +568,7 @@ const TextStreamContainer = React.memo(function TextStreamContainer({
           height: '100%',
           overflowY: 'auto',
           overflowX: 'auto', // Allow horizontal scrolling when needed
+          overscrollBehavior: 'contain',
           display: 'flex',
           flexDirection: 'column',
           maxWidth: '100%',
@@ -626,9 +620,6 @@ const TextStreamContainer = React.memo(function TextStreamContainer({
         {agentThinkingSteps && agentThinkingSteps.length > 0 && (
           <AgentThinkingSteps steps={agentThinkingSteps} isRunning={isLoading} />
         )}
-
-        {/* This is an invisible element that we'll scroll to */}
-        <div ref={messagesEndRef} />
       </Box>
 
       {showScrollButton && (

--- a/ai-assistant/packages/ai-ui/src/components/panel/AIPanelComponent/AIPanelComponent.tsx
+++ b/ai-assistant/packages/ai-ui/src/components/panel/AIPanelComponent/AIPanelComponent.tsx
@@ -160,9 +160,11 @@ const AIPanelComponent = React.memo(
         flexShrink={0}
         sx={{
           height: '100%',
+          minHeight: 0,
           width: width,
           borderLeft: '2px solid',
           position: 'relative',
+          overflow: 'hidden',
         }}
       >
         {hasValidConfig && clusterNotifier}

--- a/ai-assistant/packages/ai-ui/src/components/settings/SettingsPage/SettingsPage.tsx
+++ b/ai-assistant/packages/ai-ui/src/components/settings/SettingsPage/SettingsPage.tsx
@@ -106,7 +106,8 @@ export interface SettingsPageProps {
   /** Async function that loads all skills and returns them for display. */
   loadSkills?: (
     onProgress?: (progress: SkillLoadProgress) => void,
-    sourceUrl?: string
+    sourceUrl?: string,
+    forceReload?: boolean
   ) => Promise<SkillDisplayInfo[]>;
   /** Callback fired when skill loading completes (for notifications). */
   onSkillsLoadComplete?: (result: { count: number; error?: string }) => void;

--- a/ai-assistant/packages/ai-ui/src/components/settings/SkillSettings/SkillSettings.test.tsx
+++ b/ai-assistant/packages/ai-ui/src/components/settings/SkillSettings/SkillSettings.test.tsx
@@ -184,7 +184,8 @@ it('immediately persists suggested repos and scopes the viewer load', async () =
         type: 'git',
         url: 'https://github.com/kubeshark/kubeshark',
         path: 'skills',
-      })
+      }),
+      undefined
     )
   );
   fireEvent.click(screen.getByRole('button', { name: 'Close viewer' }));

--- a/ai-assistant/packages/ai-ui/src/components/settings/SkillSettings/SkillSettings.tsx
+++ b/ai-assistant/packages/ai-ui/src/components/settings/SkillSettings/SkillSettings.tsx
@@ -206,7 +206,8 @@ export interface SkillSettingsProps {
    */
   loadSkills?: (
     onProgress?: (progress: SkillLoadProgress) => void,
-    sourceIdentity?: string
+    sourceIdentity?: string,
+    forceReload?: boolean
   ) => Promise<SkillDisplayInfo[]>;
   /** Callback fired when skill loading completes (for notifications). */
   onSkillsLoadComplete?: (result: { count: number; error?: string }) => void;
@@ -982,13 +983,13 @@ export function SkillSettings({
             setViewerOpen(false);
             setActiveRepoIdentity(null);
           }}
-          loadSkills={onProgress => {
+          loadSkills={(onProgress, forceReload) => {
             // Pass source identity so the host loads only this exact URL/path pair.
             // the progress bar from resetting between multiple enabled sources
             if (activeRepoIdentity) {
-              return loadSkills(onProgress, activeRepoIdentity);
+              return loadSkills(onProgress, activeRepoIdentity, forceReload);
             }
-            return loadSkills(onProgress);
+            return loadSkills(onProgress, undefined, forceReload);
           }}
           title={
             activeRepoIdentity

--- a/ai-assistant/packages/ai-ui/src/components/settings/SkillsViewerDialog/SkillsViewerDialog.test.tsx
+++ b/ai-assistant/packages/ai-ui/src/components/settings/SkillsViewerDialog/SkillsViewerDialog.test.tsx
@@ -143,8 +143,10 @@ it('reloads skills and reports completion', async () => {
   const onLoadComplete = vi.fn();
   renderDialog({ loadSkills, onLoadComplete });
   await screen.findAllByText('1 skill · 9.4 KB');
+  expect(loadSkills).toHaveBeenNthCalledWith(1, expect.any(Function), false);
   fireEvent.click(screen.getByRole('button', { name: 'Reload' }));
   await waitFor(() => expect(loadSkills).toHaveBeenCalledTimes(2));
+  expect(loadSkills).toHaveBeenNthCalledWith(2, expect.any(Function), true);
   expect(onLoadComplete).toHaveBeenLastCalledWith({ count: 1 });
 });
 

--- a/ai-assistant/packages/ai-ui/src/components/settings/SkillsViewerDialog/SkillsViewerDialog.tsx
+++ b/ai-assistant/packages/ai-ui/src/components/settings/SkillsViewerDialog/SkillsViewerDialog.tsx
@@ -69,8 +69,12 @@ export interface SkillsViewerDialogProps {
   /**
    * Async function that loads skills and returns them for display.
    * Receives an optional onProgress callback for real-time download/extract progress.
+   * The second argument is true only when the user explicitly requests a reload.
    */
-  loadSkills: (onProgress?: (progress: SkillLoadProgress) => void) => Promise<SkillDisplayInfo[]>;
+  loadSkills: (
+    onProgress?: (progress: SkillLoadProgress) => void,
+    forceReload?: boolean
+  ) => Promise<SkillDisplayInfo[]>;
   /** Component used to render dialog shells. */
   DialogSlot?: React.ElementType;
   /** Callback fired when loading completes (with count or error). */
@@ -201,39 +205,42 @@ export function SkillsViewerDialog({
     }
   }, []);
 
-  const doLoad = useCallback(async () => {
-    const requestId = ++loadRequestId.current;
-    setLoading(true);
-    setError(null);
-    setProgress({
-      phase: 'downloading',
-      bytesDownloaded: 0,
-      totalBytes: 0,
-      filesFound: 0,
-      totalFiles: 0,
-    });
-    try {
-      const loaded = await loadSkillsRef.current(onProgressThrottled);
-      if (loadRequestId.current !== requestId) return;
-      setProgress(null);
-      setSkills(loaded);
-      onLoadCompleteRef.current?.({ count: loaded.length });
-    } catch (loadError) {
-      if (loadRequestId.current !== requestId) return;
-      const message = loadError instanceof Error ? loadError.message : String(loadError);
-      setError(message);
-      setProgress(null);
-      onLoadCompleteRef.current?.({ count: 0, error: message });
-    } finally {
-      if (loadRequestId.current === requestId) {
-        setLoading(false);
+  const doLoad = useCallback(
+    async (forceReload = false) => {
+      const requestId = ++loadRequestId.current;
+      setLoading(true);
+      setError(null);
+      setProgress({
+        phase: 'downloading',
+        bytesDownloaded: 0,
+        totalBytes: 0,
+        filesFound: 0,
+        totalFiles: 0,
+      });
+      try {
+        const loaded = await loadSkillsRef.current(onProgressThrottled, forceReload);
+        if (loadRequestId.current !== requestId) return;
+        setProgress(null);
+        setSkills(loaded);
+        onLoadCompleteRef.current?.({ count: loaded.length });
+      } catch (loadError) {
+        if (loadRequestId.current !== requestId) return;
+        const message = loadError instanceof Error ? loadError.message : String(loadError);
+        setError(message);
+        setProgress(null);
+        onLoadCompleteRef.current?.({ count: 0, error: message });
+      } finally {
+        if (loadRequestId.current === requestId) {
+          setLoading(false);
+        }
       }
-    }
-  }, [onProgressThrottled]);
+    },
+    [onProgressThrottled]
+  );
 
   useEffect(() => {
     if (open) {
-      void doLoad();
+      void doLoad(false);
     }
     return () => {
       loadRequestId.current += 1;
@@ -504,7 +511,11 @@ export function SkillsViewerDialog({
       </DialogContent>
       <DialogActions>
         {!loading && skills.length > 0 && (
-          <Button onClick={doLoad} startIcon={<Icon aria-hidden icon="mdi:refresh" />} size="small">
+          <Button
+            onClick={() => void doLoad(true)}
+            startIcon={<Icon aria-hidden icon="mdi:refresh" />}
+            size="small"
+          >
             {t('Reload')}
           </Button>
         )}

--- a/ai-assistant/packages/ai-ui/src/diagnosis/ProactiveDiagnosisManager.test.ts
+++ b/ai-assistant/packages/ai-ui/src/diagnosis/ProactiveDiagnosisManager.test.ts
@@ -4,7 +4,11 @@ vi.mock('@headlamp-k8s/ai-common/prompts/baseAssistantPrompt', () => ({
   basePrompt: 'base prompt',
 }));
 
-import { type EventDigest, ProactiveDiagnosisManager } from './ProactiveDiagnosisManager';
+import {
+  type EventDigest,
+  ProactiveDiagnosisManager,
+  SINGLE_EVENT_QUEUE_TIMEOUT_MS,
+} from './ProactiveDiagnosisManager';
 
 const createEvent = (overrides: Partial<EventDigest> = {}): EventDigest => ({
   uid: 'uid-1',
@@ -105,6 +109,50 @@ describe('ProactiveDiagnosisManager', () => {
 
     await expect(resultPromise).resolves.toMatchObject({ diagnosis: 'diagnosis', pending: false });
     expect(diagnose).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs a table-triggered diagnosis after the closed panel initializes its mock function', async () => {
+    manager.stop();
+    manager.start();
+
+    const resultPromise = manager.diagnoseSingleEvent(createEvent());
+    expect(manager.getDiagnosis('uid-1')).toMatchObject({ pending: true });
+
+    manager.setDiagnoseFn(async () => 'Canned mock diagnosis for the failing Pod.');
+
+    await expect(resultPromise).resolves.toMatchObject({
+      diagnosis: 'Canned mock diagnosis for the failing Pod.',
+      pending: false,
+      loading: false,
+    });
+  });
+
+  it('rejects a queued table diagnosis when diagnosis is stopped', async () => {
+    const diagnose = vi.fn(async () => 'late diagnosis');
+    const resultPromise = manager.diagnoseSingleEvent(createEvent());
+
+    manager.stop();
+    await expect(resultPromise).rejects.toThrow('Proactive diagnosis was stopped');
+    manager.setDiagnoseFn(diagnose);
+
+    expect(diagnose).not.toHaveBeenCalled();
+    expect(manager.getDiagnosis('uid-1')).toMatchObject({
+      pending: false,
+      error: 'Proactive diagnosis was stopped',
+    });
+  });
+
+  it('times out a queued table diagnosis when setup never becomes ready', async () => {
+    vi.useFakeTimers();
+    const resultPromise = manager.diagnoseSingleEvent(createEvent());
+
+    vi.advanceTimersByTime(SINGLE_EVENT_QUEUE_TIMEOUT_MS);
+    await expect(resultPromise).rejects.toThrow('Diagnosis setup timed out');
+    expect(manager.getDiagnosis('uid-1')).toMatchObject({
+      pending: false,
+      error: 'Diagnosis setup timed out',
+    });
+    vi.useRealTimers();
   });
 
   it('hasDiagnosis is true only for successful diagnoses', async () => {
@@ -341,6 +389,7 @@ describe('ProactiveDiagnosisManager', () => {
   });
 
   it('queues single-event requests behind an active cycle and preserves thinking steps', async () => {
+    vi.useFakeTimers();
     const first = deferred<string>();
     const calls: string[] = [];
     manager.setDiagnoseFn(async (prompt, onStep) => {
@@ -352,7 +401,12 @@ describe('ProactiveDiagnosisManager', () => {
     const queued = manager.diagnoseSingleEvent(
       createEvent({ uid: 'queued', objectName: 'queued-app' })
     );
+    const queuedResolved = vi.fn();
+    void queued.then(queuedResolved);
     expect(manager.isRunning()).toBe(true);
+    vi.advanceTimersByTime(SINGLE_EVENT_QUEUE_TIMEOUT_MS);
+    await Promise.resolve();
+    expect(queuedResolved).not.toHaveBeenCalled();
     first.resolve('cycle diagnosis');
     await cycle;
     await expect(queued).resolves.toMatchObject({
@@ -361,6 +415,32 @@ describe('ProactiveDiagnosisManager', () => {
       thinkingSteps: [expect.objectContaining({ content: 'working' })],
     });
     expect(calls).toHaveLength(2);
+    vi.useRealTimers();
+  });
+
+  it('times out queued work when the provider is removed during an active cycle', async () => {
+    vi.useFakeTimers();
+    const first = deferred<string>();
+    const diagnoseFn = vi.fn(() => first.promise);
+    manager.setDiagnoseFn(diagnoseFn);
+    const cycle = manager.diagnoseEvents([createEvent()]);
+    const queued = manager.diagnoseSingleEvent(
+      createEvent({ uid: 'queued', objectName: 'queued-app' })
+    );
+    const rejection = expect(queued).rejects.toThrow('Diagnosis setup timed out');
+
+    manager.setDiagnoseFn(null);
+    first.resolve('cycle diagnosis');
+    await cycle;
+    vi.advanceTimersByTime(SINGLE_EVENT_QUEUE_TIMEOUT_MS);
+
+    await rejection;
+    expect(diagnoseFn).toHaveBeenCalledTimes(1);
+    expect(manager.getDiagnosis('queued')).toMatchObject({
+      pending: false,
+      error: 'Diagnosis setup timed out',
+    });
+    vi.useRealTimers();
   });
 
   it('waits for a pending batch event without diagnosing it twice', async () => {

--- a/ai-assistant/packages/ai-ui/src/diagnosis/ProactiveDiagnosisManager.test.ts
+++ b/ai-assistant/packages/ai-ui/src/diagnosis/ProactiveDiagnosisManager.test.ts
@@ -111,6 +111,22 @@ describe('ProactiveDiagnosisManager', () => {
     expect(diagnose).toHaveBeenCalledTimes(1);
   });
 
+  it('rejects queued diagnosis if the function is installed while disabled', async () => {
+    const diagnose = vi.fn(async () => 'diagnosis');
+    const resultPromise = manager.diagnoseSingleEvent(createEvent());
+    const rejection = expect(resultPromise).rejects.toThrow('Proactive diagnosis is disabled');
+    Reflect.set(manager, 'enabled', false);
+
+    manager.setDiagnoseFn(diagnose);
+
+    await rejection;
+    expect(diagnose).not.toHaveBeenCalled();
+    expect(manager.getDiagnosis('uid-1')).toMatchObject({
+      pending: false,
+      error: 'Proactive diagnosis is disabled',
+    });
+  });
+
   it('runs a table-triggered diagnosis after the closed panel initializes its mock function', async () => {
     manager.stop();
     manager.start();

--- a/ai-assistant/packages/ai-ui/src/diagnosis/ProactiveDiagnosisManager.ts
+++ b/ai-assistant/packages/ai-ui/src/diagnosis/ProactiveDiagnosisManager.ts
@@ -70,6 +70,8 @@ export type DiagnosisStepCallback = (step: DiagnosisThinkingStep) => void;
 
 type DiagnoseFn = (prompt: string, onStep?: DiagnosisStepCallback) => Promise<string>;
 
+export const SINGLE_EVENT_QUEUE_TIMEOUT_MS = 30_000;
+
 export class ProactiveDiagnosisManager extends EventEmitter {
   /** uid → DiagnosisResult */
   private cache = new Map<string, DiagnosisResult>();
@@ -80,6 +82,7 @@ export class ProactiveDiagnosisManager extends EventEmitter {
     event: EventDigest;
     resolve: (r: DiagnosisResult) => void;
     reject: (error: unknown) => void;
+    timeout?: ReturnType<typeof setTimeout>;
   }> = [];
   /** The function to call to get a diagnosis from the AI */
   private diagnoseFn: DiagnoseFn | null = null;
@@ -111,8 +114,18 @@ export class ProactiveDiagnosisManager extends EventEmitter {
    */
   setDiagnoseFn(fn: DiagnoseFn | null): void {
     this.diagnoseFn = fn;
-    if (fn && !this.running) {
-      this._drainSingleEventQueue();
+    if (fn) {
+      for (const request of this.singleEventQueue) {
+        if (request.timeout) clearTimeout(request.timeout);
+        request.timeout = undefined;
+      }
+      if (!this.running) {
+        this._drainSingleEventQueue();
+      }
+    } else {
+      for (const request of this.singleEventQueue) {
+        this._armQueuedRequestTimeout(request);
+      }
     }
   }
 
@@ -139,6 +152,7 @@ export class ProactiveDiagnosisManager extends EventEmitter {
    */
   stop(): void {
     this.enabled = false;
+    this._rejectSingleEventQueue('Proactive diagnosis was stopped');
     this.emit('status-change', { enabled: false });
   }
 
@@ -357,7 +371,15 @@ export class ProactiveDiagnosisManager extends EventEmitter {
         this.emit('diagnosis-update', pendingResult);
       }
       return new Promise<DiagnosisResult>((resolve, reject) => {
-        this.singleEventQueue.push({ event, resolve, reject });
+        const queuedRequest: (typeof this.singleEventQueue)[number] = {
+          event,
+          resolve,
+          reject,
+        };
+        if (!this.diagnoseFn) {
+          this._armQueuedRequestTimeout(queuedRequest);
+        }
+        this.singleEventQueue.push(queuedRequest);
       });
     }
 
@@ -443,9 +465,11 @@ export class ProactiveDiagnosisManager extends EventEmitter {
    * Process queued single-event diagnosis requests one by one.
    */
   private _drainSingleEventQueue(): void {
-    if (!this.diagnoseFn || this.running || this.singleEventQueue.length === 0) return;
+    if (!this.enabled || !this.diagnoseFn || this.running || this.singleEventQueue.length === 0)
+      return;
     const next = this.singleEventQueue.shift();
     if (!next) return;
+    if (next.timeout) clearTimeout(next.timeout);
     const cached = this.cache.get(next.event.uid);
     if (cached && !cached.loading && !cached.pending && !cached.error) {
       next.resolve(cached);
@@ -453,6 +477,42 @@ export class ProactiveDiagnosisManager extends EventEmitter {
       return;
     }
     this._executeSingleDiagnosis(next.event).then(next.resolve).catch(next.reject);
+  }
+
+  private _rejectSingleEventQueue(message: string): void {
+    const queued = this.singleEventQueue.splice(0);
+    for (const request of queued) {
+      this._rejectQueuedRequest(request, message);
+    }
+  }
+
+  private _armQueuedRequestTimeout(request: (typeof this.singleEventQueue)[number]): void {
+    if (request.timeout) return;
+    request.timeout = setTimeout(() => {
+      const index = this.singleEventQueue.indexOf(request);
+      if (index < 0) return;
+      this.singleEventQueue.splice(index, 1);
+      this._rejectQueuedRequest(request, 'Diagnosis setup timed out');
+    }, SINGLE_EVENT_QUEUE_TIMEOUT_MS);
+  }
+
+  private _rejectQueuedRequest(
+    request: (typeof this.singleEventQueue)[number],
+    message: string
+  ): void {
+    if (request.timeout) clearTimeout(request.timeout);
+    const result: DiagnosisResult = {
+      eventUid: request.event.uid,
+      event: request.event,
+      diagnosis: '',
+      diagnosedAt: Date.now(),
+      loading: false,
+      pending: false,
+      error: message,
+    };
+    this.cache.set(request.event.uid, result);
+    this.emit('diagnosis-update', result);
+    request.reject(new Error(message));
   }
 
   /**

--- a/ai-assistant/packages/ai-ui/src/diagnosis/ProactiveDiagnosisManager.ts
+++ b/ai-assistant/packages/ai-ui/src/diagnosis/ProactiveDiagnosisManager.ts
@@ -115,6 +115,10 @@ export class ProactiveDiagnosisManager extends EventEmitter {
   setDiagnoseFn(fn: DiagnoseFn | null): void {
     this.diagnoseFn = fn;
     if (fn) {
+      if (!this.enabled) {
+        this._rejectSingleEventQueue('Proactive diagnosis is disabled');
+        return;
+      }
       for (const request of this.singleEventQueue) {
         if (request.timeout) clearTimeout(request.timeout);
         request.timeout = undefined;

--- a/ai-assistant/src/agent-mode-default.test.ts
+++ b/ai-assistant/src/agent-mode-default.test.ts
@@ -18,9 +18,8 @@
  * Tests for the agent-mode default behaviour in modal.tsx.
  *
  * The rule: default to chat mode (isAgentMode = false).
- * Only auto-enable Holmes agent mode on first mount when:
- *   1. There is NO configured chat provider, AND
- *   2. Holmes agent health check returns true.
+ * Auto-enable Holmes on mount when it is available, unless the user has
+ * explicitly selected Chat during the current panel session.
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -35,11 +34,12 @@ async function shouldAutoEnableAgentMode(opts: {
   holmesAvailable: boolean;
   isAlreadyAgentMode: boolean;
   hasExistingAgent: boolean;
+  userSelectedChat?: boolean;
 }): Promise<boolean> {
-  const { holmesAvailable, isAlreadyAgentMode, hasExistingAgent } = opts;
+  const { holmesAvailable, isAlreadyAgentMode, hasExistingAgent, userSelectedChat } = opts;
 
   // Mirror the guard in the useEffect (hasChatProvider no longer blocks):
-  if (isAlreadyAgentMode || hasExistingAgent) return false;
+  if (userSelectedChat || isAlreadyAgentMode || hasExistingAgent) return false;
 
   // Holmes wins if reachable, regardless of chat provider.
   return holmesAvailable;
@@ -87,7 +87,7 @@ describe('agent mode default behaviour', () => {
     expect(result).toBe(false);
   });
 
-  it('auto-enables agent mode only when there is no chat provider AND Holmes is reachable', async () => {
+  it('auto-enables agent mode when there is no chat provider and Holmes is reachable', async () => {
     const result = await shouldAutoEnableAgentMode({
       hasChatProvider: false,
       holmesAvailable: true,
@@ -113,6 +113,17 @@ describe('agent mode default behaviour', () => {
       holmesAvailable: true,
       isAlreadyAgentMode: false,
       hasExistingAgent: true,
+    });
+    expect(result).toBe(false);
+  });
+
+  it('does NOT re-enable Holmes after the user explicitly selects Chat', async () => {
+    const result = await shouldAutoEnableAgentMode({
+      hasChatProvider: true,
+      holmesAvailable: true,
+      isAlreadyAgentMode: false,
+      hasExistingAgent: false,
+      userSelectedChat: true,
     });
     expect(result).toBe(false);
   });

--- a/ai-assistant/src/components/settings/Settings.test.tsx
+++ b/ai-assistant/src/components/settings/Settings.test.tsx
@@ -20,6 +20,7 @@ import { describe, expect, it, vi } from 'vitest';
 const skillManagerMock = vi.hoisted(() => ({
   constructorArgs: [] as unknown[][],
   loadedConfigs: [] as unknown[],
+  invalidations: 0,
 }));
 
 vi.mock('@headlamp-k8s/ai-common/skills/config', async () => {
@@ -43,7 +44,10 @@ vi.mock('@headlamp-k8s/ai-common/skills/SkillManager', () => ({
     constructor(...args: unknown[]) {
       skillManagerMock.constructorArgs.push(args);
     }
-    invalidateCache() {}
+    invalidateCache() {
+      skillManagerMock.invalidations += 1;
+    }
+    setSkillCache() {}
     async loadAllSkillsWithErrors(config: unknown) {
       skillManagerMock.loadedConfigs.push(config);
       return { skills: [], errors: [] };
@@ -123,12 +127,21 @@ describe('Settings', () => {
     capturedProps.length = 0;
     skillManagerMock.constructorArgs.length = 0;
     skillManagerMock.loadedConfigs.length = 0;
+    skillManagerMock.invalidations = 0;
     render(React.createElement(Settings));
     const loadSkills = capturedProps[0].loadSkills as (
       onProgress?: unknown,
-      sourceIdentity?: string
+      sourceIdentity?: string,
+      forceReload?: boolean
     ) => Promise<unknown[]>;
     await loadSkills(undefined, JSON.stringify(['git', 'https://github.com/example/repo', 'two']));
+    expect(skillManagerMock.invalidations).toBe(0);
+    await loadSkills(
+      undefined,
+      JSON.stringify(['git', 'https://github.com/example/repo', 'two']),
+      true
+    );
+    expect(skillManagerMock.invalidations).toBe(1);
     expect(skillManagerMock.constructorArgs[0]).toHaveLength(2);
     expect(skillManagerMock.loadedConfigs[0]).toEqual(
       expect.objectContaining({

--- a/ai-assistant/src/components/settings/Settings.tsx
+++ b/ai-assistant/src/components/settings/Settings.tsx
@@ -16,6 +16,7 @@
 
 import type { CommandRunner } from '@headlamp-k8s/ai-common/providers/detectProvider';
 import {
+  BrowserSkillCache,
   createFetchHttpClient,
   createNoopFileSystem,
 } from '@headlamp-k8s/ai-common/skills/adapters/browser';
@@ -77,13 +78,16 @@ export default function Settings() {
   const loadSkills = React.useCallback(
     async (
       onProgress?: (progress: any) => void,
-      sourceIdentity?: string
+      sourceIdentity?: string,
+      forceReload?: boolean
     ): Promise<SkillDisplayInfo[]> => {
       if (!skillManagerRef.current) {
         skillManagerRef.current = new SkillManager(createNoopFileSystem(), createFetchHttpClient());
+        skillManagerRef.current.setSkillCache(new BrowserSkillCache());
       }
-      // Invalidate cache to force fresh load
-      skillManagerRef.current.invalidateCache();
+      if (forceReload) {
+        skillManagerRef.current.invalidateCache();
+      }
       const config = getSkillsConfig(pluginStore.get());
 
       // When a source identity is given, load only that exact URL/path source.
@@ -104,7 +108,8 @@ export default function Settings() {
 
       const { skills, errors } = await skillManagerRef.current.loadAllSkillsWithErrors(
         filteredConfig,
-        onProgress ? (_url, p) => onProgress(p) : undefined
+        onProgress ? (_url, p) => onProgress(p) : undefined,
+        forceReload
       );
 
       // Surface per-source errors so the user knows what failed

--- a/ai-assistant/src/index.tsx
+++ b/ai-assistant/src/index.tsx
@@ -79,6 +79,9 @@ function AIDiagnosisButton({ event }: { event: Event }) {
     };
 
     if (!proactiveDiagnosisManager.hasDiagnosis(eventUid)) {
+      // The panel owns the diagnosis function and may still be unmounted.
+      // Enable the manager now so this request queues until the panel opens.
+      proactiveDiagnosisManager.start();
       proactiveDiagnosisManager.diagnoseSingleEvent(eventDigest).catch(err => {
         console.error('[AIDiagnosisButton] Failed to diagnose event:', err);
       });

--- a/ai-assistant/src/modal.tsx
+++ b/ai-assistant/src/modal.tsx
@@ -365,6 +365,7 @@ export default function AIPrompt(props: {
   const [showHolmesSetup, setShowHolmesSetup] = React.useState(false);
   const [isHolmesRetrying, setIsHolmesRetrying] = React.useState(false);
   const holmesHealthRequestGateRef = React.useRef(new HolmesHealthRequestGate());
+  const userSelectedChatRef = React.useRef(false);
 
   const [showEditor, setShowEditor] = React.useState(false);
   const [editorContent, setEditorContent] = React.useState('');
@@ -1449,8 +1450,10 @@ export default function AIPrompt(props: {
   const handleToggleAgentModeRequest = React.useCallback(
     (enabled: boolean) => {
       if (enabled) {
+        userSelectedChatRef.current = false;
         void handleUseHolmes();
       } else {
+        userSelectedChatRef.current = true;
         holmesHealthRequestGateRef.current.invalidate();
         setIsHolmesRetrying(false);
         setShowHolmesSetup(false);
@@ -1466,7 +1469,7 @@ export default function AIPrompt(props: {
   // default to it regardless of whether a chat provider is also configured.
   // Fall back to chat mode only when Holmes is not reachable.
   React.useEffect(() => {
-    if (isAgentMode || holmesAgentRef.current) return;
+    if (userSelectedChatRef.current || isAgentMode || holmesAgentRef.current) return;
 
     // If mock agent is enabled, skip health check and go straight to agent mode
     if (pluginSettings?.devOptions?.enableMockAgent) {
@@ -1819,6 +1822,7 @@ export default function AIPrompt(props: {
         onRetry={handleUseHolmes}
         isRetrying={isHolmesRetrying}
         onDismiss={() => {
+          userSelectedChatRef.current = true;
           holmesHealthRequestGateRef.current.invalidate();
           setIsHolmesRetrying(false);
           setShowHolmesSetup(false);

--- a/ai-assistant/src/modal.tsx
+++ b/ai-assistant/src/modal.tsx
@@ -1840,11 +1840,13 @@ export default function AIPrompt(props: {
     return (
       <Box
         sx={{
-          height: '100vh',
+          height: '100%',
+          minHeight: 0,
           display: 'flex',
           flexDirection: 'column',
           alignItems: 'center',
           justifyContent: 'center',
+          overflow: 'hidden',
           p: 3,
           textAlign: 'center',
         }}
@@ -1885,10 +1887,11 @@ export default function AIPrompt(props: {
   }
 
   return (
-    <div ref={rootRef}>
+    <div ref={rootRef} style={{ height: '100%', minHeight: 0 }}>
       <Box
         sx={{
-          height: '100vh',
+          height: '100%',
+          minHeight: 0,
           display: 'flex',
           flexDirection: 'column',
           overflow: 'hidden', // Prevent horizontal overflow
@@ -1913,7 +1916,8 @@ export default function AIPrompt(props: {
           justifyContent="flex-end"
           alignItems="stretch"
           sx={{
-            height: '100%',
+            flex: '1 1 0',
+            minHeight: 0,
             padding: 1,
             overflow: 'hidden', // Prevent overflow
             maxWidth: '100%',
@@ -1927,9 +1931,10 @@ export default function AIPrompt(props: {
             item
             xs
             sx={{
-              height: '100%',
-              overflowY: 'auto',
-              overflowX: 'auto', // Allow horizontal scrolling when needed
+              minHeight: 0,
+              display: 'flex',
+              flexDirection: 'column',
+              overflow: 'hidden',
               maxWidth: '100%',
               minWidth: 0,
             }}

--- a/ai-assistant/src/modal.tsx
+++ b/ai-assistant/src/modal.tsx
@@ -21,6 +21,7 @@ import LangChainAssistantSession from '@headlamp-k8s/ai-common/assistant/LangCha
 import type { ConversationMessage } from '@headlamp-k8s/ai-common/conversation/types';
 import { getProviderById } from '@headlamp-k8s/ai-common/providers/catalog';
 import {
+  BrowserSkillCache,
   createFetchHttpClient,
   createNoopFileSystem,
 } from '@headlamp-k8s/ai-common/skills/adapters/browser';
@@ -641,6 +642,7 @@ export default function AIPrompt(props: {
     // Reuse existing SkillManager instance to preserve its in-memory cache
     if (!skillManagerRef.current) {
       skillManagerRef.current = new SkillManager(createNoopFileSystem(), createFetchHttpClient());
+      skillManagerRef.current.setSkillCache(new BrowserSkillCache());
     }
     (aiManager as LangChainAssistantSession).setSkillManager(skillManagerRef.current, skillsConfig);
   }, [aiManager, pluginSettings]);


### PR DESCRIPTION
## Summary

- reuse downloaded skills until an explicit reload
- queue table-triggered diagnoses until the assistant is ready
- preserve explicit Chat mode selection
- contain sidebar scrolling and keep user messages visible

## Testing

- scroll on chat window up and down, show not show white bar at bottom of screen
- can select chat dialog option in chat window when using testing agent.
- diagnosis didn't come up right away on first click when using testing agent
- click view skills button, doesn't reload skills each time now

---

- `npm --prefix packages/ai-ui run check`
- `npm run check`
- `npm run build`
- each atomic commit validated independently
