### PR TITLE
app-catalog: Add schema-driven form editor for chart values

### DIFF
--- a/app-catalog/locales/cs/translation.json
+++ b/app-catalog/locales/cs/translation.json
@@ -17,6 +17,7 @@
   "Installation request for {{ releaseName }} accepted": "",
   "Error creating release request {{ error }}": "",
   "Error adding repository {{ error }}": "",
+  "Cannot switch to the form view: the YAML contains errors": "",
   "App: {{ name }}": "",
   "Release Name *": "",
   "Enter a name for the release": "",
@@ -25,6 +26,8 @@
   "Versions *": "",
   "Select Version": "",
   "Release Description *": "",
+  "Form View": "",
+  "YAML View": "",
   "Close": "",
   "Installing": "",
   "Search": "",
@@ -51,6 +54,7 @@
   "Powered by ArtifactHub": "",
   "App-Catalog Settings": "",
   "Settings": "",
+  "This chart does not provide a values schema. Use the YAML view to edit values.": "",
   "Failed to delete release {{ name }}{{ message }}": "",
   "Successfully deleted release {{ name }}": "",
   "Uninstall App": "",
@@ -89,5 +93,6 @@
   "Installed": "",
   "Current Version": "",
   "Latest Version": "",
-  "Version": ""
+  "Version": "",
+  "Actions": ""
 }

--- a/app-catalog/locales/de/translation.json
+++ b/app-catalog/locales/de/translation.json
@@ -17,6 +17,7 @@
   "Installation request for {{ releaseName }} accepted": "",
   "Error creating release request {{ error }}": "",
   "Error adding repository {{ error }}": "",
+  "Cannot switch to the form view: the YAML contains errors": "",
   "App: {{ name }}": "",
   "Release Name *": "",
   "Enter a name for the release": "",
@@ -25,6 +26,8 @@
   "Versions *": "",
   "Select Version": "",
   "Release Description *": "",
+  "Form View": "",
+  "YAML View": "",
   "Close": "",
   "Installing": "",
   "Search": "",
@@ -51,6 +54,7 @@
   "Powered by ArtifactHub": "",
   "App-Catalog Settings": "",
   "Settings": "",
+  "This chart does not provide a values schema. Use the YAML view to edit values.": "",
   "Failed to delete release {{ name }}{{ message }}": "",
   "Successfully deleted release {{ name }}": "",
   "Uninstall App": "",
@@ -89,5 +93,6 @@
   "Installed": "",
   "Current Version": "",
   "Latest Version": "",
-  "Version": ""
+  "Version": "",
+  "Actions": ""
 }

--- a/app-catalog/locales/en/translation.json
+++ b/app-catalog/locales/en/translation.json
@@ -17,6 +17,7 @@
   "Installation request for {{ releaseName }} accepted": "Installation request for {{ releaseName }} accepted",
   "Error creating release request {{ error }}": "Error creating release request {{ error }}",
   "Error adding repository {{ error }}": "Error adding repository {{ error }}",
+  "Cannot switch to the form view: the YAML contains errors": "Cannot switch to the form view: the YAML contains errors",
   "App: {{ name }}": "App: {{ name }}",
   "Release Name *": "Release Name *",
   "Enter a name for the release": "Enter a name for the release",
@@ -25,6 +26,8 @@
   "Versions *": "Versions *",
   "Select Version": "Select Version",
   "Release Description *": "Release Description *",
+  "Form View": "Form View",
+  "YAML View": "YAML View",
   "Close": "Close",
   "Installing": "Installing",
   "Search": "Search",
@@ -51,6 +54,7 @@
   "Powered by ArtifactHub": "Powered by ArtifactHub",
   "App-Catalog Settings": "App-Catalog Settings",
   "Settings": "Settings",
+  "This chart does not provide a values schema. Use the YAML view to edit values.": "This chart does not provide a values schema. Use the YAML view to edit values.",
   "Failed to delete release {{ name }}{{ message }}": "Failed to delete release {{ name }}{{ message }}",
   "Successfully deleted release {{ name }}": "Successfully deleted release {{ name }}",
   "Uninstall App": "Uninstall App",
@@ -89,5 +93,6 @@
   "Installed": "Installed",
   "Current Version": "Current Version",
   "Latest Version": "Latest Version",
-  "Version": "Version"
+  "Version": "Version",
+  "Actions": "Actions"
 }

--- a/app-catalog/locales/es/translation.json
+++ b/app-catalog/locales/es/translation.json
@@ -17,6 +17,7 @@
   "Installation request for {{ releaseName }} accepted": "",
   "Error creating release request {{ error }}": "",
   "Error adding repository {{ error }}": "",
+  "Cannot switch to the form view: the YAML contains errors": "",
   "App: {{ name }}": "",
   "Release Name *": "",
   "Enter a name for the release": "",
@@ -25,6 +26,8 @@
   "Versions *": "",
   "Select Version": "",
   "Release Description *": "",
+  "Form View": "",
+  "YAML View": "",
   "Close": "",
   "Installing": "",
   "Search": "",
@@ -51,6 +54,7 @@
   "Powered by ArtifactHub": "",
   "App-Catalog Settings": "",
   "Settings": "",
+  "This chart does not provide a values schema. Use the YAML view to edit values.": "",
   "Failed to delete release {{ name }}{{ message }}": "",
   "Successfully deleted release {{ name }}": "",
   "Uninstall App": "",
@@ -89,5 +93,6 @@
   "Installed": "",
   "Current Version": "",
   "Latest Version": "",
-  "Version": ""
+  "Version": "",
+  "Actions": ""
 }

--- a/app-catalog/locales/fr/translation.json
+++ b/app-catalog/locales/fr/translation.json
@@ -17,6 +17,7 @@
   "Installation request for {{ releaseName }} accepted": "",
   "Error creating release request {{ error }}": "",
   "Error adding repository {{ error }}": "",
+  "Cannot switch to the form view: the YAML contains errors": "",
   "App: {{ name }}": "",
   "Release Name *": "",
   "Enter a name for the release": "",
@@ -25,6 +26,8 @@
   "Versions *": "",
   "Select Version": "",
   "Release Description *": "",
+  "Form View": "",
+  "YAML View": "",
   "Close": "",
   "Installing": "",
   "Search": "",
@@ -51,6 +54,7 @@
   "Powered by ArtifactHub": "",
   "App-Catalog Settings": "",
   "Settings": "",
+  "This chart does not provide a values schema. Use the YAML view to edit values.": "",
   "Failed to delete release {{ name }}{{ message }}": "",
   "Successfully deleted release {{ name }}": "",
   "Uninstall App": "",
@@ -89,5 +93,6 @@
   "Installed": "",
   "Current Version": "",
   "Latest Version": "",
-  "Version": ""
+  "Version": "",
+  "Actions": ""
 }

--- a/app-catalog/locales/hu/translation.json
+++ b/app-catalog/locales/hu/translation.json
@@ -17,6 +17,7 @@
   "Installation request for {{ releaseName }} accepted": "",
   "Error creating release request {{ error }}": "",
   "Error adding repository {{ error }}": "",
+  "Cannot switch to the form view: the YAML contains errors": "",
   "App: {{ name }}": "",
   "Release Name *": "",
   "Enter a name for the release": "",
@@ -25,6 +26,8 @@
   "Versions *": "",
   "Select Version": "",
   "Release Description *": "",
+  "Form View": "",
+  "YAML View": "",
   "Close": "",
   "Installing": "",
   "Search": "",
@@ -51,6 +54,7 @@
   "Powered by ArtifactHub": "",
   "App-Catalog Settings": "",
   "Settings": "",
+  "This chart does not provide a values schema. Use the YAML view to edit values.": "",
   "Failed to delete release {{ name }}{{ message }}": "",
   "Successfully deleted release {{ name }}": "",
   "Uninstall App": "",
@@ -89,5 +93,6 @@
   "Installed": "",
   "Current Version": "",
   "Latest Version": "",
-  "Version": ""
+  "Version": "",
+  "Actions": ""
 }

--- a/app-catalog/locales/id/translation.json
+++ b/app-catalog/locales/id/translation.json
@@ -17,6 +17,7 @@
   "Installation request for {{ releaseName }} accepted": "",
   "Error creating release request {{ error }}": "",
   "Error adding repository {{ error }}": "",
+  "Cannot switch to the form view: the YAML contains errors": "",
   "App: {{ name }}": "",
   "Release Name *": "",
   "Enter a name for the release": "",
@@ -25,6 +26,8 @@
   "Versions *": "",
   "Select Version": "",
   "Release Description *": "",
+  "Form View": "",
+  "YAML View": "",
   "Close": "",
   "Installing": "",
   "Search": "",
@@ -51,6 +54,7 @@
   "Powered by ArtifactHub": "",
   "App-Catalog Settings": "",
   "Settings": "",
+  "This chart does not provide a values schema. Use the YAML view to edit values.": "",
   "Failed to delete release {{ name }}{{ message }}": "",
   "Successfully deleted release {{ name }}": "",
   "Uninstall App": "",
@@ -89,5 +93,6 @@
   "Installed": "",
   "Current Version": "",
   "Latest Version": "",
-  "Version": ""
+  "Version": "",
+  "Actions": ""
 }

--- a/app-catalog/locales/it/translation.json
+++ b/app-catalog/locales/it/translation.json
@@ -17,6 +17,7 @@
   "Installation request for {{ releaseName }} accepted": "",
   "Error creating release request {{ error }}": "",
   "Error adding repository {{ error }}": "",
+  "Cannot switch to the form view: the YAML contains errors": "",
   "App: {{ name }}": "",
   "Release Name *": "",
   "Enter a name for the release": "",
@@ -25,6 +26,8 @@
   "Versions *": "",
   "Select Version": "",
   "Release Description *": "",
+  "Form View": "",
+  "YAML View": "",
   "Close": "",
   "Installing": "",
   "Search": "",
@@ -51,6 +54,7 @@
   "Powered by ArtifactHub": "",
   "App-Catalog Settings": "",
   "Settings": "",
+  "This chart does not provide a values schema. Use the YAML view to edit values.": "",
   "Failed to delete release {{ name }}{{ message }}": "",
   "Successfully deleted release {{ name }}": "",
   "Uninstall App": "",
@@ -89,5 +93,6 @@
   "Installed": "",
   "Current Version": "",
   "Latest Version": "",
-  "Version": ""
+  "Version": "",
+  "Actions": ""
 }

--- a/app-catalog/locales/ja/translation.json
+++ b/app-catalog/locales/ja/translation.json
@@ -17,6 +17,7 @@
   "Installation request for {{ releaseName }} accepted": "",
   "Error creating release request {{ error }}": "",
   "Error adding repository {{ error }}": "",
+  "Cannot switch to the form view: the YAML contains errors": "",
   "App: {{ name }}": "",
   "Release Name *": "",
   "Enter a name for the release": "",
@@ -25,6 +26,8 @@
   "Versions *": "",
   "Select Version": "",
   "Release Description *": "",
+  "Form View": "",
+  "YAML View": "",
   "Close": "",
   "Installing": "",
   "Search": "",
@@ -51,6 +54,7 @@
   "Powered by ArtifactHub": "",
   "App-Catalog Settings": "",
   "Settings": "",
+  "This chart does not provide a values schema. Use the YAML view to edit values.": "",
   "Failed to delete release {{ name }}{{ message }}": "",
   "Successfully deleted release {{ name }}": "",
   "Uninstall App": "",
@@ -89,5 +93,6 @@
   "Installed": "",
   "Current Version": "",
   "Latest Version": "",
-  "Version": ""
+  "Version": "",
+  "Actions": ""
 }

--- a/app-catalog/locales/ko/translation.json
+++ b/app-catalog/locales/ko/translation.json
@@ -17,6 +17,7 @@
   "Installation request for {{ releaseName }} accepted": "",
   "Error creating release request {{ error }}": "",
   "Error adding repository {{ error }}": "",
+  "Cannot switch to the form view: the YAML contains errors": "",
   "App: {{ name }}": "",
   "Release Name *": "",
   "Enter a name for the release": "",
@@ -25,6 +26,8 @@
   "Versions *": "",
   "Select Version": "",
   "Release Description *": "",
+  "Form View": "",
+  "YAML View": "",
   "Close": "",
   "Installing": "",
   "Search": "",
@@ -51,6 +54,7 @@
   "Powered by ArtifactHub": "",
   "App-Catalog Settings": "",
   "Settings": "",
+  "This chart does not provide a values schema. Use the YAML view to edit values.": "",
   "Failed to delete release {{ name }}{{ message }}": "",
   "Successfully deleted release {{ name }}": "",
   "Uninstall App": "",
@@ -89,5 +93,6 @@
   "Installed": "",
   "Current Version": "",
   "Latest Version": "",
-  "Version": ""
+  "Version": "",
+  "Actions": ""
 }

--- a/app-catalog/locales/nl/translation.json
+++ b/app-catalog/locales/nl/translation.json
@@ -17,6 +17,7 @@
   "Installation request for {{ releaseName }} accepted": "",
   "Error creating release request {{ error }}": "",
   "Error adding repository {{ error }}": "",
+  "Cannot switch to the form view: the YAML contains errors": "",
   "App: {{ name }}": "",
   "Release Name *": "",
   "Enter a name for the release": "",
@@ -25,6 +26,8 @@
   "Versions *": "",
   "Select Version": "",
   "Release Description *": "",
+  "Form View": "",
+  "YAML View": "",
   "Close": "",
   "Installing": "",
   "Search": "",
@@ -51,6 +54,7 @@
   "Powered by ArtifactHub": "",
   "App-Catalog Settings": "",
   "Settings": "",
+  "This chart does not provide a values schema. Use the YAML view to edit values.": "",
   "Failed to delete release {{ name }}{{ message }}": "",
   "Successfully deleted release {{ name }}": "",
   "Uninstall App": "",
@@ -89,5 +93,6 @@
   "Installed": "",
   "Current Version": "",
   "Latest Version": "",
-  "Version": ""
+  "Version": "",
+  "Actions": ""
 }

--- a/app-catalog/locales/pl/translation.json
+++ b/app-catalog/locales/pl/translation.json
@@ -17,6 +17,7 @@
   "Installation request for {{ releaseName }} accepted": "",
   "Error creating release request {{ error }}": "",
   "Error adding repository {{ error }}": "",
+  "Cannot switch to the form view: the YAML contains errors": "",
   "App: {{ name }}": "",
   "Release Name *": "",
   "Enter a name for the release": "",
@@ -25,6 +26,8 @@
   "Versions *": "",
   "Select Version": "",
   "Release Description *": "",
+  "Form View": "",
+  "YAML View": "",
   "Close": "",
   "Installing": "",
   "Search": "",
@@ -51,6 +54,7 @@
   "Powered by ArtifactHub": "",
   "App-Catalog Settings": "",
   "Settings": "",
+  "This chart does not provide a values schema. Use the YAML view to edit values.": "",
   "Failed to delete release {{ name }}{{ message }}": "",
   "Successfully deleted release {{ name }}": "",
   "Uninstall App": "",
@@ -89,5 +93,6 @@
   "Installed": "",
   "Current Version": "",
   "Latest Version": "",
-  "Version": ""
+  "Version": "",
+  "Actions": ""
 }

--- a/app-catalog/locales/pt-BR/translation.json
+++ b/app-catalog/locales/pt-BR/translation.json
@@ -17,6 +17,7 @@
   "Installation request for {{ releaseName }} accepted": "",
   "Error creating release request {{ error }}": "",
   "Error adding repository {{ error }}": "",
+  "Cannot switch to the form view: the YAML contains errors": "",
   "App: {{ name }}": "",
   "Release Name *": "",
   "Enter a name for the release": "",
@@ -25,6 +26,8 @@
   "Versions *": "",
   "Select Version": "",
   "Release Description *": "",
+  "Form View": "",
+  "YAML View": "",
   "Close": "",
   "Installing": "",
   "Search": "",
@@ -51,6 +54,7 @@
   "Powered by ArtifactHub": "",
   "App-Catalog Settings": "",
   "Settings": "",
+  "This chart does not provide a values schema. Use the YAML view to edit values.": "",
   "Failed to delete release {{ name }}{{ message }}": "",
   "Successfully deleted release {{ name }}": "",
   "Uninstall App": "",
@@ -89,5 +93,6 @@
   "Installed": "",
   "Current Version": "",
   "Latest Version": "",
-  "Version": ""
+  "Version": "",
+  "Actions": ""
 }

--- a/app-catalog/locales/pt-PT/translation.json
+++ b/app-catalog/locales/pt-PT/translation.json
@@ -17,6 +17,7 @@
   "Installation request for {{ releaseName }} accepted": "",
   "Error creating release request {{ error }}": "",
   "Error adding repository {{ error }}": "",
+  "Cannot switch to the form view: the YAML contains errors": "",
   "App: {{ name }}": "",
   "Release Name *": "",
   "Enter a name for the release": "",
@@ -25,6 +26,8 @@
   "Versions *": "",
   "Select Version": "",
   "Release Description *": "",
+  "Form View": "",
+  "YAML View": "",
   "Close": "",
   "Installing": "",
   "Search": "",
@@ -51,6 +54,7 @@
   "Powered by ArtifactHub": "",
   "App-Catalog Settings": "",
   "Settings": "",
+  "This chart does not provide a values schema. Use the YAML view to edit values.": "",
   "Failed to delete release {{ name }}{{ message }}": "",
   "Successfully deleted release {{ name }}": "",
   "Uninstall App": "",
@@ -89,5 +93,6 @@
   "Installed": "",
   "Current Version": "",
   "Latest Version": "",
-  "Version": ""
+  "Version": "",
+  "Actions": ""
 }

--- a/app-catalog/locales/ru/translation.json
+++ b/app-catalog/locales/ru/translation.json
@@ -17,6 +17,7 @@
   "Installation request for {{ releaseName }} accepted": "",
   "Error creating release request {{ error }}": "",
   "Error adding repository {{ error }}": "",
+  "Cannot switch to the form view: the YAML contains errors": "",
   "App: {{ name }}": "",
   "Release Name *": "",
   "Enter a name for the release": "",
@@ -25,6 +26,8 @@
   "Versions *": "",
   "Select Version": "",
   "Release Description *": "",
+  "Form View": "",
+  "YAML View": "",
   "Close": "",
   "Installing": "",
   "Search": "",
@@ -51,6 +54,7 @@
   "Powered by ArtifactHub": "",
   "App-Catalog Settings": "",
   "Settings": "",
+  "This chart does not provide a values schema. Use the YAML view to edit values.": "",
   "Failed to delete release {{ name }}{{ message }}": "",
   "Successfully deleted release {{ name }}": "",
   "Uninstall App": "",
@@ -89,5 +93,6 @@
   "Installed": "",
   "Current Version": "",
   "Latest Version": "",
-  "Version": ""
+  "Version": "",
+  "Actions": ""
 }

--- a/app-catalog/locales/sv/translation.json
+++ b/app-catalog/locales/sv/translation.json
@@ -17,6 +17,7 @@
   "Installation request for {{ releaseName }} accepted": "",
   "Error creating release request {{ error }}": "",
   "Error adding repository {{ error }}": "",
+  "Cannot switch to the form view: the YAML contains errors": "",
   "App: {{ name }}": "",
   "Release Name *": "",
   "Enter a name for the release": "",
@@ -25,6 +26,8 @@
   "Versions *": "",
   "Select Version": "",
   "Release Description *": "",
+  "Form View": "",
+  "YAML View": "",
   "Close": "",
   "Installing": "",
   "Search": "",
@@ -51,6 +54,7 @@
   "Powered by ArtifactHub": "",
   "App-Catalog Settings": "",
   "Settings": "",
+  "This chart does not provide a values schema. Use the YAML view to edit values.": "",
   "Failed to delete release {{ name }}{{ message }}": "",
   "Successfully deleted release {{ name }}": "",
   "Uninstall App": "",
@@ -89,5 +93,6 @@
   "Installed": "",
   "Current Version": "",
   "Latest Version": "",
-  "Version": ""
+  "Version": "",
+  "Actions": ""
 }

--- a/app-catalog/locales/tr/translation.json
+++ b/app-catalog/locales/tr/translation.json
@@ -17,6 +17,7 @@
   "Installation request for {{ releaseName }} accepted": "",
   "Error creating release request {{ error }}": "",
   "Error adding repository {{ error }}": "",
+  "Cannot switch to the form view: the YAML contains errors": "",
   "App: {{ name }}": "",
   "Release Name *": "",
   "Enter a name for the release": "",
@@ -25,6 +26,8 @@
   "Versions *": "",
   "Select Version": "",
   "Release Description *": "",
+  "Form View": "",
+  "YAML View": "",
   "Close": "",
   "Installing": "",
   "Search": "",
@@ -51,6 +54,7 @@
   "Powered by ArtifactHub": "",
   "App-Catalog Settings": "",
   "Settings": "",
+  "This chart does not provide a values schema. Use the YAML view to edit values.": "",
   "Failed to delete release {{ name }}{{ message }}": "",
   "Successfully deleted release {{ name }}": "",
   "Uninstall App": "",
@@ -89,5 +93,6 @@
   "Installed": "",
   "Current Version": "",
   "Latest Version": "",
-  "Version": ""
+  "Version": "",
+  "Actions": ""
 }

--- a/app-catalog/locales/zh-Hans/translation.json
+++ b/app-catalog/locales/zh-Hans/translation.json
@@ -17,6 +17,7 @@
   "Installation request for {{ releaseName }} accepted": "",
   "Error creating release request {{ error }}": "",
   "Error adding repository {{ error }}": "",
+  "Cannot switch to the form view: the YAML contains errors": "",
   "App: {{ name }}": "",
   "Release Name *": "",
   "Enter a name for the release": "",
@@ -25,6 +26,8 @@
   "Versions *": "",
   "Select Version": "",
   "Release Description *": "",
+  "Form View": "",
+  "YAML View": "",
   "Close": "",
   "Installing": "",
   "Search": "",
@@ -51,6 +54,7 @@
   "Powered by ArtifactHub": "",
   "App-Catalog Settings": "",
   "Settings": "",
+  "This chart does not provide a values schema. Use the YAML view to edit values.": "",
   "Failed to delete release {{ name }}{{ message }}": "",
   "Successfully deleted release {{ name }}": "",
   "Uninstall App": "",
@@ -89,5 +93,6 @@
   "Installed": "",
   "Current Version": "",
   "Latest Version": "",
-  "Version": ""
+  "Version": "",
+  "Actions": ""
 }

--- a/app-catalog/locales/zh-Hant/translation.json
+++ b/app-catalog/locales/zh-Hant/translation.json
@@ -17,6 +17,7 @@
   "Installation request for {{ releaseName }} accepted": "",
   "Error creating release request {{ error }}": "",
   "Error adding repository {{ error }}": "",
+  "Cannot switch to the form view: the YAML contains errors": "",
   "App: {{ name }}": "",
   "Release Name *": "",
   "Enter a name for the release": "",
@@ -25,6 +26,8 @@
   "Versions *": "",
   "Select Version": "",
   "Release Description *": "",
+  "Form View": "",
+  "YAML View": "",
   "Close": "",
   "Installing": "",
   "Search": "",
@@ -51,6 +54,7 @@
   "Powered by ArtifactHub": "",
   "App-Catalog Settings": "",
   "Settings": "",
+  "This chart does not provide a values schema. Use the YAML view to edit values.": "",
   "Failed to delete release {{ name }}{{ message }}": "",
   "Successfully deleted release {{ name }}": "",
   "Uninstall App": "",
@@ -89,5 +93,6 @@
   "Installed": "",
   "Current Version": "",
   "Latest Version": "",
-  "Version": ""
+  "Version": "",
+  "Actions": ""
 }

--- a/app-catalog/src/api/charts.tsx
+++ b/app-catalog/src/api/charts.tsx
@@ -185,6 +185,54 @@ export function fetchChartValues(packageID: string, packageVersion: string) {
 }
 
 /**
+ * Fetches the values schema (values.schema.json) for a specific package and version.
+ *
+ * Not all charts ship a values schema; in that case (or on any fetch/parse error)
+ * this resolves to null so callers can fall back to the plain YAML editor.
+ *
+ * @param packageID - The ID of the package to fetch the values schema for.
+ * @param packageVersion - The version of the package to fetch the values schema for.
+ * @returns A promise that resolves to the parsed JSON Schema object, or null if unavailable.
+ */
+export async function fetchChartValuesSchema(
+  packageID: string,
+  packageVersion: string
+): Promise<Record<string, any> | null> {
+  const chartCfg = getCatalogConfig();
+  try {
+    if (!isElectron()) {
+      // The values schema is only available through the Artifact Hub API.
+      if (chartCfg.chartProfile !== COMMUNITY_REPO) {
+        return null;
+      }
+      const url =
+        `${SERVICE_PROXY}/${chartCfg.catalogNamespace}/${chartCfg.catalogName}?` +
+        getURLSearchParams(`api/v1/packages/${packageID}/${packageVersion}/values-schema`);
+
+      const response = await request(url, { isJSON: false }, true, true, {});
+      const text = await response.text();
+      const schema = JSON.parse(text);
+      return typeof schema === 'object' && schema !== null ? schema : null;
+    }
+
+    // Use /externalproxy for App-catalog desktop version
+    const response = await fetch(`http://localhost:4466/externalproxy`, {
+      headers: {
+        'Forward-To': `https://artifacthub.io/api/v1/packages/${packageID}/${packageVersion}/values-schema`,
+      },
+    });
+    if (!response.ok) {
+      return null;
+    }
+    const schema = await response.json();
+    return typeof schema === 'object' && schema !== null ? schema : null;
+  } catch {
+    // Chart has no values schema, or the response was not valid JSON.
+    return null;
+  }
+}
+
+/**
  * Fetches the chart icon from the Artifact repository based on the provided icon name.
  *
  * @param iconName - The name of the icon to fetch.

--- a/app-catalog/src/components/charts/EditorDialog.tsx
+++ b/app-catalog/src/components/charts/EditorDialog.tsx
@@ -1,17 +1,32 @@
 import { K8s, useTranslation } from '@kinvolk/headlamp-plugin/lib';
 import { Dialog, Loader } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 import Editor from '@monaco-editor/react';
-import { Box, Button, DialogActions, DialogContent, DialogTitle, TextField } from '@mui/material';
+import {
+  Box,
+  Button,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Tab,
+  Tabs,
+  TextField,
+} from '@mui/material';
 import { Autocomplete } from '@mui/material';
 import _ from 'lodash';
 import { useSnackbar } from 'notistack';
 import { useEffect, useState } from 'react';
 import { getCatalogConfig } from '../../api/catalogConfig';
-import { fetchChartDetailFromArtifact, fetchChartValues } from '../../api/charts';
+import {
+  fetchChartDetailFromArtifact,
+  fetchChartValues,
+  fetchChartValuesSchema,
+} from '../../api/charts';
 import { createRelease, getActionStatus } from '../../api/releases';
 import { addRepository } from '../../api/repository';
 import { APP_CATALOG_HELM_REPOSITORY } from '../../constants/catalog';
 import { jsonToYAML, yamlToJSON } from '../../helpers';
+import { flattenSchemaToFields, SchemaFormField } from '../../helpers/valuesSchema';
+import { ValuesForm } from './ValuesForm';
 
 type FieldType = {
   value: string;
@@ -41,6 +56,8 @@ export function EditorDialog(props: {
   const [selectedVersion, setSelectedVersion] = useState<FieldType>();
   const [selectedNamespace, setSelectedNamespace] = useState<FieldType>();
   const [releaseName, setReleaseName] = useState('');
+  const [schemaFields, setSchemaFields] = useState<SchemaFormField[]>([]);
+  const [valuesTab, setValuesTab] = useState<'form' | 'yaml'>('yaml');
   const namespaceNames = namespaces?.map(namespace => ({
     value: namespace.metadata.name,
     title: namespace.metadata.name,
@@ -57,6 +74,22 @@ export function EditorDialog(props: {
       setSelectedNamespace(namespaceNames[0]);
     }
   }, [selectedNamespace, namespaceNames]);
+
+  // Fetch the chart's values schema (if any) and derive the form fields from it.
+  // Charts without a schema simply fall back to the YAML-only editor.
+  function refreshValuesSchema(packageID: string, packageVersion: string) {
+    // The values schema endpoint is only available through the Artifact Hub API,
+    // which identifies packages by their package_id.
+    if (chartCfg.chartProfile === chartProfile) {
+      setSchemaFields([]);
+      return;
+    }
+    fetchChartValuesSchema(packageID, packageVersion).then(schema => {
+      const fields = flattenSchemaToFields(schema);
+      setSchemaFields(fields);
+      setValuesTab(fields.length > 0 ? 'form' : 'yaml');
+    });
+  }
 
   // Fetch chart values for a given package and version (when chart version changed in editor dialog)
   function refreshChartValue(packageID: string, packageVersion: string) {
@@ -76,6 +109,7 @@ export function EditorDialog(props: {
     const packageID = chartCfg.chartProfile === chartProfile ? chart.name : chart.package_id;
     const packageVersion = selectedVersion?.value ?? chart.version;
     setChartValuesLoading(true);
+    refreshValuesSchema(packageID, packageVersion);
     fetchChartValues(packageID, packageVersion)
       .then((response: any) => {
         setChartValuesLoading(false);
@@ -246,6 +280,25 @@ export function EditorDialog(props: {
     }
   }
 
+  // The form view needs the current values as an object. If the YAML in the
+  // editor is invalid (e.g. mid-edit), keep the user on the YAML view.
+  let parsedChartValues: Record<string, any> | null = null;
+  try {
+    parsedChartValues = yamlToJSON(chartValues) as Record<string, any>;
+  } catch {
+    parsedChartValues = null;
+  }
+
+  function handleValuesTabChange(newTab: 'form' | 'yaml') {
+    if (newTab === 'form' && parsedChartValues === null) {
+      enqueueSnackbar(t('Cannot switch to the form view: the YAML contains errors'), {
+        variant: 'warning',
+      });
+      return;
+    }
+    setValuesTab(newTab);
+  }
+
   return (
     <Dialog
       open={openEditor}
@@ -349,25 +402,47 @@ export function EditorDialog(props: {
           {chartValuesLoading ? (
             <Loader title="" />
           ) : (
-            <Editor
-              value={chartValues}
-              onChange={value => {
-                if (!value) {
-                  return;
-                }
-                setChartValues(value);
-              }}
-              onMount={editor => {
-                setInstallLoading(false);
-                editor.focus();
-              }}
-              language="yaml"
-              height="500px"
-              options={{
-                selectOnLineNumbers: true,
-              }}
-              theme={themeName === 'dark' ? 'vs-dark' : 'light'}
-            />
+            <>
+              {schemaFields.length > 0 && (
+                <Tabs
+                  value={valuesTab}
+                  onChange={(event, newTab) => handleValuesTabChange(newTab)}
+                  sx={{ mb: 1 }}
+                >
+                  <Tab label={t('Form View')} value="form" />
+                  <Tab label={t('YAML View')} value="yaml" />
+                </Tabs>
+              )}
+              {valuesTab === 'form' && schemaFields.length > 0 ? (
+                <ValuesForm
+                  fields={schemaFields}
+                  values={parsedChartValues ?? {}}
+                  onValuesChange={newValues => {
+                    setChartValues(jsonToYAML(newValues));
+                  }}
+                />
+              ) : (
+                <Editor
+                  value={chartValues}
+                  onChange={value => {
+                    if (!value) {
+                      return;
+                    }
+                    setChartValues(value);
+                  }}
+                  onMount={editor => {
+                    setInstallLoading(false);
+                    editor.focus();
+                  }}
+                  language="yaml"
+                  height="500px"
+                  options={{
+                    selectOnLineNumbers: true,
+                  }}
+                  theme={themeName === 'dark' ? 'vs-dark' : 'light'}
+                />
+              )}
+            </>
           )}
         </Box>
       </DialogContent>

--- a/app-catalog/src/components/charts/ValuesForm.tsx
+++ b/app-catalog/src/components/charts/ValuesForm.tsx
@@ -1,0 +1,132 @@
+import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
+import {
+  Box,
+  Checkbox,
+  FormControlLabel,
+  MenuItem,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import { getValueAtPath, SchemaFormField, setValueAtPath } from '../../helpers/valuesSchema';
+
+/**
+ * Renders a simple form for a chart's values, driven by the fields extracted
+ * from the chart's values.schema.json. Field edits are propagated back to the
+ * caller as an updated values object so the YAML editor stays in sync.
+ */
+export function ValuesForm(props: {
+  fields: SchemaFormField[];
+  values: Record<string, any>;
+  onValuesChange: (values: Record<string, any>) => void;
+}) {
+  const { fields, values, onValuesChange } = props;
+  const { t } = useTranslation();
+
+  if (fields.length === 0) {
+    return (
+      <Box p={3} textAlign="center">
+        <Typography variant="body1" color="text.secondary">
+          {t('This chart does not provide a values schema. Use the YAML view to edit values.')}
+        </Typography>
+      </Box>
+    );
+  }
+
+  function handleFieldChange(field: SchemaFormField, rawValue: any) {
+    let value: any = rawValue;
+    if (field.type === 'number' || field.type === 'integer') {
+      if (rawValue === '') {
+        // Clearing a numeric field restores the schema/chart default.
+        value = field.defaultValue;
+      } else {
+        const parsed = field.type === 'integer' ? parseInt(rawValue, 10) : parseFloat(rawValue);
+        if (isNaN(parsed)) {
+          return;
+        }
+        value = parsed;
+      }
+    }
+    onValuesChange(setValueAtPath(values, field.path, value));
+  }
+
+  return (
+    <Box
+      sx={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))',
+        gap: 2,
+        p: 2,
+        maxHeight: '500px',
+        overflowY: 'auto',
+      }}
+    >
+      {fields.map(field => {
+        const id = `values-form-${field.path.join('-')}`;
+        const currentValue = getValueAtPath(values, field.path) ?? field.defaultValue;
+        const label = field.path.join('.');
+        const labelWithRequired = field.required ? `${label} *` : label;
+
+        if (field.type === 'boolean') {
+          return (
+            <Tooltip key={id} title={field.description ?? ''}>
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    id={id}
+                    checked={!!currentValue}
+                    onChange={event => handleFieldChange(field, event.target.checked)}
+                  />
+                }
+                label={labelWithRequired}
+              />
+            </Tooltip>
+          );
+        }
+
+        if (field.type === 'enum') {
+          return (
+            <TextField
+              key={id}
+              id={id}
+              select
+              size="small"
+              label={labelWithRequired}
+              helperText={field.description}
+              value={currentValue ?? ''}
+              onChange={event => handleFieldChange(field, event.target.value)}
+            >
+              {(field.enumValues ?? []).map(option => (
+                <MenuItem key={String(option)} value={option}>
+                  {String(option)}
+                </MenuItem>
+              ))}
+            </TextField>
+          );
+        }
+
+        return (
+          <TextField
+            key={id}
+            id={id}
+            size="small"
+            type={field.type === 'string' ? 'text' : 'number'}
+            label={labelWithRequired}
+            helperText={field.description}
+            value={currentValue ?? ''}
+            inputProps={
+              field.type === 'string'
+                ? undefined
+                : {
+                    min: field.minimum,
+                    max: field.maximum,
+                    step: field.type === 'integer' ? 1 : 'any',
+                  }
+            }
+            onChange={event => handleFieldChange(field, event.target.value)}
+          />
+        );
+      })}
+    </Box>
+  );
+}

--- a/app-catalog/src/helpers/valuesSchema.test.ts
+++ b/app-catalog/src/helpers/valuesSchema.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'vitest';
+import { flattenSchemaToFields, getValueAtPath, setValueAtPath } from './valuesSchema';
+
+describe('flattenSchemaToFields', () => {
+  it('returns an empty list for null or invalid schemas', () => {
+    expect(flattenSchemaToFields(null)).toEqual([]);
+    expect(flattenSchemaToFields({} as any)).toEqual([]);
+    expect(flattenSchemaToFields('nope' as any)).toEqual([]);
+  });
+
+  it('extracts primitive fields with metadata', () => {
+    const schema = {
+      type: 'object',
+      required: ['replicaCount'],
+      properties: {
+        replicaCount: {
+          type: 'integer',
+          title: 'Replica Count',
+          description: 'Number of replicas',
+          default: 3,
+          minimum: 1,
+          maximum: 10,
+        },
+        enableTLS: { type: 'boolean', default: false },
+        name: { type: 'string' },
+      },
+    };
+    const fields = flattenSchemaToFields(schema);
+    expect(fields).toHaveLength(3);
+
+    const replicas = fields[0];
+    expect(replicas.path).toEqual(['replicaCount']);
+    expect(replicas.label).toBe('Replica Count');
+    expect(replicas.description).toBe('Number of replicas');
+    expect(replicas.type).toBe('integer');
+    expect(replicas.defaultValue).toBe(3);
+    expect(replicas.required).toBe(true);
+    expect(replicas.minimum).toBe(1);
+    expect(replicas.maximum).toBe(10);
+
+    expect(fields[1]).toMatchObject({ path: ['enableTLS'], type: 'boolean', required: false });
+    expect(fields[2]).toMatchObject({ path: ['name'], label: 'name', type: 'string' });
+  });
+
+  it('recurses into nested objects', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        server: {
+          type: 'object',
+          properties: {
+            image: {
+              type: 'object',
+              properties: {
+                tag: { type: 'string' },
+              },
+            },
+          },
+        },
+      },
+    };
+    const fields = flattenSchemaToFields(schema);
+    expect(fields).toHaveLength(1);
+    expect(fields[0].path).toEqual(['server', 'image', 'tag']);
+  });
+
+  it('recurses into objects without an explicit type when properties exist', () => {
+    const schema = {
+      properties: {
+        server: {
+          properties: {
+            name: { type: 'string' },
+          },
+        },
+      },
+    };
+    const fields = flattenSchemaToFields(schema);
+    expect(fields).toHaveLength(1);
+    expect(fields[0].path).toEqual(['server', 'name']);
+  });
+
+  it('extracts enum fields', () => {
+    const schema = {
+      properties: {
+        pullPolicy: {
+          type: 'string',
+          enum: ['Always', 'IfNotPresent', 'Never'],
+          default: 'IfNotPresent',
+        },
+      },
+    };
+    const fields = flattenSchemaToFields(schema);
+    expect(fields).toHaveLength(1);
+    expect(fields[0].type).toBe('enum');
+    expect(fields[0].enumValues).toEqual(['Always', 'IfNotPresent', 'Never']);
+    expect(fields[0].defaultValue).toBe('IfNotPresent');
+  });
+
+  it('handles nullable union types like ["string", "null"]', () => {
+    const schema = {
+      properties: {
+        priorityClassName: { type: ['string', 'null'] },
+      },
+    };
+    const fields = flattenSchemaToFields(schema);
+    expect(fields).toHaveLength(1);
+    expect(fields[0].type).toBe('string');
+  });
+
+  it('skips arrays and free-form objects', () => {
+    const schema = {
+      properties: {
+        env: { type: 'array' },
+        annotations: { type: 'object' },
+        extra: {},
+      },
+    };
+    expect(flattenSchemaToFields(schema)).toEqual([]);
+  });
+
+  it('caps the number of extracted fields', () => {
+    const properties: Record<string, any> = {};
+    for (let i = 0; i < 500; i++) {
+      properties[`field${i}`] = { type: 'string' };
+    }
+    const fields = flattenSchemaToFields({ properties });
+    expect(fields.length).toBeLessThanOrEqual(200);
+  });
+
+  it('stops recursing past the maximum depth', () => {
+    // Build a schema nested deeper than the depth limit.
+    let leaf: Record<string, any> = { type: 'string' };
+    for (let i = 0; i < 10; i++) {
+      leaf = { type: 'object', properties: { nested: leaf } };
+    }
+    const fields = flattenSchemaToFields({ properties: { root: leaf } });
+    expect(fields).toEqual([]);
+  });
+});
+
+describe('getValueAtPath', () => {
+  it('reads nested values', () => {
+    const values = { server: { image: { tag: 'v1' } } };
+    expect(getValueAtPath(values, ['server', 'image', 'tag'])).toBe('v1');
+  });
+
+  it('returns undefined for missing paths', () => {
+    expect(getValueAtPath({}, ['a', 'b'])).toBeUndefined();
+    expect(getValueAtPath(null, ['a'])).toBeUndefined();
+    expect(getValueAtPath({ a: 'leaf' }, ['a', 'b'])).toBeUndefined();
+  });
+});
+
+describe('setValueAtPath', () => {
+  it('sets nested values without mutating the original', () => {
+    const values = { server: { image: { tag: 'v1' }, name: 'srv' } };
+    const result = setValueAtPath(values, ['server', 'image', 'tag'], 'v2');
+    expect(result.server.image.tag).toBe('v2');
+    expect(result.server.name).toBe('srv');
+    expect(values.server.image.tag).toBe('v1');
+  });
+
+  it('creates intermediate objects as needed', () => {
+    const result = setValueAtPath({}, ['a', 'b', 'c'], 42);
+    expect(result).toEqual({ a: { b: { c: 42 } } });
+  });
+
+  it('replaces non-object intermediates', () => {
+    const result = setValueAtPath({ a: 'scalar' }, ['a', 'b'], 1);
+    expect(result).toEqual({ a: { b: 1 } });
+  });
+
+  it('handles null values object', () => {
+    expect(setValueAtPath(null, ['a'], 1)).toEqual({ a: 1 });
+    expect(setValueAtPath(null, [], 1)).toEqual({});
+  });
+});

--- a/app-catalog/src/helpers/valuesSchema.ts
+++ b/app-catalog/src/helpers/valuesSchema.ts
@@ -1,0 +1,152 @@
+/**
+ * Helpers to turn a Helm chart's values.schema.json (JSON Schema) into a flat
+ * list of primitive form fields that can be rendered as simple form controls.
+ *
+ * Only primitive leaf properties (string, number, integer, boolean and enums)
+ * are extracted; arrays and free-form objects are left to the YAML editor.
+ */
+
+export interface SchemaFormField {
+  /** Property path in the values object, e.g. ['server', 'image', 'tag']. */
+  path: string[];
+  /** Human readable label, from the schema title or the last path segment. */
+  label: string;
+  /** Description from the schema, if any. */
+  description?: string;
+  /** Primitive field type. */
+  type: 'string' | 'number' | 'integer' | 'boolean' | 'enum';
+  /** Allowed values when the property declares an enum. */
+  enumValues?: any[];
+  /** Default value from the schema, if any. */
+  defaultValue?: any;
+  /** Whether the property is listed in the parent's `required` array. */
+  required: boolean;
+  /** Minimum/maximum constraints for numeric fields. */
+  minimum?: number;
+  maximum?: number;
+}
+
+// Guard against pathological or deeply nested schemas.
+const MAX_DEPTH = 6;
+const MAX_FIELDS = 200;
+
+function resolveType(prop: Record<string, any>): string | undefined {
+  // "type" may be a string or an array like ["string", "null"].
+  if (Array.isArray(prop.type)) {
+    return prop.type.find((entry: string) => entry !== 'null');
+  }
+  return prop.type;
+}
+
+/**
+ * Flattens a JSON Schema into a list of primitive form fields.
+ *
+ * @param schema - The parsed values.schema.json object.
+ * @returns The list of extracted fields, in schema order.
+ */
+export function flattenSchemaToFields(schema: Record<string, any> | null): SchemaFormField[] {
+  const fields: SchemaFormField[] = [];
+  if (!schema || typeof schema !== 'object') {
+    return fields;
+  }
+
+  function walk(node: Record<string, any>, path: string[], depth: number) {
+    if (fields.length >= MAX_FIELDS || depth > MAX_DEPTH) {
+      return;
+    }
+    const properties = node?.properties;
+    if (!properties || typeof properties !== 'object') {
+      return;
+    }
+    const required: string[] = Array.isArray(node.required) ? node.required : [];
+
+    for (const [name, rawProp] of Object.entries(properties)) {
+      if (fields.length >= MAX_FIELDS) {
+        return;
+      }
+      const prop = rawProp as Record<string, any>;
+      if (!prop || typeof prop !== 'object') {
+        continue;
+      }
+      const propPath = [...path, name];
+      const type = resolveType(prop);
+
+      if (Array.isArray(prop.enum) && prop.enum.length > 0) {
+        fields.push({
+          path: propPath,
+          label: prop.title || name,
+          description: prop.description,
+          type: 'enum',
+          enumValues: prop.enum,
+          defaultValue: prop.default,
+          required: required.includes(name),
+        });
+      } else if (type === 'string' || type === 'number' || type === 'integer') {
+        fields.push({
+          path: propPath,
+          label: prop.title || name,
+          description: prop.description,
+          type,
+          defaultValue: prop.default,
+          required: required.includes(name),
+          minimum: typeof prop.minimum === 'number' ? prop.minimum : undefined,
+          maximum: typeof prop.maximum === 'number' ? prop.maximum : undefined,
+        });
+      } else if (type === 'boolean') {
+        fields.push({
+          path: propPath,
+          label: prop.title || name,
+          description: prop.description,
+          type: 'boolean',
+          defaultValue: prop.default,
+          required: required.includes(name),
+        });
+      } else if (type === 'object' || (!type && prop.properties)) {
+        walk(prop, propPath, depth + 1);
+      }
+      // Arrays and free-form objects are intentionally skipped; they are
+      // better edited directly in the YAML editor.
+    }
+  }
+
+  walk(schema, [], 0);
+  return fields;
+}
+
+/**
+ * Reads a value at the given path from a nested object.
+ */
+export function getValueAtPath(values: Record<string, any> | null, path: string[]): any {
+  let current: any = values;
+  for (const key of path) {
+    if (current === null || typeof current !== 'object') {
+      return undefined;
+    }
+    current = current[key];
+  }
+  return current;
+}
+
+/**
+ * Returns a copy of `values` with `value` set at the given path, creating
+ * intermediate objects as needed. The original object is not mutated.
+ */
+export function setValueAtPath(
+  values: Record<string, any> | null,
+  path: string[],
+  value: any
+): Record<string, any> {
+  if (path.length === 0) {
+    return values ?? {};
+  }
+  const root: Record<string, any> = { ...(values ?? {}) };
+  let current = root;
+  for (let i = 0; i < path.length - 1; i++) {
+    const key = path[i];
+    const next = current[key];
+    current[key] = next && typeof next === 'object' && !Array.isArray(next) ? { ...next } : {};
+    current = current[key];
+  }
+  current[path[path.length - 1]] = value;
+  return root;
+}


### PR DESCRIPTION
## Summary

Implements the interactive Helm values form editor proposed in #903.

When a chart ships a `values.schema.json`, the install dialog now shows a **Form View** tab alongside the existing **YAML View**:

- Form controls are generated from the JSON Schema: text fields for strings, number inputs (with min/max/step) for numbers/integers, checkboxes for booleans, and select dropdowns for enums.
- Edits in the form are written back to the YAML immediately, so both views stay in sync.
- Switching to the form view is blocked (with a warning snackbar) while the YAML contains parse errors, so no user edits are lost.
- Nested objects are flattened into dotted paths (e.g. `server.image.tag`); arrays and free-form objects are intentionally left to the YAML editor.
- Charts without a schema keep the current YAML-only behavior — no tabs are shown.

## Implementation

- `api/charts.tsx`: new `fetchChartValuesSchema()` using the Artifact Hub `/packages/{id}/{version}/values-schema` endpoint (via `/externalproxy` on desktop, `/serviceproxy` for the in-cluster community-repo profile). Resolves to `null` when the chart has no schema.
- `helpers/valuesSchema.ts`: pure helpers to flatten a JSON Schema into primitive form fields (with depth/field caps for pathological schemas, nullable union type handling) and immutable path get/set utilities.
- `components/charts/ValuesForm.tsx`: renders the form fields.
- `components/charts/EditorDialog.tsx`: fetches the schema alongside chart values, adds the Form/YAML tabs.
- Translation catalogs updated for the new strings.

## Testing

- 15 new unit tests for the schema flattening and path helpers (`vitest`), all passing.
- `tsc`, `eslint`, and `headlamp-plugin build` pass (the only `tsc` error is the pre-existing `react-syntax-highlighter` one in `Details.tsx`, unrelated).
- Verified the values-schema endpoint against a real chart (`prometheus-community/prometheus`).

Fixes #903