### PR TITLE
argocd: namespaces: Add GitOps insights section

### DIFF
--- a/argocd/src/components/namespaces/ArgoNamespaceInsights.tsx
+++ b/argocd/src/components/namespaces/ArgoNamespaceInsights.tsx
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Icon } from '@iconify/react';
+import {
+  Link,
+  SectionBox,
+  SimpleTable,
+  StatusLabel,
+} from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { Box, Typography } from '@mui/material';
+import type { ComponentProps } from 'react';
+import { ArgoApplication } from '../../resources/application';
+import { getHealthStatus, getSyncStatus } from '../applications/statusHelpers';
+
+type HeadlampStatus = ComponentProps<typeof StatusLabel>['status'];
+
+interface NamespaceResource {
+  kind?: string;
+  metadata?: {
+    name?: string;
+  };
+  getName?: () => string;
+}
+
+/**
+ * Adds Argo CD context to Headlamp's built-in Namespace detail page.
+ *
+ * The section shows Applications that are either stored in this namespace or
+ * deploy workloads into it. That distinction matters for Argo CD because the
+ * Application CR usually lives in the Argo CD control-plane namespace, while
+ * its destination namespace can be somewhere else.
+ */
+export default function ArgoNamespaceInsights(props: { resource: NamespaceResource }) {
+  const resource = props.resource;
+
+  if (resource?.kind !== 'Namespace') {
+    return null;
+  }
+
+  const namespaceName = resource.metadata?.name ?? resource.getName?.();
+  if (!namespaceName) {
+    return null;
+  }
+
+  return <NamespaceInsights namespaceName={namespaceName} />;
+}
+
+function NamespaceInsights(props: { namespaceName: string }) {
+  const [applications, error] = ArgoApplication.useList();
+  const apps = applications ?? [];
+  const relatedApps = getNamespaceApplications(apps, props.namespaceName);
+  const storedApps = relatedApps.filter(app => app.metadata.namespace === props.namespaceName);
+  const targetApps = relatedApps.filter(app => app.destinationNamespace === props.namespaceName);
+  const attentionApps = relatedApps.filter(
+    app => app.syncStatus !== 'Synced' || app.healthStatus !== 'Healthy'
+  );
+
+  return (
+    <SectionBox title="GitOps Insights">
+      {error ? (
+        <InsightsEmptyState message="Unable to load Argo CD Applications for this namespace." />
+      ) : !applications ? (
+        <InsightsEmptyState message="Loading Argo CD Applications..." />
+      ) : relatedApps.length === 0 ? (
+        <InsightsEmptyState message="No Argo CD Applications are stored in or targeting this namespace." />
+      ) : (
+        <>
+          <Box
+            sx={{
+              display: 'grid',
+              gridTemplateColumns: { xs: '1fr', md: 'repeat(3, minmax(0, 1fr))' },
+              gap: 2,
+              mb: 2,
+            }}
+          >
+            <InsightCard
+              icon="mdi:folder-outline"
+              title="Stored Here"
+              value={storedApps.length}
+              caption="Application CRs in this namespace"
+            />
+            <InsightCard
+              icon="mdi:target"
+              title="Deploying Here"
+              value={targetApps.length}
+              caption="Applications targeting this namespace"
+            />
+            <InsightCard
+              icon={
+                attentionApps.length > 0 ? 'mdi:alert-circle-outline' : 'mdi:check-circle-outline'
+              }
+              title={attentionApps.length > 0 ? 'Needs Attention' : 'All Healthy'}
+              value={attentionApps.length}
+              caption={
+                attentionApps.length > 0 ? 'Not synced or not healthy' : 'No sync or health issues'
+              }
+              status={attentionApps.length > 0 ? 'warning' : 'success'}
+            />
+          </Box>
+
+          <SimpleTable
+            data={relatedApps}
+            columns={[
+              {
+                label: 'Application',
+                getter: (app: ArgoApplication) => (
+                  <Link
+                    routeName="argocd-application-detail"
+                    params={{ namespace: app.metadata.namespace, name: app.metadata.name }}
+                  >
+                    {app.metadata.name}
+                  </Link>
+                ),
+                sort: (a: ArgoApplication, b: ArgoApplication) =>
+                  a.metadata.name.localeCompare(b.metadata.name),
+              },
+              {
+                label: 'Scope',
+                getter: (app: ArgoApplication) => getAppNamespaceScope(app, props.namespaceName),
+                sort: true,
+              },
+              {
+                label: 'Project',
+                getter: (app: ArgoApplication) => app.project,
+                sort: true,
+              },
+              {
+                label: 'Target Namespace',
+                getter: (app: ArgoApplication) => app.destinationNamespace,
+                sort: true,
+              },
+              {
+                label: 'Sync',
+                getter: (app: ArgoApplication) => (
+                  <StatusLabel status={getSyncStatus(app.syncStatus)}>{app.syncStatus}</StatusLabel>
+                ),
+                sort: (a: ArgoApplication, b: ArgoApplication) =>
+                  a.syncStatus.localeCompare(b.syncStatus),
+              },
+              {
+                label: 'Health',
+                getter: (app: ArgoApplication) => (
+                  <StatusLabel status={getHealthStatus(app.healthStatus)}>
+                    {app.healthStatus}
+                  </StatusLabel>
+                ),
+                sort: (a: ArgoApplication, b: ArgoApplication) =>
+                  a.healthStatus.localeCompare(b.healthStatus),
+              },
+            ]}
+          />
+        </>
+      )}
+    </SectionBox>
+  );
+}
+
+function InsightCard(props: {
+  icon: string;
+  title: string;
+  value: number;
+  caption: string;
+  status?: HeadlampStatus;
+}) {
+  return (
+    <Box
+      sx={theme => ({
+        border: `1px solid ${theme.palette.divider}`,
+        borderRadius: 1,
+        display: 'flex',
+        alignItems: 'center',
+        gap: 1.5,
+        p: 1.5,
+      })}
+    >
+      <Box
+        sx={theme => ({
+          width: 38,
+          height: 38,
+          borderRadius: 1,
+          display: 'grid',
+          placeItems: 'center',
+          bgcolor:
+            props.status === 'success'
+              ? theme.palette.success.main
+              : props.status === 'warning'
+              ? theme.palette.warning.main
+              : theme.palette.action.selected,
+          color: props.status ? theme.palette.common.white : theme.palette.text.secondary,
+          flex: '0 0 auto',
+        })}
+      >
+        <Icon icon={props.icon} width={22} height={22} />
+      </Box>
+      <Box sx={{ minWidth: 0 }}>
+        <Typography variant="h6" sx={{ lineHeight: 1.1 }}>
+          {props.value}
+        </Typography>
+        <Typography variant="subtitle2" sx={{ fontWeight: 700 }}>
+          {props.title}
+        </Typography>
+        <Typography variant="caption" color="text.secondary">
+          {props.caption}
+        </Typography>
+      </Box>
+    </Box>
+  );
+}
+
+function InsightsEmptyState(props: { message: string }) {
+  return (
+    <Box
+      sx={theme => ({
+        border: `1px solid ${theme.palette.divider}`,
+        borderRadius: 1,
+        color: 'text.secondary',
+        p: 2,
+        textAlign: 'center',
+      })}
+    >
+      {props.message}
+    </Box>
+  );
+}
+
+function getNamespaceApplications(apps: ArgoApplication[], namespaceName: string) {
+  const byKey: Record<string, ArgoApplication> = {};
+
+  apps.forEach(app => {
+    const isStoredHere = app.metadata.namespace === namespaceName;
+    const deploysHere = app.destinationNamespace === namespaceName;
+
+    if (isStoredHere || deploysHere) {
+      byKey[`${app.metadata.namespace}/${app.metadata.name}`] = app;
+    }
+  });
+
+  return Object.values(byKey).sort((a, b) => a.metadata.name.localeCompare(b.metadata.name));
+}
+
+function getAppNamespaceScope(app: ArgoApplication, namespaceName: string) {
+  const isStoredHere = app.metadata.namespace === namespaceName;
+  const deploysHere = app.destinationNamespace === namespaceName;
+
+  if (isStoredHere && deploysHere) {
+    return 'Stored and deploys here';
+  }
+  if (isStoredHere) {
+    return 'Stored here';
+  }
+  return 'Deploys here';
+}

--- a/argocd/src/index.test.tsx
+++ b/argocd/src/index.test.tsx
@@ -16,6 +16,7 @@
 
 import type * as React from 'react';
 import { describe, expect, it, vi } from 'vitest';
+import ArgoNamespaceInsights from './components/namespaces/ArgoNamespaceInsights';
 
 const {
   mockRegisterDetailsViewSectionsProcessor,
@@ -170,7 +171,8 @@ describe('argocd plugin', () => {
     expect(mockRegisterDetailsViewSectionsProcessor).toHaveBeenCalledWith(expect.any(Function));
 
     const processor = mockRegisterDetailsViewSectionsProcessor.mock.calls[0][0];
-    const processedSections = processor({ kind: 'Namespace' }, [
+    const namespace = { kind: 'Namespace', metadata: { name: 'argocd' } };
+    const processedSections = processor(namespace, [
       { id: 'MAIN_HEADER', section: null },
       { id: 'METADATA', section: null },
       { id: 'headlamp.namespace-owned-resourcequotas', section: null },
@@ -182,5 +184,11 @@ describe('argocd plugin', () => {
       'argocd.namespace-gitops-insights',
       'headlamp.namespace-owned-resourcequotas',
     ]);
+
+    const insightsSection = processedSections[2];
+    expect(insightsSection.section).toMatchObject({
+      type: ArgoNamespaceInsights,
+      props: { resource: namespace },
+    });
   });
 });

--- a/argocd/src/index.test.tsx
+++ b/argocd/src/index.test.tsx
@@ -17,15 +17,23 @@
 import type * as React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
-const { mockRegisterRoute, mockRegisterSidebarEntry, mockRegisterSidebarEntryFilter } = vi.hoisted(
-  () => ({
-    mockRegisterRoute: vi.fn(),
-    mockRegisterSidebarEntry: vi.fn(),
-    mockRegisterSidebarEntryFilter: vi.fn(),
-  })
-);
+const {
+  mockRegisterDetailsViewSectionsProcessor,
+  mockRegisterRoute,
+  mockRegisterSidebarEntry,
+  mockRegisterSidebarEntryFilter,
+} = vi.hoisted(() => ({
+  mockRegisterDetailsViewSectionsProcessor: vi.fn(),
+  mockRegisterRoute: vi.fn(),
+  mockRegisterSidebarEntry: vi.fn(),
+  mockRegisterSidebarEntryFilter: vi.fn(),
+}));
 
 vi.mock('@kinvolk/headlamp-plugin/lib', () => ({
+  DefaultDetailsViewSection: {
+    METADATA: 'METADATA',
+  },
+  registerDetailsViewSectionsProcessor: mockRegisterDetailsViewSectionsProcessor,
   registerRoute: mockRegisterRoute,
   registerSidebarEntry: mockRegisterSidebarEntry,
   registerSidebarEntryFilter: mockRegisterSidebarEntryFilter,
@@ -54,6 +62,7 @@ vi.mock('@kinvolk/headlamp-plugin/lib/CommonComponents', () => ({
   ActionButton: () => null,
   AuthVisible: ({ children }: { children: React.ReactNode }) => children,
   DetailsGrid: () => null,
+  Link: ({ children }: { children: React.ReactNode }) => children,
   NameValueTable: () => null,
   ResourceListView: () => null,
   SectionBox: () => null,
@@ -67,6 +76,7 @@ vi.mock('@kinvolk/headlamp-plugin/lib/components/common', () => ({
 
 vi.mock('@iconify/react', () => ({
   addIcon: vi.fn(),
+  Icon: () => null,
 }));
 
 vi.mock('notistack', () => ({
@@ -154,5 +164,23 @@ describe('argocd plugin', () => {
 
   it('should register the CRD sidebar entry filter', () => {
     expect(mockRegisterSidebarEntryFilter).toHaveBeenCalledWith(expect.any(Function));
+  });
+
+  it('should register the namespace Argo CD insights details section', () => {
+    expect(mockRegisterDetailsViewSectionsProcessor).toHaveBeenCalledWith(expect.any(Function));
+
+    const processor = mockRegisterDetailsViewSectionsProcessor.mock.calls[0][0];
+    const processedSections = processor({ kind: 'Namespace' }, [
+      { id: 'MAIN_HEADER', section: null },
+      { id: 'METADATA', section: null },
+      { id: 'headlamp.namespace-owned-resourcequotas', section: null },
+    ]);
+
+    expect(processedSections.map((section: { id: string }) => section.id)).toEqual([
+      'MAIN_HEADER',
+      'METADATA',
+      'argocd.namespace-gitops-insights',
+      'headlamp.namespace-owned-resourcequotas',
+    ]);
   });
 });

--- a/argocd/src/index.tsx
+++ b/argocd/src/index.tsx
@@ -16,16 +16,20 @@
 
 import { addIcon } from '@iconify/react';
 import {
+  DefaultDetailsViewSection,
   K8s,
+  registerDetailsViewSectionsProcessor,
   registerRoute,
   registerSidebarEntry,
   registerSidebarEntryFilter,
   Utils,
 } from '@kinvolk/headlamp-plugin/lib';
+import type { ReactNode } from 'react';
 import ApplicationDetail from './components/applications/Detail';
 import ApplicationList from './components/applications/List';
 import AppProjectDetail from './components/appprojects/Detail';
 import AppProjectList from './components/appprojects/List';
+import ArgoNamespaceInsights from './components/namespaces/ArgoNamespaceInsights';
 
 // ---------------------------------------------------------------------------
 // CRD Detection Guard — hide Argo CD sidebar entries on clusters without
@@ -79,6 +83,45 @@ registerSidebarEntryFilter(entry => {
   }
   return entry;
 });
+
+const NAMESPACE_GITOPS_INSIGHTS_SECTION_ID = 'argocd.namespace-gitops-insights';
+
+registerDetailsViewSectionsProcessor(function addNamespaceGitOpsInsightsSection(
+  resource,
+  sections
+) {
+  if (!resource || resource.kind !== 'Namespace') {
+    return sections;
+  }
+
+  const insightsIndex = sections.findIndex(
+    section => getDetailsSectionId(section) === NAMESPACE_GITOPS_INSIGHTS_SECTION_ID
+  );
+  if (insightsIndex !== -1) {
+    return sections;
+  }
+
+  const metadataIndex = sections.findIndex(
+    section => getDetailsSectionId(section) === DefaultDetailsViewSection.METADATA
+  );
+  if (metadataIndex === -1) {
+    return sections;
+  }
+
+  const reorderedSections = [...sections];
+  reorderedSections.splice(metadataIndex + 1, 0, {
+    id: NAMESPACE_GITOPS_INSIGHTS_SECTION_ID,
+    section: ArgoNamespaceInsights,
+  });
+  return reorderedSections;
+});
+
+function getDetailsSectionId(section: { id?: string } | ReactNode) {
+  if (typeof section === 'object' && section !== null && 'id' in section) {
+    return section.id;
+  }
+  return undefined;
+}
 
 // Register the official Argo CD logo as an offline Iconify icon (CSP-safe:
 // no external fetch). Sourced from the Simple Icons "argo" glyph.

--- a/argocd/src/index.tsx
+++ b/argocd/src/index.tsx
@@ -111,7 +111,7 @@ registerDetailsViewSectionsProcessor(function addNamespaceGitOpsInsightsSection(
   const reorderedSections = [...sections];
   reorderedSections.splice(metadataIndex + 1, 0, {
     id: NAMESPACE_GITOPS_INSIGHTS_SECTION_ID,
-    section: ArgoNamespaceInsights,
+    section: <ArgoNamespaceInsights resource={resource} />,
   });
   return reorderedSections;
 });


### PR DESCRIPTION
## Summary
This PR adds a Namespace GitOps Insights section to the built-in Headlamp Namespace detail page. It gives users Argo CD context directly where they are already inspecting namespace resources.

### Why Namespace GitOps Insights?
In Argo CD, an Application CR can be stored in one namespace, usually the Argo CD control-plane namespace, while deploying workloads into another namespace. Headlamp's default Namespace page shows Kubernetes-native objects like ResourceQuotas, LimitRanges, and Pods, but it does not explain which GitOps Applications are connected to that namespace.

This section closes that gap by showing Applications that are either stored in the current namespace or targeting it as their destination namespace. This keeps the namespace page useful without replacing the normal Argo CD Application views.

## Changes
### Added
src/components/namespaces/ArgoNamespaceInsights.tsx ? Adds a Namespace detail section with summary cards for Applications stored here, Applications deploying here, and Applications needing attention. Also includes a table with Application, scope, project, target namespace, sync status, and health status.

### Changed
src/index.tsx ? Registers a details view sections processor that inserts Namespace GitOps Insights after the Namespace metadata section.
src/index.test.tsx ? Adds test coverage to verify the Namespace GitOps Insights section is registered in the expected position.

### Steps to Test
Have a running Kubernetes cluster with Argo CD installed and Headlamp accessible.
Navigate to a Namespace detail page, for example the argocd namespace.
Verify the Namespace GitOps Insights section appears after the metadata section.
Verify Applications stored in or targeting that namespace appear in the table.
Verify the summary cards show stored, deploying, and attention counts.
Navigate to a namespace with no related Argo CD Applications and verify the empty state appears.
