### PR TITLE
plugin-catalog: add Install/Update buttons on plugin cards

### DIFF
--- a/plugin-catalog/src/components/plugins/Detail.tsx
+++ b/plugin-catalog/src/components/plugins/Detail.tsx
@@ -20,10 +20,11 @@ import {
   Typography,
 } from '@mui/material';
 import Markdown from 'markdown-to-jsx';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router';
 import semver from 'semver';
 import LoadingButton from './LoadingButton';
+import { pollPluginManagerStatus } from './pluginManagerAction';
 
 const { createRouteURL } = Router;
 
@@ -392,45 +393,55 @@ export function PluginDetail() {
   const [selectedVersion, setSelectedVersion] = useState<string>('');
   // Tracks the most recent version-readme request so out-of-order responses are ignored.
   const latestReadmeRequest = React.useRef<string>('');
+  const currentActionRef = useRef(currentAction);
+  currentActionRef.current = currentAction;
+  const pluginDetailRef = useRef(pluginDetail);
+  pluginDetailRef.current = pluginDetail;
   const url = `https://artifacthub.io/packages/headlamp/${repoName}/${pluginName}`;
   const { t } = useTranslation();
 
   const fetchStatus = async () => {
     try {
-      let status = await PluginManager.getStatus(identifier);
+      const actionAtStart = currentActionRef.current;
+      const status = await pollPluginManagerStatus(identifier, {
+        isCancelled: () => false,
+        shouldContinue: () => !!currentActionRef.current,
+        onStatus: nextStatus => {
+          if (nextStatus.type === 'error' || nextStatus.type === 'success') {
+            return;
+          }
+          // @todo: PluginManager ProgressResp doesn't have a percentage.
+          setCurrentActionState(nextStatus.type);
+          setCurrentActionMessage(nextStatus.message ?? null);
+        },
+      });
+
+      if (!status) {
+        return;
+      }
+
       if (status.type === 'error' && status.message === 'No such operation in progress') {
         setCurrentActionState(null);
         setCurrentActionProgress(0);
         setCurrentAction(null);
         return;
       }
-      while (status && currentAction) {
-        if (status.type === 'error' || status.type === 'success') {
-          const enrichedPluginData = await checkIfPluginIsInstalled(pluginDetail!);
+
+      if (status.type === 'error' || status.type === 'success') {
+        if (pluginDetailRef.current) {
+          const enrichedPluginData = await checkIfPluginIsInstalled(pluginDetailRef.current);
           setPluginDetail(enrichedPluginData);
-          setCurrentActionState(null);
-          setCurrentActionMessage(null);
-          setCurrentActionProgress(0);
-          setCurrentAction(null);
-
-          // Set alert message
-          setAlertMessage(
-            status.type === 'success'
-              ? t('{{action}} completed successfully.', { action: t(currentAction ?? '') })
-              : t('Error: {{message}}', { message: status.message })
-          );
-
-          break;
         }
-        // @todo: PluginManager ProgressResp doesn't have a percentage.
-        // if (status.percentage !== undefined) {
-        //   setCurrentActionProgress(status.percentage);
-        // }
-        setCurrentActionState(status.type);
-        setCurrentActionMessage(status.message);
+        setCurrentActionState(null);
+        setCurrentActionMessage(null);
+        setCurrentActionProgress(0);
+        setCurrentAction(null);
 
-        await new Promise(resolve => setTimeout(resolve, 1000));
-        status = await PluginManager.getStatus(identifier);
+        setAlertMessage(
+          status.type === 'success'
+            ? t('{{action}} completed successfully.', { action: t(actionAtStart ?? '') })
+            : t('Error: {{message}}', { message: status.message })
+        );
       }
     } catch (error) {
       setCurrentActionState(null);

--- a/plugin-catalog/src/components/plugins/List.tsx
+++ b/plugin-catalog/src/components/plugins/List.tsx
@@ -50,6 +50,8 @@ export interface PluginPackage {
   };
   isInstalled?: boolean;
   isUpdateAvailable?: boolean;
+  /** Headlamp PluginManager display name when installed (for Update without re-listing). */
+  installedPluginName?: string;
 }
 
 async function fetchPlugins(offset: number, org?: string) {
@@ -128,12 +130,19 @@ async function processPlugins() {
   } catch (err) {
     console.log('plugin-catalog: Failed to list plugins', err);
   }
-  const installedVersions: Record<string, string> = pluginData.reduce((acc, plugin) => {
-    if (plugin.folderName && plugin.artifacthubVersion) {
-      acc[plugin.folderName] = plugin.artifacthubVersion;
-    }
-    return acc;
-  }, {});
+  const installedByFolder: Record<string, { version: string; pluginName: string }> =
+    pluginData.reduce(
+      (acc, plugin) => {
+        if (plugin.folderName && plugin.artifacthubVersion) {
+          acc[plugin.folderName] = {
+            version: plugin.artifacthubVersion,
+            pluginName: plugin.pluginName || plugin.folderName,
+          };
+        }
+        return acc;
+      },
+      {} as Record<string, { version: string; pluginName: string }>
+    );
 
   // Merge all plugins and org-specific plugins, removing duplicates
   const mergedPlugins = [...allPlugins, ...orgPlugins];
@@ -143,14 +152,16 @@ async function processPlugins() {
 
   const pluginsWithInstallStatus = uniquePlugins
     .map((pkg: PluginPackage) => {
-      const installedVersion = installedVersions[pkg.name];
+      const installed = installedByFolder[pkg.name];
       let isInstalled = false;
       let isUpdateAvailable = false;
+      let installedPluginName: string | undefined;
 
-      if (installedVersion) {
+      if (installed) {
         isInstalled = true;
-        if (semver.valid(pkg.version) && semver.valid(installedVersion)) {
-          isUpdateAvailable = semver.gt(pkg.version, installedVersion);
+        installedPluginName = installed.pluginName;
+        if (semver.valid(pkg.version) && semver.valid(installed.version)) {
+          isUpdateAvailable = semver.gt(pkg.version, installed.version);
         }
       }
 
@@ -158,6 +169,7 @@ async function processPlugins() {
         ...pkg,
         isInstalled,
         isUpdateAvailable,
+        installedPluginName,
       };
     })
     // Reorder so plugins with logos show first.

--- a/plugin-catalog/src/components/plugins/List.tsx
+++ b/plugin-catalog/src/components/plugins/List.tsx
@@ -131,18 +131,15 @@ async function processPlugins() {
     console.log('plugin-catalog: Failed to list plugins', err);
   }
   const installedByFolder: Record<string, { version: string; pluginName: string }> =
-    pluginData.reduce(
-      (acc, plugin) => {
-        if (plugin.folderName && plugin.artifacthubVersion) {
-          acc[plugin.folderName] = {
-            version: plugin.artifacthubVersion,
-            pluginName: plugin.pluginName || plugin.folderName,
-          };
-        }
-        return acc;
-      },
-      {} as Record<string, { version: string; pluginName: string }>
-    );
+    pluginData.reduce((acc, plugin) => {
+      if (plugin.folderName && plugin.artifacthubVersion) {
+        acc[plugin.folderName] = {
+          version: plugin.artifacthubVersion,
+          pluginName: plugin.pluginName || plugin.folderName,
+        };
+      }
+      return acc;
+    }, {} as Record<string, { version: string; pluginName: string }>);
 
   // Merge all plugins and org-specific plugins, removing duplicates
   const mergedPlugins = [...allPlugins, ...orgPlugins];

--- a/plugin-catalog/src/components/plugins/PluginCard.stories.tsx
+++ b/plugin-catalog/src/components/plugins/PluginCard.stories.tsx
@@ -54,6 +54,8 @@ Default.args = {
   signed: false,
   production_organizations_count: 0,
   ts: 1708839350,
+  isInstalled: false,
+  isUpdateAvailable: false,
   repository: {
     url: 'https://github.com/yolossn/headlamp-plugins',
     kind: 21,
@@ -84,4 +86,24 @@ NoOfficialOrVerified.args = {
     official: false,
     verified_publisher: false,
   },
+};
+
+export const NotInstalled = Template.bind({});
+NotInstalled.args = {
+  ...Default.args,
+  isInstalled: false,
+};
+
+export const Installed = Template.bind({});
+Installed.args = {
+  ...Default.args,
+  isInstalled: true,
+  isUpdateAvailable: false,
+};
+
+export const UpdateAvailable = Template.bind({});
+UpdateAvailable.args = {
+  ...Default.args,
+  isInstalled: true,
+  isUpdateAvailable: true,
 };

--- a/plugin-catalog/src/components/plugins/PluginCard.test.tsx
+++ b/plugin-catalog/src/components/plugins/PluginCard.test.tsx
@@ -31,7 +31,7 @@ vi.mock('@kinvolk/headlamp-plugin/lib', () => ({
 }));
 
 vi.mock('@kinvolk/headlamp-plugin/lib/CommonComponents', () => ({
-  Link: ({ children }: { children: React.ReactNode }) => <a href="#">{children}</a>,
+  Link: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
 }));
 
 vi.mock('./plugin-icon.svg', () => ({

--- a/plugin-catalog/src/components/plugins/PluginCard.test.tsx
+++ b/plugin-catalog/src/components/plugins/PluginCard.test.tsx
@@ -1,0 +1,130 @@
+import { PluginManager } from '@kinvolk/headlamp-plugin/lib';
+import { configureStore } from '@reduxjs/toolkit';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { Provider } from 'react-redux';
+import { BrowserRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { PluginPackage } from './List';
+import { PluginCard } from './PluginCard';
+
+vi.mock('@kinvolk/headlamp-plugin/lib', () => ({
+  PluginManager: {
+    install: vi.fn(),
+    update: vi.fn(),
+    cancel: vi.fn(),
+    getStatus: vi.fn(async () => ({ type: 'success', message: 'ok' })),
+    list: vi.fn(),
+  },
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, string>) => {
+      if (!params) {
+        return key;
+      }
+      return Object.entries(params).reduce(
+        (msg, [name, value]) => msg.replace(`{{${name}}}`, value),
+        key
+      );
+    },
+  }),
+}));
+
+vi.mock('@kinvolk/headlamp-plugin/lib/CommonComponents', () => ({
+  Link: ({ children }: { children: React.ReactNode }) => <a href="#">{children}</a>,
+}));
+
+vi.mock('./plugin-icon.svg', () => ({
+  default: () => <svg data-testid="plugin-icon" />,
+}));
+
+const store = configureStore({
+  reducer: (state = { drawerMode: { isDetailDrawerEnabled: false } }) => state,
+});
+
+function renderCard(plugin: PluginPackage) {
+  return render(
+    <Provider store={store}>
+      <BrowserRouter>
+        <PluginCard plugin={plugin} />
+      </BrowserRouter>
+    </Provider>
+  );
+}
+
+const basePlugin: PluginPackage = {
+  package_id: 'pkg-1',
+  name: 'sample_plugin',
+  normalized_name: 'sample_plugin',
+  logo_image_id: '',
+  stars: 0,
+  display_name: 'Sample Plugin',
+  description: 'A sample plugin for tests',
+  version: '1.0.0',
+  deprecated: false,
+  has_values_schema: false,
+  signed: false,
+  production_organizations_count: 0,
+  ts: 0,
+  official: false,
+  repository: {
+    url: 'https://example.com',
+    kind: 21,
+    name: 'headlamp',
+    official: false,
+    user_alias: '',
+    display_name: 'Headlamp',
+    repository_id: 'repo-1',
+    scanner_disabled: false,
+    verified_publisher: false,
+  },
+};
+
+describe('PluginCard install/update actions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('Install button calls PluginManager.install', async () => {
+    const user = userEvent.setup();
+    renderCard({ ...basePlugin, isInstalled: false });
+
+    await user.click(screen.getByRole('button', { name: 'Install' }));
+
+    expect(PluginManager.install).toHaveBeenCalledWith(
+      'headlamp_sample_plugin',
+      'Sample Plugin',
+      'https://artifacthub.io/packages/headlamp/headlamp/sample_plugin'
+    );
+  });
+
+  test('Update button uses installedPluginName without listing plugins', async () => {
+    const user = userEvent.setup();
+    renderCard({
+      ...basePlugin,
+      isInstalled: true,
+      isUpdateAvailable: true,
+      installedPluginName: 'Sample Plugin Installed',
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Update' }));
+
+    expect(PluginManager.list).not.toHaveBeenCalled();
+    expect(PluginManager.update).toHaveBeenCalledWith(
+      'headlamp_sample_plugin',
+      'Sample Plugin Installed'
+    );
+  });
+
+  test('in-progress action shows an accessible Cancel control', async () => {
+    const user = userEvent.setup();
+    vi.mocked(PluginManager.getStatus).mockImplementation(
+      () => new Promise(() => undefined) as Promise<{ type: string; message?: string }>
+    );
+
+    renderCard({ ...basePlugin, isInstalled: false });
+    await user.click(screen.getByRole('button', { name: 'Install' }));
+
+    expect(await screen.findByRole('button', { name: 'Cancel' })).toBeTruthy();
+  });
+});

--- a/plugin-catalog/src/components/plugins/PluginCard.test.tsx
+++ b/plugin-catalog/src/components/plugins/PluginCard.test.tsx
@@ -119,7 +119,7 @@ describe('PluginCard install/update actions', () => {
   test('in-progress action shows an accessible Cancel control', async () => {
     const user = userEvent.setup();
     vi.mocked(PluginManager.getStatus).mockImplementation(
-      () => new Promise(() => undefined) as Promise<{ type: string; message?: string }>
+      () => new Promise(() => undefined) as ReturnType<typeof PluginManager.getStatus>
     );
 
     renderCard({ ...basePlugin, isInstalled: false });

--- a/plugin-catalog/src/components/plugins/PluginCard.tsx
+++ b/plugin-catalog/src/components/plugins/PluginCard.tsx
@@ -18,6 +18,7 @@ import {
 import React, { useEffect, useState } from 'react';
 import { PluginPackage } from './List';
 import PluginIcon from './plugin-icon.svg';
+import { pollPluginManagerStatus } from './pluginManagerAction';
 
 export interface PluginCardProps {
   plugin: PluginPackage;
@@ -69,23 +70,27 @@ export function PluginCard(props: PluginCardProps) {
       }
 
       try {
-        let status = await PluginManager.getStatus(identifier);
-        while (!cancelled && status && currentAction) {
-          if (status.type === 'error' && status.message === 'No such operation in progress') {
-            setCurrentAction(null);
-            return;
-          }
-          if (status.type === 'error' || status.type === 'success') {
-            setCurrentAction(null);
-            setAlertMessage(
-              status.type === 'success'
-                ? t('{{action}} completed successfully.', { action: t(currentAction) })
-                : t('Error: {{message}}', { message: status.message })
-            );
-            return;
-          }
-          await new Promise(resolve => setTimeout(resolve, 1000));
-          status = await PluginManager.getStatus(identifier);
+        const status = await pollPluginManagerStatus(identifier, {
+          isCancelled: () => cancelled,
+          shouldContinue: () => !!currentAction,
+        });
+
+        if (cancelled || !status) {
+          return;
+        }
+
+        if (status.type === 'error' && status.message === 'No such operation in progress') {
+          setCurrentAction(null);
+          return;
+        }
+
+        if (status.type === 'error' || status.type === 'success') {
+          setCurrentAction(null);
+          setAlertMessage(
+            status.type === 'success'
+              ? t('{{action}} completed successfully.', { action: t(currentAction) })
+              : t('Error: {{message}}', { message: status.message })
+          );
         }
       } catch (error) {
         if (!cancelled) {
@@ -109,18 +114,15 @@ export function PluginCard(props: PluginCardProps) {
     PluginManager.install(identifier, plugin.display_name || plugin.name, artifactHubURL);
   };
 
-  const handleUpdate = async (event: React.MouseEvent) => {
+  const handleUpdate = (event: React.MouseEvent) => {
     event.preventDefault();
     event.stopPropagation();
     setCurrentAction('Update');
-    try {
-      const data = (await PluginManager.list()) as { folderName?: string; pluginName?: string }[];
-      const installed = data.find(p => p.folderName === plugin.name);
-      PluginManager.update(identifier, installed?.pluginName || plugin.name);
-    } catch (error) {
-      setCurrentAction(null);
-      setAlertMessage(t('An unexpected error occurred: {{error}}', { error: String(error) }));
-    }
+    // Prefer the name from List's install scan so we do not call PluginManager.list() again.
+    PluginManager.update(
+      identifier,
+      plugin.installedPluginName || plugin.display_name || plugin.name
+    );
   };
 
   const handleCancel = (event: React.MouseEvent) => {
@@ -133,8 +135,14 @@ export function PluginCard(props: PluginCardProps) {
   let actionContent: React.ReactNode;
   if (currentAction) {
     actionContent = (
-      <Button variant="contained" onClick={handleCancel} sx={actionButtonSx} size="small">
-        <CircularProgress color="inherit" size={18} />
+      <Button
+        variant="contained"
+        onClick={handleCancel}
+        sx={actionButtonSx}
+        size="small"
+        aria-label={t('Cancel')}
+      >
+        <CircularProgress color="inherit" size={18} aria-hidden />
       </Button>
     );
   } else if (!plugin.isInstalled) {
@@ -176,6 +184,8 @@ export function PluginCard(props: PluginCardProps) {
       />
       <Card
         sx={{
+          display: 'flex',
+          flexDirection: 'column',
           height: '100%',
         }}
       >
@@ -237,6 +247,7 @@ export function PluginCard(props: PluginCardProps) {
             paddingTop: 0,
             paddingBottom: 0,
             marginBottom: 0,
+            flex: 1,
           }}
         >
           <Box
@@ -331,6 +342,7 @@ export function PluginCard(props: PluginCardProps) {
         <CardActions
           sx={{
             justifyContent: 'flex-end',
+            marginTop: 'auto',
             padding: '14px',
           }}
         >

--- a/plugin-catalog/src/components/plugins/PluginCard.tsx
+++ b/plugin-catalog/src/components/plugins/PluginCard.tsx
@@ -1,17 +1,21 @@
 import { Icon, InlineIcon } from '@iconify/react';
-import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
+import { PluginManager, useTranslation } from '@kinvolk/headlamp-plugin/lib';
 import { Link as HeadlampRouterLink } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 import {
   Box,
+  Button,
   Card,
   CardActions,
   CardContent,
   CardMedia,
+  CircularProgress,
   Divider,
   Link,
+  Snackbar,
   Tooltip,
   Typography,
 } from '@mui/material';
+import React, { useEffect, useState } from 'react';
 import { PluginPackage } from './List';
 import PluginIcon from './plugin-icon.svg';
 
@@ -19,12 +23,157 @@ export interface PluginCardProps {
   plugin: PluginPackage;
 }
 
+function pluginSnackbarAction(closeCallback: () => void, t: (key: string) => string) {
+  return (
+    <>
+      <Button
+        color="inherit"
+        onClick={() => {
+          window.location.reload();
+        }}
+      >
+        {t('Reload Now')}
+      </Button>
+      <Button color="inherit" onClick={closeCallback}>
+        {t('Close')}
+      </Button>
+    </>
+  );
+}
+
+const actionButtonSx = {
+  backgroundColor: '#000',
+  color: 'white',
+  textTransform: 'none' as const,
+  '&:hover': {
+    color: 'inherit',
+  },
+};
+
 export function PluginCard(props: PluginCardProps) {
   const { plugin } = props;
   const { t } = useTranslation();
+  const [currentAction, setCurrentAction] = useState<'Install' | 'Update' | null>(null);
+  const [alertMessage, setAlertMessage] = useState<string | null>(null);
+
+  const repoName = plugin.repository?.name || '';
+  const identifier = `${repoName}_${plugin.name}`;
+  const artifactHubURL = `https://artifacthub.io/packages/headlamp/${repoName}/${plugin.name}`;
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function pollStatus() {
+      if (!currentAction) {
+        return;
+      }
+
+      try {
+        let status = await PluginManager.getStatus(identifier);
+        while (!cancelled && status && currentAction) {
+          if (status.type === 'error' && status.message === 'No such operation in progress') {
+            setCurrentAction(null);
+            return;
+          }
+          if (status.type === 'error' || status.type === 'success') {
+            setCurrentAction(null);
+            setAlertMessage(
+              status.type === 'success'
+                ? t('{{action}} completed successfully.', { action: t(currentAction) })
+                : t('Error: {{message}}', { message: status.message })
+            );
+            return;
+          }
+          await new Promise(resolve => setTimeout(resolve, 1000));
+          status = await PluginManager.getStatus(identifier);
+        }
+      } catch (error) {
+        if (!cancelled) {
+          setCurrentAction(null);
+          setAlertMessage(t('An unexpected error occurred: {{error}}', { error: String(error) }));
+        }
+      }
+    }
+
+    pollStatus();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [currentAction, identifier, t]);
+
+  const handleInstall = (event: React.MouseEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+    setCurrentAction('Install');
+    PluginManager.install(identifier, plugin.display_name || plugin.name, artifactHubURL);
+  };
+
+  const handleUpdate = async (event: React.MouseEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+    setCurrentAction('Update');
+    try {
+      const data = (await PluginManager.list()) as { folderName?: string; pluginName?: string }[];
+      const installed = data.find(p => p.folderName === plugin.name);
+      PluginManager.update(identifier, installed?.pluginName || plugin.name);
+    } catch (error) {
+      setCurrentAction(null);
+      setAlertMessage(t('An unexpected error occurred: {{error}}', { error: String(error) }));
+    }
+  };
+
+  const handleCancel = (event: React.MouseEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+    PluginManager.cancel(identifier);
+    setCurrentAction(null);
+  };
+
+  let actionContent: React.ReactNode;
+  if (currentAction) {
+    actionContent = (
+      <Button variant="contained" onClick={handleCancel} sx={actionButtonSx} size="small">
+        <CircularProgress color="inherit" size={18} />
+      </Button>
+    );
+  } else if (!plugin.isInstalled) {
+    actionContent = (
+      <Button variant="contained" onClick={handleInstall} sx={actionButtonSx} size="small">
+        {t('Install')}
+      </Button>
+    );
+  } else if (plugin.isUpdateAvailable) {
+    actionContent = (
+      <Button variant="contained" onClick={handleUpdate} sx={actionButtonSx} size="small">
+        {t('Update')}
+      </Button>
+    );
+  } else {
+    actionContent = <Typography>{t('Installed')}</Typography>;
+  }
 
   return (
     <Box maxWidth="30%" width="400px" m={1}>
+      <Snackbar
+        sx={{
+          '& .MuiSnackbarContent-root': {
+            backgroundColor: 'rgb(49, 49, 49)',
+            color: '#fff',
+          },
+        }}
+        open={!!alertMessage}
+        onClose={() => setAlertMessage(null)}
+        message={
+          <Tooltip title={alertMessage || ''} arrow>
+            <Typography>
+              {alertMessage ? alertMessage.substring(0, Math.min(50, alertMessage.length)) : null}
+            </Typography>
+          </Tooltip>
+        }
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        action={pluginSnackbarAction(() => setAlertMessage(null), t)}
+      />
       <Card
         sx={{
           height: '100%',
@@ -181,16 +330,11 @@ export function PluginCard(props: PluginCardProps) {
         </CardContent>
         <CardActions
           sx={{
-            justifyContent: 'space-between',
+            justifyContent: 'flex-end',
             padding: '14px',
           }}
         >
-          <span></span>
-          {plugin.isInstalled && (
-            <Typography>
-              {plugin.isUpdateAvailable ? t('Update available') : t('Installed')}
-            </Typography>
-          )}
+          {actionContent}
         </CardActions>
       </Card>
     </Box>

--- a/plugin-catalog/src/components/plugins/__snapshots__/PluginCard.stories.storyshot
+++ b/plugin-catalog/src/components/plugins/__snapshots__/PluginCard.stories.storyshot
@@ -91,15 +91,18 @@ exports[`Storyshots PluginCard Default 1`] = `
       </div>
       <div
         class="MuiCardActions-root MuiCardActions-spacing css-dnrpxu-MuiCardActions-root"
-        style="justify-content: space-between; padding: 14px;"
+        style="justify-content: flex-end; padding: 14px;"
       >
-        <a
-          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-srrjpp-MuiTypography-root-MuiLink-root"
-          href="https://github.com/yolossn/headlamp-plugins"
-          target="_blank"
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorPrimary css-1ph1nd0-MuiButtonBase-root-MuiButton-root"
+          tabindex="0"
+          type="button"
         >
-          Learn More
-        </a>
+          Install
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
       </div>
     </div>
   </div>
@@ -203,15 +206,18 @@ exports[`Storyshots PluginCard Long Description 1`] = `
       </div>
       <div
         class="MuiCardActions-root MuiCardActions-spacing css-dnrpxu-MuiCardActions-root"
-        style="justify-content: space-between; padding: 14px;"
+        style="justify-content: flex-end; padding: 14px;"
       >
-        <a
-          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-srrjpp-MuiTypography-root-MuiLink-root"
-          href="https://github.com/yolossn/headlamp-plugins"
-          target="_blank"
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorPrimary css-1ph1nd0-MuiButtonBase-root-MuiButton-root"
+          tabindex="0"
+          type="button"
         >
-          Learn More
-        </a>
+          Install
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
       </div>
     </div>
   </div>
@@ -306,15 +312,340 @@ exports[`Storyshots PluginCard No Official Or Verified 1`] = `
       </div>
       <div
         class="MuiCardActions-root MuiCardActions-spacing css-dnrpxu-MuiCardActions-root"
-        style="justify-content: space-between; padding: 14px;"
+        style="justify-content: flex-end; padding: 14px;"
       >
-        <a
-          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-srrjpp-MuiTypography-root-MuiLink-root"
-          href="https://github.com/yolossn/headlamp-plugins"
-          target="_blank"
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorPrimary css-1ph1nd0-MuiButtonBase-root-MuiButton-root"
+          tabindex="0"
+          type="button"
         >
-          Learn More
-        </a>
+          Install
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots PluginCard Not Installed 1`] = `
+<div>
+  <div
+    class="MuiBox-root css-z0sk23"
+  >
+    <div
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-bhp9pd-MuiPaper-root-MuiCard-root"
+    >
+      <div
+        class="MuiBox-root css-1iuu6zq"
+        heigh="60px"
+      >
+        <img
+          class="MuiCardMedia-root MuiCardMedia-media MuiCardMedia-img css-o69gx8-MuiCardMedia-root"
+          src="https://artifacthub.io/image/9efd017f-25e8-4c7f-a80f-e920dc1dd4ac"
+          style="width: 60px; margin: 1rem; align-self: flex-start;"
+        />
+        <div
+          class="MuiBox-root css-q5lf8z"
+        >
+          <span />
+          <span />
+        </div>
+      </div>
+      <div
+        class="MuiCardContent-root css-46bh2p-MuiCardContent-root"
+        style="margin: 1rem 0rem; height: 15vh; overflow: hidden; padding-top: 0px;"
+      >
+        <div
+          class="MuiBox-root css-0"
+          style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap;"
+        >
+          <span
+            aria-label="App catalog Headlamp Plugin Test"
+            class=""
+            data-mui-internal-clone-element="true"
+          />
+          <h5
+            class="MuiTypography-root MuiTypography-h5 css-xqgeko-MuiTypography-root"
+          >
+            <a
+              class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-srrjpp-MuiTypography-root-MuiLink-root"
+              href="/"
+            >
+              App catalog Headlamp Plugin Test
+            </a>
+          </h5>
+        </div>
+        <div
+          class="MuiBox-root css-1pup0r6"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+          >
+            v
+            0.0.3
+          </p>
+          <div
+            class="MuiBox-root css-1isemmb"
+            style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap;"
+          >
+            <p
+              aria-label="test-123"
+              class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+              data-mui-internal-clone-element="true"
+            >
+              test-123
+            </p>
+          </div>
+        </div>
+        <hr
+          class="MuiDivider-root MuiDivider-fullWidth css-9mgopn-MuiDivider-root"
+        />
+        <div
+          class="MuiBox-root css-164r41r"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+          >
+            <span
+              aria-label="App catalog plugin for Headlamp"
+              class=""
+              data-mui-internal-clone-element="true"
+            >
+              App catalog plugin for Headlamp
+            </span>
+          </p>
+        </div>
+      </div>
+      <div
+        class="MuiCardActions-root MuiCardActions-spacing css-dnrpxu-MuiCardActions-root"
+        style="justify-content: flex-end; padding: 14px;"
+      >
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorPrimary css-1ph1nd0-MuiButtonBase-root-MuiButton-root"
+          tabindex="0"
+          type="button"
+        >
+          Install
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots PluginCard Installed 1`] = `
+<div>
+  <div
+    class="MuiBox-root css-z0sk23"
+  >
+    <div
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-bhp9pd-MuiPaper-root-MuiCard-root"
+    >
+      <div
+        class="MuiBox-root css-1iuu6zq"
+        heigh="60px"
+      >
+        <img
+          class="MuiCardMedia-root MuiCardMedia-media MuiCardMedia-img css-o69gx8-MuiCardMedia-root"
+          src="https://artifacthub.io/image/9efd017f-25e8-4c7f-a80f-e920dc1dd4ac"
+          style="width: 60px; margin: 1rem; align-self: flex-start;"
+        />
+        <div
+          class="MuiBox-root css-q5lf8z"
+        >
+          <span />
+          <span />
+        </div>
+      </div>
+      <div
+        class="MuiCardContent-root css-46bh2p-MuiCardContent-root"
+        style="margin: 1rem 0rem; height: 15vh; overflow: hidden; padding-top: 0px;"
+      >
+        <div
+          class="MuiBox-root css-0"
+          style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap;"
+        >
+          <span
+            aria-label="App catalog Headlamp Plugin Test"
+            class=""
+            data-mui-internal-clone-element="true"
+          />
+          <h5
+            class="MuiTypography-root MuiTypography-h5 css-xqgeko-MuiTypography-root"
+          >
+            <a
+              class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-srrjpp-MuiTypography-root-MuiLink-root"
+              href="/"
+            >
+              App catalog Headlamp Plugin Test
+            </a>
+          </h5>
+        </div>
+        <div
+          class="MuiBox-root css-1pup0r6"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+          >
+            v
+            0.0.3
+          </p>
+          <div
+            class="MuiBox-root css-1isemmb"
+            style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap;"
+          >
+            <p
+              aria-label="test-123"
+              class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+              data-mui-internal-clone-element="true"
+            >
+              test-123
+            </p>
+          </div>
+        </div>
+        <hr
+          class="MuiDivider-root MuiDivider-fullWidth css-9mgopn-MuiDivider-root"
+        />
+        <div
+          class="MuiBox-root css-164r41r"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+          >
+            <span
+              aria-label="App catalog plugin for Headlamp"
+              class=""
+              data-mui-internal-clone-element="true"
+            >
+              App catalog plugin for Headlamp
+            </span>
+          </p>
+        </div>
+      </div>
+      <div
+        class="MuiCardActions-root MuiCardActions-spacing css-dnrpxu-MuiCardActions-root"
+        style="justify-content: flex-end; padding: 14px;"
+      >
+        <p
+          class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+        >
+          Installed
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots PluginCard Update Available 1`] = `
+<div>
+  <div
+    class="MuiBox-root css-z0sk23"
+  >
+    <div
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-bhp9pd-MuiPaper-root-MuiCard-root"
+    >
+      <div
+        class="MuiBox-root css-1iuu6zq"
+        heigh="60px"
+      >
+        <img
+          class="MuiCardMedia-root MuiCardMedia-media MuiCardMedia-img css-o69gx8-MuiCardMedia-root"
+          src="https://artifacthub.io/image/9efd017f-25e8-4c7f-a80f-e920dc1dd4ac"
+          style="width: 60px; margin: 1rem; align-self: flex-start;"
+        />
+        <div
+          class="MuiBox-root css-q5lf8z"
+        >
+          <span />
+          <span />
+        </div>
+      </div>
+      <div
+        class="MuiCardContent-root css-46bh2p-MuiCardContent-root"
+        style="margin: 1rem 0rem; height: 15vh; overflow: hidden; padding-top: 0px;"
+      >
+        <div
+          class="MuiBox-root css-0"
+          style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap;"
+        >
+          <span
+            aria-label="App catalog Headlamp Plugin Test"
+            class=""
+            data-mui-internal-clone-element="true"
+          />
+          <h5
+            class="MuiTypography-root MuiTypography-h5 css-xqgeko-MuiTypography-root"
+          >
+            <a
+              class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-srrjpp-MuiTypography-root-MuiLink-root"
+              href="/"
+            >
+              App catalog Headlamp Plugin Test
+            </a>
+          </h5>
+        </div>
+        <div
+          class="MuiBox-root css-1pup0r6"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+          >
+            v
+            0.0.3
+          </p>
+          <div
+            class="MuiBox-root css-1isemmb"
+            style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap;"
+          >
+            <p
+              aria-label="test-123"
+              class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+              data-mui-internal-clone-element="true"
+            >
+              test-123
+            </p>
+          </div>
+        </div>
+        <hr
+          class="MuiDivider-root MuiDivider-fullWidth css-9mgopn-MuiDivider-root"
+        />
+        <div
+          class="MuiBox-root css-164r41r"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+          >
+            <span
+              aria-label="App catalog plugin for Headlamp"
+              class=""
+              data-mui-internal-clone-element="true"
+            >
+              App catalog plugin for Headlamp
+            </span>
+          </p>
+        </div>
+      </div>
+      <div
+        class="MuiCardActions-root MuiCardActions-spacing css-dnrpxu-MuiCardActions-root"
+        style="justify-content: flex-end; padding: 14px;"
+      >
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorPrimary css-1ph1nd0-MuiButtonBase-root-MuiButton-root"
+          tabindex="0"
+          type="button"
+        >
+          Update
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
       </div>
     </div>
   </div>

--- a/plugin-catalog/src/components/plugins/pluginManagerAction.test.ts
+++ b/plugin-catalog/src/components/plugins/pluginManagerAction.test.ts
@@ -1,0 +1,31 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { pollPluginManagerStatus } from './pluginManagerAction';
+
+const getStatus = vi.fn();
+
+vi.mock('@kinvolk/headlamp-plugin/lib', () => ({
+  PluginManager: {
+    getStatus: (...args: unknown[]) => getStatus(...args),
+  },
+}));
+
+describe('pollPluginManagerStatus', () => {
+  beforeEach(() => {
+    getStatus.mockReset();
+  });
+
+  test('returns success when the operation completes', async () => {
+    getStatus
+      .mockResolvedValueOnce({ type: 'in-progress', message: 'working' })
+      .mockResolvedValueOnce({ type: 'success', message: 'done' });
+
+    const status = await pollPluginManagerStatus('repo_plugin', {
+      isCancelled: () => false,
+      shouldContinue: () => true,
+      intervalMs: 1,
+    });
+
+    expect(status).toEqual({ type: 'success', message: 'done' });
+    expect(getStatus).toHaveBeenCalledTimes(2);
+  });
+});

--- a/plugin-catalog/src/components/plugins/pluginManagerAction.ts
+++ b/plugin-catalog/src/components/plugins/pluginManagerAction.ts
@@ -1,0 +1,39 @@
+import { PluginManager } from '@kinvolk/headlamp-plugin/lib';
+
+/** Status payload returned by PluginManager.getStatus while an action runs. */
+export type PluginManagerStatus = {
+  type: string;
+  message?: string;
+};
+
+/**
+ * Polls PluginManager until the operation finishes, errors, or is cancelled.
+ * Shared by PluginCard and Detail.
+ */
+export async function pollPluginManagerStatus(
+  identifier: string,
+  options: {
+    isCancelled: () => boolean;
+    shouldContinue: () => boolean;
+    intervalMs?: number;
+    onStatus?: (status: PluginManagerStatus) => void;
+  }
+): Promise<PluginManagerStatus | null> {
+  const intervalMs = options.intervalMs ?? 1000;
+  let status = (await PluginManager.getStatus(identifier)) as PluginManagerStatus | null;
+
+  while (!options.isCancelled() && options.shouldContinue() && status) {
+    options.onStatus?.(status);
+
+    if (status.type === 'error' && status.message === 'No such operation in progress') {
+      return status;
+    }
+    if (status.type === 'error' || status.type === 'success') {
+      return status;
+    }
+    await new Promise(resolve => setTimeout(resolve, intervalMs));
+    status = (await PluginManager.getStatus(identifier)) as PluginManagerStatus | null;
+  }
+
+  return null;
+}


### PR DESCRIPTION
Fixes #142
## Summary
- Add **Install** / **Update** buttons on Plugin Catalog cards so users can install or upgrade without opening the detail page
- Reuses the existing `PluginManager` install/update + confirm/reload flow from the detail view
- Fixes #142

## Test plan
- [ ] Run `npm start` in `plugin-catalog` and load it in desktop Headlamp
- [ ] Uninstalled plugin card shows **Install** → confirm → install succeeds → reload → card shows **Installed**
- [ ] Installed plugin with a newer version shows **Update** and updates successfully
- [ ] Up-to-date installed plugin shows **Installed** (no button)
- [ ] Storybook: PluginCard NotInstalled / Installed / UpdateAvailable

<img width="1867" height="502" alt="image" src="https://github.com/user-attachments/assets/0dff8a18-8ca0-461b-ba24-fec4bf57d8d2" />
<img width="1885" height="872" alt="image" src="https://github.com/user-attachments/assets/aa3b3677-d728-4682-aa11-47fbadc4f1ea" />
