### PR TITLE
fix: restore DiskMetricsChart toolbar visibility

### DIFF
--- a/prometheus/src/components/Chart/DiskMetricsChart/DiskMetricsChart.tsx
+++ b/prometheus/src/components/Chart/DiskMetricsChart/DiskMetricsChart.tsx
@@ -83,12 +83,7 @@ export function DiskMetricsChart(props: DiskMetricsChartProps) {
   const subPath = getPrometheusSubPath(cluster);
   return (
     <SectionBox>
-      <Box
-        display="flex"
-        justifyContent="space-around"
-        alignItems="center"
-        style={{ marginBottom: '0.5rem', margin: '0 auto', width: '0%' }}
-      >
+      <Box display="flex" justifyContent="flex-end" alignItems="center" mb={2}>
         {state === prometheusState.INSTALLED && (
           <>
             <Box>{t('Disk')}</Box>


### PR DESCRIPTION
fixes #980 

The toolbar Box had width:'0%' set inline, which collapsed the container to zero pixels. The 'Disk' label and pause/play IconButton were rendered in the DOM but completely invisible and inaccessible to users, making it impossible to pause auto-refresh on the disk chart.

The margin shorthand (margin:'0 auto') also overrode the intended marginBottom:'0.5rem', losing the bottom spacing as a side effect.

Replace the inline style with the same MUI Box props used by sibling charts (KedaChart, KarpenterChart): display=flex, justifyContent= flex-end, alignItems=center, mb={2}.