### PR TITLE
Fix HelmChart source links

### DIFF
--- a/flux/src/sources/SourceList.tsx
+++ b/flux/src/sources/SourceList.tsx
@@ -126,15 +126,17 @@ function FluxSource(props: FluxSourceCustomResourceRendererProps) {
         if (sourceName) {
           return (
             <Link
-              routeName={'source'}
-              params={{
-                namespace: item.jsonData.metadata.namespace,
-                pluralName: PluralName(item.jsonData.spec.sourceRef.kind),
-                name: sourceName,
-              }}
-            >
-              {sourceName}
-            </Link>
+            routeName={'source'}
+            params={{
+              namespace:
+                item.jsonData.spec.sourceRef.namespace ??
+                item.jsonData.metadata.namespace,
+              pluralName: PluralName(item.jsonData.spec.sourceRef.kind),
+              name: sourceName,
+            }}
+          >
+            {sourceName}
+          </Link>
           );
         }
         return '-';

--- a/flux/src/sources/SourceList.tsx
+++ b/flux/src/sources/SourceList.tsx
@@ -15,6 +15,7 @@ import {
 } from '../common/Resources';
 import Table, { TableProps } from '../common/Table';
 import { useNamespaces } from '../helpers';
+import { PluralName } from '../helpers/pluralName';
 
 export function FluxSources() {
   const { t } = useTranslation();
@@ -128,7 +129,7 @@ function FluxSource(props: FluxSourceCustomResourceRendererProps) {
               routeName={'source'}
               params={{
                 namespace: item.jsonData.metadata.namespace,
-                pluralName: item.jsonData.spec.sourceRef.kind,
+                pluralName: PluralName(item.jsonData.spec.sourceRef.kind),
                 name: sourceName,
               }}
             >


### PR DESCRIPTION
  #Summary

This fixes the source link generated for HelmChart resources.

The link was using sourceRef.kind directly, while the route expects the plural resource name. This caused navigation to fail for resources such as GitRepository.

This change uses the existing PluralName() helper to generate the correct route name before creating the link.

  #Testing
Built the plugin successfully with npx headlamp-plugin build.
Verified that the project builds without errors.
