### PR TITLE
keda: Fix a11y violations

### DIFF
--- a/keda/locales/en/translation.json
+++ b/keda/locales/en/translation.json
@@ -44,6 +44,7 @@
   "Pause scaling for {{name}} and set the replica count to a specific value.": "Pause scaling for {{name}} and set the replica count to a specific value.",
   "Replicas": "Replicas",
   "Cancel": "Cancel",
+  "Checking KEDA installation status": "Checking KEDA installation status",
   "Invalid number: replicas must be a non-negative integer": "Invalid number: replicas must be a non-negative integer",
   "Successfully set paused replicas to {{value}} for {{name}}": "Successfully set paused replicas to {{value}} for {{name}}",
   "Failed to set paused replicas for {{name}}": "Failed to set paused replicas for {{name}}",

--- a/keda/src/components/common/CommonComponents.tsx
+++ b/keda/src/components/common/CommonComponents.tsx
@@ -39,7 +39,7 @@ export function NotInstalledBanner({ isLoading = false }: NotInstalledBannerProp
   if (isLoading) {
     return (
       <Box display="flex" justifyContent="center" alignItems="center" p={2} minHeight="200px">
-        <CircularProgress />
+        <CircularProgress aria-label={t('Checking KEDA installation status')} />
       </Box>
     );
   }
@@ -544,7 +544,7 @@ export function makeJobStatusLabel(job: Job) {
       <Box display="inline">
         <StatusLabel status={conditionInfo.status as StatusLabelProps['status']}>
           {condition.type}
-          <Icon aria-label="hidden" icon={conditionInfo.icon} width="1.2rem" height="1.2rem" />
+          <Icon aria-hidden="true" icon={conditionInfo.icon} width="1.2rem" height="1.2rem" />
         </StatusLabel>
       </Box>
     </LightTooltip>

--- a/keda/src/components/scaledobjects/Detail.tsx
+++ b/keda/src/components/scaledobjects/Detail.tsx
@@ -9,6 +9,7 @@ import {
 } from '@kinvolk/headlamp-plugin/lib/components/common';
 import Deployment from '@kinvolk/headlamp-plugin/lib/k8s/deployment';
 import StatefulSet from '@kinvolk/headlamp-plugin/lib/k8s/statefulSet';
+import { Typography } from '@mui/material';
 import { useParams } from 'react-router-dom';
 import { ScaledObject, ScalingModifierMetricType } from '../../resources/scaledobject';
 import { KedaInstallCheck, TriggersSection } from '../common/CommonComponents';
@@ -239,7 +240,9 @@ export function ScaledObjectDetail(props: { namespace?: string; name?: string })
                                     {item.spec.advanced.horizontalPodAutoscalerConfig.behavior
                                       .scaleDown && (
                                       <>
-                                        <h4>{t('Scale Down')}</h4>
+                                        <Typography component="h3" variant="h6">
+                                          {t('Scale Down')}
+                                        </Typography>
                                         <NameValueTable
                                           rows={[
                                             {
@@ -287,7 +290,9 @@ export function ScaledObjectDetail(props: { namespace?: string; name?: string })
                                     {item.spec.advanced.horizontalPodAutoscalerConfig.behavior
                                       .scaleUp && (
                                       <>
-                                        <h4>{t('Scale Up')}</h4>
+                                        <Typography component="h3" variant="h6">
+                                          {t('Scale Up')}
+                                        </Typography>
                                         <NameValueTable
                                           rows={[
                                             {


### PR DESCRIPTION
These changes fix accessibility (a11y) violations in the KEDA plugin surfaced by an axe-core pass over the components. The plugin looks and behaves exactly as before for sighted mouse users, while becoming more usable for keyboard and screen-reader users.

### Changes

- Add a translated accessible name to the KEDA installation status indicator
- Hide decorative job status icons from screen readers
- Fix heading order for the scale-up and scale-down configuration sections