### PR TITLE
cluster-api: Fix kubeconfig DOMException on cluster connect

### DIFF
--- a/cluster-api/src/components/actions/index.tsx
+++ b/cluster-api/src/components/actions/index.tsx
@@ -50,9 +50,10 @@ export function getErrorMessage(error: unknown): string {
  * Connect a Cluster to Headlamp using its kubeconfig Secret.
  *
  * Contract: secret.jsonData.data.value is a base64-encoded kubeconfig YAML
- * (standard Kubernetes Secret encoding). We decode it via TextDecoder so that
- * binary cert bytes in the base64 payload do not cause atob() to throw
- * InvalidCharacterError.
+ * (standard Kubernetes Secret encoding), and Headlamp.setCluster() also
+ * expects the kubeconfig as base64 (see ClusterRequest.kubeconfig and
+ * KubeConfigLoader's own `encodeBase64(yaml.dump(...))` call in Headlamp
+ * core), so it is passed through unchanged.
  */
 async function connectClusterToHeadlamp(
   resource: Cluster,
@@ -96,10 +97,7 @@ async function connectClusterToHeadlamp(
     loadingRef.current = true;
     enqueueSnackbar('Connecting to cluster...', { variant: 'info' });
 
-    const bytes = Uint8Array.from(atob(kubeconfigBase64), c => c.charCodeAt(0));
-    const kubeconfig = new TextDecoder('utf-8').decode(bytes);
-
-    await Headlamp.setCluster({ kubeconfig });
+    await Headlamp.setCluster({ kubeconfig: kubeconfigBase64 });
     enqueueSnackbar('Cluster connected successfully', { variant: 'success' });
   } catch (error) {
     enqueueSnackbar(`Failed to connect: ${getErrorMessage(error)}`, { variant: 'error' });


### PR DESCRIPTION
## What broke

Using "Connect Cluster" on a CAPI workload cluster in in-cluster mode throws an uncaught `DOMException: String contains an invalid character` and leaves the app unusable until the cache is cleared. Reported in #894.

## Root cause

`connectClusterToHeadlamp()` in `cluster-api/src/components/actions/index.tsx` decodes the kubeconfig Secret's base64 value to raw YAML, then passes that raw YAML to `Headlamp.setCluster()`. But `setCluster`'s `kubeconfig` field is base64-encoded — see:

- `ClusterRequest.kubeconfig`: `/** KubeConfig (base64 encoded)*/`
- Headlamp core's own `KubeConfigLoader.tsx`, which calls `setCluster({ kubeconfig: encodeBase64(yaml.dump(selectedClusterConfig)) })`

So the raw YAML gets stored in IndexedDB and later handed to code that expects base64, which throws when it hits non-base64 characters.

## Fix

Drop the decode step and pass the Secret's base64 value straight through to `setCluster()`, matching how the rest of Headlamp core produces that field.

## Testing

Ran locally in the `cluster-api` plugin directory:
- `tsc --noEmit`: clean
- `eslint --max-warnings 0`: clean
- `vitest run`: passing
- `headlamp-plugin build`: succeeds

Fixes #894