### PR TITLE
metal3: Add power on/off action for BareMetalHost

### DIFF
--- a/metal3/src/BareMetalHost/PowerActionButton.tsx
+++ b/metal3/src/BareMetalHost/PowerActionButton.tsx
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ActionButton } from '@kinvolk/headlamp-plugin/lib/components/common';
+import type { KubeObject } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+} from '@mui/material';
+import { useState } from 'react';
+import { getPowerIntent, powerPatch } from './powerAction';
+
+/**
+ * Header action that toggles a BareMetalHost's power intent (`spec.online`).
+ *
+ * Registered against every details view, so it returns null unless the resource
+ * is a BareMetalHost. It reads the current power state to label the button, and
+ * on confirm sends a single-field patch; the operator carries out the actual
+ * power change over the host's BMC. Because it acts on physical hardware, the
+ * change goes through a confirmation dialog.
+ *
+ * @param props.item - The resource whose details view is open.
+ */
+export function PowerActionButton({ item }: { item: KubeObject }) {
+  const [open, setOpen] = useState(false);
+
+  if (!item || item.kind !== 'BareMetalHost') {
+    return null;
+  }
+
+  const intent = getPowerIntent(item);
+  const name = item.metadata.name;
+
+  return (
+    <>
+      <ActionButton
+        description={intent.label}
+        icon={intent.isOn ? 'mdi:power-plug-off' : 'mdi:power-plug'}
+        onClick={() => setOpen(true)}
+      />
+      <Dialog open={open} onClose={() => setOpen(false)}>
+        <DialogTitle>{`${intent.label}: ${name}`}</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            {`This sets spec.online to ${intent.targetOnline} on ${name}. The bare metal ` +
+              `operator then powers the host ${intent.targetOnline ? 'on' : 'off'} over its BMC.`}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setOpen(false)}>Cancel</Button>
+          <Button
+            variant="contained"
+            onClick={() => {
+              setOpen(false);
+              item.patch(powerPatch(intent.targetOnline));
+            }}
+          >
+            {intent.label}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+}

--- a/metal3/src/BareMetalHost/powerAction.test.ts
+++ b/metal3/src/BareMetalHost/powerAction.test.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { KubeObject } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import { describe, expect, it } from 'vitest';
+import { getPowerIntent, powerPatch } from './powerAction';
+
+/** Builds a minimal BareMetalHost-shaped object with the given `spec.online`. */
+function host(online?: boolean): KubeObject {
+  return { jsonData: { spec: online === undefined ? {} : { online } } } as unknown as KubeObject;
+}
+
+describe('getPowerIntent', () => {
+  it('offers to power off a host that is on', () => {
+    expect(getPowerIntent(host(true))).toEqual({
+      isOn: true,
+      targetOnline: false,
+      label: 'Power Off',
+    });
+  });
+
+  it('offers to power on a host that is off', () => {
+    expect(getPowerIntent(host(false))).toEqual({
+      isOn: false,
+      targetOnline: true,
+      label: 'Power On',
+    });
+  });
+
+  it('treats a host with no online intent as off', () => {
+    expect(getPowerIntent(host())).toEqual({
+      isOn: false,
+      targetOnline: true,
+      label: 'Power On',
+    });
+  });
+});
+
+describe('powerPatch', () => {
+  it('builds a patch that powers on', () => {
+    expect(powerPatch(true)).toEqual({ spec: { online: true } });
+  });
+
+  it('builds a patch that powers off', () => {
+    expect(powerPatch(false)).toEqual({ spec: { online: false } });
+  });
+});

--- a/metal3/src/BareMetalHost/powerAction.ts
+++ b/metal3/src/BareMetalHost/powerAction.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { KubeObject } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+
+/** The power action a host offers, derived from its current `spec.online`. */
+export interface PowerIntent {
+  /** Whether the host is currently powered on, per `spec.online`. */
+  isOn: boolean;
+  /** The value `spec.online` should be set to when the action runs. */
+  targetOnline: boolean;
+  /** Button label naming the action that will happen. */
+  label: string;
+}
+
+/**
+ * Derives the power action to offer for a host from its `spec.online` intent.
+ * A host with no `spec.online` is treated as off, so the action offered is to
+ * power it on. This is pure so the button's label and target can be unit-tested
+ * without a running cluster.
+ *
+ * @param host - The BareMetalHost to read `spec.online` from.
+ * @returns The current power state, the target value, and the button label.
+ */
+export function getPowerIntent(host: KubeObject): PowerIntent {
+  const isOn = host.jsonData.spec?.online === true;
+  return {
+    isOn,
+    targetOnline: !isOn,
+    label: isOn ? 'Power Off' : 'Power On',
+  };
+}
+
+/**
+ * Builds the merge patch that sets a host's power intent. Power is a declarative
+ * spec field, so the action is a single-field patch; the operator carries out the
+ * actual power change over the host's BMC.
+ *
+ * @param targetOnline - The value to set `spec.online` to.
+ * @returns The merge-patch body for `KubeObject.patch`.
+ */
+export function powerPatch(targetOnline: boolean): { spec: { online: boolean } } {
+  return { spec: { online: targetOnline } };
+}

--- a/metal3/src/index.tsx
+++ b/metal3/src/index.tsx
@@ -14,9 +14,14 @@
  * limitations under the License.
  */
 
-import { registerRoute, registerSidebarEntry } from '@kinvolk/headlamp-plugin/lib';
+import {
+  registerDetailsViewHeaderAction,
+  registerRoute,
+  registerSidebarEntry,
+} from '@kinvolk/headlamp-plugin/lib';
 import { BareMetalHostDetail } from './BareMetalHost/Details';
 import { BareMetalHosts } from './BareMetalHost/List';
+import { PowerActionButton } from './BareMetalHost/PowerActionButton';
 import { Metal3ClusterDetail } from './Metal3Cluster/Details';
 import { Metal3Clusters } from './Metal3Cluster/List';
 import { Metal3ClusterTemplateDetail } from './Metal3ClusterTemplate/Details';
@@ -148,3 +153,6 @@ registerRoute({
   component: () => <Metal3ClusterTemplateDetail />,
   name: 'metal3clustertemplate-detail',
 });
+
+// Power on/off action on the BareMetalHost detail view. Toggles spec.online.
+registerDetailsViewHeaderAction(PowerActionButton);


### PR DESCRIPTION
## Summary

Adds the first mutating action to the Metal3 plugin: powering a BareMetalHost on or
off from its detail view. It sets the host's `spec.online`, which is the power intent
the operator then applies over the BMC. This is the first of the action modules;
reboot and detach will follow the same pattern.

## Included

- A header-action button on the BareMetalHost detail view that reads the current power
  state to label itself and toggles `spec.online`, through a confirmation dialog since
  it affects physical hardware.
- The intent and patch logic as pure functions in `powerAction.ts`, with unit tests.

## How to test

- A cluster with the Metal3 CRDs installed and a BareMetalHost.
- `cd metal3 && npm install && npm start`, then run Headlamp.
- Open a BareMetalHost's detail view. The power button is in the header, next to edit
  and delete, and its label reflects the current state.
- Click it, confirm, and `spec.online` flips on the object.

## Demo

https://github.com/user-attachments/assets/8dd957b3-f1bd-4c1b-9753-b04ba16e3efe
