### PR TITLE
flux: Fix a11y violations

### DIFF
--- a/flux/locales/en/translation.json
+++ b/flux/locales/en/translation.json
@@ -52,6 +52,7 @@
   "Least Failed First": "Least Failed First",
   "Least Successful": "Least Successful",
   "Least Total Resources": "Least Total Resources",
+  "Link HelmReleases to Kustomizations instead of HelmRepositories": "Link HelmReleases to Kustomizations instead of HelmRepositories",
   "Logs": "Logs",
   "Message": "Message",
   "Metrics": "Metrics",

--- a/flux/src/checkflux/index.tsx
+++ b/flux/src/checkflux/index.tsx
@@ -21,7 +21,11 @@ export default function Flux404(props: Readonly<{ message: string; docs?: string
       <h1>{t(message)}</h1>
       <p>
         {t('Follow the')}{' '}
-        <Link target="_blank" href={docs ?? 'https://fluxcd.io/docs/installation/'}>
+        <Link
+          target="_blank"
+          rel="noopener noreferrer"
+          href={docs ?? 'https://fluxcd.io/docs/installation/'}
+        >
           {t('installation guide')}
         </Link>{' '}
         {t('to install flux on your cluster')}
@@ -38,7 +42,7 @@ export function NotSupported(props: { typeName: string }) {
       <p>{t('Flux installation has no support for {{typeName}}.', { typeName: t(typeName) })}</p>
       <p>
         {t('Follow the')}{' '}
-        <Link target="_blank" href="https://fluxcd.io/docs/installation/">
+        <Link target="_blank" rel="noopener noreferrer" href="https://fluxcd.io/docs/installation/">
           {t('installation guide')}
         </Link>{' '}
         {t('to support {{typeName}} on your cluster', { typeName: t(typeName) })}

--- a/flux/src/common/Link.tsx
+++ b/flux/src/common/Link.tsx
@@ -34,7 +34,7 @@ export default function Link(props: { url: string; wrap?: boolean }) {
   }
 
   const LinkComponent = () => (
-    <MuiLink href={href} target="_blank">
+    <MuiLink href={href} target="_blank" rel="noopener noreferrer">
       {url}
     </MuiLink>
   );

--- a/flux/src/flagger/availabilitycheck.tsx
+++ b/flux/src/flagger/availabilitycheck.tsx
@@ -24,6 +24,7 @@ export default function FlaggerAvailabilityCheck({ children }) {
           Follow the{' '}
           <Link
             target="_blank"
+            rel="noopener noreferrer"
             href="https://docs.flagger.app/install/flagger-install-on-kubernetes"
           >
             installation guide

--- a/flux/src/settings/index.tsx
+++ b/flux/src/settings/index.tsx
@@ -1,4 +1,4 @@
-import { ConfigStore } from '@kinvolk/headlamp-plugin/lib';
+import { ConfigStore, useTranslation } from '@kinvolk/headlamp-plugin/lib';
 import { NameValueTable } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 import { Typography } from '@mui/material';
 import Box from '@mui/material/Box';
@@ -8,6 +8,7 @@ import { type ChangeEvent, type ReactNode, useEffect, useState } from 'react';
 
 interface AutoSaveSwitchProps {
   settingKey: keyof PluginConfig;
+  label: string;
   onSave: (key: keyof PluginConfig, value: boolean) => void;
   defaultValue?: boolean;
   helperText?: ReactNode;
@@ -15,6 +16,7 @@ interface AutoSaveSwitchProps {
 
 function AutoSaveSwitch({
   settingKey,
+  label,
   onSave,
   defaultValue,
   helperText = null,
@@ -44,7 +46,7 @@ function AutoSaveSwitch({
 
   return (
     <>
-      <Switch checked={value} onChange={handleChange} />
+      <Switch checked={value} inputProps={{ 'aria-label': label }} onChange={handleChange} />
       {helperText && <FormHelperText sx={{ ml: 1.75, mt: 0.5 }}>{helperText}</FormHelperText>}
     </>
   );
@@ -65,6 +67,8 @@ const DEFAULT_CONFIG: PluginConfig = {
 export const store = new ConfigStore<PluginConfig>('@headlamp-k8s/flux');
 
 export function FluxSettings() {
+  const { t } = useTranslation();
+  const linkHRelLabel = t('Link HelmReleases to Kustomizations instead of HelmRepositories');
   const [currentConfig, setCurrentConfig] = useState<PluginConfig>(() => ({
     ...DEFAULT_CONFIG,
     ...store.get(),
@@ -78,10 +82,11 @@ export function FluxSettings() {
 
   const settingsRows = [
     {
-      name: 'Link HelmReleases to Kustomizations instead of HelmRepositories',
+      name: linkHRelLabel,
       value: (
         <AutoSaveSwitch
           settingKey="linkHRelToKs"
+          label={linkHRelLabel}
           defaultValue={currentConfig?.linkHRelToKs}
           onSave={handleSave}
         />


### PR DESCRIPTION
These changes fix accessibility (a11y) violations in the flux plugin surfaced by an axe-core pass over the components. The plugin looks and behaves exactly as before for sighted mouse users, while becoming usable for keyboard and screen-reader users.

### Changes

- Add a translated accessible name to the Flux map settings switch
- Add `rel="noopener noreferrer"` to external links opened in a new tab