### PR TITLE
kmesh: visual indicators for waypoint and namespace

### DIFF
--- a/kmesh/src/components/namespace/NamespaceEnrollment.tsx
+++ b/kmesh/src/components/namespace/NamespaceEnrollment.tsx
@@ -1,0 +1,52 @@
+import { K8s } from '@kinvolk/headlamp-plugin/lib';
+import { SectionBox, StatusLabel } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { Box, Typography } from '@mui/material';
+
+/**
+ * Renders the Kmesh Enrollment status section in the Namespace detail view.
+ * It checks for the `istio.io/dataplane-mode` label on the Namespace resource.
+ */
+export default function NamespaceEnrollment(props: {
+  resource: InstanceType<typeof K8s.ResourceClasses.Namespace>;
+}) {
+  const { resource } = props;
+
+  // We only want to render this for Namespaces
+  if (!resource || resource.kind !== 'Namespace') {
+    return null;
+  }
+
+  const labels = resource.metadata?.labels || {};
+  const dataplaneMode = labels['istio.io/dataplane-mode'];
+  const useWaypoint = labels['istio.io/use-waypoint'];
+
+  const isEnrolled = dataplaneMode === 'Kmesh';
+
+  return (
+    <SectionBox title="Kmesh Enrollment">
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <Typography variant="body2" sx={{ width: '120px', fontWeight: 'bold' }}>
+            Dataplane Mode:
+          </Typography>
+          <StatusLabel status={isEnrolled ? 'success' : ''}>
+            {isEnrolled ? 'Kmesh' : 'Not Enrolled'}
+          </StatusLabel>
+        </Box>
+
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <Typography variant="body2" sx={{ width: '120px', fontWeight: 'bold' }}>
+            Waypoint:
+          </Typography>
+          <Typography variant="body2">
+            {useWaypoint ? (
+              useWaypoint
+            ) : (
+              <span style={{ color: 'text.secondary' }}>None assigned</span>
+            )}
+          </Typography>
+        </Box>
+      </Box>
+    </SectionBox>
+  );
+}

--- a/kmesh/src/components/waypoints/Detail.tsx
+++ b/kmesh/src/components/waypoints/Detail.tsx
@@ -1,3 +1,9 @@
+import {
+  ObjectEventList,
+  SectionBox,
+  SimpleTable,
+  StatusLabel,
+} from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 import { MainInfoSection } from '@kinvolk/headlamp-plugin/lib/components/common';
 import { useParams } from 'react-router-dom';
 import { Waypoint } from '../../resources/waypoint';
@@ -43,6 +49,49 @@ export default function WaypointDetail(props: WaypointDetailProps) {
   return <WaypointDetailContent name={name} namespace={namespace} cluster={cluster} />;
 }
 
+function ConditionsTable({ conditions }: { conditions?: any[] }) {
+  if (!conditions || conditions.length === 0) {
+    return null;
+  }
+
+  return (
+    <SectionBox title="Conditions">
+      <SimpleTable
+        data={conditions}
+        columns={[
+          {
+            label: 'Type',
+            getter: (c: any) => c.type,
+          },
+          {
+            label: 'Status',
+            getter: (c: any) => {
+              const statusType =
+                c.status === 'True' ? 'success' : c.status === 'False' ? 'error' : 'warning';
+              return <StatusLabel status={statusType}>{c.status}</StatusLabel>;
+            },
+          },
+          {
+            label: 'Reason',
+            getter: (c: any) => c.reason,
+          },
+          {
+            label: 'Message',
+            getter: (c: any) => c.message,
+          },
+          {
+            label: 'Last Transition',
+            getter: (c: any) =>
+              c.lastTransitionTime && !c.lastTransitionTime.startsWith('1970-01-01')
+                ? new Date(c.lastTransitionTime).toLocaleString()
+                : '-',
+          },
+        ]}
+      />
+    </SectionBox>
+  );
+}
+
 function WaypointDetailContent({
   name,
   namespace,
@@ -55,25 +104,29 @@ function WaypointDetailContent({
   const [waypoint, error] = Waypoint.useGet(name, namespace, { cluster });
 
   return (
-    <MainInfoSection
-      resource={waypoint}
-      error={error}
-      title="Waypoint Details"
-      backLink={kmeshRoutePaths.waypointsList}
-      extraInfo={[
-        {
-          name: 'Gateway Class',
-          value: waypoint?.spec?.gatewayClassName,
-        },
-        {
-          name: 'Image',
-          value: waypoint?.image,
-        },
-        {
-          name: 'Current Status',
-          value: waypoint?.currentStatus,
-        },
-      ]}
-    />
+    <>
+      <MainInfoSection
+        resource={waypoint}
+        error={error}
+        title="Waypoint Details"
+        backLink={kmeshRoutePaths.waypointsList}
+        extraInfo={[
+          {
+            name: 'Gateway Class',
+            value: waypoint?.spec?.gatewayClassName,
+          },
+          {
+            name: 'Image',
+            value: waypoint?.image,
+          },
+          {
+            name: 'Current Status',
+            value: waypoint?.currentStatus,
+          },
+        ]}
+      />
+      {waypoint && <ConditionsTable conditions={waypoint.status?.conditions} />}
+      {waypoint && <ObjectEventList object={waypoint as any} />}
+    </>
   );
 }

--- a/kmesh/src/index.tsx
+++ b/kmesh/src/index.tsx
@@ -1,10 +1,15 @@
-import { registerRoute, registerSidebarEntry } from '@kinvolk/headlamp-plugin/lib';
+import {
+  registerDetailsViewSection,
+  registerRoute,
+  registerSidebarEntry,
+} from '@kinvolk/headlamp-plugin/lib';
 import type { ComponentType } from 'react';
 import AuthzPolicies from './components/daemon/AuthzPolicies';
 import EbpfMaps from './components/daemon/EbpfMaps';
 import HealthDashboard from './components/daemon/HealthDashboard';
 import ObservabilityPanel from './components/daemon/ObservabilityPanel';
 import XdsConfigDump from './components/daemon/XdsConfigDump';
+import NamespaceEnrollment from './components/namespace/NamespaceEnrollment';
 import KmeshNodeInfoDetail from './components/nodeinfo/Detail';
 import KmeshNodeInfoList from './components/nodeinfo/List';
 import WaypointDetail from './components/waypoints/Detail';
@@ -182,3 +187,6 @@ registerRoute({
   exact: true,
   component: () => <EbpfMaps />,
 });
+
+// Register Namespace Enrollment section in the details view
+registerDetailsViewSection(NamespaceEnrollment);

--- a/kmesh/src/index.tsx
+++ b/kmesh/src/index.tsx
@@ -1,8 +1,13 @@
-import { registerRoute, registerSidebarEntry } from '@kinvolk/headlamp-plugin/lib';
+import {
+  registerDetailsViewSection,
+  registerRoute,
+  registerSidebarEntry,
+} from '@kinvolk/headlamp-plugin/lib';
 import type { ComponentType } from 'react';
 import HealthDashboard from './components/daemon/HealthDashboard';
 import ObservabilityPanel from './components/daemon/ObservabilityPanel';
 import XdsConfigDump from './components/daemon/XdsConfigDump';
+import NamespaceEnrollment from './components/namespace/NamespaceEnrollment';
 import WaypointDetail from './components/waypoints/Detail';
 import WaypointList from './components/waypoints/List';
 import { kmeshRouteNames, kmeshRoutePaths } from './utils/kmeshRoutes';
@@ -136,3 +141,6 @@ registerRoute({
   exact: true,
   component: () => <ObservabilityPanel />,
 });
+
+// Register Namespace Enrollment section in the details view
+registerDetailsViewSection(NamespaceEnrollment);


### PR DESCRIPTION
## Description
Currently, users working with Kmesh have to switch back and forth between Headlamp and CLI tools to inspect if namespaces are enrolled in the mesh, or to check the status of their L7 waypoints. This PR introduces lightweight visual indicators directly into the Headlamp UI to provide immediate visibility of Kmesh resources alongside standard Kubernetes resources, significantly improving the operator experience.

## Changes Implemented

This PR splits the enhancements into two distinct commits for clarity:

### 1. Namespace Enrollment Status
*   **Added `NamespaceEnrollment.tsx` component**: Checks the `istio.io/dataplane-mode` and `istio.io/use-waypoint` labels on K8s Namespace resources.
*   **Detail View Integration**: Dynamically injected a new "Kmesh Enrollment" section into Headlamp's standard Namespace detail view using the `registerDetailsViewSection` API. 
*   **Visual Badges**: Displays a 🟢 Green "Kmesh" badge if the namespace is enrolled, or a grey "Not Enrolled" badge otherwise. It also surfaces the assigned waypoint name.

### 2. Waypoint Observability (Status & Events)
*   **Status Conditions Table**: Extended `src/components/waypoints/Detail.tsx` to parse the Gateway API `status.conditions` array for Waypoints. Displays the status using color-coded Headlamp `<StatusLabel>` badges (Success/Warning/Error).
*   **Date Fallback Fix**: Implemented logic to gracefully handle uninitialized `lastTransitionTime` values (which Kmesh/Kubernetes sometimes reports as UNIX epoch `1970-01-01T00:00:00Z`).
*   **Kubernetes Events Integration**: Integrated Headlamp's native `<ObjectEventList />` component into the Waypoint detail view to instantly surface any relevant cluster events (e.g., provisioning failures, IP assignments) directly tied to the waypoint resource.

## How to Test
1. Make sure you are running Headlamp with the Kmesh plugin locally.
2. Label a namespace in your cluster: `kubectl label ns default istio.io/dataplane-mode=Kmesh istio.io/use-waypoint=kmesh-waypoint`.
3. Open the Headlamp UI, navigate to **Cluster -> Namespaces**, and click on the `default` namespace. Scroll down to verify the new "Kmesh Enrollment" section.
4. Navigate to the **KMesh -> Waypoints** section and click on any waypoint. Verify that the "Conditions" table and "Events" table render correctly below the main info section.
