### PR TITLE
ai-assistant: Forward user id_token in HolmesAgent for per-user RBAC

### DIFF
--- a/ai-assistant/packages/ai-common/src/agents/holmes/client.test.ts
+++ b/ai-assistant/packages/ai-common/src/agents/holmes/client.test.ts
@@ -194,6 +194,32 @@ describe('holmesClient', () => {
       expect(agent.getThreadId()).toMatch(/^thread-\d+$/);
     });
 
+    it('forwards bearer token in Authorization header when authToken option is provided', () => {
+      const agent = new HolmesAgent('http://localhost:5050', { authToken: 'test-user-id-token' });
+      const harness = privateAgent(agent);
+      // @ts-ignore
+      const headers = (harness.agent as any).options?.headers || (harness.agent as any).headers;
+      expect(headers).toEqual(
+        expect.objectContaining({
+          Authorization: 'Bearer test-user-id-token',
+        })
+      );
+    });
+
+    it('forwards custom headers provided in HolmesAgentOptions', () => {
+      const agent = new HolmesAgent('http://localhost:5050', {
+        headers: { 'X-Custom-Header': 'custom-val' },
+      });
+      const harness = privateAgent(agent);
+      // @ts-ignore
+      const headers = (harness.agent as any).options?.headers || (harness.agent as any).headers;
+      expect(headers).toEqual(
+        expect.objectContaining({
+          'X-Custom-Header': 'custom-val',
+        })
+      );
+    });
+
     it('resets thread with new ID', async () => {
       const agent = new HolmesAgent();
       const firstId = agent.getThreadId();

--- a/ai-assistant/packages/ai-common/src/agents/holmes/client.ts
+++ b/ai-assistant/packages/ai-common/src/agents/holmes/client.ts
@@ -305,11 +305,21 @@ export function getHolmesProxyBaseUrl(cluster: string, config?: HolmesPluginConf
 }
 
 /**
+ * Configuration options for HolmesAgent.
+ */
+export interface HolmesAgentOptions {
+  /** Optional user authentication bearer token (e.g. id_token) to forward for per-user RBAC. */
+  authToken?: string;
+  /** Custom HTTP headers to include with AG-UI HTTP requests. */
+  headers?: Record<string, string>;
+}
+
+/**
  * HolmesAgent wraps @ag-ui/client's HttpAgent to communicate with the
  * Holmes ag-ui server via SSE.
  *
  * Usage:
- *   const agent = new HolmesAgent(getHolmesProxyBaseUrl(cluster));
+ *   const agent = new HolmesAgent(getHolmesProxyBaseUrl(cluster), { authToken: userToken });
  *   agent.subscribe({ onTextMessageContentEvent: ... });
  *   agent.addMessage({ id: '1', role: 'user', content: 'What pods are failing?' });
  *   await agent.runAgent({ runId: 'run-1' });
@@ -318,6 +328,8 @@ export class HolmesAgent {
   private agent: HttpAgent;
   private baseUrl: string;
   private threadId: string;
+  private authToken?: string;
+  private customHeaders?: Record<string, string>;
   private subscriberList: Array<{
     subscriber: AgentSubscriber;
     unsubscribe: () => void;
@@ -332,10 +344,13 @@ export class HolmesAgent {
    * Creates a Holmes agent client for the provided ag-ui base URL.
    *
    * @param baseUrl - Holmes service or proxy base URL.
+   * @param options - Additional options including user authentication token and custom headers.
    */
-  constructor(baseUrl: string = DEFAULT_AGUI_URL) {
+  constructor(baseUrl: string = DEFAULT_AGUI_URL, options?: HolmesAgentOptions) {
     this.baseUrl = baseUrl;
     this.threadId = `thread-${Date.now()}`;
+    this.authToken = options?.authToken;
+    this.customHeaders = options?.headers;
     this.agent = this.createAgent();
   }
 
@@ -347,12 +362,19 @@ export class HolmesAgent {
   private createAgent(): HttpAgent {
     const url = `${this.baseUrl}/api/agui/chat`;
     console.debug('[HolmesAgent] Creating HttpAgent with URL:', url);
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      ...this.customHeaders,
+    };
+
+    if (this.authToken && !headers['Authorization'] && !headers['authorization']) {
+      headers['Authorization'] = `Bearer ${this.authToken}`;
+    }
+
     return new HttpAgent({
       url,
       threadId: this.threadId,
-      headers: {
-        'Content-Type': 'application/json',
-      },
+      headers,
     });
   }
 


### PR DESCRIPTION
## Summary

Introducing `HolmesAgentOptions` to `HolmesAgent` and forwarding the user's `authToken` (`id_token`) as an `Authorization: Bearer <token>` header to the AG-UI Holmes client.

Fixes #971

## Changes
- **`ai-common/src/agents/holmes/client.ts`**:
  - Added `HolmesAgentOptions` interface accepting `authToken` and custom `headers`.
  - Updated `createAgent()` to include `Authorization: Bearer <authToken>` when provided.
- **`ai-common/src/agents/holmes/client.test.ts`**:
  - Added unit tests verifying token and header propagation.
