### PR TITLE
metal3: Add reboot and detach actions for BareMetalHost

### DIFF
--- a/metal3/src/BareMetalHost/DetachActionButton.tsx
+++ b/metal3/src/BareMetalHost/DetachActionButton.tsx
@@ -23,40 +23,36 @@ import {
   DialogContent,
   DialogContentText,
   DialogTitle,
-  FormControlLabel,
-  Radio,
-  RadioGroup,
 } from '@mui/material';
 import { useState } from 'react';
-import { RebootMode, rebootPatch } from './rebootAction';
+import { detachPatch, getDetachIntent } from './detachAction';
 
 /**
- * Header action that reboots a BareMetalHost.
+ * Header action that detaches or re-attaches a BareMetalHost.
  *
  * Registered against every details view, so it returns null unless the resource is a
- * BareMetalHost. Reboot is imperative: on confirm it writes the reboot annotation, and
- * the operator reboots the host over its BMC and clears the annotation. The dialog lets
- * the user choose a soft or hard reboot, and confirms because it affects physical
- * hardware.
+ * BareMetalHost. Detaching takes the host out of the operator's management without
+ * deleting it; attaching returns it. The button label reflects the current state, and
+ * on confirm it writes or removes the detached annotation.
  *
  * @param props.item - The resource whose details view is open.
  */
-export function RebootActionButton({ item }: { item: KubeObject }) {
+export function DetachActionButton({ item }: { item: KubeObject }) {
   const [open, setOpen] = useState(false);
-  const [mode, setMode] = useState<RebootMode>('soft');
   const [submitError, setSubmitError] = useState<string | null>(null);
 
   if (!item || item.kind !== 'BareMetalHost') {
     return null;
   }
 
+  const intent = getDetachIntent(item);
   const name = item.metadata.name;
 
   // Sends the patch, closing the dialog on success and surfacing the failure in
   // place otherwise, so a rejected request is never left unhandled or unseen.
   async function submit() {
     try {
-      await item.patch(rebootPatch(mode));
+      await item.patch(detachPatch(intent.targetDetached));
       setOpen(false);
     } catch (err) {
       setSubmitError(err instanceof Error ? err.message : String(err));
@@ -66,30 +62,22 @@ export function RebootActionButton({ item }: { item: KubeObject }) {
   return (
     <>
       <ActionButton
-        description="Reboot"
-        icon="mdi:restart"
+        description={intent.label}
+        icon={intent.isDetached ? 'mdi:link-variant' : 'mdi:link-variant-off'}
         onClick={() => {
           setSubmitError(null);
           setOpen(true);
         }}
       />
       <Dialog open={open} onClose={() => setOpen(false)}>
-        <DialogTitle>{`Reboot: ${name}`}</DialogTitle>
+        <DialogTitle>{`${intent.label}: ${name}`}</DialogTitle>
         <DialogContent>
           <DialogContentText>
-            {`This asks the operator to reboot ${name} over its BMC. A soft reboot is graceful; ` +
-              `a hard reboot is a power cycle.`}
+            {intent.targetDetached
+              ? `This detaches ${name}, taking it out of the operator's management without ` +
+                `deleting it. The operator stops reconciling it until it is attached again.`
+              : `This attaches ${name}, returning it to the operator's management.`}
           </DialogContentText>
-          <RadioGroup
-            row
-            name="reboot-mode"
-            aria-label="Reboot mode"
-            value={mode}
-            onChange={e => setMode(e.target.value as RebootMode)}
-          >
-            <FormControlLabel value="soft" control={<Radio />} label="Soft" />
-            <FormControlLabel value="hard" control={<Radio />} label="Hard" />
-          </RadioGroup>
           {submitError && (
             <DialogContentText color="error" sx={{ mt: 1 }}>
               {submitError}
@@ -99,7 +87,7 @@ export function RebootActionButton({ item }: { item: KubeObject }) {
         <DialogActions>
           <Button onClick={() => setOpen(false)}>Cancel</Button>
           <Button variant="contained" onClick={submit}>
-            Reboot
+            {intent.label}
           </Button>
         </DialogActions>
       </Dialog>

--- a/metal3/src/BareMetalHost/DetachActionButton.tsx
+++ b/metal3/src/BareMetalHost/DetachActionButton.tsx
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ActionButton } from '@kinvolk/headlamp-plugin/lib/components/common';
+import type { KubeObject } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+} from '@mui/material';
+import { useState } from 'react';
+import { detachPatch, getDetachIntent } from './detachAction';
+
+/**
+ * Header action that detaches or re-attaches a BareMetalHost.
+ *
+ * Registered against every details view, so it returns null unless the resource is a
+ * BareMetalHost. Detaching takes the host out of the operator's management without
+ * deleting it; attaching returns it. The button label reflects the current state, and
+ * on confirm it writes or removes the detached annotation.
+ *
+ * @param props.item - The resource whose details view is open.
+ */
+export function DetachActionButton({ item }: { item: KubeObject }) {
+  const [open, setOpen] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  if (!item || item.kind !== 'BareMetalHost') {
+    return null;
+  }
+
+  const intent = getDetachIntent(item);
+  const name = item.metadata.name;
+
+  // Sends the patch, closing the dialog on success and surfacing the failure in
+  // place otherwise, so a rejected request is never left unhandled or unseen.
+  async function submit() {
+    try {
+      await item.patch(detachPatch(intent.targetDetached));
+      setOpen(false);
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  return (
+    <>
+      <ActionButton
+        description={intent.label}
+        icon={intent.isDetached ? 'mdi:link-variant' : 'mdi:link-variant-off'}
+        onClick={() => {
+          setSubmitError(null);
+          setOpen(true);
+        }}
+      />
+      <Dialog open={open} onClose={() => setOpen(false)}>
+        <DialogTitle>{`${intent.label}: ${name}`}</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            {intent.targetDetached
+              ? `This detaches ${name}, taking it out of the operator's management without ` +
+                `deleting it. The operator stops reconciling it until it is attached again.`
+              : `This attaches ${name}, returning it to the operator's management.`}
+          </DialogContentText>
+          {submitError && (
+            <DialogContentText color="error" sx={{ mt: 1 }}>
+              {submitError}
+            </DialogContentText>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setOpen(false)}>Cancel</Button>
+          <Button variant="contained" onClick={submit}>
+            {intent.label}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+}

--- a/metal3/src/BareMetalHost/RebootActionButton.tsx
+++ b/metal3/src/BareMetalHost/RebootActionButton.tsx
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ActionButton } from '@kinvolk/headlamp-plugin/lib/components/common';
+import type { KubeObject } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  FormControlLabel,
+  Radio,
+  RadioGroup,
+} from '@mui/material';
+import { useState } from 'react';
+import { RebootMode, rebootPatch } from './rebootAction';
+
+/**
+ * Header action that reboots a BareMetalHost.
+ *
+ * Registered against every details view, so it returns null unless the resource is a
+ * BareMetalHost. Reboot is imperative: on confirm it writes the reboot annotation, and
+ * the operator reboots the host over its BMC and clears the annotation. The dialog lets
+ * the user choose a soft or hard reboot, and confirms because it affects physical
+ * hardware.
+ *
+ * @param props.item - The resource whose details view is open.
+ */
+export function RebootActionButton({ item }: { item: KubeObject }) {
+  const [open, setOpen] = useState(false);
+  const [mode, setMode] = useState<RebootMode>('soft');
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  if (!item || item.kind !== 'BareMetalHost') {
+    return null;
+  }
+
+  const name = item.metadata.name;
+
+  // Sends the patch, closing the dialog on success and surfacing the failure in
+  // place otherwise, so a rejected request is never left unhandled or unseen.
+  async function submit() {
+    try {
+      await item.patch(rebootPatch(mode));
+      setOpen(false);
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  return (
+    <>
+      <ActionButton
+        description="Reboot"
+        icon="mdi:restart"
+        onClick={() => {
+          setSubmitError(null);
+          setOpen(true);
+        }}
+      />
+      <Dialog open={open} onClose={() => setOpen(false)}>
+        <DialogTitle>{`Reboot: ${name}`}</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            {`This asks the operator to reboot ${name} over its BMC. A soft reboot is graceful; ` +
+              `a hard reboot is a power cycle.`}
+          </DialogContentText>
+          <RadioGroup
+            row
+            name="reboot-mode"
+            aria-label="Reboot mode"
+            value={mode}
+            onChange={e => setMode(e.target.value as RebootMode)}
+          >
+            <FormControlLabel value="soft" control={<Radio />} label="Soft" />
+            <FormControlLabel value="hard" control={<Radio />} label="Hard" />
+          </RadioGroup>
+          {submitError && (
+            <DialogContentText color="error" sx={{ mt: 1 }}>
+              {submitError}
+            </DialogContentText>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setOpen(false)}>Cancel</Button>
+          <Button variant="contained" onClick={submit}>
+            Reboot
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+}

--- a/metal3/src/BareMetalHost/detachAction.test.ts
+++ b/metal3/src/BareMetalHost/detachAction.test.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { KubeObject } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import { describe, expect, it } from 'vitest';
+import { DETACHED_ANNOTATION, detachPatch, getDetachIntent } from './detachAction';
+
+/** Builds a minimal BareMetalHost-shaped object, optionally already detached. */
+function host(detached?: boolean): KubeObject {
+  return {
+    jsonData: { metadata: { annotations: detached ? { [DETACHED_ANNOTATION]: '' } : {} } },
+  } as unknown as KubeObject;
+}
+
+describe('getDetachIntent', () => {
+  it('offers to detach a host that is attached', () => {
+    expect(getDetachIntent(host(false))).toEqual({
+      isDetached: false,
+      targetDetached: true,
+      label: 'Detach',
+    });
+  });
+
+  it('offers to attach a host that is detached', () => {
+    expect(getDetachIntent(host(true))).toEqual({
+      isDetached: true,
+      targetDetached: false,
+      label: 'Attach',
+    });
+  });
+});
+
+describe('detachPatch', () => {
+  it('adds the annotation to detach', () => {
+    expect(detachPatch(true)).toEqual({
+      metadata: { annotations: { [DETACHED_ANNOTATION]: '' } },
+    });
+  });
+
+  it('sets the annotation to null to re-attach', () => {
+    expect(detachPatch(false)).toEqual({
+      metadata: { annotations: { [DETACHED_ANNOTATION]: null } },
+    });
+  });
+});

--- a/metal3/src/BareMetalHost/detachAction.test.ts
+++ b/metal3/src/BareMetalHost/detachAction.test.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { KubeObject } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import { describe, expect, it } from 'vitest';
+import { DETACHED_ANNOTATION, detachPatch, getDetachIntent } from './detachAction';
+
+/** Builds a minimal BareMetalHost-shaped object, optionally already detached. */
+function host(detached?: boolean): KubeObject {
+  return {
+    jsonData: { metadata: { annotations: detached ? { [DETACHED_ANNOTATION]: '' } : {} } },
+  } as unknown as KubeObject;
+}
+
+describe('getDetachIntent', () => {
+  it('offers to detach a host that is attached', () => {
+    expect(getDetachIntent(host(false))).toEqual({
+      isDetached: false,
+      targetDetached: true,
+      label: 'Detach',
+    });
+  });
+
+  it('offers to attach a host that is detached', () => {
+    expect(getDetachIntent(host(true))).toEqual({
+      isDetached: true,
+      targetDetached: false,
+      label: 'Attach',
+    });
+  });
+});
+
+describe('detachPatch', () => {
+  it('adds the annotation to detach', () => {
+    expect(detachPatch(true)).toEqual({
+      metadata: { annotations: { [DETACHED_ANNOTATION]: '' } },
+    });
+  });
+
+  it('sets the annotation to null to re-attach', () => {
+    expect(detachPatch(false)).toEqual({
+      metadata: { annotations: { [DETACHED_ANNOTATION]: null } },
+    });
+  });
+});

--- a/metal3/src/BareMetalHost/detachAction.ts
+++ b/metal3/src/BareMetalHost/detachAction.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { KubeObject } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+
+/** Annotation that takes the host out of the operator's management without deleting it. */
+export const DETACHED_ANNOTATION = 'baremetalhost.metal3.io/detached';
+
+/** The detach action a host offers, derived from whether the annotation is present. */
+export interface DetachIntent {
+  /** Whether the host is currently detached. */
+  isDetached: boolean;
+  /** Whether the action will detach (true) or re-attach (false). */
+  targetDetached: boolean;
+  /** Button label naming the action that will happen. */
+  label: string;
+}
+
+/**
+ * Derives the detach action to offer for a host from the presence of the detached
+ * annotation. Pure, so the button's label and target can be unit-tested without a
+ * running cluster.
+ *
+ * @param host - The BareMetalHost to read the annotation from.
+ * @returns The current detached state, the target, and the button label.
+ */
+export function getDetachIntent(host: KubeObject): DetachIntent {
+  const isDetached = host.jsonData.metadata?.annotations?.[DETACHED_ANNOTATION] !== undefined;
+  return {
+    isDetached,
+    targetDetached: !isDetached,
+    label: isDetached ? 'Attach' : 'Detach',
+  };
+}
+
+/**
+ * Builds the merge patch that detaches or re-attaches a host. Detaching adds the
+ * annotation; attaching removes it by setting it to null, which a merge patch drops.
+ *
+ * @param detach - True to detach, false to re-attach.
+ * @returns The merge-patch body for `KubeObject.patch`.
+ */
+export function detachPatch(detach: boolean): {
+  metadata: { annotations: Record<string, string | null> };
+} {
+  return { metadata: { annotations: { [DETACHED_ANNOTATION]: detach ? '' : null } } };
+}

--- a/metal3/src/BareMetalHost/detachAction.ts
+++ b/metal3/src/BareMetalHost/detachAction.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { KubeObject } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+
+/** Annotation that takes the host out of the operator's management without deleting it. */
+export const DETACHED_ANNOTATION = 'baremetalhost.metal3.io/detached';
+
+/** The detach action a host offers, derived from whether the annotation is present. */
+export interface DetachIntent {
+  /** Whether the host is currently detached. */
+  isDetached: boolean;
+  /** Whether the action will detach (true) or re-attach (false). */
+  targetDetached: boolean;
+  /** Button label naming the action that will happen. */
+  label: string;
+}
+
+/**
+ * Derives the detach action to offer for a host from the presence of the detached
+ * annotation. Pure, so the button's label and target can be unit-tested without a
+ * running cluster.
+ *
+ * @param host - The BareMetalHost to read the annotation from.
+ * @returns The current detached state, the target, and the button label.
+ */
+export function getDetachIntent(host: KubeObject): DetachIntent {
+  const isDetached = host.jsonData.metadata?.annotations?.[DETACHED_ANNOTATION] !== undefined;
+  return {
+    isDetached,
+    targetDetached: !isDetached,
+    label: isDetached ? 'Attach' : 'Detach',
+  };
+}
+
+/**
+ * Builds the merge patch that detaches or re-attaches a host. Detaching adds the
+ * annotation; attaching removes it by setting it to null, which a merge patch drops.
+ *
+ * @param detach - True to detach, false to re-attach.
+ * @returns The merge-patch body for `KubeObject.patch`.
+ */
+export function detachPatch(detach: boolean): {
+  metadata: { annotations: Record<string, string | null> };
+} {
+  return { metadata: { annotations: { [DETACHED_ANNOTATION]: detach ? '' : null } } };
+}

--- a/metal3/src/BareMetalHost/rebootAction.test.ts
+++ b/metal3/src/BareMetalHost/rebootAction.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The Kubernetes Authors
+ * Copyright 2026 The Kubernetes Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metal3/src/BareMetalHost/rebootAction.test.ts
+++ b/metal3/src/BareMetalHost/rebootAction.test.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { REBOOT_ANNOTATION, rebootPatch } from './rebootAction';
+
+describe('rebootPatch', () => {
+  it('builds a soft reboot patch', () => {
+    expect(rebootPatch('soft')).toEqual({
+      metadata: { annotations: { [REBOOT_ANNOTATION]: '{"mode":"soft"}' } },
+    });
+  });
+
+  it('builds a hard reboot patch', () => {
+    expect(rebootPatch('hard')).toEqual({
+      metadata: { annotations: { [REBOOT_ANNOTATION]: '{"mode":"hard"}' } },
+    });
+  });
+});

--- a/metal3/src/BareMetalHost/rebootAction.ts
+++ b/metal3/src/BareMetalHost/rebootAction.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Annotation that asks the operator to reboot the host; the operator clears it once done. */
+export const REBOOT_ANNOTATION = 'reboot.metal3.io';
+
+/** Reboot mode: a soft (graceful) reboot or a hard (power-cycle) reset. */
+export type RebootMode = 'soft' | 'hard';
+
+/**
+ * Builds the patch that asks the operator to reboot the host. Reboot is imperative,
+ * unlike power: adding the annotation triggers one reboot and the operator removes it
+ * when done. The mode is carried in the annotation value as `{ mode }`, matching the
+ * operator's `RebootAnnotationArguments`.
+ *
+ * @param mode - Soft for a graceful reboot, hard for a power cycle.
+ * @returns The merge-patch body for `KubeObject.patch`.
+ */
+export function rebootPatch(mode: RebootMode): {
+  metadata: { annotations: Record<string, string> };
+} {
+  return { metadata: { annotations: { [REBOOT_ANNOTATION]: JSON.stringify({ mode }) } } };
+}

--- a/metal3/src/BareMetalHost/rebootAction.ts
+++ b/metal3/src/BareMetalHost/rebootAction.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The Kubernetes Authors
+ * Copyright 2026 The Kubernetes Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metal3/src/index.tsx
+++ b/metal3/src/index.tsx
@@ -19,6 +19,7 @@ import {
   registerRoute,
   registerSidebarEntry,
 } from '@kinvolk/headlamp-plugin/lib';
+import { DetachActionButton } from './BareMetalHost/DetachActionButton';
 import { BareMetalHostDetail } from './BareMetalHost/Details';
 import { BareMetalHosts } from './BareMetalHost/List';
 import { PowerActionButton } from './BareMetalHost/PowerActionButton';
@@ -232,3 +233,6 @@ registerDetailsViewHeaderAction(PowerActionButton);
 
 // Reboot action on the BareMetalHost detail view (reboot annotation, soft or hard).
 registerDetailsViewHeaderAction(RebootActionButton);
+
+// Detach action on the BareMetalHost detail view (detached annotation; toggles attach).
+registerDetailsViewHeaderAction(DetachActionButton);

--- a/metal3/src/index.tsx
+++ b/metal3/src/index.tsx
@@ -22,6 +22,7 @@ import {
 import { BareMetalHostDetail } from './BareMetalHost/Details';
 import { BareMetalHosts } from './BareMetalHost/List';
 import { PowerActionButton } from './BareMetalHost/PowerActionButton';
+import { RebootActionButton } from './BareMetalHost/RebootActionButton';
 import { Metal3ClusterDetail } from './Metal3Cluster/Details';
 import { Metal3Clusters } from './Metal3Cluster/List';
 import { Metal3ClusterTemplateDetail } from './Metal3ClusterTemplate/Details';
@@ -228,3 +229,6 @@ registerRoute({
 
 // Power on/off action on the BareMetalHost detail view. Toggles spec.online.
 registerDetailsViewHeaderAction(PowerActionButton);
+
+// Reboot action on the BareMetalHost detail view (reboot annotation, soft or hard).
+registerDetailsViewHeaderAction(RebootActionButton);


### PR DESCRIPTION

## Summary

Adds the next two mutating actions to the Metal3 plugin, reboot and detach, on the
BareMetalHost detail view. With power (#920) these are the three host actions from the
issue. Both are annotation-driven, unlike power's spec field:

- **Reboot** writes the `reboot.metal3.io` annotation; the operator reboots the host
  over its BMC and clears the annotation. The dialog offers a soft or hard reboot.
- **Detach** writes the `baremetalhost.metal3.io/detached` annotation, taking the host
  out of the operator's management without deleting it. The button toggles to Attach,
  which removes the annotation.

## Included

- Reboot and detach header-action buttons on the BareMetalHost detail view, each with a
  confirmation dialog.
- The annotation/patch logic as pure functions (`rebootAction.ts`, `detachAction.ts`)
  with unit tests.

## How to test

- A cluster with the Metal3 CRDs installed and a BareMetalHost.
- `cd metal3 && npm install && npm start`, then run Headlamp.
- Open a BareMetalHost's detail view; Reboot and Detach are in the header next to Power.
- Reboot: pick soft or hard and confirm; the `reboot.metal3.io` annotation is written.
- Detach: confirm; the `baremetalhost.metal3.io/detached` annotation is written and the
  button flips to Attach.

Stacked on #920, which adds the power action and the header-action wiring this builds on.

## Demo

https://github.com/user-attachments/assets/4a2fe700-5585-40a3-92ec-c3ea0024c1f5



