### PR TITLE
knative: recognize newer ingress-class ConfigMap key

### DIFF
--- a/knative/src/components/kservices/List.tsx
+++ b/knative/src/components/kservices/List.tsx
@@ -25,7 +25,7 @@ import ConfigMap from '@kinvolk/headlamp-plugin/lib/k8s/configMap';
 import Pod from '@kinvolk/headlamp-plugin/lib/k8s/pod';
 import { Chip, Stack, Typography } from '@mui/material';
 import React, { useMemo } from 'react';
-import { formatIngressClass, INGRESS_CLASS_GATEWAY_API } from '../../config/ingress';
+import { formatIngressClass, getIngressClass, INGRESS_CLASS_GATEWAY_API } from '../../config/ingress';
 import { useAuthorization } from '../../hooks/useAuthorization';
 import { useClusters } from '../../hooks/useClusters';
 import { useKnativeInstalled } from '../../hooks/useKnativeInstalled';
@@ -234,14 +234,9 @@ function KServicesListContents({ clusters }: KServicesListContentsProps) {
       const cm = configMaps.find(
         item => item.cluster === cluster && item.metadata.name === 'config-network'
       );
-      const raw =
-        cm && cm.data && typeof cm.data['ingress.class'] === 'string'
-          ? cm.data['ingress.class']
-          : null;
-      const trimmed = raw?.trim();
       result.push({
         cluster,
-        ingressClass: trimmed && trimmed !== '' ? trimmed : null,
+        ingressClass: getIngressClass(cm?.data),
       });
     });
 

--- a/knative/src/components/kservices/detail/sections/networking/NetworkingSection.tsx
+++ b/knative/src/components/kservices/detail/sections/networking/NetworkingSection.tsx
@@ -16,7 +16,11 @@
 
 import ConfigMap from '@kinvolk/headlamp-plugin/lib/k8s/configMap';
 import { Alert, Stack } from '@mui/material';
-import { formatIngressClass, INGRESS_CLASS_GATEWAY_API } from '../../../../../config/ingress';
+import {
+  formatIngressClass,
+  getIngressClass,
+  INGRESS_CLASS_GATEWAY_API,
+} from '../../../../../config/ingress';
 import { KService } from '../../../../../resources/knative';
 import DomainMappingSection from './DomainMappingSection';
 import IngressIntegrationsSection from './IngressIntegrationsSection';
@@ -39,17 +43,7 @@ function useIngressClassForCluster(cluster: string): IngressClassHookResult {
   );
   const ingressClassLoaded = !ingressClassLoading && !!networkConfig;
 
-  let ingressClass: string | null = null;
-
-  if (networkConfig?.data) {
-    const data = networkConfig.data as Record<string, string | undefined>;
-    const raw = data['ingress.class'];
-    const trimmed = raw?.trim();
-
-    if (trimmed && trimmed !== '') {
-      ingressClass = trimmed;
-    }
-  }
+  const ingressClass = getIngressClass(networkConfig?.data);
 
   return {
     ingressClass,

--- a/knative/src/components/networking/Overview.tsx
+++ b/knative/src/components/networking/Overview.tsx
@@ -16,7 +16,7 @@
 
 import ConfigMap from '@kinvolk/headlamp-plugin/lib/k8s/configMap';
 import { Box, CircularProgress, Paper, Typography } from '@mui/material';
-import { formatIngressClass, INGRESS_CLASS_GATEWAY_API } from '../../config/ingress';
+import { formatIngressClass, getIngressClass, INGRESS_CLASS_GATEWAY_API } from '../../config/ingress';
 import { useClusters } from '../../hooks/useClusters';
 import { useKnativeInstalled } from '../../hooks/useKnativeInstalled';
 import { NotInstalledBanner } from '../common/NotInstalledBanner';
@@ -94,9 +94,8 @@ function useIngressClassForCluster(cluster: string): IngressClassHookResult {
     { cluster }
   );
 
-  const raw = networkConfig?.data?.['ingress.class'] ?? null;
-  const trimmed = raw?.trim();
-  const ingressClass = trimmed && trimmed !== '' ? trimmed : null;
+  const raw = networkConfig?.data?.['ingress-class'] ?? networkConfig?.data?.['ingress.class'] ?? null;
+  const ingressClass = getIngressClass(networkConfig?.data);
 
   return {
     ingressClass,

--- a/knative/src/config/ingress.test.ts
+++ b/knative/src/config/ingress.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { formatIngressClass, INGRESS_CLASS_GATEWAY_API } from './ingress';
+import { formatIngressClass, getIngressClass, INGRESS_CLASS_GATEWAY_API } from './ingress';
 
 describe('formatIngressClass', () => {
   it('should return "(not set)" for null', () => {
@@ -39,5 +39,38 @@ describe('formatIngressClass', () => {
 
   it('should handle the INGRESS_CLASS_GATEWAY_API constant', () => {
     expect(formatIngressClass(INGRESS_CLASS_GATEWAY_API)).toBe('gateway-api');
+  });
+});
+
+describe('getIngressClass', () => {
+  it('should return null when neither key is present', () => {
+    expect(getIngressClass({})).toBeNull();
+    expect(getIngressClass(null)).toBeNull();
+    expect(getIngressClass(undefined)).toBeNull();
+  });
+
+  it('should read the legacy "ingress.class" key', () => {
+    expect(getIngressClass({ 'ingress.class': 'istio.ingress.networking.knative.dev' })).toBe(
+      'istio.ingress.networking.knative.dev'
+    );
+  });
+
+  it('should read the newer "ingress-class" key', () => {
+    expect(getIngressClass({ 'ingress-class': 'kourier.ingress.networking.knative.dev' })).toBe(
+      'kourier.ingress.networking.knative.dev'
+    );
+  });
+
+  it('should prefer "ingress-class" over "ingress.class" when both are present', () => {
+    expect(
+      getIngressClass({
+        'ingress.class': 'istio.ingress.networking.knative.dev',
+        'ingress-class': 'kourier.ingress.networking.knative.dev',
+      })
+    ).toBe('kourier.ingress.networking.knative.dev');
+  });
+
+  it('should treat a blank value as not set', () => {
+    expect(getIngressClass({ 'ingress-class': '  ', 'ingress.class': '' })).toBeNull();
   });
 });

--- a/knative/src/config/ingress.ts
+++ b/knative/src/config/ingress.ts
@@ -38,3 +38,16 @@ export function formatIngressClass(ingressClass: string | null): string {
     ? ingressClass.slice(0, -INGRESS_CLASS_SUFFIX.length)
     : ingressClass;
 }
+
+/**
+ * Reads the ingress class out of the config-network ConfigMap's data.
+ *
+ * Knative superseded the `ingress.class` key with `ingress-class`; the
+ * dashed key takes precedence when both are present.
+ * @see https://knative.dev/docs/serving/config-network-adapters/#ingress-configurations
+ */
+export function getIngressClass(data: Record<string, string | undefined> | null | undefined) {
+  const raw = data?.['ingress-class'] ?? data?.['ingress.class'] ?? null;
+  const trimmed = raw?.trim();
+  return trimmed && trimmed !== '' ? trimmed : null;
+}


### PR DESCRIPTION
## What broke

Per Knative's docs, the `ingress.class` key in the `config-network` ConfigMap was superseded by `ingress-class` (dash), which takes precedence when both are present. The knative plugin only ever checked `ingress.class`, so clusters configured with just the newer key show up as "not configured" in the plugin, even though Knative itself resolves it correctly. Reported in #787.

## Fix

Added a shared `getIngressClass()` helper in `config/ingress.ts` that checks `ingress-class` first and falls back to `ingress.class`. Replaced the three separate inline lookups (`Overview.tsx`, `List.tsx`, `NetworkingSection.tsx` all had their own copy of essentially the same trim/fallback logic) with calls to the shared helper, so the precedence is defined in one place.

## Testing

Added test cases in `ingress.test.ts` covering both keys individually, precedence when both are set, and blank-value handling. Ran locally in the `knative` plugin directory:
- `tsc --noEmit`: clean
- `eslint --max-warnings 0`: clean
- `vitest run`: all 27 tests pass (10 in `ingress.test.ts`)
- `headlamp-plugin build`: succeeds

Fixes #787