### PR TITLE
fix: prevent setState-after-unmount and async race in chart shells

### DIFF
--- a/prometheus/src/components/Chart/DiskMetricsChart/DiskMetricsChart.tsx
+++ b/prometheus/src/components/Chart/DiskMetricsChart/DiskMetricsChart.tsx
@@ -48,19 +48,24 @@ export function DiskMetricsChart(props: DiskMetricsChartProps) {
   const [isVisible, setIsVisible] = useState<boolean>(false);
 
   useEffect(() => {
+    let cancelled = false;
+
     const isEnabled = cluster ? clusterConfig?.[cluster]?.isMetricsEnabled ?? false : false;
     setIsVisible(isEnabled);
 
     if (!isEnabled) {
       setState(prometheusState.UNKNOWN);
       setPrometheusPrefix(null);
-      return;
+      return () => {
+        cancelled = true;
+      };
     }
 
     setState(prometheusState.LOADING);
     (async () => {
       try {
         const prefix = await getPrometheusPrefix(cluster);
+        if (cancelled) return;
         if (prefix) {
           setPrometheusPrefix(prefix);
           setState(prometheusState.INSTALLED);
@@ -68,10 +73,16 @@ export function DiskMetricsChart(props: DiskMetricsChartProps) {
           setState(prometheusState.UNKNOWN);
         }
       } catch (e) {
-        console.error('Error checking Prometheus installation:', e);
-        setState(prometheusState.ERROR);
+        if (!cancelled) {
+          console.error('Error checking Prometheus installation:', e);
+          setState(prometheusState.ERROR);
+        }
       }
     })();
+
+    return () => {
+      cancelled = true;
+    };
   }, [clusterConfig, cluster]);
 
   if (!isVisible) {

--- a/prometheus/src/components/Chart/KarpenterChart/KarpenterChart.tsx
+++ b/prometheus/src/components/Chart/KarpenterChart/KarpenterChart.tsx
@@ -58,19 +58,24 @@ export function KarpenterChart(props: KarpenterChartProps) {
   const [isVisible, setIsVisible] = useState<boolean>(false);
 
   useEffect(() => {
+    let cancelled = false;
+
     const isEnabled = clusterConfig?.[cluster]?.isMetricsEnabled || false;
     setIsVisible(isEnabled);
 
     if (!isEnabled) {
       setState(prometheusState.UNKNOWN);
       setPrometheusPrefix(null);
-      return;
+      return () => {
+        cancelled = true;
+      };
     }
 
     setState(prometheusState.LOADING);
     (async () => {
       try {
         const prefix = await getPrometheusPrefix(cluster);
+        if (cancelled) return;
         if (prefix) {
           setPrometheusPrefix(prefix);
           setState(prometheusState.INSTALLED);
@@ -78,10 +83,16 @@ export function KarpenterChart(props: KarpenterChartProps) {
           setState(prometheusState.UNKNOWN);
         }
       } catch (e) {
-        console.error('Error checking Prometheus installation:', e);
-        setState(prometheusState.ERROR);
+        if (!cancelled) {
+          console.error('Error checking Prometheus installation:', e);
+          setState(prometheusState.ERROR);
+        }
       }
     })();
+
+    return () => {
+      cancelled = true;
+    };
   }, [clusterConfig, cluster]);
 
   const interval = getPrometheusInterval(cluster);

--- a/prometheus/src/components/Chart/KedaChart/KedaChart.tsx
+++ b/prometheus/src/components/Chart/KedaChart/KedaChart.tsx
@@ -124,19 +124,24 @@ export function KedaChart(props: KedaChartProps) {
   const [isVisible, setIsVisible] = useState<boolean>(false);
 
   useEffect(() => {
+    let cancelled = false;
+
     const isEnabled = clusterConfig?.[cluster]?.isMetricsEnabled || false;
     setIsVisible(isEnabled);
 
     if (!isEnabled) {
       setState(prometheusState.UNKNOWN);
       setPrometheusPrefix(null);
-      return;
+      return () => {
+        cancelled = true;
+      };
     }
 
     setState(prometheusState.LOADING);
     (async () => {
       try {
         const prefix = await getPrometheusPrefix(cluster);
+        if (cancelled) return;
         if (prefix) {
           setPrometheusPrefix(prefix);
           setState(prometheusState.INSTALLED);
@@ -144,10 +149,16 @@ export function KedaChart(props: KedaChartProps) {
           setState(prometheusState.UNKNOWN);
         }
       } catch (e) {
-        console.error('Error checking Prometheus installation:', e);
-        setState(prometheusState.ERROR);
+        if (!cancelled) {
+          console.error('Error checking Prometheus installation:', e);
+          setState(prometheusState.ERROR);
+        }
       }
     })();
+
+    return () => {
+      cancelled = true;
+    };
   }, [clusterConfig, cluster]);
 
   const interval = getPrometheusInterval(cluster);

--- a/prometheus/src/components/Chart/StrimziChart/StrimziChart.tsx
+++ b/prometheus/src/components/Chart/StrimziChart/StrimziChart.tsx
@@ -166,19 +166,24 @@ export function StrimziChart(props: StrimziChartProps) {
   const [isVisible, setIsVisible] = useState<boolean>(false);
 
   useEffect(() => {
+    let cancelled = false;
+
     const isEnabled = clusterConfig?.[cluster]?.isMetricsEnabled || false;
     setIsVisible(isEnabled);
 
     if (!isEnabled) {
       setState(prometheusState.UNKNOWN);
       setPrometheusPrefix(null);
-      return;
+      return () => {
+        cancelled = true;
+      };
     }
 
     setState(prometheusState.LOADING);
     (async () => {
       try {
         const prefix = await getPrometheusPrefix(cluster);
+        if (cancelled) return;
         if (prefix) {
           setPrometheusPrefix(prefix);
           setState(prometheusState.INSTALLED);
@@ -186,10 +191,16 @@ export function StrimziChart(props: StrimziChartProps) {
           setState(prometheusState.UNKNOWN);
         }
       } catch (e) {
-        console.error('Error checking Prometheus installation:', e);
-        setState(prometheusState.ERROR);
+        if (!cancelled) {
+          console.error('Error checking Prometheus installation:', e);
+          setState(prometheusState.ERROR);
+        }
       }
     })();
+
+    return () => {
+      cancelled = true;
+    };
   }, [clusterConfig, cluster]);
 
   const interval = getPrometheusInterval(cluster);


### PR DESCRIPTION
Add a cancelled flag to the async IIFE inside the Prometheus config useEffect of all four chart shell components (KarpenterChart, StrimziChart, KedaChart, DiskMetricsChart).
Fixes #978 

Previously the IIFE had no cleanup/cancellation, so:
- Navigating away while getPrometheusPrefix() was in flight caused setState/setPrometheusPrefix to run on an unmounted component.
- Rapidly switching clusters could let a slower, stale response overwrite the state set by the newer cluster's response.

The fix returns a cleanup function from useEffect that sets cancelled = true. Every state-setter after an await is now guarded by if (cancelled) return so dead-component updates are suppressed and stale chains exit immediately on the first check.