### PR TITLE
strimzi: Declare both API versions on the resource classes

### DIFF
--- a/strimzi/src/components/KafkaConnectList.tsx
+++ b/strimzi/src/components/KafkaConnectList.tsx
@@ -6,7 +6,7 @@ import {
   type ColumnType,
   type ResourceTableColumn,
 } from '@kinvolk/headlamp-plugin/lib/components/common';
-import { KafkaConnect, KafkaConnectV1 } from '../resources/kafkaConnect';
+import { KafkaConnect } from '../resources/kafkaConnect';
 import { readyChipProps } from '../utils/readyChip';
 import { useStrimziApiVersions } from '../hooks/useStrimziApiVersions';
 import { StrimziNotInstalledMessage } from './StrimziNotInstalledMessage';
@@ -21,8 +21,7 @@ import { StrimziNotInstalledMessage } from './StrimziNotInstalledMessage';
  */
 export function KafkaConnectList() {
   const theme = useTheme();
-  const { ready, installed, kafka: kafkaVersion } = useStrimziApiVersions();
-  const KafkaConnectClass = kafkaVersion === 'v1' ? KafkaConnectV1 : KafkaConnect;
+  const { ready, installed } = useStrimziApiVersions();
 
   if (ready && !installed) return <StrimziNotInstalledMessage />;
 
@@ -70,6 +69,6 @@ export function KafkaConnectList() {
   ];
 
   return (
-    <ResourceListView title="Kafka Connect Clusters" resourceClass={KafkaConnectClass} columns={columns} />
+    <ResourceListView title="Kafka Connect Clusters" resourceClass={KafkaConnect} columns={columns} />
   );
 }

--- a/strimzi/src/components/KafkaConnectorList.tsx
+++ b/strimzi/src/components/KafkaConnectorList.tsx
@@ -15,7 +15,7 @@ import {
   type ColumnType,
   type ResourceTableColumn,
 } from '@kinvolk/headlamp-plugin/lib/components/common';
-import { KafkaConnector, KafkaConnectorV1 } from '../resources/kafkaConnector';
+import { KafkaConnector } from '../resources/kafkaConnector';
 import type { KafkaConnectorInterface, KafkaConnectorState } from '../resources/kafkaConnector';
 import { getErrorMessage } from '../utils/errors';
 import { useStrimziApiVersions } from '../hooks/useStrimziApiVersions';
@@ -41,7 +41,6 @@ const STATE_CHIP_COLORS: Record<KafkaConnectorState, 'success' | 'warning' | 'de
 export function KafkaConnectorList() {
   const theme = useTheme();
   const { ready, installed, kafka: kafkaVersion } = useStrimziApiVersions();
-  const KafkaConnectorClass = kafkaVersion === 'v1' ? KafkaConnectorV1 : KafkaConnector;
 
   if (ready && !installed) return <StrimziNotInstalledMessage />;
 
@@ -190,7 +189,7 @@ export function KafkaConnectorList() {
 
   return (
     <>
-      <ResourceListView title="Kafka Connectors" resourceClass={KafkaConnectorClass} columns={columns} />
+      <ResourceListView title="Kafka Connectors" resourceClass={KafkaConnector} columns={columns} />
       <Dialog
         open={pendingState !== null}
         onClose={() => setPendingState(null)}

--- a/strimzi/src/components/KafkaList.tsx
+++ b/strimzi/src/components/KafkaList.tsx
@@ -5,15 +5,14 @@ import {
   type ColumnType,
   type ResourceTableColumn,
 } from '@kinvolk/headlamp-plugin/lib/components/common';
-import { Kafka, KafkaV1 } from '../resources/kafka';
+import { Kafka } from '../resources/kafka';
 import { KafkaTopologyModal } from './KafkaTopologyModal';
 import type { KafkaInterface } from '../resources/kafka';
 import { useStrimziApiVersions } from '../hooks/useStrimziApiVersions';
 import { StrimziNotInstalledMessage } from './StrimziNotInstalledMessage';
 
 export function KafkaList() {
-  const { ready, installed, kafka: kafkaVersion } = useStrimziApiVersions();
-  const KafkaClass = kafkaVersion === 'v1' ? KafkaV1 : Kafka;
+  const { ready, installed } = useStrimziApiVersions();
 
   if (ready && !installed) return <StrimziNotInstalledMessage />;
 
@@ -67,7 +66,7 @@ export function KafkaList() {
     <>
       <ResourceListView
         title="Kafka Clusters"
-        resourceClass={KafkaClass}
+        resourceClass={Kafka}
         columns={columns}
       />
       <KafkaTopologyModal

--- a/strimzi/src/components/KafkaTopicList.tsx
+++ b/strimzi/src/components/KafkaTopicList.tsx
@@ -7,7 +7,7 @@ import {
   type ColumnType,
   type ResourceTableColumn,
 } from '@kinvolk/headlamp-plugin/lib/components/common';
-import { Kafka, KafkaV1, KafkaTopic, KafkaTopicV1 } from '../resources';
+import { Kafka, KafkaTopic } from '../resources';
 import type { KafkaTopicInterface } from '../resources';
 import { getErrorMessage } from '../utils/errors';
 import { clusterNamespaces, clusterNamesInNamespace } from '../utils/clusters';
@@ -19,13 +19,11 @@ import { TopicFormModal, type TopicFormData } from './TopicFormModal';
 export function KafkaTopicList() {
   const theme = useTheme();
   const { ready, installed, kafka: kafkaVersion } = useStrimziApiVersions();
-  const KafkaClass = kafkaVersion === 'v1' ? KafkaV1 : Kafka;
-  const KafkaTopicClass = kafkaVersion === 'v1' ? KafkaTopicV1 : KafkaTopic;
   const kafkaApiPath = `/apis/kafka.strimzi.io/${kafkaVersion}`;
 
   // All hooks must be called before any early return (Rules of Hooks).
   // useList returns null while loading, so normalise to an array up front.
-  const { items } = KafkaClass.useList({});
+  const { items } = Kafka.useList({});
   const kafkaClusters = items ?? [];
   const [toast, setToast] = React.useState<ToastMessage | null>(null);
   const [showCreateDialog, setShowCreateDialog] = React.useState(false);
@@ -257,7 +255,7 @@ export function KafkaTopicList() {
     <>
       <ResourceListView
         title="Kafka Topics"
-        resourceClass={KafkaTopicClass}
+        resourceClass={KafkaTopic}
         columns={columns}
         headerProps={{
           titleSideActions: [

--- a/strimzi/src/components/KafkaUserList.tsx
+++ b/strimzi/src/components/KafkaUserList.tsx
@@ -7,7 +7,7 @@ import {
   type ColumnType,
   type ResourceTableColumn,
 } from '@kinvolk/headlamp-plugin/lib/components/common';
-import { Kafka, KafkaV1, KafkaUser, KafkaUserV1 } from '../resources';
+import { Kafka, KafkaUser } from '../resources';
 import type { CreateKafkaUserPayload, KafkaUserInterface } from '../resources';
 import { getErrorMessage } from '../utils/errors';
 import { clusterNamespaces, clusterNamesInNamespace } from '../utils/clusters';
@@ -20,13 +20,11 @@ import { KafkaUserCreateFormModal, type UserFormData } from './KafkaUserCreateFo
 export function KafkaUserList() {
   const theme = useTheme();
   const { ready, installed, kafka: kafkaVersion } = useStrimziApiVersions();
-  const KafkaClass = kafkaVersion === 'v1' ? KafkaV1 : Kafka;
-  const KafkaUserClass = kafkaVersion === 'v1' ? KafkaUserV1 : KafkaUser;
   const kafkaApiPath = `/apis/kafka.strimzi.io/${kafkaVersion}`;
 
   // All hooks must be called before any early return (Rules of Hooks).
   // useList returns null while loading, so normalise to an array up front.
-  const { items } = KafkaClass.useList({});
+  const { items } = Kafka.useList({});
   const kafkaClusters = items ?? [];
   const [toast, setToast] = React.useState<ToastMessage | null>(null);
   const [showCreateDialog, setShowCreateDialog] = React.useState(false);
@@ -273,7 +271,7 @@ export function KafkaUserList() {
     <>
       <ResourceListView
         title="Kafka Users"
-        resourceClass={KafkaUserClass}
+        resourceClass={KafkaUser}
         columns={columns}
         headerProps={{
           titleSideActions: [

--- a/strimzi/src/crds.ts
+++ b/strimzi/src/crds.ts
@@ -19,15 +19,10 @@ export interface K8sListResponse<T> {
 // Re-export resource classes and their interfaces
 export {
   Kafka,
-  KafkaV1,
   KafkaConnect,
-  KafkaConnectV1,
   KafkaConnector,
-  KafkaConnectorV1,
   KafkaTopic,
-  KafkaTopicV1,
   KafkaUser,
-  KafkaUserV1,
   type ConnectorPlugin,
   type KafkaConnectInterface,
   type KafkaConnectSpec,

--- a/strimzi/src/hooks/useStrimziApiVersions.ts
+++ b/strimzi/src/hooks/useStrimziApiVersions.ts
@@ -2,15 +2,16 @@
  * React hook that returns the Strimzi API versions available on the
  * current cluster, triggering a re-render once the probe completes.
  *
- * Components use the returned `kafka` and `core` version strings to
- * select the right KubeObject class and to build API paths for direct
- * `ApiProxy.request` calls.
+ * Components use the returned `kafka` and `core` version strings to build
+ * API paths for direct `ApiProxy.request` calls, and `installed` to tell a
+ * cluster without Strimzi apart from one that simply has no resources yet.
+ * KubeObject classes do not need this: they declare every supported version
+ * and Headlamp negotiates the one the cluster serves.
  *
  * @example
  * ```tsx
  * const { kafka: kafkaVersion } = useStrimziApiVersions();
- * const KafkaClass = kafkaVersion === 'v1' ? KafkaV1 : Kafka;
- * return <ResourceListView resourceClass={KafkaClass} ... />;
+ * await ApiProxy.request(`/apis/kafka.strimzi.io/${kafkaVersion}/kafkatopics`);
  * ```
  */
 import React from 'react';

--- a/strimzi/src/mapView.tsx
+++ b/strimzi/src/mapView.tsx
@@ -6,12 +6,11 @@ import { KafkaConnectDetail } from './components/connects/Detail';
 import { KafkaConnectorDetail } from './components/connectors/Detail';
 import { KafkaTopicDetail } from './components/topics/Detail';
 import { KafkaUserDetail } from './components/users/Detail';
-import { useStrimziApiVersions } from './hooks/useStrimziApiVersions';
-import { Kafka, KafkaV1 } from './resources/kafka';
-import { KafkaConnect, KafkaConnectV1 } from './resources/kafkaConnect';
-import { KafkaConnector, KafkaConnectorV1 } from './resources/kafkaConnector';
-import { KafkaTopic, KafkaTopicV1 } from './resources/kafkaTopic';
-import { KafkaUser, KafkaUserV1 } from './resources/kafkaUser';
+import { Kafka } from './resources/kafka';
+import { KafkaConnect } from './resources/kafkaConnect';
+import { KafkaConnector } from './resources/kafkaConnector';
+import { KafkaTopic } from './resources/kafkaTopic';
+import { KafkaUser } from './resources/kafkaUser';
 
 const STRIMZI_BLUE = 'rgb(0, 132, 255)';
 const CLUSTER_LABEL = 'strimzi.io/cluster';
@@ -62,20 +61,16 @@ const connectIcon = <Icon icon="mdi:transit-connection-variant" width="100%" hei
 const connectorIcon = <Icon icon="mdi:swap-horizontal" width="100%" height="100%" color={STRIMZI_BLUE} />;
 
 /**
- * Strimzi 1.0+ retires the v1beta2 API and serves the CRDs as v1. Each map
- * source resolves the API version the current cluster actually serves (via
- * the shared `useStrimziApiVersions` probe) and picks the matching KubeObject
- * class, the same way the list and detail views do. Pinning v1beta2 here
- * would leave the map empty on v1-only clusters.
+ * Strimzi 1.0+ retires the v1beta2 API and serves the CRDs as v1. The resource
+ * classes declare both versions, so Headlamp negotiates the one the cluster
+ * actually serves and the map works on old and new clusters alike.
  */
 const kafkaSource = {
   id: 'strimzi-kafkas',
   label: 'Kafka clusters',
   icon: kafkaIcon,
   useData() {
-    const { kafka: kafkaVersion } = useStrimziApiVersions();
-    const KafkaClass = kafkaVersion === 'v1' ? KafkaV1 : Kafka;
-    const [kafkas] = KafkaClass.useList();
+    const [kafkas] = Kafka.useList();
     return useMemo(() => {
       if (!kafkas) return null;
       const KafkaNodeDetails = makeDetailsComponent(KafkaDetail);
@@ -95,11 +90,8 @@ const kafkaTopicSource = {
   label: 'Kafka topics',
   icon: topicIcon,
   useData() {
-    const { kafka: kafkaVersion } = useStrimziApiVersions();
-    const KafkaTopicClass = kafkaVersion === 'v1' ? KafkaTopicV1 : KafkaTopic;
-    const KafkaClass = kafkaVersion === 'v1' ? KafkaV1 : Kafka;
-    const [topics] = KafkaTopicClass.useList();
-    const [kafkas] = KafkaClass.useList();
+    const [topics] = KafkaTopic.useList();
+    const [kafkas] = Kafka.useList();
     return useMemo(() => {
       if (!topics) return null;
       const TopicNodeDetails = makeDetailsComponent(KafkaTopicDetail);
@@ -127,11 +119,8 @@ const kafkaUserSource = {
   label: 'Kafka users',
   icon: userIcon,
   useData() {
-    const { kafka: kafkaVersion } = useStrimziApiVersions();
-    const KafkaUserClass = kafkaVersion === 'v1' ? KafkaUserV1 : KafkaUser;
-    const KafkaClass = kafkaVersion === 'v1' ? KafkaV1 : Kafka;
-    const [users] = KafkaUserClass.useList();
-    const [kafkas] = KafkaClass.useList();
+    const [users] = KafkaUser.useList();
+    const [kafkas] = Kafka.useList();
     return useMemo(() => {
       if (!users) return null;
       const UserNodeDetails = makeDetailsComponent(KafkaUserDetail);
@@ -159,9 +148,7 @@ const kafkaConnectSource = {
   label: 'Kafka Connect clusters',
   icon: connectIcon,
   useData() {
-    const { kafka: kafkaVersion } = useStrimziApiVersions();
-    const KafkaConnectClass = kafkaVersion === 'v1' ? KafkaConnectV1 : KafkaConnect;
-    const [connects] = KafkaConnectClass.useList();
+    const [connects] = KafkaConnect.useList();
     return useMemo(() => {
       if (!connects) return null;
       const ConnectNodeDetails = makeDetailsComponent(KafkaConnectDetail);
@@ -181,11 +168,8 @@ const kafkaConnectorSource = {
   label: 'Kafka connectors',
   icon: connectorIcon,
   useData() {
-    const { kafka: kafkaVersion } = useStrimziApiVersions();
-    const KafkaConnectorClass = kafkaVersion === 'v1' ? KafkaConnectorV1 : KafkaConnector;
-    const KafkaConnectClass = kafkaVersion === 'v1' ? KafkaConnectV1 : KafkaConnect;
-    const [connectors] = KafkaConnectorClass.useList();
-    const [connects] = KafkaConnectClass.useList();
+    const [connectors] = KafkaConnector.useList();
+    const [connects] = KafkaConnect.useList();
     return useMemo(() => {
       if (!connectors) return null;
       const ConnectorNodeDetails = makeDetailsComponent(KafkaConnectorDetail);

--- a/strimzi/src/resources/index.ts
+++ b/strimzi/src/resources/index.ts
@@ -3,14 +3,12 @@ export * from './kafka';
 export * from './kafkaTopic';
 export {
   KafkaUser,
-  KafkaUserV1,
   type CreateKafkaUserPayload,
   type KafkaUserInterface,
   type KafkaUserSpec,
 } from './kafkaUser';
 export {
   KafkaConnect,
-  KafkaConnectV1,
   type ConnectorPlugin,
   type KafkaConnectInterface,
   type KafkaConnectSpec,
@@ -18,7 +16,6 @@ export {
 } from './kafkaConnect';
 export {
   KafkaConnector,
-  KafkaConnectorV1,
   type KafkaConnectorInterface,
   type KafkaConnectorSpec,
   type KafkaConnectorState,

--- a/strimzi/src/resources/kafka.ts
+++ b/strimzi/src/resources/kafka.ts
@@ -51,7 +51,7 @@ export interface KafkaInterface extends KubeObjectInterface {
  * @see https://strimzi.io/docs/operators/latest/full/configuring.html#type-Kafka-reference
  */
 export class Kafka extends KubeObject<KafkaInterface> {
-  static apiVersion = 'kafka.strimzi.io/v1beta2';
+  static apiVersion = ['kafka.strimzi.io/v1', 'kafka.strimzi.io/v1beta2'];
   static kind = 'Kafka';
   static apiName = 'kafkas';
   static isNamespaced = true;
@@ -95,9 +95,4 @@ export class Kafka extends KubeObject<KafkaInterface> {
     if (k !== undefined) return String(k);
     return 'N/A';
   }
-}
-
-/** Kafka resource class targeting the `kafka.strimzi.io/v1` API (Strimzi 1.0.0+). */
-export class KafkaV1 extends Kafka {
-  static apiVersion = 'kafka.strimzi.io/v1';
 }

--- a/strimzi/src/resources/kafkaConnect.ts
+++ b/strimzi/src/resources/kafkaConnect.ts
@@ -74,7 +74,7 @@ export interface KafkaConnectInterface extends KubeObjectInterface {
  * @see https://strimzi.io/docs/operators/latest/full/configuring.html#type-KafkaConnect-reference
  */
 export class KafkaConnect extends KubeObject<KafkaConnectInterface> {
-  static apiVersion = 'kafka.strimzi.io/v1beta2';
+  static apiVersion = ['kafka.strimzi.io/v1', 'kafka.strimzi.io/v1beta2'];
   static kind = 'KafkaConnect';
   static apiName = 'kafkaconnects';
   static isNamespaced = true;
@@ -120,9 +120,4 @@ export class KafkaConnect extends KubeObject<KafkaConnectInterface> {
   get connectorPlugins(): ConnectorPlugin[] {
     return this.status?.connectorPlugins ?? [];
   }
-}
-
-/** KafkaConnect resource class targeting the `kafka.strimzi.io/v1` API (Strimzi 1.0.0+). */
-export class KafkaConnectV1 extends KafkaConnect {
-  static apiVersion = 'kafka.strimzi.io/v1';
 }

--- a/strimzi/src/resources/kafkaConnector.ts
+++ b/strimzi/src/resources/kafkaConnector.ts
@@ -76,7 +76,7 @@ export interface KafkaConnectorInterface extends KubeObjectInterface {
  * @see https://strimzi.io/docs/operators/latest/full/configuring.html#type-KafkaConnector-reference
  */
 export class KafkaConnector extends KubeObject<KafkaConnectorInterface> {
-  static apiVersion = 'kafka.strimzi.io/v1beta2';
+  static apiVersion = ['kafka.strimzi.io/v1', 'kafka.strimzi.io/v1beta2'];
   static kind = 'KafkaConnector';
   static apiName = 'kafkaconnectors';
   static isNamespaced = true;
@@ -108,7 +108,10 @@ export class KafkaConnector extends KubeObject<KafkaConnectorInterface> {
     return this.jsonData?.metadata?.labels?.['strimzi.io/cluster'] ?? '';
   }
 
-  /** Desired state from the spec, normalised to a `KafkaConnectorState`. */
+  /**
+   * Desired state from the spec, normalised to a `KafkaConnectorState`.
+   * `spec.pause` only exists in v1beta2; v1 resources never carry it.
+   */
   get desiredState(): KafkaConnectorState {
     if (this.spec?.state) return this.spec.state;
     if (this.spec?.pause) return 'paused';
@@ -123,18 +126,5 @@ export class KafkaConnector extends KubeObject<KafkaConnectorInterface> {
   /** Effective max tasks (status if reported by operator, else spec). */
   get tasksMax(): number | undefined {
     return this.status?.tasksMax ?? this.spec?.tasksMax;
-  }
-}
-
-/**
- * KafkaConnector resource class targeting the `kafka.strimzi.io/v1` API
- * (Strimzi 1.0.0+). In v1, `spec.pause` is removed; `spec.state` is the
- * only supported lifecycle field.
- */
-export class KafkaConnectorV1 extends KafkaConnector {
-  static apiVersion = 'kafka.strimzi.io/v1';
-
-  get desiredState(): KafkaConnectorState {
-    return this.spec?.state ?? 'running';
   }
 }

--- a/strimzi/src/resources/kafkaTopic.ts
+++ b/strimzi/src/resources/kafkaTopic.ts
@@ -23,7 +23,7 @@ export interface KafkaTopicInterface extends KubeObjectInterface {
  * @see https://strimzi.io/docs/operators/latest/full/configuring.html#type-KafkaTopic-reference
  */
 export class KafkaTopic extends KubeObject<KafkaTopicInterface> {
-  static apiVersion = 'kafka.strimzi.io/v1beta2';
+  static apiVersion = ['kafka.strimzi.io/v1', 'kafka.strimzi.io/v1beta2'];
   static kind = 'KafkaTopic';
   static apiName = 'kafkatopics';
   static isNamespaced = true;
@@ -51,9 +51,4 @@ export class KafkaTopic extends KubeObject<KafkaTopicInterface> {
   get replicas(): number {
     return this.spec?.replicas ?? 0;
   }
-}
-
-/** KafkaTopic resource class targeting the `kafka.strimzi.io/v1` API (Strimzi 1.0.0+). */
-export class KafkaTopicV1 extends KafkaTopic {
-  static apiVersion = 'kafka.strimzi.io/v1';
 }

--- a/strimzi/src/resources/kafkaUser.ts
+++ b/strimzi/src/resources/kafkaUser.ts
@@ -56,7 +56,7 @@ export interface CreateKafkaUserPayload {
  * @see https://strimzi.io/docs/operators/latest/full/configuring.html#type-KafkaUser-reference
  */
 export class KafkaUser extends KubeObject<KafkaUserInterface> {
-  static apiVersion = 'kafka.strimzi.io/v1beta2';
+  static apiVersion = ['kafka.strimzi.io/v1', 'kafka.strimzi.io/v1beta2'];
   static kind = 'KafkaUser';
   static apiName = 'kafkausers';
   static isNamespaced = true;
@@ -84,9 +84,4 @@ export class KafkaUser extends KubeObject<KafkaUserInterface> {
   get authorizationType(): string {
     return this.spec?.authorization?.type ?? 'None';
   }
-}
-
-/** KafkaUser resource class targeting the `kafka.strimzi.io/v1` API (Strimzi 1.0.0+). */
-export class KafkaUserV1 extends KafkaUser {
-  static apiVersion = 'kafka.strimzi.io/v1';
 }


### PR DESCRIPTION
## Problem

On a Strimzi 1.0+ cluster, which only serves the `v1` API, the **Kafka Clusters**
list stays empty ("Resource not found") and the detail pages fail to load, while
the Topics and Users lists work. The failing requests go to `v1beta2`:

```
GET /apis/kafka.strimzi.io/v1beta2/kafkas                     404
GET /apis/kafka.strimzi.io/v1beta2/namespaces/…/kafkas/…      404
```

The plugin picked a `v1` or `v1beta2` KubeObject class at render time, with the
`v1` variants subclassing the `v1beta2` ones:

```ts
export class Kafka   extends KubeObject { static apiVersion = 'kafka.strimzi.io/v1beta2'; }
export class KafkaV1 extends Kafka      { static apiVersion = 'kafka.strimzi.io/v1'; }
```

Headlamp caches the computed endpoint on the class (`_internalApiEndpoint`), and
static members are inherited in JavaScript, so whichever variant is used first
wins. The version probe starts out reporting `v1beta2` until it resolves, so the
landing page renders with the base class, that caches its `v1beta2` endpoint, and
`KafkaV1` then reads the same cached endpoint through the prototype chain and
keeps querying `v1beta2` forever. Topics happen to work only because you reach
them after the probe has resolved, so the `v1` variant is touched first — which is
why the failure looked erratic.

## Fix

Declare every supported version on a single class and let Headlamp negotiate the
one the cluster serves (its endpoint dispatcher moves to the next entry on a 404):

```ts
static apiVersion = ['kafka.strimzi.io/v1', 'kafka.strimzi.io/v1beta2'];
```

This is the pattern the `flux` and `kubeflow` plugins already use. It removes the
five `*V1` subclasses and the per-component class selection, so there is no longer
any inheritance to poison — 60 lines lighter overall.

`useStrimziApiVersions` stays, but only for what it is actually needed for: the
direct `ApiProxy.request` paths (create/edit/delete, node pools, pod sets) and
telling a cluster without Strimzi apart from one that has no resources yet.

## Testing

Verified on a Strimzi **1.1.0** cluster serving only `v1`
(`kafka.strimzi.io/v1`, CRD `v1 served=true storage=true`):

| Build | Lists | Kafka Clusters | Detail pages |
| --- | --- | --- | --- |
| published `0.4.0-alpha` | broken | broken | broken |
| current `main` | topics/users OK | empty | fail to load |
| this branch | OK | OK | OK |

`tsc`, `eslint` and the full test suite (71 tests) pass.
