### PR TITLE
metal3: Show the BMC protocol and flag a missing scheme

### DIFF
--- a/metal3/src/BareMetalHost/Details.tsx
+++ b/metal3/src/BareMetalHost/Details.tsx
@@ -16,8 +16,10 @@
 
 import { DetailsGrid } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 import { Link } from '@kinvolk/headlamp-plugin/lib/components/common';
+import { Typography } from '@mui/material';
 import { useParams } from 'react-router-dom';
 import { CRDGuard } from '../common/CRDGuard';
+import { parseBmcScheme } from './bmcScheme';
 import { bareMetalHostClass } from './List';
 
 /**
@@ -98,6 +100,27 @@ export function BareMetalHostDetail(props: { name?: string; namespace?: string }
             {
               name: 'BMC Address',
               value: item.jsonData.spec?.bmc?.address || '-',
+            },
+            {
+              // Protocol derived from the BMC address scheme. A missing or unknown
+              // scheme is flagged, since the operator silently treats a schemeless
+              // address as IPMI.
+              name: 'Protocol',
+              value: (() => {
+                const s = parseBmcScheme(item.jsonData.spec?.bmc?.address);
+                if (s.status === 'ok') {
+                  return s.protocol;
+                }
+                const warning =
+                  s.status === 'missing'
+                    ? 'No scheme in the BMC address; the operator will treat it as IPMI.'
+                    : `Unrecognised scheme "${s.scheme}".`;
+                return (
+                  <Typography component="span" sx={{ color: 'warning.main' }}>
+                    {warning}
+                  </Typography>
+                );
+              })(),
             },
           ]
         }

--- a/metal3/src/BareMetalHost/bmcScheme.test.ts
+++ b/metal3/src/BareMetalHost/bmcScheme.test.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { parseBmcScheme } from './bmcScheme';
+
+describe('parseBmcScheme', () => {
+  it('recognises redfish', () => {
+    expect(parseBmcScheme('redfish://host')).toEqual({
+      scheme: 'redfish',
+      protocol: 'Redfish',
+      status: 'ok',
+    });
+  });
+
+  it('recognises ipmi', () => {
+    expect(parseBmcScheme('ipmi://192.168.1.10')).toEqual({
+      scheme: 'ipmi',
+      protocol: 'IPMI',
+      status: 'ok',
+    });
+  });
+
+  it('recognises idrac-virtualmedia', () => {
+    expect(parseBmcScheme('idrac-virtualmedia://host').status).toBe('ok');
+  });
+
+  it('tolerates the +https suffix on the redfish family', () => {
+    expect(parseBmcScheme('redfish+https://host')).toEqual({
+      scheme: 'redfish',
+      protocol: 'Redfish',
+      status: 'ok',
+    });
+  });
+
+  it('lower-cases the scheme', () => {
+    expect(parseBmcScheme('REDFISH://host').status).toBe('ok');
+  });
+
+  it('flags a missing scheme as the IPMI trap', () => {
+    expect(parseBmcScheme('bmc.example.com:8443')).toEqual({
+      scheme: '',
+      protocol: 'Unknown',
+      status: 'missing',
+    });
+  });
+
+  it('flags undefined and empty as missing', () => {
+    expect(parseBmcScheme(undefined).status).toBe('missing');
+    expect(parseBmcScheme('').status).toBe('missing');
+  });
+
+  it('flags an unrecognised scheme as unknown', () => {
+    expect(parseBmcScheme('foobar://host')).toEqual({
+      scheme: 'foobar',
+      protocol: 'foobar',
+      status: 'unknown',
+    });
+  });
+});

--- a/metal3/src/BareMetalHost/bmcScheme.test.ts
+++ b/metal3/src/BareMetalHost/bmcScheme.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The Kubernetes Authors
+ * Copyright 2026 The Kubernetes Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metal3/src/BareMetalHost/bmcScheme.ts
+++ b/metal3/src/BareMetalHost/bmcScheme.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Protocol label per BMC type the operator registers a handler for. */
+const PROTOCOL_LABELS: Record<string, string> = {
+  ipmi: 'IPMI',
+  libvirt: 'libvirt',
+  redfish: 'Redfish',
+  'idrac-redfish': 'iDRAC (Redfish)',
+  'ilo5-redfish': 'iLO 5 (Redfish)',
+  'redfish-virtualmedia': 'Redfish virtual media',
+  'idrac-virtualmedia': 'iDRAC virtual media',
+  'ilo5-virtualmedia': 'iLO 5 virtual media',
+  'redfish-uefihttp': 'Redfish UEFI HTTP',
+};
+
+/** Whether a BMC scheme is recognised, absent, or unrecognised. */
+export type BmcSchemeStatus = 'ok' | 'missing' | 'unknown';
+
+/** The result of parsing a BMC address scheme. */
+export interface BmcScheme {
+  /** The scheme parsed from the address (lower-cased), or '' when there is none. */
+  scheme: string;
+  /** A human protocol label, or the raw scheme when unrecognised. */
+  protocol: string;
+  /** Whether the scheme is recognised ('ok'), absent ('missing'), or unknown. */
+  status: BmcSchemeStatus;
+}
+
+/**
+ * Parses and classifies the scheme of a BMC address. The vendor and protocol live
+ * only in the URL scheme, so a missing scheme is the trap the operator silently reads
+ * as IPMI, and an unrecognised scheme fails the same way. Both are flagged so the UI
+ * can warn instead of letting the host fail registration with a generic error. The
+ * Redfish family's optional `+http`/`+https` suffix is tolerated.
+ *
+ * @param address - The value of `spec.bmc.address`, e.g. "redfish://host".
+ * @returns The parsed scheme, a protocol label, and its status.
+ */
+export function parseBmcScheme(address: string | undefined): BmcScheme {
+  const raw = (address ?? '').trim();
+  const match = raw.match(/^([a-zA-Z0-9-]+)(\+https?)?:\/\//);
+  if (!match) {
+    return { scheme: '', protocol: 'Unknown', status: 'missing' };
+  }
+  const type = match[1].toLowerCase();
+  if (type in PROTOCOL_LABELS) {
+    return { scheme: type, protocol: PROTOCOL_LABELS[type], status: 'ok' };
+  }
+  return { scheme: type, protocol: type, status: 'unknown' };
+}

--- a/metal3/src/BareMetalHost/bmcScheme.ts
+++ b/metal3/src/BareMetalHost/bmcScheme.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The Kubernetes Authors
+ * Copyright 2026 The Kubernetes Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary

Adds a Protocol row to the BareMetalHost detail view, derived from the BMC address scheme, plus the client-side scheme check from the design.

The parser reads the scheme of the BMC address, maps it to a protocol like Redfish, iDRAC, iLO, or IPMI, and classifies it as ok, missing, or unknown against the operator's registered handlers. It handles the redfish +http and +https suffix, and it is pure and unit-tested so a create form can reuse it later.

The detail view shows the protocol for a recognised scheme, and warns when the scheme is missing or unknown, because the operator silently treats a schemeless address as IPMI and the host then fails to register with no hint.

Confirmed against the metal3-docs design, bmc-address.md, which documents both the protocol-in-scheme model and the missing-scheme-becomes-IPMI behaviour.

## Screenshots

