### PR TITLE
kyverno: Probe kyverno.io/v2 independently of legacy v1

### DIFF
--- a/kyverno/src/hooks/useKyvernoCRDs.test.ts
+++ b/kyverno/src/hooks/useKyvernoCRDs.test.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ApiProxy } from '@kinvolk/headlamp-plugin/lib';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { probeCluster } from './useKyvernoCRDs';
+
+vi.mock('@kinvolk/headlamp-plugin/lib', () => ({
+  ApiProxy: {
+    request: vi.fn(),
+  },
+}));
+
+function mockApiGroups(available: string[]) {
+  vi.mocked(ApiProxy.request).mockImplementation((path: string) => {
+    if (available.includes(path)) {
+      return Promise.resolve({});
+    }
+    return Promise.reject(new Error('not found'));
+  });
+}
+
+describe('probeCluster', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('detects cleanup/exceptions/v2 reports when kyverno.io/v2 is present, even without legacy v1', async () => {
+    // A CEL-only Kyverno install: clusterpolicies/policies (v1) disabled,
+    // but cleanuppolicies/policyexceptions (v2) still enabled — a supported
+    // configuration per Kyverno's own Helm chart CRD toggles.
+    mockApiGroups(['/apis/policies.kyverno.io/v1', '/apis/kyverno.io/v2']);
+    const status = await probeCluster('cel-only-cluster');
+
+    expect(status.legacy).toBe(false);
+    expect(status.cel).toBe(true);
+    expect(status.cleanup).toBe(true);
+    expect(status.exceptions).toBe(true);
+    expect(status.kyvernoV2Reports).toBe(true);
+  });
+
+  it('reports everything false when no API group is installed', async () => {
+    mockApiGroups([]);
+    const status = await probeCluster('no-kyverno-cluster');
+
+    expect(status.legacy).toBe(false);
+    expect(status.cel).toBe(false);
+    expect(status.cleanup).toBe(false);
+    expect(status.exceptions).toBe(false);
+    expect(status.kyvernoV2Reports).toBe(false);
+    expect(status.reports).toBe(false);
+    expect(status.ephemeralReports).toBe(false);
+  });
+
+  it('detects a stock install with both legacy and v2 present', async () => {
+    mockApiGroups([
+      '/apis/kyverno.io/v1',
+      '/apis/wgpolicyk8s.io/v1alpha2',
+      '/apis/reports.kyverno.io/v1',
+      '/apis/kyverno.io/v2',
+    ]);
+    const status = await probeCluster('stock-cluster');
+
+    expect(status.legacy).toBe(true);
+    expect(status.reports).toBe(true);
+    expect(status.ephemeralReports).toBe(true);
+    expect(status.cleanup).toBe(true);
+    expect(status.exceptions).toBe(true);
+    expect(status.kyvernoV2Reports).toBe(true);
+  });
+});

--- a/kyverno/src/hooks/useKyvernoCRDs.ts
+++ b/kyverno/src/hooks/useKyvernoCRDs.ts
@@ -59,32 +59,29 @@ function notify(cluster: string, status: KyvernoCRDStatus) {
   listeners.get(cluster)?.forEach(fn => fn(status));
 }
 
-async function probeCluster(cluster: string): Promise<KyvernoCRDStatus> {
+// Exported for unit testing — kept SDK-free (just the ApiProxy calls) so
+// probing logic can be verified without mounting the hook.
+export async function probeCluster(cluster: string): Promise<KyvernoCRDStatus> {
   const existing = inFlight.get(cluster);
   if (existing) return existing;
 
   const promise = (async () => {
-    const [legacy, cel, reports, ephemeralReports] = await Promise.all([
+    const [legacy, cel, reports, ephemeralReports, v2] = await Promise.all([
       checkAPIGroup('/apis/kyverno.io/v1'),
       checkAPIGroup('/apis/policies.kyverno.io/v1'),
       checkAPIGroup('/apis/wgpolicyk8s.io/v1alpha2'),
       checkAPIGroup('/apis/reports.kyverno.io/v1'),
+      checkAPIGroup('/apis/kyverno.io/v2'),
     ]);
 
     // kyverno.io/v2 hosts cleanup, exceptions, and admission/background scan reports.
     // The API-group-level probe doesn't tell us *which* CRDs are inside, so we treat
-    // all v2 features as available together, matching what stock Kyverno installs.
-    let cleanup = false;
-    let exceptions = false;
-    let kyvernoV2Reports = false;
-    if (legacy) {
-      const v2 = await checkAPIGroup('/apis/kyverno.io/v2');
-      if (v2) {
-        cleanup = true;
-        exceptions = true;
-        kyvernoV2Reports = true;
-      }
-    }
+    // all v2 features as available together. This is probed independently of `legacy`:
+    // Kyverno's Helm chart lets cleanuppolicies/policyexceptions be enabled while
+    // clusterpolicies/policies (v1) are disabled, e.g. a CEL-only install.
+    const cleanup = v2;
+    const exceptions = v2;
+    const kyvernoV2Reports = v2;
 
     const status: KyvernoCRDStatus = {
       legacy,


### PR DESCRIPTION
## What broke

`useKyvernoCRDs` only checks whether `kyverno.io/v2` (CleanupPolicy, PolicyException, admission/background-scan reports) is available when `kyverno.io/v1` (legacy ClusterPolicy/Policy) is also present:

```ts
if (legacy) {
  const v2 = await checkAPIGroup('/apis/kyverno.io/v2');
  ...
}
```

Kyverno's own Helm chart (`charts/kyverno/charts/crds/values.yaml`) toggles `clusterpolicies`/`policies` (v1) and `cleanuppolicies`/`policyexceptions` (v2) as independent flags, so a CEL-only install (`clusterpolicies: false`, `policies: false`) can still have cleanup policies and exceptions enabled. On that kind of cluster, `CRDGuard` (`requires="cleanup"` / `"exceptions"` / `"kyvernoV2Reports"`) always shows "not detected on this cluster" for those pages, even though the CRDs are genuinely installed, because the v2 probe never runs.

Filed as #950.

## Fix

Probe `kyverno.io/v2` in the same `Promise.all` as the other API groups instead of gating it behind `legacy`.

## Testing

Added `useKyvernoCRDs.test.ts` (none existed before) covering:
- CEL-only + v2 present → cleanup/exceptions/kyvernoV2Reports all `true` (the regression case — confirmed this fails against the old code with `cleanup: false`)
- nothing installed → everything `false`
- stock install (v1 + v2 both present) → everything `true`

Ran locally in the `kyverno` plugin directory:
- `tsc --noEmit`: clean
- `eslint --max-warnings 0`: clean
- `vitest run`: all 8 tests pass
- `headlamp-plugin build`: succeeds

Fixes #950