### PR TITLE
metal3: Tidy the Metal3 sidebar labels and add entry icons

### DIFF
--- a/metal3/src/Metal3Remediation/Details.tsx
+++ b/metal3/src/Metal3Remediation/Details.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DetailsGrid } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { useParams } from 'react-router-dom';
+import { CRDGuard } from '../common/CRDGuard';
+import { metal3RemediationClass } from './List';
+
+/**
+ * Detail view for a single Metal3Remediation.
+ *
+ * A Metal3Remediation drives the repair of an unhealthy machine, usually by
+ * rebooting or reprovisioning the host, according to its strategy. `DetailsGrid`
+ * renders the standard metadata and Events; the `extraInfo` callback surfaces the
+ * strategy and retry state.
+ *
+ * @param props.name - Remediation name; falls back to the `:name` route param.
+ * @param props.namespace - Remediation namespace; falls back to the `:namespace` route param.
+ */
+export function Metal3RemediationDetail(props: { name?: string; namespace?: string }) {
+  const params = useParams<{ name: string; namespace: string }>();
+  const { name = params.name, namespace = params.namespace } = props;
+
+  return (
+    <CRDGuard
+      crdName="metal3remediations.infrastructure.cluster.x-k8s.io"
+      resourceLabel="Metal3 Remediation"
+    >
+      <DetailsGrid
+        resourceType={metal3RemediationClass()}
+        name={name}
+        namespace={namespace}
+        withEvents
+        extraInfo={(item: any) =>
+          item && [
+            {
+              name: 'Phase',
+              value: item.jsonData.status?.phase || '-',
+            },
+            {
+              name: 'Strategy',
+              value: item.jsonData.spec?.strategy?.type || '-',
+            },
+            {
+              name: 'Retry Limit',
+              value:
+                item.jsonData.spec?.strategy?.retryLimit === undefined
+                  ? '-'
+                  : String(item.jsonData.spec.strategy.retryLimit),
+            },
+            {
+              name: 'Retry Count',
+              value: String(item.jsonData.status?.retryCount ?? 0),
+            },
+            {
+              name: 'Last Remediated',
+              value: item.jsonData.status?.lastRemediated || '-',
+            },
+          ]
+        }
+      />
+    </CRDGuard>
+  );
+}

--- a/metal3/src/Metal3Remediation/List.tsx
+++ b/metal3/src/Metal3Remediation/List.tsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ResourceListView } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import type { KubeObject } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import { makeCustomResourceClass } from '@kinvolk/headlamp-plugin/lib/lib/k8s/crd';
+import { CRDGuard } from '../common/CRDGuard';
+
+/** Defines the Metal3Remediation custom resource (group/version/kind) for the plugin. */
+export function metal3RemediationClass() {
+  const group = 'infrastructure.cluster.x-k8s.io';
+  const version = 'v1beta2';
+  const Metal3Remediation = makeCustomResourceClass({
+    apiInfo: [{ group, version }],
+    kind: 'Metal3Remediation',
+    pluralName: 'metal3remediations',
+    singularName: 'Metal3Remediation',
+    isNamespaced: true,
+  });
+
+  return class extendedMetal3RemediationClass extends Metal3Remediation {
+    static get detailsRoute() {
+      return 'metal3remediation-detail';
+    }
+  };
+}
+
+/** List view for Metal3Remediation resources, guarded by CRD presence. */
+export function Metal3Remediations() {
+  return (
+    <CRDGuard
+      crdName="metal3remediations.infrastructure.cluster.x-k8s.io"
+      resourceLabel="Metal3 Remediation"
+    >
+      <ResourceListView
+        title="Metal3 Remediations"
+        resourceClass={metal3RemediationClass()}
+        columns={[
+          'name',
+          'namespace',
+          {
+            id: 'phase',
+            label: 'Phase',
+            getValue: (r: KubeObject) => r.jsonData.status?.phase || '-',
+          },
+          {
+            id: 'strategy',
+            label: 'Strategy',
+            getValue: (r: KubeObject) => r.jsonData.spec?.strategy?.type || '-',
+          },
+          {
+            // Retry progress as count / limit.
+            id: 'retry',
+            label: 'Retries',
+            getValue: (r: KubeObject) => {
+              const count = r.jsonData.status?.retryCount ?? 0;
+              const limit = r.jsonData.spec?.strategy?.retryLimit;
+              return limit === undefined ? String(count) : `${count} / ${limit}`;
+            },
+          },
+          'age',
+        ]}
+      />
+    </CRDGuard>
+  );
+}

--- a/metal3/src/Metal3RemediationTemplate/Details.tsx
+++ b/metal3/src/Metal3RemediationTemplate/Details.tsx
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DetailsGrid } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { useParams } from 'react-router-dom';
+import { CRDGuard } from '../common/CRDGuard';
+import { metal3RemediationTemplateClass } from './List';
+
+/**
+ * Detail view for a single Metal3RemediationTemplate.
+ *
+ * A Metal3RemediationTemplate is a blueprint that defines the remediation
+ * strategy Metal3Remediations are stamped from; its `spec.template.spec` is the
+ * embedded remediation spec. `DetailsGrid` renders the standard metadata and
+ * Events; the `extraInfo` callback surfaces the strategy.
+ *
+ * @param props.name - Template name; falls back to the `:name` route param.
+ * @param props.namespace - Template namespace; falls back to the `:namespace` route param.
+ */
+export function Metal3RemediationTemplateDetail(props: { name?: string; namespace?: string }) {
+  const params = useParams<{ name: string; namespace: string }>();
+  const { name = params.name, namespace = params.namespace } = props;
+
+  return (
+    <CRDGuard
+      crdName="metal3remediationtemplates.infrastructure.cluster.x-k8s.io"
+      resourceLabel="Metal3 Remediation Template"
+    >
+      <DetailsGrid
+        resourceType={metal3RemediationTemplateClass()}
+        name={name}
+        namespace={namespace}
+        withEvents
+        extraInfo={(item: any) => {
+          const strategy = item?.jsonData.spec?.template?.spec?.strategy;
+          return (
+            item && [
+              {
+                name: 'Strategy',
+                value: strategy?.type || '-',
+              },
+              {
+                name: 'Retry Limit',
+                value: strategy?.retryLimit === undefined ? '-' : String(strategy.retryLimit),
+              },
+            ]
+          );
+        }}
+      />
+    </CRDGuard>
+  );
+}

--- a/metal3/src/Metal3RemediationTemplate/List.tsx
+++ b/metal3/src/Metal3RemediationTemplate/List.tsx
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ResourceListView } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import type { KubeObject } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import { makeCustomResourceClass } from '@kinvolk/headlamp-plugin/lib/lib/k8s/crd';
+import { CRDGuard } from '../common/CRDGuard';
+
+/** Defines the Metal3RemediationTemplate custom resource (group/version/kind) for the plugin. */
+export function metal3RemediationTemplateClass() {
+  const group = 'infrastructure.cluster.x-k8s.io';
+  const version = 'v1beta2';
+  const Metal3RemediationTemplate = makeCustomResourceClass({
+    apiInfo: [{ group, version }],
+    kind: 'Metal3RemediationTemplate',
+    pluralName: 'metal3remediationtemplates',
+    singularName: 'Metal3RemediationTemplate',
+    isNamespaced: true,
+  });
+
+  return class extendedMetal3RemediationTemplateClass extends Metal3RemediationTemplate {
+    static get detailsRoute() {
+      return 'metal3remediationtemplate-detail';
+    }
+  };
+}
+
+/** List view for Metal3RemediationTemplate resources, guarded by CRD presence. */
+export function Metal3RemediationTemplates() {
+  return (
+    <CRDGuard
+      crdName="metal3remediationtemplates.infrastructure.cluster.x-k8s.io"
+      resourceLabel="Metal3 Remediation Template"
+    >
+      <ResourceListView
+        title="Metal3 Remediation Templates"
+        resourceClass={metal3RemediationTemplateClass()}
+        columns={[
+          'name',
+          'namespace',
+          {
+            // Remediation strategy from the embedded remediation spec.
+            id: 'strategy',
+            label: 'Strategy',
+            getValue: (t: KubeObject) => t.jsonData.spec?.template?.spec?.strategy?.type || '-',
+          },
+          'age',
+        ]}
+      />
+    </CRDGuard>
+  );
+}

--- a/metal3/src/index.tsx
+++ b/metal3/src/index.tsx
@@ -79,7 +79,7 @@ registerRoute({
 registerSidebarEntry({
   parent: 'metal3',
   name: 'metal3machines',
-  label: 'Metal3 Machines',
+  label: 'Machines',
   url: '/metal3/metal3machines',
 });
 
@@ -101,7 +101,7 @@ registerRoute({
 registerSidebarEntry({
   parent: 'metal3',
   name: 'metal3machinetemplates',
-  label: 'Metal3 Machine Templates',
+  label: 'Machine Templates',
   url: '/metal3/metal3machinetemplates',
 });
 
@@ -123,7 +123,7 @@ registerRoute({
 registerSidebarEntry({
   parent: 'metal3',
   name: 'metal3clusters',
-  label: 'Metal3 Clusters',
+  label: 'Clusters',
   url: '/metal3/metal3clusters',
 });
 
@@ -145,7 +145,7 @@ registerRoute({
 registerSidebarEntry({
   parent: 'metal3',
   name: 'metal3clustertemplates',
-  label: 'Metal3 Cluster Templates',
+  label: 'Cluster Templates',
   url: '/metal3/metal3clustertemplates',
 });
 
@@ -167,7 +167,7 @@ registerRoute({
 registerSidebarEntry({
   parent: 'metal3',
   name: 'metal3datas',
-  label: 'Metal3 Data',
+  label: 'Data',
   url: '/metal3/metal3datas',
 });
 
@@ -189,7 +189,7 @@ registerRoute({
 registerSidebarEntry({
   parent: 'metal3',
   name: 'metal3dataclaims',
-  label: 'Metal3 Data Claims',
+  label: 'Data Claims',
   url: '/metal3/metal3dataclaims',
 });
 
@@ -211,7 +211,7 @@ registerRoute({
 registerSidebarEntry({
   parent: 'metal3',
   name: 'metal3datatemplates',
-  label: 'Metal3 Data Templates',
+  label: 'Data Templates',
   url: '/metal3/metal3datatemplates',
 });
 
@@ -233,7 +233,7 @@ registerRoute({
 registerSidebarEntry({
   parent: 'metal3',
   name: 'metal3remediations',
-  label: 'Metal3 Remediations',
+  label: 'Remediations',
   url: '/metal3/metal3remediations',
 });
 
@@ -255,7 +255,7 @@ registerRoute({
 registerSidebarEntry({
   parent: 'metal3',
   name: 'metal3remediationtemplates',
-  label: 'Metal3 Remediation Templates',
+  label: 'Remediation Templates',
   url: '/metal3/metal3remediationtemplates',
 });
 

--- a/metal3/src/index.tsx
+++ b/metal3/src/index.tsx
@@ -36,6 +36,10 @@ import { Metal3MachineDetail } from './Metal3Machine/Details';
 import { Metal3Machines } from './Metal3Machine/List';
 import { Metal3MachineTemplateDetail } from './Metal3MachineTemplate/Details';
 import { Metal3MachineTemplates } from './Metal3MachineTemplate/List';
+import { Metal3RemediationDetail } from './Metal3Remediation/Details';
+import { Metal3Remediations } from './Metal3Remediation/List';
+import { Metal3RemediationTemplateDetail } from './Metal3RemediationTemplate/Details';
+import { Metal3RemediationTemplates } from './Metal3RemediationTemplate/List';
 
 // Parent Metal3 group. Its url points at the first child's list so the group
 // header is itself navigable.
@@ -224,6 +228,50 @@ registerRoute({
   sidebar: 'metal3datatemplates',
   component: () => <Metal3DataTemplateDetail />,
   name: 'metal3datatemplate-detail',
+});
+
+registerSidebarEntry({
+  parent: 'metal3',
+  name: 'metal3remediations',
+  label: 'Metal3 Remediations',
+  url: '/metal3/metal3remediations',
+});
+
+registerRoute({
+  path: '/metal3/metal3remediations',
+  sidebar: 'metal3remediations',
+  component: Metal3Remediations,
+  name: 'metal3remediations-list',
+  exact: true,
+});
+
+registerRoute({
+  path: '/metal3/metal3remediations/:namespace/:name',
+  sidebar: 'metal3remediations',
+  component: () => <Metal3RemediationDetail />,
+  name: 'metal3remediation-detail',
+});
+
+registerSidebarEntry({
+  parent: 'metal3',
+  name: 'metal3remediationtemplates',
+  label: 'Metal3 Remediation Templates',
+  url: '/metal3/metal3remediationtemplates',
+});
+
+registerRoute({
+  path: '/metal3/metal3remediationtemplates',
+  sidebar: 'metal3remediationtemplates',
+  component: Metal3RemediationTemplates,
+  name: 'metal3remediationtemplates-list',
+  exact: true,
+});
+
+registerRoute({
+  path: '/metal3/metal3remediationtemplates/:namespace/:name',
+  sidebar: 'metal3remediationtemplates',
+  component: () => <Metal3RemediationTemplateDetail />,
+  name: 'metal3remediationtemplate-detail',
 });
 
 // Power on/off action on the BareMetalHost detail view. Toggles spec.online.

--- a/metal3/src/index.tsx
+++ b/metal3/src/index.tsx
@@ -54,6 +54,7 @@ registerSidebarEntry({
 registerSidebarEntry({
   parent: 'metal3',
   name: 'baremetalhosts',
+  icon: 'mdi:server-network',
   label: 'Bare Metal Hosts',
   url: '/metal3/baremetalhosts',
 });
@@ -79,6 +80,7 @@ registerRoute({
 registerSidebarEntry({
   parent: 'metal3',
   name: 'metal3machines',
+  icon: 'mdi:desktop-classic',
   label: 'Machines',
   url: '/metal3/metal3machines',
 });
@@ -101,6 +103,7 @@ registerRoute({
 registerSidebarEntry({
   parent: 'metal3',
   name: 'metal3machinetemplates',
+  icon: 'mdi:shape-outline',
   label: 'Machine Templates',
   url: '/metal3/metal3machinetemplates',
 });
@@ -123,6 +126,7 @@ registerRoute({
 registerSidebarEntry({
   parent: 'metal3',
   name: 'metal3clusters',
+  icon: 'mdi:kubernetes',
   label: 'Clusters',
   url: '/metal3/metal3clusters',
 });
@@ -145,6 +149,7 @@ registerRoute({
 registerSidebarEntry({
   parent: 'metal3',
   name: 'metal3clustertemplates',
+  icon: 'mdi:shape-outline',
   label: 'Cluster Templates',
   url: '/metal3/metal3clustertemplates',
 });
@@ -167,6 +172,7 @@ registerRoute({
 registerSidebarEntry({
   parent: 'metal3',
   name: 'metal3datas',
+  icon: 'mdi:database',
   label: 'Data',
   url: '/metal3/metal3datas',
 });
@@ -189,6 +195,7 @@ registerRoute({
 registerSidebarEntry({
   parent: 'metal3',
   name: 'metal3dataclaims',
+  icon: 'mdi:database-check',
   label: 'Data Claims',
   url: '/metal3/metal3dataclaims',
 });
@@ -211,6 +218,7 @@ registerRoute({
 registerSidebarEntry({
   parent: 'metal3',
   name: 'metal3datatemplates',
+  icon: 'mdi:shape-outline',
   label: 'Data Templates',
   url: '/metal3/metal3datatemplates',
 });
@@ -233,6 +241,7 @@ registerRoute({
 registerSidebarEntry({
   parent: 'metal3',
   name: 'metal3remediations',
+  icon: 'mdi:wrench',
   label: 'Remediations',
   url: '/metal3/metal3remediations',
 });
@@ -255,6 +264,7 @@ registerRoute({
 registerSidebarEntry({
   parent: 'metal3',
   name: 'metal3remediationtemplates',
+  icon: 'mdi:shape-outline',
   label: 'Remediation Templates',
   url: '/metal3/metal3remediationtemplates',
 });

--- a/metal3/test-files/metal3remediation.yaml
+++ b/metal3/test-files/metal3remediation.yaml
@@ -1,0 +1,29 @@
+# Sample Metal3Remediation and Metal3RemediationTemplate for trying out the plugin locally.
+#
+#   kubectl apply -f metal3/test-files/metal3remediation.yaml
+#
+# They appear under Metal3 > Metal3 Remediations and Metal3 Remediation Templates.
+# A Metal3RemediationTemplate is the blueprint remediations are stamped from; a
+# Metal3Remediation drives the repair of an unhealthy machine per its strategy.
+# The phase and retry count are set by the CAPM3 controller as it reconciles.
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: Metal3RemediationTemplate
+metadata:
+  name: sample-remediationtemplate
+  namespace: default
+spec:
+  template:
+    spec:
+      strategy:
+        type: Reboot
+        retryLimit: 3
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: Metal3Remediation
+metadata:
+  name: sample-remediation
+  namespace: default
+spec:
+  strategy:
+    type: Reboot
+    retryLimit: 3


### PR DESCRIPTION
## Summary

Two small sidebar tweaks:

- Drop the redundant "Metal3" prefix from the child labels, since they already sit under the Metal3 header. So "Metal3 Machines" becomes "Machines", and so on.
- Add an icon to each entry, like the cluster-api plugin does.

Stacked on #905.

## Screenshots

<img width="200" height="350" alt="image" src="https://github.com/user-attachments/assets/c53061d9-28ce-454b-ba45-e8f368663bef" />
