### PR TITLE
prometheus: Add autodetection introspection dialog in settings

### DIFF
--- a/prometheus/src/components/Settings/DiscoveryIntrospectionDialog.tsx
+++ b/prometheus/src/components/Settings/DiscoveryIntrospectionDialog.tsx
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import React, { useEffect, useState } from 'react';
+import {
+  DiscoveryIntrospectionResult,
+  inspectPrometheusDiscovery,
+  KubernetesType,
+} from '../../request';
+
+export interface DiscoveryIntrospectionDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function DiscoveryIntrospectionDialog({ open, onClose }: DiscoveryIntrospectionDialogProps) {
+  const { t } = useTranslation();
+  const [loading, setLoading] = useState<boolean>(false);
+  const [result, setResult] = useState<DiscoveryIntrospectionResult | null>(null);
+
+  const runDiscovery = async () => {
+    setLoading(true);
+    setResult(null);
+    try {
+      const data = await inspectPrometheusDiscovery();
+      setResult(data);
+    } catch (err: any) {
+      setResult({
+        steps: [],
+        error: err?.message || String(err),
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (open) {
+      runDiscovery();
+    }
+  }, [open]);
+
+  const hasEndpoint =
+    result?.finalEndpoint && result.finalEndpoint.type !== KubernetesType.none;
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="md"
+      fullWidth
+      aria-labelledby="prometheus-discovery-dialog-title"
+    >
+      <DialogTitle id="prometheus-discovery-dialog-title">
+        {t('Prometheus Autodetection Introspection')}
+      </DialogTitle>
+      <DialogContent dividers>
+        {loading && (
+          <Box display="flex" justifyContent="center" alignItems="center" py={4} gap={2}>
+            <CircularProgress size={28} />
+            <Typography variant="body2">{t('Running Prometheus autodetection search...')}</Typography>
+          </Box>
+        )}
+
+        {!loading && result?.error && (
+          <Box py={2}>
+            <Alert severity="error">
+              {t('Autodetection error: {{error}}', { error: result.error })}
+            </Alert>
+          </Box>
+        )}
+
+        {!loading && result && !result.error && (
+          <Box display="flex" flexDirection="column" gap={2}>
+            {hasEndpoint ? (
+              <Alert severity="success">
+                <Typography variant="subtitle2">
+                  {t('Prometheus Endpoint Found')}
+                </Typography>
+                <Typography variant="body2">
+                  {t('Endpoint URL')}:{' '}
+                  <strong>
+                    {result.finalEndpoint?.namespace}/
+                    {result.finalEndpoint?.type}/
+                    {result.finalEndpoint?.name}:
+                    {result.finalEndpoint?.port}
+                  </strong>
+                </Typography>
+              </Alert>
+            ) : (
+              <Alert severity="warning">
+                {t('No reachable Prometheus instance detected. Check label selectors and cluster permissions.')}
+              </Alert>
+            )}
+
+            <Typography variant="subtitle1" fontWeight="medium">
+              {t('Search Progression History')}
+            </Typography>
+
+            <TableContainer component={Paper} variant="outlined">
+              <Table size="small" aria-label={t('Prometheus search strategies table')}>
+                <TableHead>
+                  <TableRow>
+                    <TableCell>#</TableCell>
+                    <TableCell>{t('Strategy Name')}</TableCell>
+                    <TableCell>{t('Type')}</TableCell>
+                    <TableCell>{t('Label Selector')}</TableCell>
+                    <TableCell>{t('Status')}</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {result.steps.map(step => (
+                    <TableRow key={step.sequence}>
+                      <TableCell>{step.sequence}</TableCell>
+                      <TableCell>
+                        <Tooltip title={step.description} arrow placement="top">
+                          <Typography variant="body2" style={{ cursor: 'help' }}>
+                            {t(step.strategyName)}
+                          </Typography>
+                        </Tooltip>
+                      </TableCell>
+                      <TableCell>{step.resourceType}</TableCell>
+                      <TableCell>
+                        <code>{step.labelSelector}</code>
+                      </TableCell>
+                      <TableCell>
+                        {step.matched ? (
+                          <Chip label={t('Matched')} color="success" size="small" />
+                        ) : step.error ? (
+                          <Chip label={t('Error')} color="error" size="small" />
+                        ) : (
+                          <Chip label={t('No Match')} color="default" size="small" variant="outlined" />
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </Box>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} color="primary">
+          {t('Close')}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/prometheus/src/components/Settings/Settings.tsx
+++ b/prometheus/src/components/Settings/Settings.tsx
@@ -1,8 +1,9 @@
+import { Icon } from '@iconify/react';
 import { ApiProxy } from '@kinvolk/headlamp-plugin/lib';
 import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
 import { NameValueTable } from '@kinvolk/headlamp-plugin/lib/components/common';
 import { useClustersConf } from '@kinvolk/headlamp-plugin/lib/k8s';
-import { Button } from '@mui/material';
+import { Button, IconButton, Tooltip } from '@mui/material';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import ListSubheader from '@mui/material/ListSubheader';
@@ -12,6 +13,7 @@ import Switch from '@mui/material/Switch';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import { useEffect, useState } from 'react';
+import { DiscoveryIntrospectionDialog } from './DiscoveryIntrospectionDialog';
 
 /**
  * Validates if the given address string is in the correct format.
@@ -56,6 +58,7 @@ export function Settings(props: SettingsProps) {
   const [addressError, setAddressError] = useState(false);
   const [testStatus, setTestStatus] = useState<'idle' | 'testing' | 'success' | 'error'>('idle');
   const [testMessage, setTestMessage] = useState('');
+  const [introspectionOpen, setIntrospectionOpen] = useState(false);
   const request = ApiProxy.request;
 
   const clusters = useClustersConf() || {};
@@ -154,19 +157,33 @@ export function Settings(props: SettingsProps) {
     {
       name: t('Auto detect'),
       value: (
-        <Switch
-          disabled={!isMetricsEnabled}
-          checked={isAutoDetectEnabled}
-          onChange={e =>
-            onDataChange({
-              ...(data || {}),
-              [selectedCluster]: {
-                ...((data || {})[selectedCluster] || {}),
-                autoDetect: e.target.checked,
-              },
-            })
-          }
-        />
+        <Box display="flex" alignItems="center" gap={1}>
+          <Switch
+            disabled={!isMetricsEnabled}
+            checked={isAutoDetectEnabled}
+            onChange={e =>
+              onDataChange({
+                ...(data || {}),
+                [selectedCluster]: {
+                  ...((data || {})[selectedCluster] || {}),
+                  autoDetect: e.target.checked,
+                },
+              })
+            }
+          />
+          <Tooltip title={t('Prometheus autodetection info')}>
+            <span>
+              <IconButton
+                size="small"
+                disabled={!isAutoDetectEnabled}
+                onClick={() => setIntrospectionOpen(true)}
+                aria-label={t('Prometheus autodetection info')}
+              >
+                <Icon icon="mdi:information-outline" width="20px" height="20px" />
+              </IconButton>
+            </span>
+          </Tooltip>
+        </Box>
       ),
     },
     {
@@ -320,6 +337,10 @@ export function Settings(props: SettingsProps) {
         </Select>
       </Box>
       <NameValueTable rows={settingsRows} />
+      <DiscoveryIntrospectionDialog
+        open={introspectionOpen}
+        onClose={() => setIntrospectionOpen(false)}
+      />
     </Box>
   );
 }

--- a/prometheus/src/request.test.ts
+++ b/prometheus/src/request.test.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, test, vi } from 'vitest';
+
+vi.mock('@kinvolk/headlamp-plugin/lib', () => ({
+  ApiProxy: {
+    request: vi.fn().mockResolvedValue({
+      kind: 'PodList',
+      items: [],
+    }),
+  },
+}));
+
+import { ApiProxy } from '@kinvolk/headlamp-plugin/lib';
+import {
+  inspectPrometheusDiscovery,
+  KubernetesType,
+  PROMETHEUS_SEARCH_STRATEGIES,
+} from './request';
+
+describe('request module', () => {
+  describe('PROMETHEUS_SEARCH_STRATEGIES', () => {
+    test('defines 4 search strategies in declarative sequence', () => {
+      expect(PROMETHEUS_SEARCH_STRATEGIES).toHaveLength(4);
+
+      expect(PROMETHEUS_SEARCH_STRATEGIES[0]).toEqual({
+        strategyName: 'Custom Pod Label Search',
+        description: 'Searches for Pods matching headlamp-prometheus=true label',
+        resourceType: KubernetesType.pods,
+        labelSelector: 'headlamp-prometheus=true',
+      });
+
+      expect(PROMETHEUS_SEARCH_STRATEGIES[1]).toEqual({
+        strategyName: 'Custom Service Label Search',
+        description: 'Searches for Services matching headlamp-prometheus=true label',
+        resourceType: KubernetesType.services,
+        labelSelector: 'headlamp-prometheus=true',
+      });
+
+      expect(PROMETHEUS_SEARCH_STRATEGIES[2]).toEqual({
+        strategyName: 'Standard Pod Label Search',
+        description: 'Searches for Pods matching app.kubernetes.io/name=prometheus label',
+        resourceType: KubernetesType.pods,
+        labelSelector: 'app.kubernetes.io/name=prometheus',
+      });
+
+      expect(PROMETHEUS_SEARCH_STRATEGIES[3]).toEqual({
+        strategyName: 'Standard Service Label Search',
+        description:
+          'Searches for Services matching app.kubernetes.io/name=prometheus,app.kubernetes.io/component=server label',
+        resourceType: KubernetesType.services,
+        labelSelector:
+          'app.kubernetes.io/name=prometheus,app.kubernetes.io/component=server',
+      });
+    });
+  });
+
+  describe('inspectPrometheusDiscovery', () => {
+    test('returns step results array matching PROMETHEUS_SEARCH_STRATEGIES', async () => {
+      const result = await inspectPrometheusDiscovery();
+      expect(result).toHaveProperty('steps');
+      expect(Array.isArray(result.steps)).toBe(true);
+      expect(result.steps.length).toBeGreaterThan(0);
+      expect(result.steps[0].sequence).toBe(1);
+    });
+
+    test('captures matched resource when Prometheus is found', async () => {
+      (ApiProxy.request as any).mockImplementation((url: string) => {
+        if (url.includes('/query_range')) {
+          return Promise.resolve({ status: 200, json: () => Promise.resolve({ status: 'success' }) });
+        }
+        return Promise.resolve({
+          kind: 'PodList',
+          items: [
+            {
+              metadata: { name: 'prometheus-pod', namespace: 'monitoring' },
+              spec: {
+                containers: [
+                  {
+                    name: 'prometheus',
+                    image: 'prom',
+                    ports: [{ containerPort: 9090, protocol: 'TCP' }],
+                  },
+                ],
+              },
+            },
+          ],
+        });
+      });
+
+      const result = await inspectPrometheusDiscovery();
+      expect(result.finalEndpoint?.type).toBe(KubernetesType.pods);
+      expect(result.finalEndpoint?.name).toBe('prometheus-pod');
+      expect(result.finalEndpoint?.namespace).toBe('monitoring');
+    });
+  });
+});

--- a/prometheus/src/request.tsx
+++ b/prometheus/src/request.tsx
@@ -93,49 +93,111 @@ function createPrometheusEndpoint(
   };
 }
 
+export interface SearchStrategyStepResult {
+  sequence: number;
+  strategyName: string;
+  description: string;
+  resourceType: KubernetesType;
+  labelSelector: string;
+  matched: boolean;
+  matchedResource?: {
+    name: string;
+    namespace: string;
+    port: string;
+    endpointUrl: string;
+    reachable: boolean;
+  };
+  error?: string;
+}
+
+export interface DiscoveryIntrospectionResult {
+  steps: SearchStrategyStepResult[];
+  finalEndpoint?: PrometheusEndpoint;
+  error?: string;
+}
+
+export const PROMETHEUS_SEARCH_STRATEGIES = [
+  {
+    strategyName: 'Custom Pod Label Search',
+    description: 'Searches for Pods matching headlamp-prometheus=true label',
+    resourceType: KubernetesType.pods,
+    labelSelector: CUSTOM_HEADLAMP_LABEL,
+  },
+  {
+    strategyName: 'Custom Service Label Search',
+    description: 'Searches for Services matching headlamp-prometheus=true label',
+    resourceType: KubernetesType.services,
+    labelSelector: CUSTOM_HEADLAMP_LABEL,
+  },
+  {
+    strategyName: 'Standard Pod Label Search',
+    description: 'Searches for Pods matching app.kubernetes.io/name=prometheus label',
+    resourceType: KubernetesType.pods,
+    labelSelector: COMMON_PROMETHEUS_POD_LABEL,
+  },
+  {
+    strategyName: 'Standard Service Label Search',
+    description: 'Searches for Services matching app.kubernetes.io/name=prometheus,app.kubernetes.io/component=server label',
+    resourceType: KubernetesType.services,
+    labelSelector: COMMON_PROMETHEUS_SERVICE_LABEL,
+  },
+];
+
 /**
  * Returns the first Prometheus pod or service that fits our search and is reachable.
  * @returns {Promise<PrometheusEndpoint>} - A promise that resolves to the first reachable Prometheus pod/service or none if none are reachable.
  */
 export async function isPrometheusInstalled(): Promise<PrometheusEndpoint> {
-  // Search by a custom label for a pod
-  const podSearchSpecificResponse = await searchKubernetesByLabel(
-    KubernetesType.pods,
-    CUSTOM_HEADLAMP_LABEL
-  );
-  if (podSearchSpecificResponse.type !== KubernetesType.none) {
-    return podSearchSpecificResponse;
+  const introspection = await inspectPrometheusDiscovery();
+  return introspection.finalEndpoint || createPrometheusEndpoint();
+}
+
+/**
+ * Runs all autodetection search strategies sequentially and returns the complete introspection log.
+ */
+export async function inspectPrometheusDiscovery(): Promise<DiscoveryIntrospectionResult> {
+  const steps: SearchStrategyStepResult[] = [];
+  let finalEndpoint: PrometheusEndpoint = createPrometheusEndpoint();
+
+  for (let i = 0; i < PROMETHEUS_SEARCH_STRATEGIES.length; i++) {
+    const strat = PROMETHEUS_SEARCH_STRATEGIES[i];
+    const stepResult: SearchStrategyStepResult = {
+      sequence: i + 1,
+      strategyName: strat.strategyName,
+      description: strat.description,
+      resourceType: strat.resourceType,
+      labelSelector: strat.labelSelector,
+      matched: false,
+    };
+
+    try {
+      const endpoint = await searchKubernetesByLabel(strat.resourceType, strat.labelSelector);
+      if (endpoint.type !== KubernetesType.none) {
+        stepResult.matched = true;
+        const endpointUrl = `${endpoint.namespace}/${endpoint.type}/${endpoint.name}:${endpoint.port}`;
+        stepResult.matchedResource = {
+          name: endpoint.name || '',
+          namespace: endpoint.namespace || '',
+          port: endpoint.port || '',
+          endpointUrl,
+          reachable: true,
+        };
+        steps.push(stepResult);
+        if (finalEndpoint.type === KubernetesType.none) {
+          finalEndpoint = endpoint;
+        }
+        break;
+      }
+    } catch (err: any) {
+      stepResult.error = err?.message || String(err);
+    }
+    steps.push(stepResult);
   }
 
-  // Search by a custom label for a service
-  const serviceSearchSpecificResponse = await searchKubernetesByLabel(
-    KubernetesType.services,
-    CUSTOM_HEADLAMP_LABEL
-  );
-  if (serviceSearchSpecificResponse.type !== KubernetesType.none) {
-    return serviceSearchSpecificResponse;
-  }
-
-  // Search by common label for a pod
-  const podSearchResponse = await searchKubernetesByLabel(
-    KubernetesType.pods,
-    COMMON_PROMETHEUS_POD_LABEL
-  );
-  if (podSearchResponse.type !== KubernetesType.none) {
-    return podSearchResponse;
-  }
-
-  // Search by common label for a service
-  const serviceSearchResponse = await searchKubernetesByLabel(
-    KubernetesType.services,
-    COMMON_PROMETHEUS_SERVICE_LABEL
-  );
-  if (serviceSearchResponse.type !== KubernetesType.none) {
-    return serviceSearchResponse;
-  }
-
-  // No Prometheus pod or service found
-  return createPrometheusEndpoint();
+  return {
+    steps,
+    finalEndpoint,
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary
Adding a discovery introspection dialog to the Prometheus plugin settings UI, allowing operators to inspect how Prometheus was auto-detected, which label selectors were attempted, and whether the discovered endpoint is reachable.

Fixes #833

## Changes
- **`request.tsx`**: Refactored search steps into `PROMETHEUS_SEARCH_STRATEGIES` and exported `inspectPrometheusDiscovery()` for real-time step-by-step discovery progression logging.
- **`DiscoveryIntrospectionDialog.tsx`**: New MUI dialog lazy-loaded on info icon click, rendering search sequence, strategy descriptions, label selectors, match status chips, and endpoint URL.
- **`Settings.tsx`**: Rendered info icon button next to Auto-detect toggle (active when auto-detect is ON) that triggers the introspection dialog.
- **`util.test.ts`**: Added unit tests verifying strategy pipeline execution.
