### PR TITLE
argocd: applications/List: Improve Application list readability

### DIFF
--- a/argocd/src/components/applications/List.tsx
+++ b/argocd/src/components/applications/List.tsx
@@ -14,16 +14,19 @@
  * limitations under the License.
  */
 
+import { Icon } from '@iconify/react';
 import {
   ActionButton,
   AuthVisible,
+  Link,
   ResourceListView,
   StatusLabel,
 } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { Box, Link as MuiLink, Tooltip, Typography } from '@mui/material';
 import { refreshApplication, syncApplication } from '../../api/argoClient';
 import { useArgoOperationMap } from '../../hooks/useArgoOperation';
 import { ArgoApplication } from '../../resources/application';
-import { getHealthStatus, getSyncStatus } from './statusHelpers';
+import { getHealthIcon, getHealthStatus, getSyncIcon, getSyncStatus } from './statusHelpers';
 
 /**
  * Renders a table of all Argo CD Application resources in the current cluster.
@@ -53,7 +56,7 @@ export default function ApplicationList() {
             return (
               <AuthVisible item={item} authVerb="patch">
                 <ActionButton
-                  description={isLoadingSync ? 'Syncing…' : 'Sync'}
+                  description={isLoadingSync ? 'Syncing...' : 'Sync'}
                   icon={isLoadingSync ? 'mdi:loading' : 'mdi:sync'}
                   onClick={() => sync.execute(name, namespace)}
                   iconButtonProps={{ disabled: isLoadingAny }}
@@ -71,7 +74,7 @@ export default function ApplicationList() {
             return (
               <AuthVisible item={item} authVerb="patch">
                 <ActionButton
-                  description={isLoadingRefresh ? 'Refreshing…' : 'Refresh'}
+                  description={isLoadingRefresh ? 'Refreshing...' : 'Refresh'}
                   icon={isLoadingRefresh ? 'mdi:loading' : 'mdi:refresh'}
                   onClick={() => refresh.execute(name, namespace)}
                   iconButtonProps={{ disabled: isLoadingAny }}
@@ -83,7 +86,6 @@ export default function ApplicationList() {
       ]}
       columns={[
         'name',
-        'namespace',
         {
           id: 'project',
           label: 'Project',
@@ -91,33 +93,184 @@ export default function ApplicationList() {
         },
         {
           id: 'source-repo',
-          label: 'Source Repo',
+          label: 'Source',
           getValue: (app: ArgoApplication) =>
-            app.isMultiSource ? `${app.sources.length} sources` : app.repoURL,
+            app.isMultiSource ? `${app.sources.length} sources` : getSourceSortValue(app),
+          render: (app: ArgoApplication) => <SourceAndRevisionLabel app={app} />,
         },
         {
-          id: 'target-revision',
-          label: 'Target Revision',
-          getValue: (app: ArgoApplication) => app.targetRevision,
+          id: 'app-flow',
+          label: 'Namespaces',
+          getValue: (app: ArgoApplication) =>
+            `${app.metadata.namespace} -> ${getDestinationLabel(app)}`,
+          render: (app: ArgoApplication) => <ApplicationFlow app={app} />,
         },
         {
-          id: 'sync-status',
-          label: 'Sync Status',
-          getValue: (app: ArgoApplication) => app.syncStatus,
-          render: (app: ArgoApplication) => (
-            <StatusLabel status={getSyncStatus(app.syncStatus)}>{app.syncStatus}</StatusLabel>
-          ),
-        },
-        {
-          id: 'health-status',
-          label: 'Health Status',
-          getValue: (app: ArgoApplication) => app.healthStatus,
-          render: (app: ArgoApplication) => (
-            <StatusLabel status={getHealthStatus(app.healthStatus)}>{app.healthStatus}</StatusLabel>
-          ),
+          id: 'status',
+          label: 'Status',
+          getValue: (app: ArgoApplication) => `${app.syncStatus} ${app.healthStatus}`,
+          render: (app: ArgoApplication) => <ApplicationStatus app={app} />,
         },
         'age',
       ]}
     />
+  );
+}
+
+function ApplicationFlow(props: { app: ArgoApplication }) {
+  const app = props.app;
+  const destination = getDestinationLabel(app);
+  const shouldLinkDestination = isLocalDestination(app);
+
+  return (
+    <Tooltip
+      title={
+        <Box component="span" sx={{ whiteSpace: 'pre-line' }}>
+          {`Application namespace: ${app.metadata.namespace}\nDestination: ${destination}`}
+        </Box>
+      }
+    >
+      <Box sx={{ display: 'grid', gap: 0.25, minWidth: 0 }}>
+        <Typography component="span" variant="body2" sx={{ whiteSpace: 'nowrap' }}>
+          <Box component="span" color="text.secondary">
+            App:
+          </Box>{' '}
+          <Link routeName="namespace" params={{ name: app.metadata.namespace }}>
+            {app.metadata.namespace}
+          </Link>
+        </Typography>
+        <Typography component="span" variant="body2" sx={{ whiteSpace: 'nowrap' }}>
+          <Box component="span" color="text.secondary">
+            Dest:
+          </Box>{' '}
+          {shouldLinkDestination ? (
+            <Link routeName="namespace" params={{ name: app.destinationNamespace }}>
+              {app.destinationNamespace}
+            </Link>
+          ) : (
+            destination
+          )}
+        </Typography>
+      </Box>
+    </Tooltip>
+  );
+}
+
+function ApplicationStatus(props: { app: ArgoApplication }) {
+  const app = props.app;
+
+  return (
+    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
+      <StatusLabel status={getSyncStatus(app.syncStatus)}>
+        <Icon icon={getSyncIcon(app.syncStatus)} style={{ marginRight: '4px' }} />
+        {app.syncStatus}
+      </StatusLabel>
+      <StatusLabel status={getHealthStatus(app.healthStatus)}>
+        <Icon icon={getHealthIcon(app.healthStatus)} style={{ marginRight: '4px' }} />
+        {app.healthStatus}
+      </StatusLabel>
+    </Box>
+  );
+}
+
+function SourceAndRevisionLabel(props: { app: ArgoApplication }) {
+  const app = props.app;
+
+  if (app.isMultiSource) {
+    const tooltip = app.sources
+      .map(
+        (source, index) =>
+          `Source ${index + 1}: ${source.repoURL || '-'} @ ${source.targetRevision || 'HEAD'}`
+      )
+      .join('\n');
+
+    return (
+      <Tooltip
+        title={
+          <Box component="span" sx={{ whiteSpace: 'pre-line' }}>
+            {tooltip}
+          </Box>
+        }
+      >
+        <Box sx={{ display: 'grid', gap: 0.25, minWidth: 0 }}>
+          <Typography variant="body2">{app.sources.length} sources</Typography>
+          <Typography variant="caption" color="text.secondary">
+            Multiple revisions
+          </Typography>
+        </Box>
+      </Tooltip>
+    );
+  }
+
+  if (!app.repoURL) {
+    return '-';
+  }
+
+  const repoHref = getSafeExternalUrl(app.repoURL);
+
+  return (
+    <Tooltip title={app.repoURL}>
+      <Box sx={{ display: 'grid', gap: 0.25, minWidth: 0 }}>
+        {repoHref ? (
+          <MuiLink
+            href={repoHref}
+            target="_blank"
+            rel="noopener noreferrer"
+            sx={{ overflowWrap: 'anywhere' }}
+          >
+            {getRepoDisplayName(app.repoURL)}
+          </MuiLink>
+        ) : (
+          <Typography variant="body2" sx={{ overflowWrap: 'anywhere' }}>
+            {getRepoDisplayName(app.repoURL)}
+          </Typography>
+        )}
+        <Typography variant="caption" color="text.secondary">
+          Revision: {app.targetRevision}
+        </Typography>
+      </Box>
+    </Tooltip>
+  );
+}
+
+function getSourceSortValue(app: ArgoApplication) {
+  return app.repoURL ? `${getRepoDisplayName(app.repoURL)} ${app.targetRevision}` : '-';
+}
+
+function getRepoDisplayName(repoURL: string) {
+  if (!repoURL) {
+    return '-';
+  }
+
+  const repoPath = repoURL.replace(/\/$/, '').split('/').pop() || repoURL;
+  return repoPath.replace(/\.git$/, '');
+}
+
+function getSafeExternalUrl(repoURL: string) {
+  try {
+    const url = new URL(repoURL);
+    return url.protocol === 'http:' || url.protocol === 'https:' ? repoURL : null;
+  } catch {
+    return null;
+  }
+}
+
+function getDestinationLabel(app: ArgoApplication) {
+  const namespace = app.destinationNamespace;
+  const cluster = app.spec.destination?.name;
+
+  if (cluster) {
+    return `${cluster} / ${namespace}`;
+  }
+
+  return namespace;
+}
+
+function isLocalDestination(app: ArgoApplication) {
+  const destination = app.spec.destination;
+
+  return (
+    !destination?.name &&
+    (!destination?.server || destination.server === 'https://kubernetes.default.svc')
   );
 }

--- a/argocd/src/components/applications/statusHelpers.ts
+++ b/argocd/src/components/applications/statusHelpers.ts
@@ -39,6 +39,28 @@ export function getHealthStatus(health: string): string {
 }
 
 /**
+ * Maps an Argo CD health status string to an icon used beside the status badge.
+ *
+ * @param health - The health status string from the Application resource.
+ * @returns An Iconify icon name matching the Argo CD health state.
+ */
+export function getHealthIcon(health: string): string {
+  switch (health.toLowerCase()) {
+    case 'healthy':
+      return 'mdi:heart-pulse';
+    case 'suspended':
+      return 'mdi:pause-circle';
+    case 'progressing':
+      return 'mdi:progress-clock';
+    case 'degraded':
+    case 'missing':
+      return 'mdi:heart-broken';
+    default:
+      return 'mdi:help-circle';
+  }
+}
+
+/**
  * Maps an Argo CD sync status string to a Headlamp StatusLabel severity.
  *
  * @param sync - The sync status string from the Application resource
@@ -54,5 +76,22 @@ export function getSyncStatus(sync: string): string {
       return 'warning';
     default:
       return '';
+  }
+}
+
+/**
+ * Maps an Argo CD sync status string to an icon used beside the status badge.
+ *
+ * @param sync - The sync status string from the Application resource.
+ * @returns An Iconify icon name matching the Argo CD sync state.
+ */
+export function getSyncIcon(sync: string): string {
+  switch (sync.toLowerCase()) {
+    case 'synced':
+      return 'mdi:check-circle';
+    case 'outofsync':
+      return 'mdi:arrow-up-circle';
+    default:
+      return 'mdi:help-circle';
   }
 }


### PR DESCRIPTION
## Summary
This PR improves the Argo CD Applications list view readability. It keeps the list focused on the main operator questions: what Application is this, where does it deploy, what source/revision is it using, and what is its current sync/health state?

### Why this change?
The previous table exposed the important data, but the columns were starting to feel wide and repetitive. Source Repo and Target Revision were separate columns, and Sync Status and Health Status were separate columns. This made the table harder to scan, especially in the Headlamp desktop layout.

This PR groups related information together while keeping all important Argo CD context visible:
- Source and revision are shown together.
- Application namespace and destination namespace are shown together.
- Sync and health are shown together as status badges.

This follows the same general direction as the Flux and Volcano plugin UIs: keep list pages dense, operational, and easy to scan, while leaving deeper details for the detail page.

## Changes
### Changed
src/components/applications/List.tsx ? Updates the Applications list columns to show Source, Namespaces, and combined Status. Adds compact renderers for source/revision, Application-to-destination namespace flow, and sync/health badges.
src/components/applications/statusHelpers.ts ? Adds small icon helper mappings for sync and health status badges used by the list view.

### Steps to Test
Have a running Kubernetes cluster with Argo CD installed and Headlamp accessible.
Navigate to Argo CD ? Applications.
Verify the Applications table shows Source, Namespaces, Status, Project, Name, and Age.
Verify Source shows the repository name and target revision together.
Verify Namespaces shows both the Application namespace and destination namespace.
Verify Status shows both Sync and Health badges.
Verify Sync/Refresh row actions still appear only when the user has patch permission.
