### PR TITLE
Kmesh: nodeinfo: Implement KmeshNodeInfo IPsec visualization

### DIFF
--- a/kmesh/src/components/nodeinfo/Detail.tsx
+++ b/kmesh/src/components/nodeinfo/Detail.tsx
@@ -1,0 +1,174 @@
+/**
+ * Detail view for a single KmeshNodeInfo resource.
+ * Shows full IPsec security state for one node: SPI, addresses, Pod CIDRs, and boot ID.
+ */
+import {
+  MainInfoSection,
+  SimpleTable,
+  StatusLabel,
+} from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Chip from '@mui/material/Chip';
+import CircularProgress from '@mui/material/CircularProgress';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+import React from 'react';
+import { useParams } from 'react-router-dom';
+import { KmeshNodeInfo } from '../../resources/kmeshNodeInfo';
+
+/**
+ * Detail view for a single KmeshNodeInfo resource.
+ */
+export default function KmeshNodeInfoDetail() {
+  const { namespace, name } = useParams<{ namespace?: string; name?: string }>();
+
+  const [nodeInfos, error] = KmeshNodeInfo.useList({ namespace });
+  const nodeInfo = nodeInfos?.find(n => n.getName() === name);
+
+  // Compute SPI consensus across all nodes in same namespace (kmesh-system)
+  const consensusSpi =
+    nodeInfos && nodeInfos.length > 0
+      ? (() => {
+          const counts = new Map<number, number>();
+          nodeInfos.forEach(n => counts.set(n.spi, (counts.get(n.spi) ?? 0) + 1));
+          let maxCount = 0;
+          let consensus = nodeInfos[0].spi;
+          counts.forEach((count, spi) => {
+            if (count > maxCount) {
+              maxCount = count;
+              consensus = spi;
+            }
+          });
+          return consensus;
+        })()
+      : null;
+
+  if (error) {
+    return <Typography color="error">Error: {String(error)}</Typography>;
+  }
+
+  if (!nodeInfos) {
+    return <CircularProgress />;
+  }
+
+  if (!nodeInfo) {
+    return (
+      <Typography color="error">
+        KmeshNodeInfo "{name}" not found in namespace "{namespace}".
+      </Typography>
+    );
+  }
+
+  const isStale = consensusSpi !== null && nodeInfo.spi !== consensusSpi;
+
+  const tableData = [
+    {
+      name: 'SPI (Key Version)',
+      value: (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <StatusLabel status={isStale ? 'error' : 'success'}>v{nodeInfo.spi}</StatusLabel>
+          {isStale ? (
+            <Typography variant="caption" color="error">
+              ⚠ Stale — cluster consensus is v{consensusSpi}
+            </Typography>
+          ) : (
+            <Typography variant="caption" color="success.main">
+              ✅ In sync with cluster
+            </Typography>
+          )}
+        </Box>
+      ),
+    },
+    {
+      name: 'Boot ID',
+      value: (
+        <Tooltip
+          title="Changes on every node reboot, triggering IPsec key rotation"
+          placement="top"
+        >
+          <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>
+            {nodeInfo.bootID || '—'}
+          </Typography>
+        </Tooltip>
+      ),
+    },
+    {
+      name: 'Node IP Addresses',
+      value:
+        nodeInfo.addresses.length > 0 ? (
+          <Box sx={{ display: 'flex', gap: 0.75, flexWrap: 'wrap' }}>
+            {nodeInfo.addresses.map(addr => (
+              <Chip key={addr} label={addr} size="small" variant="outlined" />
+            ))}
+          </Box>
+        ) : (
+          'None'
+        ),
+    },
+    {
+      name: 'Pod CIDRs',
+      value:
+        nodeInfo.podCIDRS.length > 0 ? (
+          <Box sx={{ display: 'flex', gap: 0.75, flexWrap: 'wrap' }}>
+            {nodeInfo.podCIDRS.map(cidr => (
+              <Chip key={cidr} label={cidr} size="small" color="info" variant="outlined" />
+            ))}
+          </Box>
+        ) : (
+          'None'
+        ),
+    },
+  ];
+
+  return (
+    <Box>
+      <MainInfoSection
+        resource={nodeInfo}
+        extraInfo={[
+          {
+            name: 'SPI (Key Version)',
+            value: `v${nodeInfo.spi}`,
+          },
+          {
+            name: 'Boot ID',
+            value: nodeInfo.bootID,
+          },
+        ]}
+      />
+
+      {/* SPI health alert */}
+      {isStale && (
+        <Alert severity="error" sx={{ mx: 2, mb: 2 }}>
+          <strong>Stale IPsec Key Detected</strong> — This node&apos;s SPI (v{nodeInfo.spi}) does
+          not match the cluster consensus (v{consensusSpi}). IPsec tunnels from this node to other
+          nodes will fail. The Kmesh IPsec controller should automatically rotate keys on next
+          reconcile or node event.
+        </Alert>
+      )}
+
+      <Box sx={{ mt: 2 }}>
+        <Typography variant="h6" sx={{ mb: 1, px: 2 }}>
+          IPsec Security Details
+        </Typography>
+        <SimpleTable
+          data={tableData}
+          columns={[
+            {
+              label: 'Property',
+              getter: (row: any) => (
+                <Typography variant="body2" sx={{ fontWeight: 600, color: 'text.secondary' }}>
+                  {row.name}
+                </Typography>
+              ),
+            },
+            {
+              label: 'Value',
+              getter: (row: any) => row.value,
+            },
+          ]}
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/kmesh/src/components/nodeinfo/List.tsx
+++ b/kmesh/src/components/nodeinfo/List.tsx
@@ -1,0 +1,170 @@
+/**
+ * List view for KmeshNodeInfo CRDs.
+ * Shows per-node IPsec security state with SPI consistency check.
+ * An SPI mismatch across nodes means IPsec key rotation is broken on that node.
+ */
+import {
+  SectionBox,
+  SimpleTable,
+  StatusLabel,
+} from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import Alert from '@mui/material/Alert';
+import AlertTitle from '@mui/material/AlertTitle';
+import Box from '@mui/material/Box';
+import Chip from '@mui/material/Chip';
+import CircularProgress from '@mui/material/CircularProgress';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+import { KmeshNodeInfo } from '../../resources/kmeshNodeInfo';
+
+/**
+ * Derives the cluster-wide consensus SPI by finding the most common value.
+ * This is used to identify nodes whose SPI key is stale (out of sync).
+ */
+function getConsensusSpi(nodes: KmeshNodeInfo[]): number | null {
+  if (nodes.length === 0) return null;
+  const counts = new Map<number, number>();
+  nodes.forEach(n => {
+    const spi = n.spi;
+    counts.set(spi, (counts.get(spi) ?? 0) + 1);
+  });
+  let maxCount = 0;
+  let consensus = nodes[0].spi;
+  counts.forEach((count, spi) => {
+    if (count > maxCount) {
+      maxCount = count;
+      consensus = spi;
+    }
+  });
+  return consensus;
+}
+
+/**
+ * List view for KmeshNodeInfo resources showing per-node IPsec state.
+ */
+export default function KmeshNodeInfoList() {
+  const [nodeInfos, error] = KmeshNodeInfo.useList();
+
+  if (error) {
+    return (
+      <SectionBox title="Node Security (IPsec)">
+        <Typography color="error">Error loading KmeshNodeInfo: {String(error)}</Typography>
+      </SectionBox>
+    );
+  }
+
+  if (!nodeInfos) {
+    return (
+      <SectionBox title="Node Security (IPsec)">
+        <CircularProgress />
+      </SectionBox>
+    );
+  }
+
+  // No nodes using IPsec (feature not enabled or no nodes reporting)
+  if (nodeInfos.length === 0) {
+    return (
+      <SectionBox title="Node Security (IPsec)">
+        <Typography color="text.secondary">
+          No KmeshNodeInfo resources found. IPsec encryption may not be enabled in this cluster.
+        </Typography>
+      </SectionBox>
+    );
+  }
+
+  const consensusSpi = getConsensusSpi(nodeInfos);
+  const stalNodes = nodeInfos.filter(n => n.spi !== consensusSpi);
+  const allInSync = stalNodes.length === 0;
+
+  return (
+    <Box>
+      {/* Cluster-wide IPsec health banner */}
+      <Alert severity={allInSync ? 'success' : 'error'} sx={{ mb: 2 }}>
+        <AlertTitle>
+          {allInSync
+            ? `IPsec Cluster SPI: v${consensusSpi} — All nodes in sync ✅`
+            : `⚠️ IPsec SPI Mismatch Detected — Cluster consensus: v${consensusSpi}`}
+        </AlertTitle>
+        {!allInSync && (
+          <>
+            <strong>
+              {stalNodes.length} node(s) have stale SPI keys:{' '}
+              {stalNodes.map(n => n.getName()).join(', ')}
+            </strong>
+            <br />
+            These nodes cannot establish secure IPsec tunnels with the rest of the cluster. A key
+            rotation may be in progress, or the Kmesh IPsec controller may have failed on those
+            nodes.
+          </>
+        )}
+      </Alert>
+
+      <SectionBox title="Node Security (IPsec)">
+        <SimpleTable
+          data={nodeInfos}
+          columns={[
+            {
+              label: 'Node Name',
+              getter: (node: KmeshNodeInfo) => node.getName(),
+              sort: true,
+            },
+            {
+              label: 'SPI (Key Version)',
+              getter: (node: KmeshNodeInfo) => {
+                const isStale = node.spi !== consensusSpi;
+                return (
+                  <StatusLabel status={isStale ? 'error' : 'success'}>
+                    {`v${node.spi}`}
+                    {isStale && ' ⚠ Stale'}
+                  </StatusLabel>
+                );
+              },
+              sort: (node: KmeshNodeInfo) => node.spi,
+            },
+            {
+              label: 'IP Addresses',
+              getter: (node: KmeshNodeInfo) => (
+                <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
+                  {node.addresses.map(addr => (
+                    <Chip key={addr} label={addr} size="small" variant="outlined" />
+                  ))}
+                </Box>
+              ),
+            },
+            {
+              label: 'Pod CIDRs',
+              getter: (node: KmeshNodeInfo) => (
+                <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
+                  {node.podCIDRS.map(cidr => (
+                    <Chip key={cidr} label={cidr} size="small" color="info" variant="outlined" />
+                  ))}
+                </Box>
+              ),
+            },
+            {
+              label: 'Boot ID',
+              getter: (node: KmeshNodeInfo) => (
+                <Tooltip title={node.bootID} placement="top">
+                  <Typography
+                    variant="body2"
+                    sx={{
+                      fontFamily: 'monospace',
+                      fontSize: '0.75rem',
+                      maxWidth: 160,
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {node.bootID}
+                  </Typography>
+                </Tooltip>
+              ),
+            },
+          ]}
+          emptyMessage="No KmeshNodeInfo resources found."
+        />
+      </SectionBox>
+    </Box>
+  );
+}

--- a/kmesh/src/index.test.ts
+++ b/kmesh/src/index.test.ts
@@ -22,4 +22,11 @@ describe('Kmesh Routes', () => {
     expect(kmeshRoutePaths.authzPolicies).toBe('/kmesh/authz-policies');
     expect(kmeshRouteNames.authzPolicies).toBe('kmesh-authz-policies');
   });
+
+  it('should define the KmeshNodeInfo (Node Security) routes correctly', () => {
+    expect(kmeshRoutePaths.nodeInfoList).toBe('/kmesh/node-security');
+    expect(kmeshRoutePaths.nodeInfoDetail).toBe('/kmesh/node-security/:namespace/:name');
+    expect(kmeshRouteNames.nodeInfoList).toBe('kmesh-nodeinfo-list');
+    expect(kmeshRouteNames.nodeInfoDetail).toBe('kmesh-nodeinfo-detail');
+  });
 });

--- a/kmesh/src/index.tsx
+++ b/kmesh/src/index.tsx
@@ -5,6 +5,8 @@ import EbpfMaps from './components/daemon/EbpfMaps';
 import HealthDashboard from './components/daemon/HealthDashboard';
 import ObservabilityPanel from './components/daemon/ObservabilityPanel';
 import XdsConfigDump from './components/daemon/XdsConfigDump';
+import KmeshNodeInfoDetail from './components/nodeinfo/Detail';
+import KmeshNodeInfoList from './components/nodeinfo/List';
 import WaypointDetail from './components/waypoints/Detail';
 import WaypointList from './components/waypoints/List';
 import { kmeshRouteNames, kmeshRoutePaths } from './utils/kmeshRoutes';
@@ -86,6 +88,16 @@ const kmeshResources: KmeshResourceRegistration[] = [
     detailRouteName: kmeshRouteNames.waypointDetail,
     ListComponent: WaypointList,
     DetailComponent: WaypointDetail,
+  },
+  {
+    sidebarName: 'kmesh-node-security',
+    label: 'Node Security',
+    listPath: kmeshRoutePaths.nodeInfoList,
+    detailPath: kmeshRoutePaths.nodeInfoDetail,
+    listRouteName: kmeshRouteNames.nodeInfoList,
+    detailRouteName: kmeshRouteNames.nodeInfoDetail,
+    ListComponent: KmeshNodeInfoList,
+    DetailComponent: KmeshNodeInfoDetail,
   },
 ];
 

--- a/kmesh/src/index.tsx
+++ b/kmesh/src/index.tsx
@@ -4,6 +4,8 @@ import AuthzPolicies from './components/daemon/AuthzPolicies';
 import HealthDashboard from './components/daemon/HealthDashboard';
 import ObservabilityPanel from './components/daemon/ObservabilityPanel';
 import XdsConfigDump from './components/daemon/XdsConfigDump';
+import KmeshNodeInfoDetail from './components/nodeinfo/Detail';
+import KmeshNodeInfoList from './components/nodeinfo/List';
 import WaypointDetail from './components/waypoints/Detail';
 import WaypointList from './components/waypoints/List';
 import { kmeshRouteNames, kmeshRoutePaths } from './utils/kmeshRoutes';
@@ -85,6 +87,16 @@ const kmeshResources: KmeshResourceRegistration[] = [
     detailRouteName: kmeshRouteNames.waypointDetail,
     ListComponent: WaypointList,
     DetailComponent: WaypointDetail,
+  },
+  {
+    sidebarName: 'kmesh-node-security',
+    label: 'Node Security',
+    listPath: kmeshRoutePaths.nodeInfoList,
+    detailPath: kmeshRoutePaths.nodeInfoDetail,
+    listRouteName: kmeshRouteNames.nodeInfoList,
+    detailRouteName: kmeshRouteNames.nodeInfoDetail,
+    ListComponent: KmeshNodeInfoList,
+    DetailComponent: KmeshNodeInfoDetail,
   },
 ];
 

--- a/kmesh/src/resources/kmeshNodeInfo.ts
+++ b/kmesh/src/resources/kmeshNodeInfo.ts
@@ -1,0 +1,80 @@
+import { KubeObject, KubeObjectInterface } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import { kmeshRoutePaths } from '../utils/kmeshRoutes';
+
+/**
+ * Specification for the KmeshNodeInfo CRD.
+ * Describes per-node IPsec security state managed by the Kmesh IPsec controller.
+ * @see kmesh/pkg/kube/apis/kmeshnodeinfo/v1alpha1/types.go
+ * @see kmesh/deploy/yaml/crd/kmesh.net_kmeshnodeinfos.yaml
+ */
+export interface KmeshNodeInfoSpec {
+  /**
+   * The SPI (Security Parameter Index) identifies the current IPsec key version.
+   * All nodes must agree on the same SPI for IPsec tunnels to function correctly.
+   * A mismatch means a node has a stale key and cannot communicate securely.
+   */
+  spi: number;
+  /**
+   * Internal IP addresses of this node used to determine which network adapter
+   * is used to encrypt and send IPsec data.
+   */
+  addresses: string[];
+  /**
+   * Node boot ID used to generate the IPsec key. Changes on every node reboot,
+   * triggering an automatic key rotation by the Kmesh IPsec controller.
+   */
+  bootID: string;
+  /**
+   * Pod CIDRs on this node. IPsec uses this to determine which traffic
+   * needs to be encrypted (destinations within these ranges go through IPsec).
+   */
+  podCIDRS: string[];
+}
+
+/**
+ * Raw Kubernetes object interface for the KmeshNodeInfo CRD.
+ */
+export interface KubeKmeshNodeInfo extends KubeObjectInterface {
+  spec?: KmeshNodeInfoSpec;
+}
+
+/**
+ * Headlamp KubeObject class for the KmeshNodeInfo CRD.
+ * Manages per-node IPsec security state in a Kmesh-enabled cluster.
+ * Group/Version/Resource: kmesh.net/v1alpha1/kmeshnodeinfos
+ * Scope: Namespaced (lives in kmesh-system namespace)
+ */
+export class KmeshNodeInfo extends KubeObject<KubeKmeshNodeInfo> {
+  static kind = 'KmeshNodeInfo';
+  static apiName = 'kmeshnodeinfos';
+  static apiVersion = 'kmesh.net/v1alpha1';
+  static isNamespaced = true;
+
+  static get detailsRoute() {
+    return kmeshRoutePaths.nodeInfoDetail;
+  }
+
+  get spec() {
+    return this.jsonData.spec;
+  }
+
+  /** IPsec key version number. Must match across all nodes in the cluster. */
+  get spi() {
+    return this.spec?.spi ?? 0;
+  }
+
+  /** Node IP addresses used for IPsec tunnel termination. */
+  get addresses() {
+    return this.spec?.addresses ?? [];
+  }
+
+  /** Pod CIDRs managed by this node, used for IPsec routing decisions. */
+  get podCIDRS() {
+    return this.spec?.podCIDRS ?? [];
+  }
+
+  /** Boot ID used for IPsec key generation; changes on every reboot. */
+  get bootID() {
+    return this.spec?.bootID ?? '';
+  }
+}

--- a/kmesh/src/utils/kmeshRoutes.ts
+++ b/kmesh/src/utils/kmeshRoutes.ts
@@ -9,6 +9,9 @@ export const kmeshRouteNames = {
   healthDashboard: 'kmesh-health-dashboard',
   observability: 'kmesh-observability',
   authzPolicies: 'kmesh-authz-policies',
+  /** KmeshNodeInfo CRD — per-node IPsec security state */
+  nodeInfoList: 'kmesh-nodeinfo-list',
+  nodeInfoDetail: 'kmesh-nodeinfo-detail',
 } as const;
 
 /**
@@ -23,4 +26,7 @@ export const kmeshRoutePaths = {
   healthDashboard: '/kmesh/health',
   observability: '/kmesh/observability',
   authzPolicies: '/kmesh/authz-policies',
+  /** KmeshNodeInfo CRD — per-node IPsec security state */
+  nodeInfoList: '/kmesh/node-security',
+  nodeInfoDetail: '/kmesh/node-security/:namespace/:name',
 } as const;

--- a/kmesh/src/utils/kmeshRoutes.ts
+++ b/kmesh/src/utils/kmeshRoutes.ts
@@ -11,6 +11,9 @@ export const kmeshRouteNames = {
   authzPolicies: 'kmesh-authz-policies',
   /** eBPF Map Viewer (dual-engine / workload mode) */
   ebpfMaps: 'kmesh-ebpf-maps',
+  /** KmeshNodeInfo CRD — per-node IPsec security state */
+  nodeInfoList: 'kmesh-nodeinfo-list',
+  nodeInfoDetail: 'kmesh-nodeinfo-detail',
 } as const;
 
 /**
@@ -28,4 +31,7 @@ export const kmeshRoutePaths = {
   /** eBPF Map Viewer — surfaces live kernel BPF maps (backends, frontends,
    *  services, endpoints, workload policies) from the dual-engine daemon. */
   ebpfMaps: '/kmesh/ebpf-maps',
+  /** KmeshNodeInfo CRD — per-node IPsec security state */
+  nodeInfoList: '/kmesh/node-security',
+  nodeInfoDetail: '/kmesh/node-security/:namespace/:name',
 } as const;


### PR DESCRIPTION
## Description

This PR implements Headlamp visualization for the `KmeshNodeInfo` Custom Resource Definition (`kmeshnodeinfos.kmesh.net/v1alpha1`). 

The `KmeshNodeInfo` CRD is an integral part of Kmesh's IPsec controller, storing per-node security state (IPsec Security Parameter Index, IP addresses, and Pod CIDRs). This PR adds a dedicated **Node Security** section to the Headlamp UI that provides operators with a cluster-wide view of IPsec health and encryption status.

### Changes Included:
- **`KmeshNodeInfo` KubeObject**: Created a typed Headlamp resource class for the CRD in `src/resources/kmeshNodeInfo.ts` mirroring the upstream Go types.
- **Cluster IPsec Security Dashboard (`List.tsx`)**: 
  - Displays all nodes and their IPsec configuration (SPI, IPs, Pod CIDRs, Boot ID).
  - Implements a **Consensus Check Algorithm**: Automatically computes the cluster-wide consensus SPI and visually flags any nodes that have a stale key (SPI mismatch).
  - Adds a top-level alert banner that turns red if any nodes are out-of-sync, warning operators of potential IPsec tunnel failures.
- **Node Security Detail View (`Detail.tsx`)**: 
  - A clean `SimpleTable` layout showing full IPsec state for a specific node.
  - Includes contextual tooltips (e.g., explaining why `bootID` triggers key rotation).
  - Explicit inline alerts if the specific node being viewed is suffering from a stale IPsec key.
- **Routing & Navigation**: Wired up the new views into the Kmesh sidebar (`kmesh-node-security`) and registered all related routes.
- **Testing**: Added unit tests for the new `KmeshNodeInfo` routes to ensure router integrity.

<img width="1547" height="296" alt="image" src="https://github.com/user-attachments/assets/d5b8097e-da74-421e-be8e-44be431387f3" />
