### PR TITLE
strimzi: Refresh the connector actions cell when the state changes

### DIFF
--- a/strimzi/src/components/KafkaConnectorList.tsx
+++ b/strimzi/src/components/KafkaConnectorList.tsx
@@ -139,7 +139,9 @@ export function KafkaConnectorList() {
     {
       id: 'actions',
       label: 'Actions',
-      getValue: () => '',
+      // The rendered button depends on the desired state, so the cell value has
+      // to change with it for the table to pick the new state up.
+      getValue: (item: KafkaConnector) => item.desiredState,
       render: (item: KafkaConnector) => {
         const desired = item.desiredState;
         if (desired === 'paused') {


### PR DESCRIPTION
## Problem

Pausing a connector from the Kafka Connectors list leaves the button on "Pause".
The Desired state column updates, but the Actions cell keeps the button it
rendered first, so the correct "Resume" only shows up after reopening Headlamp.

## Fix

The Actions column returned a constant value from `getValue`, so the cell value
never changed. Return the desired state instead, the same way the Status and
Desired state columns already follow the resource.

Tested on a Strimzi 1.1 cluster: pausing and resuming now switch the button
straight away. `tsc`, `eslint` and the test suite (71 tests) pass.
