### PR TITLE
flux: Prepare 0.7.0 release

### DIFF
--- a/flux/0.7.0/README.md
+++ b/flux/0.7.0/README.md
@@ -1,0 +1,123 @@
+# Flux
+
+The Flux plugin provides a way to visualize Flux (should be installed in your cluster) in Headlamp. Flux is a tool for implementing GitOps and synchronizing Kubernetes clusters with sources of configuration (like Git repositories). It also automates updates to configuration when there is new code to deploy.
+
+This plugin adds a new item (Flux) to the sidebar to give the user an overview of the Flux installation on the cluster.
+
+## Flux Installation
+
+Please refer to the [official installation guide](https://fluxcd.io/flux/installation/) for Flux to learn to install it.
+
+## Plugin Installation in Headlamp for Desktop
+
+Go to the Plugin Catalog, search for the Flux plugin, and click the Install button. Reload the UI (Navigation menu > Reload, or use the notification after installing the plugin) to see the new Flux item in the sidebar.
+
+## Installing the Flux Headlamp plugin in a Headlamp deployment
+
+If you are deploying Headlamp using Helm, you can use the following HelmRelease manifest to install the Flux Headlamp plugin with your Headlamp deployment:
+
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: headlamp
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: HelmRepository
+metadata:
+  name: headlamp
+  namespace: headlamp
+spec:
+  interval: 1m0s
+  timeout: 1m0s
+  url: https://headlamp-k8s.github.io/headlamp/
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: headlamp
+  namespace: headlamp
+spec:
+  chart:
+    spec:
+      chart: headlamp
+      sourceRef:
+        kind: HelmRepository
+        name: headlamp
+      version: "*"
+  interval: 1m0s
+  values:
+    ingress:
+      enabled: true
+      ingressClassName: nginx
+      annotations:
+        cert-manager.io/cluster-issuer: letsencrypt-http01-nginx-issuer
+      hosts:
+        - host: example.com # Change me
+          paths:
+            - path: /
+              type: ImplementationSpecific
+      tls:
+        - secretName: headlamp-tls
+          hosts:
+            - example.com # Change me
+    config:
+      pluginsDir: /build/plugins
+    initContainers:
+      - command:
+          - /bin/sh
+          - -c
+          - mkdir -p /build/plugins && cp -r /plugins/* /build/plugins/ && chown -R 100:101 /build
+        image: ghcr.io/headlamp-k8s/headlamp-plugin-flux:latest
+        imagePullPolicy: Always
+        name: headlamp-plugins
+        securityContext:
+          runAsNonRoot: false
+          privileged: false
+          runAsUser: 0
+          runAsGroup: 0
+        volumeMounts:
+          - mountPath: /build/plugins
+            name: headlamp-plugins
+    persistentVolumeClaim:
+      accessModes:
+        - ReadWriteOnce
+      enabled: true
+      size: 1Gi
+    volumeMounts:
+      - mountPath: /build/plugins
+        name: headlamp-plugins
+    volumes:
+      - name: headlamp-plugins
+        persistentVolumeClaim:
+          claimName: headlamp # The name of the Helm release
+```
+
+As alternative, you can also use the Use EmptyDir (Ephemeral Shared Volume) to pass files from the init containers to the main container.
+
+```yaml
+config:
+  pluginsDir: /build/plugins
+initContainers:
+  - command:
+      - /bin/sh
+      - -c
+      - mkdir -p /build/plugins && cp -r /plugins/* /build/plugins/ && chown -R 100:101 /build
+    image: ghcr.io/headlamp-k8s/headlamp-plugin-flux:latest
+    imagePullPolicy: Always
+    name: headlamp-plugins
+    securityContext:
+      runAsNonRoot: false
+      privileged: false
+      runAsUser: 0
+      runAsGroup: 0
+    volumeMounts:
+      - mountPath: /build/plugins
+        name: headlamp-plugins
+volumeMounts:
+  - mountPath: /build/plugins
+    name: headlamp-plugins
+volumes:
+  - name: headlamp-plugins
+    emptyDir: {}
+```

--- a/flux/0.7.0/artifacthub-pkg.yml
+++ b/flux/0.7.0/artifacthub-pkg.yml
@@ -1,0 +1,41 @@
+version: 0.7.0
+name: headlamp_flux
+displayName: Flux
+createdAt: "2026-07-30T10:33:17Z"
+logoURL: "https://raw.githubusercontent.com/headlamp-k8s/plugins/main/flux/logo.png"
+description: A UI for viewing and managing Flux for Git Ops.
+changes:
+  - kind: added
+    description: "Add Terraform resources and reconciliation support"
+  - kind: added
+    description: "Show a health banner on the Flux overview"
+  - kind: added
+    description: "Protect Flux-managed resources from mutating actions and provide read-only YAML access"
+  - kind: added
+    description: "Add internationalization support for plugin strings"
+  - kind: added
+    description: "Support generic controllers in the flux-system namespace"
+  - kind: changed
+    description: "Hide Flux navigation and show an installation prompt when Flux is not installed"
+  - kind: changed
+    description: "Preserve cluster context when resolving plugin URLs"
+  - kind: changed
+    description: "Update headlamp-plugin to 0.14.0 and refresh dependencies"
+  - kind: fixed
+    description: "Fix Helm inventory loading when the inventory is empty"
+  - kind: fixed
+    description: "Show 100% health when no Flux resources exist"
+  - kind: fixed
+    description: "Fix canary views on older Headlamp versions"
+  - kind: fixed
+    description: "Fix invalid next reconciliation times"
+  - kind: fixed
+    description: "Fix force reconciliation dialog and notification text"
+  - kind: fixed
+    description: "Fix the map failing to load when Flux is not installed"
+annotations:
+  headlamp/plugin/archive-url: >-
+    https://github.com/headlamp-k8s/plugins/releases/download/flux-0.7.0/headlamp-k8s-flux-0.7.0.tar.gz
+  headlamp/plugin/archive-checksum: SHA256:837dc962a4ca485b86b010e5a3463d3ffc71c51778125394f006a210921b7c65
+  headlamp/plugin/version-compat: ">=0.22"
+  headlamp/plugin/distro-compat: in-cluster,web,docker-desktop,desktop

--- a/flux/package-lock.json
+++ b/flux/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@headlamp-k8s/flux",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@headlamp-k8s/flux",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "dependencies": {
         "yaml": "^2.5.0"
       },

--- a/flux/package.json
+++ b/flux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@headlamp-k8s/flux",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "A UI for viewing and managing Flux for Git Ops",
   "scripts": {
     "start": "headlamp-plugin start",


### PR DESCRIPTION
## Summary

- bump the Flux plugin and lockfile to 0.7.0
- add the versioned README and Artifact Hub metadata
- document user-facing changes since 0.6.0, including Terraform support, managed-resource protections, i18n, generic controllers, and Flux-not-installed handling
- point Artifact Hub at the 0.7.0 archive with the generated SHA-256 checksum
