### PR TITLE
fix(flux): add missing namespace filter box to Sources view

### DIFF
--- a/flux/src/sources/SourceList.tsx
+++ b/flux/src/sources/SourceList.tsx
@@ -1,5 +1,9 @@
 import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
-import { Link, SectionBox } from '@kinvolk/headlamp-plugin/lib/components/common';
+import {
+  Link,
+  SectionBox,
+  SectionFilterHeader,
+} from '@kinvolk/headlamp-plugin/lib/components/common';
 import type { KubeObjectClass } from '@kinvolk/headlamp-plugin/lib/lib/k8s/cluster';
 import { useFilterFunc } from '@kinvolk/headlamp-plugin/lib/Utils';
 import React from 'react';
@@ -154,7 +158,7 @@ function FluxSource(props: FluxSourceCustomResourceRendererProps) {
   }
 
   return (
-    <SectionBox title={title}>
+    <SectionBox title={<SectionFilterHeader title={title} />}>
       <Table
         data={resources}
         columns={columns}


### PR DESCRIPTION
Wrapped the title passed to SectionBox with SectionFilterHeader, matching the pattern used across the rest of the plugin's list views:
`<SectionBox title={<SectionFilterHeader title={title} />}>`

Fixes #957 