### PR TITLE
kueue: Add Workload views

### DIFF
--- a/kueue/README.md
+++ b/kueue/README.md
@@ -6,29 +6,32 @@ See the [Kueue getting started guide](https://kueue.sigs.k8s.io/docs/getting-sta
 
 ## Current Scope
 
-This plugin currently reads Kueue `ClusterQueue`, `LocalQueue`, and `ResourceFlavor` resources from the Kubernetes API and displays them in basic list and detail pages. It registers a Kueue sidebar section with entries for these resources.
+This plugin currently reads Kueue `ClusterQueue`, `LocalQueue`, `ResourceFlavor`, and `Workload` resources from the Kubernetes API and displays them in basic list and detail pages. It registers a Kueue sidebar section with entries for these resources.
 
-Kueue resources such as `Workload` and additional queueing views will be added in later PRs.
+Additional queueing views will be added in later PRs.
 
 ## Prerequisites
 
 Kueue CRDs must be installed in the cluster before the plugin can list resources. See the [Kueue installation guide](https://kueue.sigs.k8s.io/docs/getting-started/installation/) for installation instructions.
 
-You can check for the `ClusterQueue`, `LocalQueue`, and `ResourceFlavor` CRDs and resources with:
+You can check for the `ClusterQueue`, `LocalQueue`, `ResourceFlavor`, and `Workload` CRDs and resources with:
 
 ```bash
 kubectl get crd clusterqueues.kueue.x-k8s.io
 kubectl get crd localqueues.kueue.x-k8s.io
 kubectl get crd resourceflavors.kueue.x-k8s.io
+kubectl get crd workloads.kueue.x-k8s.io
 kubectl get clusterqueues
 kubectl get localqueues -A
 kubectl get localqueue <name> -n <namespace> -o yaml
 kubectl get resourceflavors
+kubectl get workloads -A
+kubectl get workload <name> -n <namespace> -o yaml
 ```
 
 ## Test Files
 
-Sample `ClusterQueue`, `LocalQueue`, and `ResourceFlavor` manifests are available in `test-files/deploy/`.
+Sample `ClusterQueue`, `LocalQueue`, `ResourceFlavor`, and Job manifests are available in `test-files/deploy/`. The sample Job uses the `team-a-queue` LocalQueue so Kueue can create a real `Workload` for local UI testing.
 
 Apply them to a cluster with Kueue installed:
 
@@ -38,15 +41,19 @@ kubectl apply -f test-files/deploy/resourceflavor-spot.yaml
 kubectl apply -f test-files/deploy/resourceflavor-topology.yaml
 kubectl apply -f test-files/deploy/clusterqueue-team-a.yaml
 kubectl apply -f test-files/deploy/localqueue-team-a.yaml
+kubectl apply -f test-files/deploy/job-sample-workload.yaml
+kubectl get workloads -A
 ```
 
-After applying the examples, open `Kueue` > `ClusterQueues`, `Kueue` > `LocalQueues`, or `Kueue` > `ResourceFlavors` in Headlamp.
+After applying the examples, open `Kueue` > `ClusterQueues`, `Kueue` > `LocalQueues`, `Kueue` > `ResourceFlavors`, or `Kueue` > `Workloads` in Headlamp.
 
 ## Development
 
 ```bash
 npm install
+npm run format
 npm run build
 npm run tsc
 npm run lint
+npm run test
 ```

--- a/kueue/src/components/workloads/Detail.tsx
+++ b/kueue/src/components/workloads/Detail.tsx
@@ -1,0 +1,565 @@
+import {
+  ConditionsSection,
+  DetailsGrid,
+  Link,
+  SectionBox,
+  SimpleTable,
+} from '@kinvolk/headlamp-plugin/lib/components/common';
+import { useParams } from 'react-router-dom';
+import {
+  AdmissionCheckState,
+  PodSet,
+  PodSetAssignment,
+  PodSetRequest,
+  ReclaimablePod,
+  Workload,
+  WorkloadSchedulingStatsEviction,
+} from '../../resources/workload';
+import {
+  renderPodSetRequests,
+  renderResourceList,
+  renderStringMap,
+  renderText,
+} from '../../resources/workloadFormatters';
+import { kueueRouteNames } from '../../utils/kueueRoutes';
+import KueueAdminResourceAccess from '../common/KueueAdminResourceAccess';
+
+/** Row rendered for Workload spec.podSets. */
+interface PodSetRow {
+  /** PodSet name. */
+  name: string;
+  /** Requested pod count. */
+  count: number | string;
+  /** Minimum count for partial admission. */
+  minCount: number | string;
+  /** Container resource requests. */
+  requests: string;
+  /** Pod template labels. */
+  labels: string;
+  /** Pod template annotations. */
+  annotations: string;
+  /** Topology request summary. */
+  topology: string;
+}
+
+/** Row rendered for Workload status.admission.podSetAssignments. */
+interface AdmissionAssignmentRow {
+  /** PodSet name. */
+  name: string;
+  /** Admitted pod count. */
+  count: number | string;
+  /** Assigned ResourceFlavors keyed by resource. */
+  flavors: string;
+  /** Admitted resource usage. */
+  resourceUsage: string;
+  /** Delayed topology request state. */
+  delayedTopologyRequest: string;
+}
+
+/** Row rendered for Workload status.admissionChecks. */
+interface AdmissionCheckRow {
+  /** AdmissionCheck name. */
+  name: string;
+  /** AdmissionCheck state. */
+  state: string;
+  /** Last state transition time. */
+  lastTransitionTime: string;
+  /** AdmissionCheck message. */
+  message: string;
+  /** Retry delay in seconds. */
+  requeueAfterSeconds: number | string;
+  /** Retry count. */
+  retryCount: number | string;
+}
+
+/** Row rendered for status.reclaimablePods. */
+interface ReclaimablePodRow {
+  /** PodSet name. */
+  name: string;
+  /** Reclaimable pod count. */
+  count: number;
+}
+
+/** Row rendered for status.resourceRequests. */
+interface ResourceRequestRow {
+  /** PodSet name. */
+  name: string;
+  /** Requested resources. */
+  resources: string;
+}
+
+/** Row rendered for status.schedulingStats.evictions. */
+interface EvictionRow {
+  /** Eviction reason. */
+  reason: string;
+  /** Underlying eviction cause. */
+  underlyingCause: string;
+  /** Eviction count. */
+  count: number;
+}
+
+/** Render the LocalQueue reference as a detail-page link when possible. */
+function renderLocalQueueLink(workload: Workload) {
+  const queueName = workload.queueName;
+  const namespace = workload.metadata.namespace;
+
+  if (!queueName || !namespace) {
+    return '-';
+  }
+
+  return (
+    <Link routeName={kueueRouteNames.localQueueDetail} params={{ namespace, name: queueName }}>
+      {queueName}
+    </Link>
+  );
+}
+
+/** Render the admitted ClusterQueue as a detail-page link when possible. */
+function renderClusterQueueLink(workload: Workload) {
+  const clusterQueue = workload.admissionClusterQueue;
+
+  if (!clusterQueue) {
+    return '-';
+  }
+
+  return (
+    <Link routeName={kueueRouteNames.clusterQueueDetail} params={{ name: clusterQueue }}>
+      {clusterQueue}
+    </Link>
+  );
+}
+
+/** Convert Workload podSets into table rows. */
+function getPodSetRows(podSets: PodSet[]): PodSetRow[] {
+  return podSets.map(podSet => ({
+    name: podSet.name || 'main',
+    count: podSet.count ?? 1,
+    minCount: podSet.minCount ?? '-',
+    requests: renderPodSetRequests(podSet),
+    labels: renderStringMap(podSet.template?.metadata?.labels),
+    annotations: renderStringMap(podSet.template?.metadata?.annotations),
+    topology: renderPodSetTopologyRequest(podSet),
+  }));
+}
+
+/** Convert admission assignments into table rows. */
+function getAdmissionAssignmentRows(
+  assignments: PodSetAssignment[] = []
+): AdmissionAssignmentRow[] {
+  return assignments.map(assignment => ({
+    name: assignment.name || 'main',
+    count: assignment.count ?? '-',
+    flavors: renderResourceList(assignment.flavors),
+    resourceUsage: renderResourceList(assignment.resourceUsage),
+    delayedTopologyRequest: renderText(assignment.delayedTopologyRequest),
+  }));
+}
+
+/** Convert admission checks into table rows. */
+function getAdmissionCheckRows(admissionChecks: AdmissionCheckState[] = []): AdmissionCheckRow[] {
+  return admissionChecks.map(admissionCheck => ({
+    name: admissionCheck.name,
+    state: renderText(admissionCheck.state),
+    lastTransitionTime: renderText(admissionCheck.lastTransitionTime),
+    message: renderText(admissionCheck.message),
+    requeueAfterSeconds: admissionCheck.requeueAfterSeconds ?? '-',
+    retryCount: admissionCheck.retryCount ?? '-',
+  }));
+}
+
+/** Convert reclaimable pods into table rows. */
+function getReclaimablePodRows(reclaimablePods: ReclaimablePod[] = []): ReclaimablePodRow[] {
+  return reclaimablePods.map(reclaimablePod => ({
+    name: reclaimablePod.name,
+    count: reclaimablePod.count,
+  }));
+}
+
+/** Convert resource request status entries into table rows. */
+function getResourceRequestRows(resourceRequests: PodSetRequest[] = []): ResourceRequestRow[] {
+  return resourceRequests.map(request => ({
+    name: request.name,
+    resources: renderResourceList(request.resources),
+  }));
+}
+
+/** Convert scheduling eviction stats into table rows. */
+function getEvictionRows(evictions: WorkloadSchedulingStatsEviction[] = []): EvictionRow[] {
+  return evictions.map(eviction => ({
+    reason: eviction.reason,
+    underlyingCause: renderText(eviction.underlyingCause),
+    count: eviction.count,
+  }));
+}
+
+/** Render a pod set topology request without dumping raw nested objects. */
+function renderPodSetTopologyRequest(podSet: PodSet) {
+  const request = podSet.topologyRequest;
+
+  if (!request) {
+    return '-';
+  }
+
+  const values = [
+    request.required ? `Required: ${request.required}` : undefined,
+    request.preferred ? `Preferred: ${request.preferred}` : undefined,
+    request.unconstrained !== undefined ? `Unconstrained: ${request.unconstrained}` : undefined,
+  ].filter(Boolean);
+
+  return values.length > 0 ? values.join('; ') : '-';
+}
+
+/** Build the extra detail section for spec.podSets. */
+function getPodSetsSection(workload: Workload) {
+  const rows = getPodSetRows(workload.podSets);
+
+  if (rows.length === 0) {
+    return null;
+  }
+
+  return {
+    id: 'pod-sets',
+    section: (
+      <SectionBox title="Pod Sets">
+        <SimpleTable
+          data={rows}
+          columns={[
+            {
+              label: 'Name',
+              getter: (row: PodSetRow) => row.name,
+            },
+            {
+              label: 'Count',
+              getter: (row: PodSetRow) => row.count,
+            },
+            {
+              label: 'Min Count',
+              getter: (row: PodSetRow) => row.minCount,
+            },
+            {
+              label: 'Requests',
+              getter: (row: PodSetRow) => row.requests,
+            },
+            {
+              label: 'Labels',
+              getter: (row: PodSetRow) => row.labels,
+            },
+            {
+              label: 'Annotations',
+              getter: (row: PodSetRow) => row.annotations,
+            },
+            {
+              label: 'Topology',
+              getter: (row: PodSetRow) => row.topology,
+            },
+          ]}
+        />
+      </SectionBox>
+    ),
+  };
+}
+
+/** Build the extra detail section for status.admission pod set assignments. */
+function getAdmissionSection(workload: Workload) {
+  const rows = getAdmissionAssignmentRows(workload.admission?.podSetAssignments);
+
+  if (rows.length === 0) {
+    return null;
+  }
+
+  return {
+    id: 'admission',
+    section: (
+      <SectionBox title="Admission">
+        <SimpleTable
+          data={rows}
+          columns={[
+            {
+              label: 'Pod Set',
+              getter: (row: AdmissionAssignmentRow) => row.name,
+            },
+            {
+              label: 'Count',
+              getter: (row: AdmissionAssignmentRow) => row.count,
+            },
+            {
+              label: 'ResourceFlavors',
+              getter: (row: AdmissionAssignmentRow) => row.flavors,
+            },
+            {
+              label: 'Resource Usage',
+              getter: (row: AdmissionAssignmentRow) => row.resourceUsage,
+            },
+            {
+              label: 'Delayed Topology',
+              getter: (row: AdmissionAssignmentRow) => row.delayedTopologyRequest,
+            },
+          ]}
+        />
+      </SectionBox>
+    ),
+  };
+}
+
+/** Build the extra detail section for status.admissionChecks. */
+function getAdmissionChecksSection(workload: Workload) {
+  const rows = getAdmissionCheckRows(workload.status.admissionChecks);
+
+  if (rows.length === 0) {
+    return null;
+  }
+
+  return {
+    id: 'admission-checks',
+    section: (
+      <SectionBox title="Admission Checks">
+        <SimpleTable
+          data={rows}
+          columns={[
+            {
+              label: 'Name',
+              getter: (row: AdmissionCheckRow) => row.name,
+            },
+            {
+              label: 'State',
+              getter: (row: AdmissionCheckRow) => row.state,
+            },
+            {
+              label: 'Last Transition',
+              getter: (row: AdmissionCheckRow) => row.lastTransitionTime,
+            },
+            {
+              label: 'Message',
+              getter: (row: AdmissionCheckRow) => row.message,
+            },
+            {
+              label: 'Requeue After Seconds',
+              getter: (row: AdmissionCheckRow) => row.requeueAfterSeconds,
+            },
+            {
+              label: 'Retry Count',
+              getter: (row: AdmissionCheckRow) => row.retryCount,
+            },
+          ]}
+        />
+      </SectionBox>
+    ),
+  };
+}
+
+/** Build the extra detail section for status.reclaimablePods. */
+function getReclaimablePodsSection(workload: Workload) {
+  const rows = getReclaimablePodRows(workload.reclaimablePods);
+
+  if (rows.length === 0) {
+    return null;
+  }
+
+  return {
+    id: 'reclaimable-pods',
+    section: (
+      <SectionBox title="Reclaimable Pods">
+        <SimpleTable
+          data={rows}
+          columns={[
+            {
+              label: 'Pod Set',
+              getter: (row: ReclaimablePodRow) => row.name,
+            },
+            {
+              label: 'Count',
+              getter: (row: ReclaimablePodRow) => row.count,
+            },
+          ]}
+        />
+      </SectionBox>
+    ),
+  };
+}
+
+/** Build the extra detail section for status.resourceRequests. */
+function getResourceRequestsSection(workload: Workload) {
+  const rows = getResourceRequestRows(workload.status.resourceRequests);
+
+  if (rows.length === 0) {
+    return null;
+  }
+
+  return {
+    id: 'resource-requests',
+    section: (
+      <SectionBox title="Resource Requests">
+        <SimpleTable
+          data={rows}
+          columns={[
+            {
+              label: 'Pod Set',
+              getter: (row: ResourceRequestRow) => row.name,
+            },
+            {
+              label: 'Resources',
+              getter: (row: ResourceRequestRow) => row.resources,
+            },
+          ]}
+        />
+      </SectionBox>
+    ),
+  };
+}
+
+/** Build the extra detail section for status.schedulingStats.evictions. */
+function getSchedulingStatsSection(workload: Workload) {
+  const rows = getEvictionRows(workload.status.schedulingStats?.evictions);
+
+  if (rows.length === 0) {
+    return null;
+  }
+
+  return {
+    id: 'scheduling-stats',
+    section: (
+      <SectionBox title="Scheduling Stats">
+        <SimpleTable
+          data={rows}
+          columns={[
+            {
+              label: 'Reason',
+              getter: (row: EvictionRow) => row.reason,
+            },
+            {
+              label: 'Underlying Cause',
+              getter: (row: EvictionRow) => row.underlyingCause,
+            },
+            {
+              label: 'Count',
+              getter: (row: EvictionRow) => row.count,
+            },
+          ]}
+        />
+      </SectionBox>
+    ),
+  };
+}
+
+/** Build the standard Headlamp conditions section for Workload status. */
+function getConditionsSection(workload: Workload) {
+  if (!workload.conditions.length) {
+    return null;
+  }
+
+  return {
+    id: 'conditions',
+    section: <ConditionsSection resource={workload.jsonData} />,
+  };
+}
+
+export default function WorkloadDetail() {
+  const { namespace, name } = useParams<{ namespace: string; name: string }>();
+
+  return (
+    <KueueAdminResourceAccess
+      resourceClass={Workload}
+      resourceLabel="Workloads"
+      verb="get"
+      accessDescription="Kueue Workloads are namespaced user workload resources."
+    >
+      <DetailsGrid
+        resourceType={Workload}
+        name={name}
+        namespace={namespace}
+        withEvents
+        extraInfo={workload =>
+          workload
+            ? [
+                {
+                  name: 'Queue',
+                  value: renderLocalQueueLink(workload),
+                },
+                {
+                  name: 'Priority',
+                  value: workload.priorityDisplay,
+                },
+                {
+                  name: 'Priority Class',
+                  value: workload.priorityClassDisplay,
+                },
+                {
+                  name: 'Active',
+                  value: workload.activeDisplay,
+                },
+                {
+                  name: 'Owner References',
+                  value: workload.ownerReferencesDisplay,
+                },
+                {
+                  name: 'Pod Sets',
+                  value: workload.podSetsDisplay,
+                },
+                {
+                  name: 'Admitted',
+                  value: workload.admittedDisplay,
+                },
+                {
+                  name: 'Finished',
+                  value: workload.finishedDisplay,
+                },
+                {
+                  name: 'Status',
+                  value: workload.statusDisplay,
+                },
+                {
+                  name: 'Admission',
+                  value: workload.admissionDisplay,
+                },
+                {
+                  name: 'Assigned ClusterQueue',
+                  value: renderClusterQueueLink(workload),
+                },
+                {
+                  name: 'Assigned ResourceFlavors',
+                  value: workload.admissionFlavorsDisplay,
+                },
+                {
+                  name: 'Reclaimable Pods',
+                  value: workload.reclaimablePodsDisplay,
+                },
+                {
+                  name: 'Requeue State',
+                  value: workload.requeueStateDisplay,
+                },
+                {
+                  name: 'Maximum Execution Time Seconds',
+                  value: workload.maximumExecutionTimeSecondsDisplay,
+                },
+                {
+                  name: 'Accumulated Past Execution Time Seconds',
+                  value: workload.accumulatedPastExecutionTimeSecondsDisplay,
+                },
+                {
+                  name: 'Assigned Cluster',
+                  value: workload.clusterNameDisplay,
+                },
+                {
+                  name: 'Nominated Clusters',
+                  value: workload.nominatedClusterNamesDisplay,
+                },
+              ]
+            : []
+        }
+        extraSections={workload =>
+          workload
+            ? [
+                getConditionsSection(workload),
+                getPodSetsSection(workload),
+                getAdmissionSection(workload),
+                getAdmissionChecksSection(workload),
+                getReclaimablePodsSection(workload),
+                getResourceRequestsSection(workload),
+                getSchedulingStatsSection(workload),
+              ].filter(Boolean)
+            : []
+        }
+      />
+    </KueueAdminResourceAccess>
+  );
+}

--- a/kueue/src/components/workloads/List.tsx
+++ b/kueue/src/components/workloads/List.tsx
@@ -1,0 +1,59 @@
+import { ResourceListView } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { Workload } from '../../resources/workload';
+import KueueAdminResourceAccess from '../common/KueueAdminResourceAccess';
+
+export default function WorkloadList() {
+  return (
+    <KueueAdminResourceAccess
+      resourceClass={Workload}
+      resourceLabel="Workloads"
+      verb="list"
+      accessDescription="Kueue Workloads are namespaced user workload resources."
+    >
+      <ResourceListView
+        title="Kueue Workloads"
+        resourceClass={Workload}
+        columns={[
+          'name',
+          'namespace',
+          {
+            id: 'queue',
+            label: 'Queue',
+            getValue: (workload: Workload) => workload.queueNameDisplay,
+          },
+          {
+            id: 'priority',
+            label: 'Priority',
+            getValue: (workload: Workload) => workload.priorityDisplay,
+          },
+          {
+            id: 'priorityClass',
+            label: 'Priority Class',
+            getValue: (workload: Workload) => workload.priorityClassDisplay,
+          },
+          {
+            id: 'active',
+            label: 'Active',
+            getValue: (workload: Workload) => workload.activeDisplay,
+          },
+          {
+            id: 'admitted',
+            label: 'Admitted',
+            getValue: (workload: Workload) => workload.admittedDisplay,
+          },
+          {
+            id: 'finished',
+            label: 'Finished',
+            getValue: (workload: Workload) => workload.finishedDisplay,
+          },
+          {
+            id: 'status',
+            label: 'Status',
+            getValue: (workload: Workload) => workload.statusDisplay,
+          },
+          'age',
+        ]}
+      />
+    </KueueAdminResourceAccess>
+  );
+}

--- a/kueue/src/index.tsx
+++ b/kueue/src/index.tsx
@@ -5,6 +5,8 @@ import LocalQueueDetail from './components/localqueues/Detail';
 import LocalQueueList from './components/localqueues/List';
 import ResourceFlavorDetail from './components/resourceflavors/Detail';
 import ResourceFlavorList from './components/resourceflavors/List';
+import WorkloadDetail from './components/workloads/Detail';
+import WorkloadList from './components/workloads/List';
 import { kueueRouteNames, kueueRoutePaths } from './utils/kueueRoutes';
 
 registerSidebarEntry({
@@ -34,6 +36,13 @@ registerSidebarEntry({
   name: 'kueue-resourceflavors',
   label: 'ResourceFlavors',
   url: kueueRoutePaths.resourceFlavorsList,
+});
+
+registerSidebarEntry({
+  parent: 'kueue',
+  name: 'kueue-workloads',
+  label: 'Workloads',
+  url: kueueRoutePaths.workloadsList,
 });
 
 registerRoute({
@@ -82,4 +91,20 @@ registerRoute({
   name: kueueRouteNames.resourceFlavorDetail,
   exact: true,
   component: () => <ResourceFlavorDetail />,
+});
+
+registerRoute({
+  path: kueueRoutePaths.workloadsList,
+  sidebar: 'kueue-workloads',
+  name: kueueRouteNames.workloadsList,
+  exact: true,
+  component: () => <WorkloadList />,
+});
+
+registerRoute({
+  path: kueueRoutePaths.workloadDetail,
+  sidebar: 'kueue-workloads',
+  name: kueueRouteNames.workloadDetail,
+  exact: true,
+  component: () => <WorkloadDetail />,
 });

--- a/kueue/src/resources/workload.ts
+++ b/kueue/src/resources/workload.ts
@@ -1,0 +1,758 @@
+import {
+  KubeObject,
+  KubeObjectInterface,
+  type KubeOwnerReference,
+} from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import { kueueApiVersions } from '../utils/kueueApi';
+import { kueueRoutePaths } from '../utils/kueueRoutes';
+import type { KueueCondition, ResourceQuantity } from './clusterQueue';
+import {
+  getAdmissionFlavorNames,
+  getWorkloadDetailRouteParams,
+  renderAdmissionClusterQueue,
+  renderAdmissionFlavors,
+  renderAdmissionSummary,
+  renderAdmittedStatus,
+  renderBoolean,
+  renderFinishedStatus,
+  renderNumber,
+  renderOwnerReferences,
+  renderPodSetsSummary,
+  renderPriority,
+  renderPriorityClassName,
+  renderQueueName,
+  renderReclaimablePodsSummary,
+  renderRequeueState,
+  renderText,
+  renderWorkloadStatus,
+} from './workloadFormatters';
+
+const WORKLOAD_API_DOCS = 'https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#workload';
+const WORKLOAD_SPEC_DOCS = 'https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#workloadspec';
+const WORKLOAD_STATUS_DOCS =
+  'https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#workloadstatus';
+
+/**
+ * Minimal Kubernetes resource list used by Kueue Workload pod sets and admission.
+ *
+ * @see https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/quantity/
+ */
+export type ResourceList = Record<string, ResourceQuantity>;
+
+/**
+ * Reference to a Kubernetes or Kueue priority class for a Workload.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#priorityclassref
+ */
+export interface PriorityClassRef {
+  /**
+   * API group of the priority class.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#priorityclassref
+   */
+  group?: 'scheduling.k8s.io' | 'kueue.x-k8s.io';
+  /**
+   * Kind of priority class.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#priorityclassref
+   */
+  kind?: 'PriorityClass' | 'WorkloadPriorityClass';
+  /**
+   * Priority class name.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#priorityclassref
+   */
+  name?: string;
+}
+
+/**
+ * Container resource requirements used to summarize pod set requests.
+ *
+ * @see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#resourcerequirements-v1-core
+ */
+export interface ContainerResources {
+  /**
+   * Minimum resources requested by this container.
+   *
+   * @see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#resourcerequirements-v1-core
+   */
+  requests?: ResourceList;
+  /**
+   * Maximum resources allowed for this container.
+   *
+   * @see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#resourcerequirements-v1-core
+   */
+  limits?: ResourceList;
+}
+
+/**
+ * Minimal container shape used by Workload pod set views.
+ *
+ * @see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#container-v1-core
+ */
+export interface PodSetContainer {
+  /**
+   * Container name.
+   *
+   * @see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#container-v1-core
+   */
+  name: string;
+  /**
+   * Container image.
+   *
+   * @see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#container-v1-core
+   */
+  image?: string;
+  /**
+   * Container resource requirements.
+   *
+   * @see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#resourcerequirements-v1-core
+   */
+  resources?: ContainerResources;
+}
+
+/**
+ * Minimal Kubernetes PodSpec fields used by Workload pod set views.
+ *
+ * @see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#podspec-v1-core
+ */
+export interface PodSpec {
+  /**
+   * Application containers in the pod template.
+   *
+   * @see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#podspec-v1-core
+   */
+  containers?: PodSetContainer[];
+  /**
+   * Init containers in the pod template.
+   *
+   * @see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#podspec-v1-core
+   */
+  initContainers?: PodSetContainer[];
+  /**
+   * Node selector from the pod template.
+   *
+   * @see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#podspec-v1-core
+   */
+  nodeSelector?: Record<string, string>;
+}
+
+/**
+ * Minimal Kubernetes PodTemplateSpec used by Kueue Workload pod sets.
+ *
+ * @see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#podtemplatespec-v1-core
+ */
+export interface PodTemplateSpec {
+  /**
+   * Template metadata; Kueue allows labels and annotations here.
+   *
+   * @see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#podtemplatespec-v1-core
+   */
+  metadata?: {
+    /** Pod template labels. */
+    labels?: Record<string, string>;
+    /** Pod template annotations. */
+    annotations?: Record<string, string>;
+  };
+  /**
+   * Pod spec for the homogeneous pod set.
+   *
+   * @see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#podtemplatespec-v1-core
+   */
+  spec?: PodSpec;
+}
+
+/**
+ * Topology request associated with a Workload pod set.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#podsettopologyrequest
+ */
+export interface PodSetTopologyRequest {
+  /**
+   * Required topology level.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#podsettopologyrequest
+   */
+  required?: string;
+  /**
+   * Preferred topology level.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#podsettopologyrequest
+   */
+  preferred?: string;
+  /**
+   * Whether Kueue may schedule without compactness constraints.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#podsettopologyrequest
+   */
+  unconstrained?: boolean;
+}
+
+/**
+ * A homogeneous set of pods in a Kueue Workload.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#podset
+ */
+export interface PodSet {
+  /**
+   * Pod set name.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#podset
+   */
+  name?: string;
+  /**
+   * Pod template for this pod set.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#podset
+   */
+  template?: PodTemplateSpec;
+  /**
+   * Number of pods in this pod set.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#podset
+   */
+  count?: number;
+  /**
+   * Minimum acceptable pod count for partial admission.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#podset
+   */
+  minCount?: number;
+  /**
+   * Topology request for this pod set.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#podset
+   */
+  topologyRequest?: PodSetTopologyRequest;
+}
+
+/**
+ * Preemption gate configured on a Workload.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#preemptiongate
+ */
+export interface PreemptionGate {
+  /**
+   * Gate name.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#preemptiongate
+   */
+  name: string;
+}
+
+/**
+ * Desired state of a Kueue Workload.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#workloadspec
+ */
+export interface WorkloadSpec {
+  /**
+   * Sets of homogeneous pods to be admitted together.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#workloadspec
+   */
+  podSets?: PodSet[];
+  /**
+   * LocalQueue associated with this Workload.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#workloadspec
+   */
+  queueName?: string;
+  /**
+   * Priority class reference used to populate Workload priority.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#workloadspec
+   */
+  priorityClassRef?: PriorityClassRef;
+  /**
+   * Numeric priority used for admission ordering.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#workloadspec
+   */
+  priority?: number;
+  /**
+   * Whether the Workload can be evaluated for admission.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#workloadspec
+   */
+  active?: boolean;
+  /**
+   * Maximum admitted execution time in seconds.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#workloadspec
+   */
+  maximumExecutionTimeSeconds?: number;
+  /**
+   * Gates controlling whether this Workload may trigger preemptions.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#workloadspec
+   */
+  preemptionGates?: PreemptionGate[];
+}
+
+/**
+ * Admission assignment for one Workload pod set.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#podsetassignment
+ */
+export interface PodSetAssignment {
+  /**
+   * Pod set name.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#podsetassignment
+   */
+  name?: string;
+  /**
+   * ResourceFlavor assigned per resource name.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#podsetassignment
+   */
+  flavors?: Record<string, string>;
+  /**
+   * Total resource usage calculated at admission.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#podsetassignment
+   */
+  resourceUsage?: ResourceList;
+  /**
+   * Count of pods taken into account at admission time.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#podsetassignment
+   */
+  count?: number;
+  /**
+   * Assigned topology details.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#podsetassignment
+   */
+  topologyAssignment?: unknown;
+  /**
+   * Whether topology assignment is delayed.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#podsetassignment
+   */
+  delayedTopologyRequest?: 'Pending' | 'Ready';
+}
+
+/**
+ * Admission result for a Workload.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#admission
+ */
+export interface Admission {
+  /**
+   * ClusterQueue that admitted this Workload.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#admission
+   */
+  clusterQueue?: string;
+  /**
+   * Per-pod-set admission assignments.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#admission
+   */
+  podSetAssignments?: PodSetAssignment[];
+}
+
+/**
+ * Requeue backoff state for a Workload evicted by PodsReadyTimeout.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#requeuestate
+ */
+export interface RequeueState {
+  /**
+   * Number of backoff requeues.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#requeuestate
+   */
+  count?: number;
+  /**
+   * Next requeue time.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#requeuestate
+   */
+  requeueAt?: string;
+}
+
+/**
+ * Pod count no longer requiring reservation within a pod set.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#reclaimablepod
+ */
+export interface ReclaimablePod {
+  /**
+   * Pod set name.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#reclaimablepod
+   */
+  name: string;
+  /**
+   * Reclaimable pod count.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#reclaimablepod
+   */
+  count: number;
+}
+
+/**
+ * Resource requests calculated for a non-admitted Workload.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#podsetrequest
+ */
+export interface PodSetRequest {
+  /**
+   * Pod set name.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#podsetrequest
+   */
+  name: string;
+  /**
+   * Requested resources for this pod set.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#podsetrequest
+   */
+  resources?: ResourceList;
+}
+
+/**
+ * Admission check state reported for a Workload.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#admissioncheckstate
+ */
+export interface AdmissionCheckState {
+  /**
+   * AdmissionCheck name.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#admissioncheckstate
+   */
+  name: string;
+  /**
+   * Current admission check state.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#admissioncheckstate
+   */
+  state?: 'Pending' | 'Ready' | 'Retry' | 'Rejected';
+  /**
+   * Last transition time.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#admissioncheckstate
+   */
+  lastTransitionTime?: string;
+  /**
+   * Human-readable transition message.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#admissioncheckstate
+   */
+  message?: string;
+  /**
+   * Delay before retrying admission.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#admissioncheckstate
+   */
+  requeueAfterSeconds?: number;
+  /**
+   * Number of retry transitions.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#admissioncheckstate
+   */
+  retryCount?: number;
+}
+
+/**
+ * Eviction statistics for a Workload.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#workloadschedulingstatseviction
+ */
+export interface WorkloadSchedulingStatsEviction {
+  /**
+   * Eviction reason.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#workloadschedulingstatseviction
+   */
+  reason: string;
+  /**
+   * Finer-grained eviction cause.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#workloadschedulingstatseviction
+   */
+  underlyingCause?: string;
+  /**
+   * Eviction count for this reason and cause.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#workloadschedulingstatseviction
+   */
+  count: number;
+}
+
+/**
+ * Scheduling statistics reported for a Workload.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#schedulingstats
+ */
+export interface SchedulingStats {
+  /**
+   * Eviction statistics grouped by reason and underlying cause.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#schedulingstats
+   */
+  evictions?: WorkloadSchedulingStatsEviction[];
+}
+
+/**
+ * Unhealthy node entry reported by topology-aware scheduling.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#unhealthynode
+ */
+export interface UnhealthyNode {
+  /**
+   * Node name.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#unhealthynode
+   */
+  name: string;
+}
+
+/**
+ * Minimal Workload condition shape used by formatter helpers.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#workloadstatus
+ */
+export type WorkloadConditionLike = Pick<KueueCondition, 'type' | 'status' | 'reason' | 'message'>;
+
+/**
+ * Observed state of a Kueue Workload.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#workloadstatus
+ */
+export interface WorkloadStatus {
+  /**
+   * Latest observations of Workload state.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#workloadstatus
+   */
+  conditions?: KueueCondition[];
+  /**
+   * Admission assigned by Kueue.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#workloadstatus
+   */
+  admission?: Admission;
+  /**
+   * Requeue backoff state.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#workloadstatus
+   */
+  requeueState?: RequeueState;
+  /**
+   * Reclaimable pod counts.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#workloadstatus
+   */
+  reclaimablePods?: ReclaimablePod[];
+  /**
+   * Admission check states required by the Workload.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#workloadstatus
+   */
+  admissionChecks?: AdmissionCheckState[];
+  /**
+   * Requested resources reported when the Workload was considered for admission.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#workloadstatus
+   */
+  resourceRequests?: PodSetRequest[];
+  /**
+   * Total seconds spent admitted in previous admit-evict cycles.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#workloadstatus
+   */
+  accumulatedPastExecutionTimeSeconds?: number;
+  /**
+   * Scheduling statistics.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#workloadstatus
+   */
+  schedulingStats?: SchedulingStats;
+  /**
+   * Nominated MultiKueue cluster names.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#workloadstatus
+   */
+  nominatedClusterNames?: string[];
+  /**
+   * Assigned MultiKueue cluster name.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#workloadstatus
+   */
+  clusterName?: string;
+  /**
+   * Unhealthy nodes reported by topology-aware scheduling.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#workloadstatus
+   */
+  unhealthyNodes?: UnhealthyNode[];
+}
+
+/**
+ * Kubernetes Workload object returned by the Kueue API.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#workload
+ */
+export interface KubeWorkload extends KubeObjectInterface {
+  /**
+   * Kubernetes object metadata for the Workload.
+   *
+   * @see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#objectmeta-v1-meta
+   */
+  metadata: KubeObjectInterface['metadata'] & {
+    /** Owner references for the job object represented by this Workload. */
+    ownerReferences?: KubeOwnerReference[];
+  };
+  /**
+   * Workload desired state.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#workloadspec
+   */
+  spec?: WorkloadSpec;
+  /**
+   * Workload observed state.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#workloadstatus
+   */
+  status?: WorkloadStatus;
+}
+
+export class Workload extends KubeObject<KubeWorkload> {
+  static kind = 'Workload';
+  static apiName = 'workloads';
+  static apiVersion = kueueApiVersions;
+  static isNamespaced = true;
+
+  static get detailsRoute() {
+    return kueueRoutePaths.workloadDetail;
+  }
+
+  get spec(): WorkloadSpec {
+    return this.jsonData.spec ?? {};
+  }
+
+  get status(): WorkloadStatus {
+    return this.jsonData.status ?? {};
+  }
+
+  get queueName() {
+    return this.spec.queueName;
+  }
+
+  get queueNameDisplay() {
+    return renderQueueName(this.queueName);
+  }
+
+  get priority() {
+    return this.spec.priority;
+  }
+
+  get priorityDisplay() {
+    return renderPriority(this.priority);
+  }
+
+  get priorityClassName() {
+    return this.spec.priorityClassRef?.name;
+  }
+
+  get priorityClassDisplay() {
+    return renderPriorityClassName(this.priorityClassName);
+  }
+
+  get activeDisplay() {
+    return renderBoolean(this.spec.active);
+  }
+
+  get maximumExecutionTimeSecondsDisplay() {
+    return renderNumber(this.spec.maximumExecutionTimeSeconds);
+  }
+
+  get podSets() {
+    return this.spec.podSets || [];
+  }
+
+  get podSetsDisplay() {
+    return renderPodSetsSummary(this.podSets);
+  }
+
+  get conditions() {
+    return this.status.conditions || [];
+  }
+
+  get admission() {
+    return this.status.admission;
+  }
+
+  get admittedDisplay() {
+    return renderAdmittedStatus(this.admission, this.conditions);
+  }
+
+  get finishedDisplay() {
+    return renderFinishedStatus(this.conditions);
+  }
+
+  get statusDisplay() {
+    return renderWorkloadStatus(this.conditions, this.spec.active, this.admission);
+  }
+
+  get admissionClusterQueue() {
+    return this.admission?.clusterQueue;
+  }
+
+  get admissionClusterQueueDisplay() {
+    return renderAdmissionClusterQueue(this.admission);
+  }
+
+  get admissionFlavors() {
+    return getAdmissionFlavorNames(this.admission);
+  }
+
+  get admissionFlavorsDisplay() {
+    return renderAdmissionFlavors(this.admission);
+  }
+
+  get admissionDisplay() {
+    return renderAdmissionSummary(this.admission);
+  }
+
+  get reclaimablePods() {
+    return this.status.reclaimablePods || [];
+  }
+
+  get reclaimablePodsDisplay() {
+    return renderReclaimablePodsSummary(this.reclaimablePods);
+  }
+
+  get requeueStateDisplay() {
+    return renderRequeueState(this.status.requeueState);
+  }
+
+  get ownerReferencesDisplay() {
+    return renderOwnerReferences(this.metadata.ownerReferences);
+  }
+
+  get accumulatedPastExecutionTimeSecondsDisplay() {
+    return renderNumber(this.status.accumulatedPastExecutionTimeSeconds);
+  }
+
+  get clusterNameDisplay() {
+    return renderText(this.status.clusterName);
+  }
+
+  get nominatedClusterNamesDisplay() {
+    const nominatedClusterNames = this.status.nominatedClusterNames || [];
+
+    return nominatedClusterNames.length > 0 ? nominatedClusterNames.join(', ') : '-';
+  }
+
+  get detailRouteParams() {
+    return getWorkloadDetailRouteParams(this.metadata.namespace, this.metadata.name);
+  }
+}
+
+export { WORKLOAD_API_DOCS, WORKLOAD_SPEC_DOCS, WORKLOAD_STATUS_DOCS };

--- a/kueue/src/resources/workloadFormatters.test.ts
+++ b/kueue/src/resources/workloadFormatters.test.ts
@@ -1,0 +1,257 @@
+import type { KubeOwnerReference } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import { describe, expect, it } from 'vitest';
+import { kueueRoutePaths } from '../utils/kueueRoutes';
+import type { PodSet, WorkloadConditionLike } from './workload';
+import {
+  findWorkloadCondition,
+  getAdmissionFlavorNames,
+  getWorkloadDetailRouteParams,
+  renderAdmissionClusterQueue,
+  renderAdmissionFlavors,
+  renderAdmissionSummary,
+  renderAdmittedStatus,
+  renderBoolean,
+  renderFinishedStatus,
+  renderNumber,
+  renderOwnerReferences,
+  renderPodSetRequests,
+  renderPodSetsSummary,
+  renderPriority,
+  renderPriorityClassName,
+  renderQueueName,
+  renderReclaimablePodsSummary,
+  renderRequeueState,
+  renderResourceList,
+  renderStringMap,
+  renderText,
+  renderWorkloadStatus,
+} from './workloadFormatters';
+
+describe('Workload formatters', () => {
+  it('formats scalar values with empty fallbacks while preserving explicit zeroes', () => {
+    expect(renderText('team-a')).toBe('team-a');
+    expect(renderText('')).toBe('-');
+    expect(renderText(null)).toBe('-');
+    expect(renderText(undefined)).toBe('-');
+
+    expect(renderNumber(0)).toBe(0);
+    expect(renderNumber(10)).toBe(10);
+    expect(renderNumber(null)).toBe('-');
+    expect(renderNumber(undefined)).toBe('-');
+
+    expect(renderBoolean(true)).toBe('Yes');
+    expect(renderBoolean(false)).toBe('No');
+    expect(renderBoolean(null)).toBe('-');
+    expect(renderBoolean(undefined)).toBe('-');
+  });
+
+  it('formats common Workload list values', () => {
+    expect(renderQueueName('sample-local-queue')).toBe('sample-local-queue');
+    expect(renderQueueName()).toBe('-');
+    expect(renderPriority(0)).toBe(0);
+    expect(renderPriority()).toBe('-');
+    expect(renderPriorityClassName('high-priority')).toBe('high-priority');
+    expect(renderPriorityClassName()).toBe('-');
+  });
+
+  it('finds Workload conditions by type', () => {
+    const conditions: WorkloadConditionLike[] = [
+      { type: 'QuotaReserved', status: 'True' },
+      { type: 'Admitted', status: 'False', reason: 'Pending' },
+    ];
+
+    expect(findWorkloadCondition(conditions, 'Admitted')).toEqual({
+      type: 'Admitted',
+      status: 'False',
+      reason: 'Pending',
+    });
+    expect(findWorkloadCondition(conditions, 'Finished')).toBeUndefined();
+  });
+
+  it('derives admitted and finished display values from admission and conditions', () => {
+    expect(renderAdmittedStatus({ clusterQueue: 'sample-cluster-queue' })).toBe('Yes');
+    expect(renderAdmittedStatus(undefined, [{ type: 'Admitted', status: 'True' }])).toBe('Yes');
+    expect(renderAdmittedStatus(undefined, [{ type: 'Admitted', status: 'False' }])).toBe('No');
+    expect(renderAdmittedStatus(undefined, [{ type: 'Admitted', status: 'Unknown' }])).toBe(
+      'Unknown'
+    );
+    expect(renderAdmittedStatus()).toBe('Unknown');
+
+    expect(renderFinishedStatus([{ type: 'Finished', status: 'True' }])).toBe('Yes');
+    expect(renderFinishedStatus([{ type: 'Finished', status: 'False' }])).toBe('No');
+    expect(renderFinishedStatus([{ type: 'Finished', status: 'Unknown' }])).toBe('Unknown');
+    expect(renderFinishedStatus()).toBe('Unknown');
+  });
+
+  it('derives readable Workload status from Kueue condition types and reasons', () => {
+    expect(renderWorkloadStatus([], false)).toBe('Deactivated');
+    expect(renderWorkloadStatus([{ type: 'Finished', status: 'True' }], true)).toBe('Finished');
+    expect(renderWorkloadStatus([{ type: 'Evicted', status: 'True' }], true)).toBe('Evicted');
+    expect(
+      renderWorkloadStatus([{ type: 'Evicted', status: 'True', reason: 'PodsReadyTimeout' }], true)
+    ).toBe('PodsReadyTimeout');
+    expect(renderWorkloadStatus([{ type: 'Preempted', status: 'True' }], true)).toBe('Preempted');
+    expect(renderWorkloadStatus([{ type: 'DeactivationTarget', status: 'True' }], true)).toBe(
+      'Deactivated'
+    );
+    expect(
+      renderWorkloadStatus(
+        [
+          { type: 'Admitted', status: 'True' },
+          { type: 'PodsReady', status: 'True' },
+        ],
+        true
+      )
+    ).toBe('Running');
+    expect(renderWorkloadStatus([{ type: 'Admitted', status: 'True' }], true)).toBe('Admitted');
+    expect(
+      renderWorkloadStatus([], true, {
+        clusterQueue: 'sample-cluster-queue',
+      })
+    ).toBe('Admitted');
+    expect(renderWorkloadStatus([{ type: 'QuotaReserved', status: 'True' }], true)).toBe('Pending');
+    expect(renderWorkloadStatus([{ type: 'Requeued', status: 'True' }], true)).toBe('Pending');
+    expect(renderWorkloadStatus([{ type: 'Admitted', status: 'False' }], true)).toBe('Pending');
+    expect(
+      renderWorkloadStatus(
+        [
+          {
+            type: 'QuotaReserved',
+            status: 'False',
+            reason: 'Inadmissible',
+            message: "LocalQueue missing-local-queue doesn't exist",
+          },
+        ],
+        true
+      )
+    ).toBe('Inadmissible');
+    expect(
+      renderWorkloadStatus([{ type: 'QuotaReserved', status: 'False', reason: 'Pending' }], true)
+    ).toBe('Pending');
+    expect(renderWorkloadStatus()).toBe('Unknown');
+  });
+
+  it('summarizes pod sets and pod set requests', () => {
+    const podSet: PodSet = {
+      name: 'main',
+      count: 2,
+      template: {
+        spec: {
+          initContainers: [
+            {
+              name: 'setup',
+              resources: {
+                requests: {
+                  memory: '64Mi',
+                },
+              },
+            },
+          ],
+          containers: [
+            {
+              name: 'worker',
+              resources: {
+                requests: {
+                  cpu: '1',
+                  memory: '128Mi',
+                },
+              },
+            },
+            {
+              name: 'sidecar',
+              resources: {},
+            },
+          ],
+        },
+      },
+    };
+
+    expect(renderPodSetsSummary()).toBe('-');
+    expect(renderPodSetsSummary([{ count: 1 }, { name: 'worker', count: 0 }])).toBe(
+      'main (1), worker (0)'
+    );
+    expect(renderPodSetsSummary([podSet])).toBe('main (2)');
+    expect(renderPodSetRequests(podSet)).toBe('setup: memory=64Mi; worker: cpu=1, memory=128Mi');
+    expect(renderPodSetRequests({ name: 'empty' })).toBe('-');
+  });
+
+  it('formats resource lists and string maps deterministically', () => {
+    expect(renderResourceList()).toBe('-');
+    expect(renderResourceList({ memory: '128Mi', cpu: '1' })).toBe('cpu=1, memory=128Mi');
+    expect(renderStringMap()).toBe('-');
+    expect(renderStringMap({ team: 'platform', app: 'trainer' })).toBe(
+      'app=trainer, team=platform'
+    );
+  });
+
+  it('formats admission cluster queue, flavor names, and admission summaries', () => {
+    const admission = {
+      clusterQueue: 'sample-cluster-queue',
+      podSetAssignments: [
+        {
+          name: 'main',
+          flavors: {
+            cpu: 'default-flavor',
+            memory: 'default-flavor',
+          },
+        },
+        {
+          name: 'worker',
+          flavors: {
+            'nvidia.com/gpu': 'gpu-flavor',
+          },
+        },
+      ],
+    };
+
+    expect(renderAdmissionClusterQueue()).toBe('-');
+    expect(renderAdmissionClusterQueue(admission)).toBe('sample-cluster-queue');
+    expect(getAdmissionFlavorNames(admission)).toEqual(['default-flavor', 'gpu-flavor']);
+    expect(renderAdmissionFlavors()).toBe('-');
+    expect(renderAdmissionFlavors(admission)).toBe('default-flavor, gpu-flavor');
+    expect(renderAdmissionSummary()).toBe('-');
+    expect(renderAdmissionSummary(admission)).toBe(
+      'ClusterQueue sample-cluster-queue; default-flavor, gpu-flavor; 2 pod set assignments'
+    );
+  });
+
+  it('formats reclaimable pods, requeue state, and owner references', () => {
+    const ownerReferences: KubeOwnerReference[] = [
+      {
+        apiVersion: 'batch/v1',
+        blockOwnerDeletion: true,
+        controller: true,
+        kind: 'Job',
+        name: 'sample-kueue-workload',
+        uid: 'uid',
+      },
+    ];
+
+    expect(renderReclaimablePodsSummary()).toBe('-');
+    expect(
+      renderReclaimablePodsSummary([
+        { name: 'main', count: 1 },
+        { name: 'worker', count: 0 },
+      ])
+    ).toBe('main: 1, worker: 0');
+    expect(renderRequeueState()).toBe('-');
+    expect(renderRequeueState({})).toBe('-');
+    expect(renderRequeueState({ count: 0, requeueAt: '2026-07-27T10:00:00Z' })).toBe(
+      'Count: 0; Requeue at: 2026-07-27T10:00:00Z'
+    );
+    expect(renderOwnerReferences()).toBe('-');
+    expect(renderOwnerReferences(ownerReferences)).toBe('Job/sample-kueue-workload');
+  });
+
+  it('builds namespaced detail route params', () => {
+    expect(kueueRoutePaths.workloadDetail).toBe('/kueue/workloads/:namespace/:name');
+    expect(getWorkloadDetailRouteParams('default', 'sample-job')).toEqual({
+      namespace: 'default',
+      name: 'sample-job',
+    });
+    expect(getWorkloadDetailRouteParams(undefined, undefined)).toEqual({
+      namespace: '',
+      name: '',
+    });
+  });
+});

--- a/kueue/src/resources/workloadFormatters.ts
+++ b/kueue/src/resources/workloadFormatters.ts
@@ -1,0 +1,294 @@
+import type { KubeOwnerReference } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import type {
+  Admission,
+  PodSet,
+  ReclaimablePod,
+  RequeueState,
+  ResourceList,
+  WorkloadConditionLike,
+} from './workload';
+
+const CONDITION_TYPES = {
+  admitted: 'Admitted',
+  quotaReserved: 'QuotaReserved',
+  finished: 'Finished',
+  podsReady: 'PodsReady',
+  evicted: 'Evicted',
+  preempted: 'Preempted',
+  requeued: 'Requeued',
+  deactivationTarget: 'DeactivationTarget',
+} as const;
+
+/** Render text values with the plugin's standard empty-value fallback. */
+export function renderText(value?: string | null) {
+  return value || '-';
+}
+
+/** Render a numeric value while preserving explicit zero values. */
+export function renderNumber(value?: number | null) {
+  return value ?? '-';
+}
+
+/** Render a boolean as a short user-facing value. */
+export function renderBoolean(value?: boolean | null) {
+  if (value === undefined || value === null) {
+    return '-';
+  }
+
+  return value ? 'Yes' : 'No';
+}
+
+/** Render Workload priority while preserving priority 0. */
+export function renderPriority(priority?: number | null) {
+  return renderNumber(priority);
+}
+
+/** Render the LocalQueue name referenced by a Workload. */
+export function renderQueueName(queueName?: string) {
+  return renderText(queueName);
+}
+
+/** Render the current priority class reference name for a Workload. */
+export function renderPriorityClassName(priorityClassName?: string) {
+  return renderText(priorityClassName);
+}
+
+/** Find a named Workload condition from status.conditions. */
+export function findWorkloadCondition(conditions: WorkloadConditionLike[] = [], type: string) {
+  return conditions.find(condition => condition.type === type);
+}
+
+/** Render whether Kueue has admitted a Workload. */
+export function renderAdmittedStatus(
+  admission?: Admission,
+  conditions: WorkloadConditionLike[] = []
+) {
+  if (admission) {
+    return 'Yes';
+  }
+
+  const admittedCondition = findWorkloadCondition(conditions, CONDITION_TYPES.admitted);
+
+  if (!admittedCondition) {
+    return 'Unknown';
+  }
+
+  if (admittedCondition.status === 'True') {
+    return 'Yes';
+  }
+
+  if (admittedCondition.status === 'False') {
+    return 'No';
+  }
+
+  return 'Unknown';
+}
+
+/** Render whether the workload's associated job finished. */
+export function renderFinishedStatus(conditions: WorkloadConditionLike[] = []) {
+  const finishedCondition = findWorkloadCondition(conditions, CONDITION_TYPES.finished);
+
+  if (!finishedCondition) {
+    return 'Unknown';
+  }
+
+  if (finishedCondition.status === 'True') {
+    return 'Yes';
+  }
+
+  if (finishedCondition.status === 'False') {
+    return 'No';
+  }
+
+  return 'Unknown';
+}
+
+/** Render a readable Workload status from Kueue condition types and reasons. */
+export function renderWorkloadStatus(
+  conditions: WorkloadConditionLike[] = [],
+  active?: boolean,
+  admission?: Admission
+) {
+  if (active === false) {
+    return 'Deactivated';
+  }
+
+  if (isConditionTrue(conditions, CONDITION_TYPES.finished)) {
+    return 'Finished';
+  }
+
+  const evictedCondition = findWorkloadCondition(conditions, CONDITION_TYPES.evicted);
+  if (evictedCondition?.status === 'True') {
+    return evictedCondition.reason || 'Evicted';
+  }
+
+  if (isConditionTrue(conditions, CONDITION_TYPES.preempted)) {
+    return 'Preempted';
+  }
+
+  if (isConditionTrue(conditions, CONDITION_TYPES.deactivationTarget)) {
+    return 'Deactivated';
+  }
+
+  if (admission || isConditionTrue(conditions, CONDITION_TYPES.admitted)) {
+    return isConditionTrue(conditions, CONDITION_TYPES.podsReady) ? 'Running' : 'Admitted';
+  }
+
+  const quotaReservedCondition = findWorkloadCondition(conditions, CONDITION_TYPES.quotaReserved);
+  if (quotaReservedCondition?.status === 'False') {
+    return quotaReservedCondition.reason || 'Pending';
+  }
+
+  const admittedCondition = findWorkloadCondition(conditions, CONDITION_TYPES.admitted);
+  if (admittedCondition?.status === 'False') {
+    return admittedCondition.reason || 'Pending';
+  }
+
+  if (
+    quotaReservedCondition?.status === 'True' ||
+    isConditionTrue(conditions, CONDITION_TYPES.requeued)
+  ) {
+    return 'Pending';
+  }
+
+  return 'Unknown';
+}
+
+/** Render a compact summary of Workload podSets for list cells. */
+export function renderPodSetsSummary(podSets: PodSet[] = []) {
+  if (podSets.length === 0) {
+    return '-';
+  }
+
+  return podSets.map(podSet => `${podSet.name || 'main'} (${podSet.count ?? 1})`).join(', ');
+}
+
+/** Render all requests from a PodSet's containers as readable text. */
+export function renderPodSetRequests(podSet: PodSet) {
+  const containers = [
+    ...(podSet.template?.spec?.initContainers || []),
+    ...(podSet.template?.spec?.containers || []),
+  ];
+  const requests = containers
+    .map(container => {
+      const resourceRequests = renderResourceList(container.resources?.requests);
+
+      if (resourceRequests === '-') {
+        return undefined;
+      }
+
+      return `${container.name}: ${resourceRequests}`;
+    })
+    .filter((value): value is string => !!value);
+
+  return requests.length > 0 ? requests.join('; ') : '-';
+}
+
+/** Render a Kubernetes ResourceList as comma-separated resource quantities. */
+export function renderResourceList(resources?: ResourceList) {
+  const entries = Object.entries(resources || {}).filter(([, value]) => value !== undefined);
+
+  if (entries.length === 0) {
+    return '-';
+  }
+
+  return entries
+    .sort(([resourceA], [resourceB]) => resourceA.localeCompare(resourceB))
+    .map(([resource, value]) => `${resource}=${value}`)
+    .join(', ');
+}
+
+/** Render Kubernetes labels or annotations as compact key-value text. */
+export function renderStringMap(values?: Record<string, string>) {
+  const entries = Object.entries(values || {});
+
+  if (entries.length === 0) {
+    return '-';
+  }
+
+  return entries
+    .sort(([keyA], [keyB]) => keyA.localeCompare(keyB))
+    .map(([key, value]) => `${key}=${value}`)
+    .join(', ');
+}
+
+/** Render assigned ClusterQueue from Workload admission. */
+export function renderAdmissionClusterQueue(admission?: Admission) {
+  return renderText(admission?.clusterQueue);
+}
+
+/** Render unique ResourceFlavor names assigned by Workload admission. */
+export function renderAdmissionFlavors(admission?: Admission) {
+  const flavors = getAdmissionFlavorNames(admission);
+
+  return flavors.length > 0 ? flavors.join(', ') : '-';
+}
+
+/** Return unique ResourceFlavor names assigned by Workload admission. */
+export function getAdmissionFlavorNames(admission?: Admission) {
+  const flavors =
+    admission?.podSetAssignments?.flatMap(assignment => Object.values(assignment.flavors || {})) ||
+    [];
+
+  return Array.from(new Set(flavors)).filter(Boolean).sort();
+}
+
+/** Render a concise admission assignment summary. */
+export function renderAdmissionSummary(admission?: Admission) {
+  if (!admission) {
+    return '-';
+  }
+
+  const clusterQueue = renderAdmissionClusterQueue(admission);
+  const flavors = renderAdmissionFlavors(admission);
+  const assignments = admission.podSetAssignments?.length || 0;
+  const assignmentLabel = assignments === 1 ? 'pod set assignment' : 'pod set assignments';
+
+  return `ClusterQueue ${clusterQueue}; ${flavors}; ${assignments} ${assignmentLabel}`;
+}
+
+/** Render reclaimable pod counts for a Workload. */
+export function renderReclaimablePodsSummary(reclaimablePods: ReclaimablePod[] = []) {
+  if (reclaimablePods.length === 0) {
+    return '-';
+  }
+
+  return reclaimablePods
+    .map(reclaimablePod => `${reclaimablePod.name}: ${reclaimablePod.count}`)
+    .join(', ');
+}
+
+/** Render requeue state as count and next requeue time. */
+export function renderRequeueState(requeueState?: RequeueState) {
+  if (!requeueState) {
+    return '-';
+  }
+
+  const values = [
+    requeueState.count !== undefined ? `Count: ${requeueState.count}` : undefined,
+    requeueState.requeueAt ? `Requeue at: ${requeueState.requeueAt}` : undefined,
+  ].filter(Boolean);
+
+  return values.length > 0 ? values.join('; ') : '-';
+}
+
+/** Render owner references without dumping raw objects. */
+export function renderOwnerReferences(ownerReferences: KubeOwnerReference[] = []) {
+  if (ownerReferences.length === 0) {
+    return '-';
+  }
+
+  return ownerReferences.map(reference => `${reference.kind}/${reference.name}`).join(', ');
+}
+
+/** Build route params for a namespaced Workload detail link. */
+export function getWorkloadDetailRouteParams(namespace?: string, name?: string) {
+  return {
+    namespace: namespace || '',
+    name: name || '',
+  };
+}
+
+function isConditionTrue(conditions: WorkloadConditionLike[], type: string) {
+  return findWorkloadCondition(conditions, type)?.status === 'True';
+}

--- a/kueue/src/utils/kueueApi.test.ts
+++ b/kueue/src/utils/kueueApi.test.ts
@@ -17,4 +17,9 @@ describe('Kueue API constants', () => {
     expect(kueueRoutePaths.clusterQueuesList).toBe('/kueue/clusterqueues');
     expect(kueueRoutePaths.clusterQueueDetail).toBe('/kueue/clusterqueues/:name');
   });
+
+  it('defines Workload list and namespaced detail routes', () => {
+    expect(kueueRoutePaths.workloadsList).toBe('/kueue/workloads');
+    expect(kueueRoutePaths.workloadDetail).toBe('/kueue/workloads/:namespace/:name');
+  });
 });

--- a/kueue/src/utils/kueueRoutes.ts
+++ b/kueue/src/utils/kueueRoutes.ts
@@ -5,6 +5,8 @@ export const kueueRouteNames = {
   localQueueDetail: 'kueue-localqueue-detail',
   resourceFlavorsList: 'kueue-resourceflavors-list',
   resourceFlavorDetail: 'kueue-resourceflavor-detail',
+  workloadsList: 'kueue-workloads-list',
+  workloadDetail: 'kueue-workload-detail',
 } as const;
 
 export const kueueRoutePaths = {
@@ -14,4 +16,6 @@ export const kueueRoutePaths = {
   localQueueDetail: '/kueue/localqueues/:namespace/:name',
   resourceFlavorsList: '/kueue/resourceflavors',
   resourceFlavorDetail: '/kueue/resourceflavors/:name',
+  workloadsList: '/kueue/workloads',
+  workloadDetail: '/kueue/workloads/:namespace/:name',
 } as const;

--- a/kueue/test-files/deploy/job-sample-workload.yaml
+++ b/kueue/test-files/deploy/job-sample-workload.yaml
@@ -1,0 +1,25 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: sample-kueue-workload
+  namespace: default
+  labels:
+    kueue.x-k8s.io/queue-name: team-a-queue
+spec:
+  suspend: true
+  parallelism: 2
+  completions: 2
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: worker
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - echo "hello from kueue"; sleep 30
+          resources:
+            requests:
+              cpu: 100m
+              memory: 64Mi


### PR DESCRIPTION
## What Changed

Adds read-only support for Kueue `Workload` resources in the Headlamp Kueue plugin.

This PR adds:

- A typed `Workload` Kubernetes resource model for the Kueue `v1beta2` API
- Workload list and detail pages
- Workloads sidebar entry under the existing Kueue section
- Workload list and detail routes
- Formatter helpers for readable queue, priority, active, admission, finished, status, pod set, admission, reclaimable pod, and requeue values
- Focused tests for Workload display helper behavior
- README updates documenting Workload support and local verification commands

## Scope

This is intentionally read-only and focused on Workload visibility.

It does not add:

- Workload mutation actions
- pause/resume flows
- create/edit/delete forms
- metrics or charts
- advanced relational navigation

## Notes

The implementation uses the current Kueue `v1beta2` schema. In particular, the UI renders priority class from `spec.priorityClassRef.name`.

## Validation

Ran from `kueue/`:

- `npm run lint`
- `npm run tsc`
- `npm run build`
- `CI=true npm run test`

Also verified locally by creating a sample Kueue-managed `Job`, confirming Kueue generated a `Workload`, and checking that the Workload appeared in Headlamp with readable list/detail values.
<img width="1440" height="811" alt="Screenshot 2026-07-23 at 4 32 58 PM" src="https://github.com/user-attachments/assets/aa95dd42-03fe-4a99-bdcb-fe0b115e559e" />
<img width="1435" height="794" alt="Screenshot 2026-07-23 at 4 33 16 PM" src="https://github.com/user-attachments/assets/a2f0b449-c599-4286-a62a-6f5716c3f2a1" />
<img width="1435" height="800" alt="Screenshot 2026-07-23 at 4 33 33 PM" src="https://github.com/user-attachments/assets/70ec5a3f-ab60-4fce-bccb-8825443a5182" />
<img width="1440" height="812" alt="Screenshot 2026-07-23 at 4 34 05 PM" src="https://github.com/user-attachments/assets/2a74c6f5-b829-4c74-b646-0cc0edc4bf76" />

