### PR TITLE
Fix kustomization inventory refresh on navigation

### DIFF
--- a/flux/src/kustomizations/Inventory.tsx
+++ b/flux/src/kustomizations/Inventory.tsx
@@ -35,8 +35,18 @@ export function GetResourcesFromInventory(
 ) {
   const [resources, setResources] = React.useState<KubeObject[]>([]);
   const { t } = useTranslation();
+  const inventoryKey = React.useMemo(
+    () => props.inventory?.map(e => `${e.id}_${e.v}`).join(',') ?? '',
+    [props.inventory]
+  );
 
   React.useEffect(() => {
+    let cancelled = false;
+    setResources([]);
+
+    if (!props.inventory?.length) {
+      return;
+    }
     props.inventory?.forEach(item => {
       const parsedID = parseID(item.id);
       const { name, namespace, group, kind } = parsedID;
@@ -54,6 +64,9 @@ export function GetResourcesFromInventory(
 
       resourceClass.apiGet(
         data => {
+          if (cancelled) {
+            return;
+          }
           // add the resource if it does not exist yet, compare with uid.
           setResources(prevResources => {
             if (prevResources.find(r => r.metadata.uid === data.metadata.uid)) {
@@ -65,6 +78,9 @@ export function GetResourcesFromInventory(
         name,
         namespace,
         () /* on error */ => {
+          if (cancelled) {
+            return;
+          }
           const resource = { metadata: { name: name, namespace: namespace } };
           setResources(prevResources => {
             return [...prevResources, resource as KubeObject];
@@ -72,7 +88,10 @@ export function GetResourcesFromInventory(
         }
       )();
     });
-  }, []);
+    return () => {
+      cancelled = true;
+    };
+  }, [inventoryKey]);
 
   return (
     <Table


### PR DESCRIPTION
## Summary

Fixes an issue where the inventory list was not refreshed when navigating between different Kustomization detail pages.

### What changed

 *Re-fetch inventory resources when the inventory entries change.
* Clear previously loaded resources before fetching the new inventory.
 *Guard asynchronous callbacks to avoid updating state after the effect has been cleaned up.
*Use a stable inventory key to avoid unnecessary refetches caused by array reference changes.

### Testing

- Built the plugin successfully with "npx headlamp-plugin build".
- Verified that navigating between different Kustomizations refreshes the inventory correctly.