### PR TITLE
Fix cross-namespace HelmChart source links

### DIFF
--- a/flux/src/sources/SourceList.tsx
+++ b/flux/src/sources/SourceList.tsx
@@ -127,7 +127,9 @@ function FluxSource(props: FluxSourceCustomResourceRendererProps) {
             <Link
               routeName={'source'}
               params={{
-                namespace: item.jsonData.metadata.namespace,
+                namespace: 
+                item.jsonData.spec.sourceRef.namespace ??
+                item.jsonData.metadata.namespace,
                 pluralName: item.jsonData.spec.sourceRef.kind,
                 name: sourceName,
               }}


### PR DESCRIPTION
## Summary

This fixes source links for HelmChart resources that reference a source in a different namespace.

The link was always using the HelmChart namespace, even when spec.sourceRef.namespace was set. As a result, clicking the source link could navigate to the wrong resource.

This change uses spec.sourceRef.namespace when available and falls back to the HelmChart namespace otherwise.

## Testing

- Built the plugin successfully with npx headlamp-plugin build.
- Verified that the project builds without errors.