### PR TITLE
feat(prometheus): add deployment-wide default configuration via Confi…

### DIFF
--- a/prometheus/src/components/Chart/CapiChart/CapiChart.tsx
+++ b/prometheus/src/components/Chart/CapiChart/CapiChart.tsx
@@ -66,6 +66,9 @@ export function CapiChart(props: CapiChartProps) {
   const [refresh, setRefresh] = useState<boolean>(true);
   const [prometheusPrefix, setPrometheusPrefix] = useState<string | null>(null);
   const [state, setState] = useState<prometheusState>(prometheusState.LOADING);
+  const [timespan, setTimespan] = useState('24h');
+  const [resolution, setResolution] = useState('medium');
+  const [subPath, setSubPath] = useState<string | null>(null);
   const [isVisible, setIsVisible] = useState<boolean>(false);
   useEffect(() => {
     const isEnabled = clusterConfig?.[cluster]?.isMetricsEnabled || false;
@@ -84,6 +87,13 @@ export function CapiChart(props: CapiChartProps) {
         if (prefix) {
           setPrometheusPrefix(prefix);
           setState(prometheusState.INSTALLED);
+          
+          const loadedInterval = await getPrometheusInterval(cluster);
+          const loadedRes = await getPrometheusResolution(cluster);
+          const loadedSubPath = await getPrometheusSubPath(cluster);
+          setTimespan(loadedInterval ?? '1h');
+          setResolution(loadedRes ?? 'medium');
+          setSubPath(loadedSubPath);
         } else {
           setState(prometheusState.UNKNOWN);
         }
@@ -94,12 +104,7 @@ export function CapiChart(props: CapiChartProps) {
     })();
   }, [clusterConfig, cluster]);
 
-  const interval = getPrometheusInterval(cluster);
-  const graphResolution = getPrometheusResolution(cluster);
-  const subPath = getPrometheusSubPath(cluster);
 
-  const [timespan, setTimespan] = useState(interval ?? '1h');
-  const [resolution, setResolution] = useState(graphResolution ?? 'medium');
   const [selectedChart, setSelectedChart] = useState<string>(
     props.defaultChart || props.chartConfigs[0]?.key || ''
   );

--- a/prometheus/src/components/Chart/DiskMetricsChart/DiskMetricsChart.tsx
+++ b/prometheus/src/components/Chart/DiskMetricsChart/DiskMetricsChart.tsx
@@ -45,6 +45,9 @@ export function DiskMetricsChart(props: DiskMetricsChartProps) {
   const [refresh, setRefresh] = useState<boolean>(true);
   const [prometheusPrefix, setPrometheusPrefix] = useState<string | null>(null);
   const [state, setState] = useState<prometheusState>(prometheusState.LOADING);
+  const [timespan, setTimespan] = useState('24h');
+  const [resolution, setResolution] = useState('medium');
+  const [subPath, setSubPath] = useState<string | null>(null);
   const [isVisible, setIsVisible] = useState<boolean>(false);
 
   useEffect(() => {
@@ -64,6 +67,13 @@ export function DiskMetricsChart(props: DiskMetricsChartProps) {
         if (prefix) {
           setPrometheusPrefix(prefix);
           setState(prometheusState.INSTALLED);
+          
+          const loadedInterval = await getPrometheusInterval(cluster);
+          const loadedRes = await getPrometheusResolution(cluster);
+          const loadedSubPath = await getPrometheusSubPath(cluster);
+          setTimespan(loadedInterval ?? '1h');
+          setResolution(loadedRes ?? 'medium');
+          setSubPath(loadedSubPath);
         } else {
           setState(prometheusState.UNKNOWN);
         }
@@ -78,9 +88,7 @@ export function DiskMetricsChart(props: DiskMetricsChartProps) {
     return null;
   }
 
-  const interval = getPrometheusInterval(cluster);
-  const resolution = getPrometheusResolution(cluster);
-  const subPath = getPrometheusSubPath(cluster);
+
   return (
     <SectionBox>
       <Box
@@ -123,7 +131,7 @@ export function DiskMetricsChart(props: DiskMetricsChartProps) {
           <DiskChart
             usageQuery={props.usageQuery}
             capacityQuery={props.capacityQuery}
-            interval={interval}
+            interval={timespan}
             resolution={resolution}
             autoRefresh={refresh}
             prometheusPrefix={prometheusPrefix}

--- a/prometheus/src/components/Chart/GenericMetricsChart/GenericMetricsChart.tsx
+++ b/prometheus/src/components/Chart/GenericMetricsChart/GenericMetricsChart.tsx
@@ -59,6 +59,9 @@ export function GenericMetricsChart(props: GenericMetricsChartProps) {
   const [refresh, setRefresh] = useState<boolean>(true);
   const [state, setState] = useState<prometheusState>(prometheusState.LOADING);
   const [prometheusPrefix, setPrometheusPrefix] = useState<string | null>(null);
+  const [timespan, setTimespan] = useState('24h');
+  const [resolution, setResolution] = useState('medium');
+  const [subPath, setSubPath] = useState<string | null>(null);
   const [isVisible, setIsVisible] = useState<boolean>(false);
   const cluster = useCluster();
   const configStore = getConfigStore();
@@ -82,6 +85,13 @@ export function GenericMetricsChart(props: GenericMetricsChartProps) {
         if (prefix) {
           setPrometheusPrefix(prefix);
           setState(prometheusState.INSTALLED);
+          
+          const loadedInterval = await getPrometheusInterval(cluster);
+          const loadedRes = await getPrometheusResolution(cluster);
+          const loadedSubPath = await getPrometheusSubPath(cluster);
+          setTimespan(loadedInterval ?? '1h');
+          setResolution(loadedRes ?? 'medium');
+          setSubPath(loadedSubPath);
         } else {
           setState(prometheusState.UNKNOWN);
         }
@@ -95,12 +105,7 @@ export function GenericMetricsChart(props: GenericMetricsChartProps) {
     setChartVariant(event.currentTarget.value);
   };
 
-  const interval = getPrometheusInterval(cluster);
-  const graphResolution = getPrometheusResolution(cluster);
-  const subPath = getPrometheusSubPath(cluster);
 
-  const [timespan, setTimespan] = useState(interval ?? '1h');
-  const [resolution, setResolution] = useState(graphResolution ?? 'medium');
 
   if (!isVisible) {
     return null;

--- a/prometheus/src/components/Chart/KarpenterChart/KarpenterChart.tsx
+++ b/prometheus/src/components/Chart/KarpenterChart/KarpenterChart.tsx
@@ -55,6 +55,9 @@ export function KarpenterChart(props: KarpenterChartProps) {
   const [refresh, setRefresh] = useState<boolean>(true);
   const [prometheusPrefix, setPrometheusPrefix] = useState<string | null>(null);
   const [state, setState] = useState<prometheusState>(prometheusState.LOADING);
+  const [timespan, setTimespan] = useState('24h');
+  const [resolution, setResolution] = useState('medium');
+  const [subPath, setSubPath] = useState<string | null>(null);
   const [isVisible, setIsVisible] = useState<boolean>(false);
 
   useEffect(() => {
@@ -74,6 +77,13 @@ export function KarpenterChart(props: KarpenterChartProps) {
         if (prefix) {
           setPrometheusPrefix(prefix);
           setState(prometheusState.INSTALLED);
+          
+          const loadedInterval = await getPrometheusInterval(cluster);
+          const loadedRes = await getPrometheusResolution(cluster);
+          const loadedSubPath = await getPrometheusSubPath(cluster);
+          setTimespan(loadedInterval ?? '1h');
+          setResolution(loadedRes ?? 'medium');
+          setSubPath(loadedSubPath);
         } else {
           setState(prometheusState.UNKNOWN);
         }
@@ -84,12 +94,7 @@ export function KarpenterChart(props: KarpenterChartProps) {
     })();
   }, [clusterConfig, cluster]);
 
-  const interval = getPrometheusInterval(cluster);
-  const graphResolution = getPrometheusResolution(cluster);
-  const subPath = getPrometheusSubPath(cluster);
 
-  const [timespan, setTimespan] = useState(interval ?? '1h');
-  const [resolution, setResolution] = useState(graphResolution ?? 'medium');
   const [selectedChart, setSelectedChart] = useState<string>(
     props.defaultChart || props.chartConfigs[0]?.key || ''
   );

--- a/prometheus/src/components/Chart/KedaChart/KedaChart.tsx
+++ b/prometheus/src/components/Chart/KedaChart/KedaChart.tsx
@@ -121,6 +121,9 @@ export function KedaChart(props: KedaChartProps) {
   const [refresh, setRefresh] = useState<boolean>(true);
   const [prometheusPrefix, setPrometheusPrefix] = useState<string | null>(null);
   const [state, setState] = useState<prometheusState>(prometheusState.LOADING);
+  const [timespan, setTimespan] = useState('24h');
+  const [resolution, setResolution] = useState('medium');
+  const [subPath, setSubPath] = useState<string | null>(null);
   const [isVisible, setIsVisible] = useState<boolean>(false);
 
   useEffect(() => {
@@ -140,6 +143,13 @@ export function KedaChart(props: KedaChartProps) {
         if (prefix) {
           setPrometheusPrefix(prefix);
           setState(prometheusState.INSTALLED);
+          
+          const loadedInterval = await getPrometheusInterval(cluster);
+          const loadedRes = await getPrometheusResolution(cluster);
+          const loadedSubPath = await getPrometheusSubPath(cluster);
+          setTimespan(loadedInterval ?? '1h');
+          setResolution(loadedRes ?? 'medium');
+          setSubPath(loadedSubPath);
         } else {
           setState(prometheusState.UNKNOWN);
         }
@@ -150,12 +160,7 @@ export function KedaChart(props: KedaChartProps) {
     })();
   }, [clusterConfig, cluster]);
 
-  const interval = getPrometheusInterval(cluster);
-  const graphResolution = getPrometheusResolution(cluster);
-  const subPath = getPrometheusSubPath(cluster);
 
-  const [timespan, setTimespan] = useState(interval ?? '1h');
-  const [resolution, setResolution] = useState(graphResolution ?? 'medium');
 
   if (!isVisible) {
     return null;

--- a/prometheus/src/components/Chart/KnativeChart/KnativeChart.tsx
+++ b/prometheus/src/components/Chart/KnativeChart/KnativeChart.tsx
@@ -112,6 +112,9 @@ export function KnativeChart({
   const [refresh, setRefresh] = useState<boolean>(true);
   const [prometheusPrefix, setPrometheusPrefix] = useState<string | null>(null);
   const [state, setState] = useState<PrometheusState>(PrometheusState.LOADING);
+  const [timespan, setTimespan] = useState('24h');
+  const [resolution, setResolution] = useState('medium');
+  const [subPath, setSubPath] = useState<string | null>(null);
   const [isVisible, setIsVisible] = useState<boolean>(false);
 
   useEffect(() => {
@@ -131,6 +134,13 @@ export function KnativeChart({
         if (prefix) {
           setPrometheusPrefix(prefix);
           setState(PrometheusState.INSTALLED);
+          
+          const loadedInterval = await getPrometheusInterval(cluster);
+          const loadedRes = await getPrometheusResolution(cluster);
+          const loadedSubPath = await getPrometheusSubPath(cluster);
+          setTimespan(loadedInterval ?? '1h');
+          setResolution(loadedRes ?? 'medium');
+          setSubPath(loadedSubPath);
         } else {
           setState(PrometheusState.UNKNOWN);
         }
@@ -141,12 +151,6 @@ export function KnativeChart({
     })();
   }, [clusterConfig, cluster]);
 
-  const interval = getPrometheusInterval(cluster);
-  const graphResolution = getPrometheusResolution(cluster);
-  const subPath = getPrometheusSubPath(cluster);
-
-  const [timespan, setTimespan] = useState(interval ?? '1h');
-  const [resolution, setResolution] = useState(graphResolution ?? 'medium');
   const [selectedChart, setSelectedChart] = useState<string>(chartConfigs[0].key);
 
   useEffect(() => {

--- a/prometheus/src/components/Chart/StrimziChart/StrimziChart.tsx
+++ b/prometheus/src/components/Chart/StrimziChart/StrimziChart.tsx
@@ -163,6 +163,9 @@ export function StrimziChart(props: StrimziChartProps) {
   const [refresh, setRefresh] = useState<boolean>(true);
   const [prometheusPrefix, setPrometheusPrefix] = useState<string | null>(null);
   const [state, setState] = useState<prometheusState>(prometheusState.LOADING);
+  const [timespan, setTimespan] = useState('24h');
+  const [resolution, setResolution] = useState('medium');
+  const [subPath, setSubPath] = useState<string | null>(null);
   const [isVisible, setIsVisible] = useState<boolean>(false);
 
   useEffect(() => {
@@ -182,6 +185,13 @@ export function StrimziChart(props: StrimziChartProps) {
         if (prefix) {
           setPrometheusPrefix(prefix);
           setState(prometheusState.INSTALLED);
+          
+          const loadedInterval = await getPrometheusInterval(cluster);
+          const loadedRes = await getPrometheusResolution(cluster);
+          const loadedSubPath = await getPrometheusSubPath(cluster);
+          setTimespan(loadedInterval ?? '1h');
+          setResolution(loadedRes ?? 'medium');
+          setSubPath(loadedSubPath);
         } else {
           setState(prometheusState.UNKNOWN);
         }
@@ -192,12 +202,7 @@ export function StrimziChart(props: StrimziChartProps) {
     })();
   }, [clusterConfig, cluster]);
 
-  const interval = getPrometheusInterval(cluster);
-  const graphResolution = getPrometheusResolution(cluster);
-  const subPath = getPrometheusSubPath(cluster);
 
-  const [timespan, setTimespan] = useState(interval ?? '1h');
-  const [resolution, setResolution] = useState(graphResolution ?? 'medium');
   const [selectedChart, setSelectedChart] = useState<string>(
     props.defaultChart || props.chartConfigs[0]?.key || ''
   );

--- a/prometheus/src/components/Chart/VolcanoChart/VolcanoChart.tsx
+++ b/prometheus/src/components/Chart/VolcanoChart/VolcanoChart.tsx
@@ -133,6 +133,9 @@ export function VolcanoChart(props: VolcanoChartProps) {
   const [refresh, setRefresh] = useState<boolean>(true);
   const [prometheusPrefix, setPrometheusPrefix] = useState<string | null>(null);
   const [state, setState] = useState<PrometheusState>(PrometheusState.LOADING);
+  const [timespan, setTimespan] = useState('24h');
+  const [resolution, setResolution] = useState('medium');
+  const [subPath, setSubPath] = useState<string | null>(null);
   const [isVisible, setIsVisible] = useState<boolean>(false);
   const [selectedChart, setSelectedChart] = useState<string>(
     props.defaultChart || props.chartConfigs[0]?.key || ''
@@ -155,6 +158,13 @@ export function VolcanoChart(props: VolcanoChartProps) {
         if (prefix) {
           setPrometheusPrefix(prefix);
           setState(PrometheusState.INSTALLED);
+          
+          const loadedInterval = await getPrometheusInterval(cluster);
+          const loadedRes = await getPrometheusResolution(cluster);
+          const loadedSubPath = await getPrometheusSubPath(cluster);
+          setTimespan(loadedInterval ?? '1h');
+          setResolution(loadedRes ?? 'medium');
+          setSubPath(loadedSubPath);
         } else {
           setState(PrometheusState.UNKNOWN);
         }
@@ -165,12 +175,7 @@ export function VolcanoChart(props: VolcanoChartProps) {
     })();
   }, [clusterConfig, cluster]);
 
-  const interval = getPrometheusInterval(cluster);
-  const graphResolution = getPrometheusResolution(cluster);
-  const subPath = getPrometheusSubPath(cluster);
 
-  const [timespan, setTimespan] = useState(interval ?? '1h');
-  const [resolution, setResolution] = useState(graphResolution ?? 'medium');
 
   if (!isVisible || props.chartConfigs.length === 0) {
     return null;

--- a/prometheus/src/components/Settings/Settings.tsx
+++ b/prometheus/src/components/Settings/Settings.tsx
@@ -12,6 +12,7 @@ import Switch from '@mui/material/Switch';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import { useEffect, useState } from 'react';
+import type { ClusterData } from '../../../util';
 
 /**
  * Validates if the given address string is in the correct format.
@@ -66,37 +67,36 @@ export function Settings(props: SettingsProps) {
     }
   }, [clusters, selectedCluster]);
 
+  const [deploymentConfig, setDeploymentConfig] = useState<Partial<ClusterData>>({});
   useEffect(() => {
-    if (selectedCluster && !data?.[selectedCluster]) {
-      onDataChange({
-        ...data,
-        [selectedCluster]: {
-          isMetricsEnabled: true,
-          autoDetect: true,
-          defaultTimespan: '24h',
-          defaultResolution: 'medium',
-        },
-      });
-    }
-  }, [selectedCluster, data, onDataChange]);
+    import('../../../util').then(({ fetchDeploymentConfig }) => {
+      fetchDeploymentConfig(selectedCluster).then(setDeploymentConfig);
+    });
+  }, [selectedCluster]);
 
-  const selectedClusterData = data?.[selectedCluster] || {};
-  const isMetricsEnabled = selectedClusterData.isMetricsEnabled ?? true;
-  const isAutoDetectEnabled = isMetricsEnabled && (selectedClusterData.autoDetect ?? true);
+  const userClusterData = data?.[selectedCluster] || {};
+  
+  const isMetricsEnabled = userClusterData.isMetricsEnabled ?? deploymentConfig.isMetricsEnabled ?? true;
+  const isAutoDetectEnabled = isMetricsEnabled && (userClusterData.autoDetect ?? deploymentConfig.autoDetect ?? true);
   const isAddressFieldEnabled = isMetricsEnabled && !isAutoDetectEnabled;
+  
+  const effectiveAddress = userClusterData.address ?? deploymentConfig.address ?? '';
+  const effectiveSubPath = userClusterData.subPath ?? deploymentConfig.subPath ?? '';
+  const effectiveTimespan = userClusterData.defaultTimespan ?? deploymentConfig.defaultTimespan ?? '24h';
+  const effectiveResolution = userClusterData.defaultResolution ?? deploymentConfig.defaultResolution ?? 'medium';
 
   useEffect(() => {
-    if (selectedClusterData.address) {
-      setAddressError(!isValidAddress(selectedClusterData.address));
+    if (effectiveAddress) {
+      setAddressError(!isValidAddress(effectiveAddress));
       setTestStatus('idle');
       setTestMessage('');
     } else {
       setAddressError(false);
     }
-  }, [selectedClusterData.address]);
+  }, [effectiveAddress]);
 
   const handleTestConnection = async () => {
-    if (!selectedClusterData.address || !isValidAddress(selectedClusterData.address)) {
+    if (!effectiveAddress || !isValidAddress(effectiveAddress)) {
       setAddressError(true);
       setTestMessage(t('Invalid Address Format'));
       setTestStatus('error');
@@ -107,10 +107,10 @@ export function Settings(props: SettingsProps) {
     setTestMessage(t('Testing Connection'));
 
     try {
-      const [namespace, serviceAndPort] = selectedClusterData.address.split('/');
+      const [namespace, serviceAndPort] = effectiveAddress.split('/');
       const [service, port] = serviceAndPort.split(':');
 
-      let subPath = selectedClusterData.subPath || '';
+      let subPath = effectiveSubPath;
       if (subPath && !subPath.startsWith('/')) {
         subPath = '/' + subPath;
       }
@@ -142,9 +142,9 @@ export function Settings(props: SettingsProps) {
             onDataChange({
               ...(data || {}),
               [selectedCluster]: {
-                ...((data || {})[selectedCluster] || {}),
+                ...userClusterData,
                 isMetricsEnabled: newMetricsEnabled,
-                autoDetect: newMetricsEnabled ? data?.[selectedCluster]?.autoDetect ?? true : false,
+                autoDetect: newMetricsEnabled ? userClusterData.autoDetect ?? deploymentConfig.autoDetect ?? true : false,
               },
             });
           }}
@@ -161,7 +161,7 @@ export function Settings(props: SettingsProps) {
             onDataChange({
               ...(data || {}),
               [selectedCluster]: {
-                ...((data || {})[selectedCluster] || {}),
+                ...userClusterData,
                 autoDetect: e.target.checked,
               },
             })
@@ -180,17 +180,18 @@ export function Settings(props: SettingsProps) {
                 addressError
                   ? t('Invalid format. Use: namespace/service-name:port')
                   : t(
-                      'Address of the Prometheus Service, only used when auto-detection is disabled. Format: namespace/service-name:port'
+                      'Address of the Prometheus Service. If left blank, the deployment default is used.'
                     )
               }
               error={addressError}
-              value={selectedClusterData.address || ''}
+              value={userClusterData.address || ''}
+              placeholder={deploymentConfig.address || ''}
               onChange={e => {
                 const newAddress = e.target.value;
                 onDataChange({
                   ...(data || {}),
                   [selectedCluster]: {
-                    ...((data || {})[selectedCluster] || {}),
+                    ...userClusterData,
                     address: newAddress,
                   },
                 });
@@ -202,7 +203,7 @@ export function Settings(props: SettingsProps) {
               disabled={
                 !isAddressFieldEnabled ||
                 addressError ||
-                !selectedClusterData.address ||
+                !effectiveAddress ||
                 testStatus === 'testing'
               }
               onClick={handleTestConnection}
@@ -226,16 +227,17 @@ export function Settings(props: SettingsProps) {
       name: t('Prometheus Service Subpath'),
       value: (
         <TextField
-          value={selectedClusterData.subPath || ''}
+          value={userClusterData.subPath || ''}
+          placeholder={deploymentConfig.subPath || ''}
           disabled={!isAddressFieldEnabled}
           helperText={t(
-            "Optional subpath to the Prometheus Service endpoint. Only used when auto-detection is disabled. Examples: 'prometheus'."
+            "Optional subpath to the Prometheus Service endpoint. Examples: 'prometheus'. If left blank, the deployment default is used."
           )}
           onChange={e => {
             const newSubPath = e.target.value;
             onDataChange({
               ...(data || {}),
-              [selectedCluster]: { ...((data || {})[selectedCluster] || {}), subPath: newSubPath },
+              [selectedCluster]: { ...userClusterData, subPath: newSubPath },
             });
           }}
         />
@@ -246,12 +248,12 @@ export function Settings(props: SettingsProps) {
       value: (
         <Select
           disabled={!isMetricsEnabled}
-          value={data?.[selectedCluster]?.defaultTimespan || '24h'}
+          value={effectiveTimespan}
           onChange={e =>
             onDataChange({
               ...(data || {}),
               [selectedCluster]: {
-                ...((data || {})[selectedCluster] || {}),
+                ...userClusterData,
                 defaultTimespan: e.target.value,
               },
             })
@@ -279,12 +281,12 @@ export function Settings(props: SettingsProps) {
       value: (
         <Select
           disabled={!isMetricsEnabled}
-          value={data?.[selectedCluster]?.defaultResolution || 'medium'}
+          value={effectiveResolution}
           onChange={e =>
             onDataChange({
               ...(data || {}),
               [selectedCluster]: {
-                ...((data || {})[selectedCluster] || {}),
+                ...userClusterData,
                 defaultResolution: e.target.value,
               },
             })

--- a/prometheus/src/util.ts
+++ b/prometheus/src/util.ts
@@ -1,4 +1,4 @@
-import { ConfigStore } from '@kinvolk/headlamp-plugin/lib';
+import { ConfigStore, ApiProxy } from '@kinvolk/headlamp-plugin/lib';
 import { KarpenterDisruptionChart } from './components/Chart/KarpenterDisruptionChart/KarpenterDisruptionChart';
 import { NodeClaimCreationChart } from './components/Chart/KarpenterNodeClaimCreationChart/KarpenterNodeClaimCreationChart';
 import { KarpenterNodeClaimsProvisionChart } from './components/Chart/KarpenterNodeClaimProvisionChart/KarpenterNodeClaimProvisionChart';
@@ -16,7 +16,7 @@ export const PLUGIN_NAME = 'prometheus';
  * @property {string} defaultTimespan - The default timespan for metrics.
  * @property {string} defaultResolution - The default resolution for metrics.
  */
-type ClusterData = {
+export type ClusterData = {
   autoDetect?: boolean;
   isMetricsEnabled?: boolean;
   address?: string;
@@ -53,6 +53,78 @@ function getClusterConfig(cluster: string): ClusterData | null {
     return null;
   }
   return conf[cluster] || null;
+}
+
+let deploymentConfigCache: Record<string, ClusterData> = {};
+let deploymentConfigPromise: Record<string, Promise<ClusterData>> = {};
+
+/**
+ * Fetches the deployment-wide default configuration from a ConfigMap.
+ * @param {string} [cluster] - The name of the cluster.
+ * @returns {Promise<ClusterData>} The deployment configuration.
+ */
+export async function fetchDeploymentConfig(cluster?: string): Promise<ClusterData> {
+  const cacheKey = cluster || 'default';
+  if (deploymentConfigCache[cacheKey]) return deploymentConfigCache[cacheKey];
+  if (!deploymentConfigPromise[cacheKey]) {
+    deploymentConfigPromise[cacheKey] = (async () => {
+      try {
+        const queryParams = new URLSearchParams();
+        queryParams.append('labelSelector', 'headlamp.kubernetes.io/prometheus-config=true');
+
+        const searchResponse = await ApiProxy.request(
+          `/api/v1/namespaces/kube-public/configmaps?${queryParams}`,
+          {
+            method: 'GET',
+          }
+        );
+        
+        if (searchResponse?.items?.length > 0) {
+            const data = searchResponse.items[0].data || {};
+            return {
+               address: data.address,
+               subPath: data.subPath,
+               defaultTimespan: data.defaultTimespan,
+               defaultResolution: data.defaultResolution,
+               autoDetect: data.autoDetect ? data.autoDetect === 'true' : undefined,
+               isMetricsEnabled: data.isMetricsEnabled ? data.isMetricsEnabled === 'true' : undefined,
+            };
+        }
+      } catch(e) {
+        console.error("Failed to fetch deployment Prometheus config", e);
+        delete deploymentConfigPromise[cacheKey];
+        throw e;
+      }
+      return {};
+    })();
+  }
+  
+  try {
+    const config = await deploymentConfigPromise[cacheKey];
+    deploymentConfigCache[cacheKey] = config;
+    return config;
+  } catch(e) {
+    return {};
+  }
+}
+
+/**
+ * Returns the effective configuration for a specific cluster by merging built-in defaults, deployment defaults, and user settings.
+ * @param {string} cluster - The name of the cluster.
+ * @returns {Promise<ClusterData>} The effective configuration for the cluster.
+ */
+export async function getEffectiveClusterConfig(cluster: string): Promise<ClusterData> {
+  const userConfig = getClusterConfig(cluster) || {};
+  const deploymentConfig = await fetchDeploymentConfig(cluster);
+  
+  return {
+    isMetricsEnabled: userConfig.isMetricsEnabled ?? deploymentConfig.isMetricsEnabled ?? true,
+    autoDetect: userConfig.autoDetect ?? deploymentConfig.autoDetect ?? true,
+    address: userConfig.address ?? deploymentConfig.address,
+    subPath: userConfig.subPath ?? deploymentConfig.subPath,
+    defaultTimespan: userConfig.defaultTimespan ?? deploymentConfig.defaultTimespan ?? '24h',
+    defaultResolution: userConfig.defaultResolution ?? deploymentConfig.defaultResolution ?? 'medium',
+  };
 }
 
 /**
@@ -97,7 +169,7 @@ export function disableMetrics(cluster: string) {
 export async function getPrometheusPrefix(cluster: string): Promise<string | null> {
   // check if cluster has autoDetect enabled
   // if so return the prometheus pod address
-  const clusterData = getClusterConfig(cluster);
+  const clusterData = await getEffectiveClusterConfig(cluster);
   if (clusterData?.autoDetect) {
     const prometheusEndpoint = await isPrometheusInstalled();
     if (prometheusEndpoint.type === KubernetesType.none) {
@@ -117,30 +189,30 @@ export async function getPrometheusPrefix(cluster: string): Promise<string | nul
 /**
  * getPrometheusSubPath returns the subpath for the Prometheus metrics.
  * @param {string} cluster - The name of the cluster.
- * @returns {string | null} The subpath for the Prometheus metrics, or null if not found.
+ * @returns {Promise<string | null>} The subpath for the Prometheus metrics, or null if not found.
  */
-export function getPrometheusSubPath(cluster: string): string | null {
-  const clusterData = getClusterConfig(cluster);
+export async function getPrometheusSubPath(cluster: string): Promise<string | null> {
+  const clusterData = await getEffectiveClusterConfig(cluster);
   return !clusterData?.subPath || clusterData.subPath === '' ? null : clusterData.subPath;
 }
 
 /**
  * getPrometheusInterval returns the default timespan for the Prometheus metrics.
  * @param {string} cluster - The name of the cluster.
- * @returns {string} The default timespan for the Prometheus metrics.
+ * @returns {Promise<string>} The default timespan for the Prometheus metrics.
  */
-export function getPrometheusInterval(cluster: string): string {
-  const clusterData = getClusterConfig(cluster);
+export async function getPrometheusInterval(cluster: string): Promise<string> {
+  const clusterData = await getEffectiveClusterConfig(cluster);
   return clusterData?.defaultTimespan ?? '24h';
 }
 
 /**
  * getPrometheusResolution returns the default resolution for the Prometheus metrics.
  * @param {string} cluster - The name of the cluster.
- * @returns {string} The default resolution for the Prometheus metrics.
+ * @returns {Promise<string>} The default resolution for the Prometheus metrics.
  */
-export function getPrometheusResolution(cluster: string): string {
-  const clusterData = getClusterConfig(cluster);
+export async function getPrometheusResolution(cluster: string): Promise<string> {
+  const clusterData = await getEffectiveClusterConfig(cluster);
   return clusterData?.defaultResolution ?? 'medium';
 }
 


### PR DESCRIPTION
## Description

This PR introduces support for a deployment-wide default configuration in the Prometheus plugin, leveraging a Kubernetes `ConfigMap`.. it fixes/builds on #969 

### Motivation

Currently, the Prometheus plugin stores the configured URL and other settings exclusively in the user's local `ConfigStore`. While this works well for individual preferences, it creates friction for administrators managing Headlamp deployments declaratively via GitOps they cannot easily provision a working out-of-the-box Prometheus integration for all users without manual configuration per browser.

### Solution

This change implements a mechanism to fetch cluster-wide default settings by reading from a `ConfigMap` labeled `headlamp.kubernetes.io/prometheus-config=true`. 

A new configuration resolution precedence is established:
1. **User Settings** (Local `ConfigStore` - highest priority)
2. **Deployment Configuration** (`ConfigMap`)
3. **Built-in Defaults** (e.g., `autoDetect: true`)

### Changes Made

- **`util.ts`**:
  - Added `fetchDeploymentConfig` to asynchronously fetch a Prometheus config `ConfigMap` across the active cluster.
  - Added `getEffectiveClusterConfig` which merges user settings, deployment settings, and default settings according to the precedence rules.
  - Refactored `getPrometheusInterval`, `getPrometheusResolution`, and `getPrometheusSubPath` to be asynchronous so they can accurately return effective configurations.
- **Chart Components**: Refactored all 8 Prometheus chart components (e.g., `GenericMetricsChart`, `KarpenterChart`, `StrimziChart`) to properly `await` the configuration getters inside their `useEffect` lifecycle hooks.
- **`Settings.tsx` UI**: Updated the settings page to properly reflect deployment defaults as placeholders/hints when no local overrides are present. It now gracefully displays the effective configuration without eagerly persisting the defaults back to the local `ConfigStore`, ensuring true user overrides are sparse and intentional.

## How to Test

1. Create a ConfigMap in your cluster with the required label (e.g., in `kube-public` namespace):
    ```yaml
    apiVersion: v1
    kind: ConfigMap
    metadata:
      name: headlamp-prometheus-default
      namespace: kube-public
      labels:
        headlamp.kubernetes.io/prometheus-config: "true"
    data:
      address: "monitoring/prometheus:9090"
      defaultTimespan: "1h"
      defaultResolution: "medium"
      autoDetect: "false"
      isMetricsEnabled: "true"
    ```
2. Open Headlamp without any prior Prometheus configuration.
3. Navigate to a metrics view (e.g., a node or pod with charts). The plugin should automatically use the `monitoring/prometheus:9090` endpoint.
4. Navigate to the Prometheus settings page. Ensure the fields dynamically reflect the `ConfigMap` defaults.
5. Override a setting (e.g., set a new address). Ensure your local settings take precedence over the `ConfigMap` defaults.