### PR TITLE
kmesh/waypoints: Add loading indicator and memoize extraInfo

### DIFF
--- a/kmesh/src/components/waypoints/Detail.tsx
+++ b/kmesh/src/components/waypoints/Detail.tsx
@@ -1,4 +1,6 @@
 import { MainInfoSection } from '@kinvolk/headlamp-plugin/lib/components/common';
+import { Box, CircularProgress, Typography } from '@mui/material';
+import { useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 import { Waypoint } from '../../resources/waypoint';
 import { kmeshRoutePaths } from '../../utils/kmeshRoutes';
@@ -54,26 +56,39 @@ function WaypointDetailContent({
 }) {
   const [waypoint, error] = Waypoint.useGet(name, namespace, { cluster });
 
+  const extraInfo = useMemo(
+    () => [
+      {
+        name: 'Gateway Class',
+        value: waypoint?.spec?.gatewayClassName ?? '-',
+      },
+      {
+        name: 'Image',
+        value: waypoint?.image ?? '-',
+      },
+      {
+        name: 'Current Status',
+        value: waypoint?.currentStatus ?? '-',
+      },
+    ],
+    [waypoint]
+  );
+
+  if (waypoint === null && !error) {
+    return (
+      <Box display="flex" justifyContent="center" alignItems="center" p={4} minHeight="200px">
+        <CircularProgress />
+      </Box>
+    );
+  }
+
   return (
     <MainInfoSection
       resource={waypoint}
       error={error}
       title="Waypoint Details"
       backLink={kmeshRoutePaths.waypointsList}
-      extraInfo={[
-        {
-          name: 'Gateway Class',
-          value: waypoint?.spec?.gatewayClassName,
-        },
-        {
-          name: 'Image',
-          value: waypoint?.image,
-        },
-        {
-          name: 'Current Status',
-          value: waypoint?.currentStatus,
-        },
-      ]}
+      extraInfo={extraInfo}
     />
   );
 }


### PR DESCRIPTION
## Summary

`WaypointDetailContent` currently does not distinguish between a resource that is still loading and one that does not exist. While `useGet()` is fetching data, the component passes `resource={null}` to `MainInfoSection`, causing an empty detail view to be rendered until the request completes.

Additionally, missing values in `extraInfo` are rendered as the literal string `"undefined"` in the UI.

## What changed

- Display a centered `CircularProgress` spinner while the `useGet()` request is in flight, matching the loading pattern used in the Volcano Overview page.
- Memoize `extraInfo` with `useMemo` to avoid unnecessary recalculations.
- Default missing `extraInfo` values to `'-'` using the nullish coalescing operator (`??`), preventing `"undefined"` from appearing in the UI.
- Preserve the existing error handling by continuing to rely on the `error` prop of `MainInfoSection`.