### PR TITLE
flux: Stop hiding sidebar children when CRD probe fails (#972)

### DIFF
--- a/flux/src/checkFluxInstalled.test.ts
+++ b/flux/src/checkFluxInstalled.test.ts
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { type ApiListFn,createCheckFluxInstalled } from './checkFluxInstalled';
+
+interface Harness {
+  check: ReturnType<typeof createCheckFluxInstalled>;
+  apiList: ReturnType<typeof vi.fn>;
+  triggerSuccess: (crds: any[]) => void;
+  triggerError: () => void;
+}
+
+function makeHarness(): Harness {
+  let onSuccess: ((data: any[]) => void) | undefined;
+  let onError: (() => void) | undefined;
+
+  const apiList = vi.fn<ApiListFn>((success, error) => {
+    onSuccess = success;
+    onError = error;
+    return () => {
+      // no-op: a real cancel-fn could clear pending state here, but the
+      // module under test never invokes the cancel; tests drive the
+      // callbacks directly via triggerSuccess / triggerError.
+    };
+  });
+
+  const check = createCheckFluxInstalled(apiList);
+
+  return {
+    check,
+    apiList,
+    triggerSuccess(crds) {
+      onSuccess?.(crds);
+    },
+    triggerError() {
+      onError?.();
+    },
+  };
+}
+
+describe('checkFluxInstalled (issue #972)', () => {
+  it("reports 'unknown' before any probe completes", () => {
+    const { check } = makeHarness();
+    expect(check.getStatus('cluster-a')).toBe('unknown');
+  });
+
+  it("reports 'installed' when the CRD list contains a fluxcd.* CRD", () => {
+    const h = makeHarness();
+    h.check.ensureChecked('cluster-a');
+    h.triggerSuccess([
+      { jsonData: { metadata: { name: 'kustomizations.kustomize.toolkit.fluxcd.io' } } },
+    ]);
+    expect(h.check.getStatus('cluster-a')).toBe('installed');
+  });
+
+  it("reports 'absent' when the CRD list succeeds with no fluxcd.* entries (Flux not installed)", () => {
+    const h = makeHarness();
+    h.check.ensureChecked('cluster-a');
+    h.triggerSuccess([{ jsonData: { metadata: { name: 'clusters.cluster.x-k8s.io' } } }]);
+    expect(h.check.getStatus('cluster-a')).toBe('absent');
+  });
+
+  // The core fix for issue #972: a probe failure MUST NOT be reported as
+  // 'absent'. Previously the error callback set the cache to `false`, which
+  // caused the sidebar filter to hide Flux child entries on any probe
+  // failure (RBAC / 403, transient 5xx, network).
+  it("reports 'error' (NOT 'absent') when the CRD list probe fails — issue #972", () => {
+    const h = makeHarness();
+    h.check.ensureChecked('cluster-a');
+    h.triggerError();
+    expect(h.check.getStatus('cluster-a')).toBe('error');
+  });
+
+  it('does not re-probe within the TTL window', () => {
+    const h = makeHarness();
+    h.check.ensureChecked('cluster-a');
+    h.check.ensureChecked('cluster-a');
+    h.check.ensureChecked('cluster-a');
+    expect(h.apiList).toHaveBeenCalledTimes(1);
+  });
+
+  it('tracks each cluster independently', () => {
+    const h = makeHarness();
+    h.check.ensureChecked('cluster-a');
+    h.check.ensureChecked('cluster-b');
+    expect(h.apiList).toHaveBeenCalledTimes(2);
+    expect(h.apiList.mock.calls[0][2]).toEqual({ cluster: 'cluster-a' });
+    expect(h.apiList.mock.calls[1][2]).toEqual({ cluster: 'cluster-b' });
+  });
+
+  it('reset() clears cached state and the next ensureChecked re-probes', () => {
+    const h = makeHarness();
+    h.check.ensureChecked('cluster-a');
+    h.triggerError();
+    expect(h.check.getStatus('cluster-a')).toBe('error');
+    h.check.reset();
+    expect(h.check.getStatus('cluster-a')).toBe('unknown');
+    h.check.ensureChecked('cluster-a');
+    expect(h.apiList).toHaveBeenCalledTimes(2);
+  });
+
+  it('handles CRD entries with missing jsonData/metadata/name gracefully', () => {
+    const h = makeHarness();
+    h.check.ensureChecked('cluster-a');
+    // The previous optional-chaining in the predicate should keep us safe.
+    expect(() =>
+      h.triggerSuccess([{}, { jsonData: {} }, { jsonData: { metadata: {} } }])
+    ).not.toThrow();
+    expect(h.check.getStatus('cluster-a')).toBe('absent');
+  });
+
+  it('a successful probe that runs after a previous error updates the status to installed/absent', () => {
+    const h = makeHarness();
+    h.check.ensureChecked('cluster-a');
+    h.triggerError();
+    expect(h.check.getStatus('cluster-a')).toBe('error');
+
+    // simulate retry within the TTL window -> no new probe is fired.
+    // Now use reset() to force a fresh probe.
+    h.check.reset();
+    h.check.ensureChecked('cluster-a');
+    h.triggerSuccess([{ jsonData: { metadata: { name: 'helmreleases.helm.toolkit.fluxcd.io' } } }]);
+    expect(h.check.getStatus('cluster-a')).toBe('installed');
+  });
+});

--- a/flux/src/checkFluxInstalled.ts
+++ b/flux/src/checkFluxInstalled.ts
@@ -51,7 +51,7 @@ export interface CheckFluxInstalledHandle {
   reset(): void;
 }
 
-const FLUX_CRD_NAME_PREFIX = 'fluxcd.';
+const FLUX_CRD_NAME_MARKER = 'fluxcd.';
 const CHECK_TTL_MS = 30 * 1000;
 
 /**
@@ -59,7 +59,7 @@ const CHECK_TTL_MS = 30 * 1000;
  * Defensive against missing fields — matches the previous check.
  */
 function hasFluxCrd(crds: ReadonlyArray<{ jsonData?: { metadata?: { name?: string } } }>): boolean {
-  return crds.some(crd => crd.jsonData?.metadata?.name?.includes(FLUX_CRD_NAME_PREFIX));
+  return crds.some(crd => crd.jsonData?.metadata?.name?.includes(FLUX_CRD_NAME_MARKER));
 }
 
 interface InternalState {

--- a/flux/src/checkFluxInstalled.ts
+++ b/flux/src/checkFluxInstalled.ts
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { K8s } from '@kinvolk/headlamp-plugin/lib';
+
+// `apiList` is invoked unbound at the call site, so its `this` parameter is
+// irrelevant for the probe. We type the injection point with a plain function
+// shape that matches the call signature (`onList`, `onError`, `opts`) without
+// the (unusable here) KubeObject class-binding `this` parameter.
+export type ApiListFn = (
+  onList: (items: ReadonlyArray<{ jsonData?: { metadata?: { name?: string } } }>) => void,
+  onError: () => void,
+  opts?: { cluster?: string }
+) => () => void;
+
+/**
+ * Result of probing whether Flux is installed on a cluster.
+ *
+ * - `unknown`: no probe has completed yet (caller should treat as "do not hide")
+ * - `installed`: a successful CRD list contained at least one Flux CRD
+ * - `absent`:   a successful CRD list contained no Flux CRDs (Flux is genuinely not installed)
+ * - `error`:    the CRD list API call failed (RBAC, network, 5xx, etc.)
+ *
+ * Crucially, `error` and `unknown` are distinct from `absent`. The sidebar
+ * filter only hides entries when the probe has confirmed Flux is `absent`.
+ * On `error` we err on the side of showing the entries so users can still
+ * navigate to the Overview page, which renders its own "Flux not installed"
+ * empty state when its own probe says so.
+ */
+export type FluxInstallStatus = 'unknown' | 'installed' | 'absent' | 'error';
+
+export interface CheckFluxInstalledHandle {
+  /** Returns the last known status for the cluster (may be 'unknown'). */
+  getStatus(cluster: string): FluxInstallStatus;
+  /** Triggers a probe if the per-cluster TTL has elapsed and no probe is in flight. */
+  ensureChecked(cluster: string): void;
+  /** Removes all cached state. Useful for tests. */
+  reset(): void;
+}
+
+const FLUX_CRD_NAME_PREFIX = 'fluxcd.';
+const CHECK_TTL_MS = 30 * 1000;
+
+/**
+ * True if any item returned by the CRD list looks like a Flux CRD.
+ * Defensive against missing fields — matches the previous check.
+ */
+function hasFluxCrd(crds: ReadonlyArray<{ jsonData?: { metadata?: { name?: string } } }>): boolean {
+  return crds.some(crd => crd.jsonData?.metadata?.name?.includes(FLUX_CRD_NAME_PREFIX));
+}
+
+interface InternalState {
+  statusByCluster: Record<string, FluxInstallStatus>;
+  lastCheckedAt: Record<string, number>;
+  inFlight: Record<string, boolean>;
+}
+
+/**
+ * Builds a CRD probe scoped to a single cluster. Uses `apiList` (callback
+ * style) so callers can wire it into non-React code paths like
+ * `registerSidebarEntryFilter`.
+ *
+ * `apiList` is injected for testability; in production this is just
+ * `K8s.ResourceClasses.CustomResourceDefinition.apiList`.
+ */
+export function createCheckFluxInstalled(
+  apiList: ApiListFn = K8s.ResourceClasses.CustomResourceDefinition.apiList.bind(
+    K8s.ResourceClasses.CustomResourceDefinition
+  ) as ApiListFn
+): CheckFluxInstalledHandle {
+  const state: InternalState = {
+    statusByCluster: {},
+    lastCheckedAt: {},
+    inFlight: {},
+  };
+
+  function probe(cluster: string) {
+    state.inFlight[cluster] = true;
+
+    const listFn = apiList(
+      crds => {
+        state.statusByCluster[cluster] = hasFluxCrd(crds) ? 'installed' : 'absent';
+        state.lastCheckedAt[cluster] = Date.now();
+        state.inFlight[cluster] = false;
+      },
+      () => {
+        // Issue #972: a probe failure (RBAC denial, transient API error,
+        // network blip, 5xx, etc.) is NOT the same as Flux being absent.
+        // Record it as 'error' and leave the sidebar entries visible.
+        state.statusByCluster[cluster] = 'error';
+        state.lastCheckedAt[cluster] = Date.now();
+        state.inFlight[cluster] = false;
+      },
+      { cluster }
+    );
+    listFn();
+  }
+
+  return {
+    getStatus(cluster: string): FluxInstallStatus {
+      return state.statusByCluster[cluster] ?? 'unknown';
+    },
+    ensureChecked(cluster: string): void {
+      const now = Date.now();
+      const fresh = now - (state.lastCheckedAt[cluster] ?? 0) < CHECK_TTL_MS;
+      if (state.inFlight[cluster] || fresh) {
+        return;
+      }
+      probe(cluster);
+    },
+    reset(): void {
+      for (const key of Object.keys(state.statusByCluster)) {
+        delete state.statusByCluster[key];
+      }
+      for (const key of Object.keys(state.lastCheckedAt)) {
+        delete state.lastCheckedAt[key];
+      }
+      for (const key of Object.keys(state.inFlight)) {
+        delete state.inFlight[key];
+      }
+    },
+  };
+}
+
+const defaultCheck = createCheckFluxInstalled();
+
+/** Returns the last known install status for the cluster. */
+export function getFluxInstallStatus(cluster: string): FluxInstallStatus {
+  return defaultCheck.getStatus(cluster);
+}
+
+/** Ensures a probe is running if the TTL has elapsed (used by the sidebar filter). */
+export function checkFluxInstalled(cluster: string): void {
+  defaultCheck.ensureChecked(cluster);
+}
+
+/** @internal — exposed only for tests. */
+export const __resetForTests = () => defaultCheck.reset();

--- a/flux/src/index.test.tsx
+++ b/flux/src/index.test.tsx
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// vi.hoisted runs before module-level mocks are installed, so all mock
+// references used inside `vi.mock` factories must be declared here.
+const mocks = vi.hoisted(() => ({
+  registerRoute: vi.fn(),
+  registerSidebarEntry: vi.fn(),
+  registerSidebarEntryFilter: vi.fn(),
+  registerMapSource: vi.fn(),
+  registerPluginSettings: vi.fn(),
+  registerKindIcon: vi.fn(),
+  registerFluxHeaderActionsProcessor: vi.fn(),
+  registerHelmRelease: vi.fn(),
+  addIcon: vi.fn(),
+  getCluster: vi.fn(() => 'cluster-a'),
+  ensureChecked: vi.fn(),
+  // mutable from tests; default is 'unknown'.
+  probeStatus: { current: 'unknown' as 'unknown' | 'installed' | 'absent' | 'error' },
+}));
+
+vi.mock('@kinvolk/headlamp-plugin/lib', () => ({
+  registerRoute: mocks.registerRoute,
+  registerSidebarEntry: mocks.registerSidebarEntry,
+  registerSidebarEntryFilter: mocks.registerSidebarEntryFilter,
+  registerMapSource: mocks.registerMapSource,
+  registerPluginSettings: mocks.registerPluginSettings,
+  registerKindIcon: mocks.registerKindIcon,
+  addIcon: mocks.addIcon,
+  Utils: { getCluster: mocks.getCluster },
+}));
+
+vi.mock('./checkFluxInstalled', () => ({
+  checkFluxInstalled: mocks.ensureChecked,
+  getFluxInstallStatus: () => mocks.probeStatus.current,
+}));
+
+vi.mock('./actions/headerActionsProcessor', () => ({
+  registerFluxHeaderActionsProcessor: mocks.registerFluxHeaderActionsProcessor,
+}));
+
+vi.mock('./helm-releases/HelmReleaseSingle', () => ({
+  registerHelmRelease: mocks.registerHelmRelease,
+  FluxHelmReleaseDetailView: () => null,
+}));
+
+vi.mock('@iconify/react', () => ({
+  addIcon: mocks.addIcon,
+  Icon: () => null,
+}));
+
+// Component imports below are referenced by the route registrations; we only
+// assert on the registration calls, so a thin stub is enough.
+vi.mock('./flagger/canaries', () => ({ default: () => null }));
+vi.mock('./flagger/canarydetails', () => ({ default: () => null }));
+vi.mock('./helm-releases/HelmReleaseList', () => ({ HelmReleases: () => null }));
+vi.mock('./image-automation/ImageAutomationList', () => ({ ImageAutomation: () => null }));
+vi.mock('./image-automation/ImageAutomationSingle', () => ({
+  FluxImageAutomationDetailView: () => null,
+}));
+vi.mock('./kustomizations/KustomizationList', () => ({ Kustomizations: () => null }));
+vi.mock('./kustomizations/KustomizationSingle', () => ({
+  FluxKustomizationDetailView: () => null,
+}));
+vi.mock('./mapView', () => ({ fluxSource: {} }));
+vi.mock('./notifications/NotificationList', () => ({ Notifications: () => null }));
+vi.mock('./notifications/NotificationSingle', () => ({ Notification: () => null }));
+vi.mock('./overview', () => ({ FluxOverview: () => null }));
+vi.mock('./runtime/RuntimeList', () => ({ FluxRunTime: () => null }));
+vi.mock('./settings', () => ({ FluxSettings: () => null }));
+vi.mock('./sources/SourceList', () => ({ FluxSources: () => null }));
+vi.mock('./sources/SourceSingle', () => ({ FluxSourceDetailView: () => null }));
+vi.mock('./terraforms/TerraformList', () => ({ TerraformList: () => null }));
+vi.mock('./terraforms/TerraformSingle', () => ({ TerraformDetailView: () => null }));
+
+// Static import triggers the module's top-level registration calls. vi.mock
+// is hoisted above this so all mocks are ready when the module runs.
+import './index';
+
+function getSidebarFilter() {
+  const call = mocks.registerSidebarEntryFilter.mock.calls[0];
+  if (!call) {
+    throw new Error('registerSidebarEntryFilter was not called');
+  }
+  return call[0] as (entry: {
+    parent?: string;
+    name: string;
+  }) => { parent?: string; name: string } | null | undefined;
+}
+
+beforeEach(() => {
+  mocks.probeStatus.current = 'unknown';
+  mocks.ensureChecked.mockClear();
+  mocks.getCluster.mockClear();
+  mocks.getCluster.mockImplementation(() => 'cluster-a');
+});
+
+// Note: do NOT call vi.clearAllMocks() here. `import './index'` runs at
+// module load time, which is when all `registerSidebarEntry` and
+// `registerRoute` calls happen. Clearing them in afterEach would erase
+// the evidence those smoke tests rely on.
+
+describe('flux plugin sidebar filter (issue #972)', () => {
+  it('registers a sidebar filter', () => {
+    expect(mocks.registerSidebarEntryFilter).toHaveBeenCalledWith(expect.any(Function));
+  });
+
+  it("passes through entries that are not children of 'flux'", () => {
+    const filter = getSidebarFilter();
+    const entry = { name: 'workloads', parent: 'cluster-menu' };
+    expect(filter(entry)).toEqual(entry);
+  });
+
+  it("always shows the 'flux' and 'overview' parent entries regardless of probe status", () => {
+    const filter = getSidebarFilter();
+    const fluxEntry = { name: 'flux', parent: null };
+    const overviewEntry = { name: 'overview', parent: 'flux' };
+    for (const status of ['unknown', 'installed', 'absent', 'error'] as const) {
+      mocks.probeStatus.current = status;
+      expect(filter(fluxEntry)).toEqual(fluxEntry);
+      expect(filter(overviewEntry)).toEqual(overviewEntry);
+    }
+  });
+
+  it("hides Flux child entries when the probe confirms Flux is 'absent'", () => {
+    mocks.probeStatus.current = 'absent';
+    const filter = getSidebarFilter();
+    const entry = { name: 'kustomizations', parent: 'flux' };
+    expect(filter(entry)).toBeNull();
+  });
+
+  // Regression test for issue #972: previously, the probe error callback
+  // set the cache to `false`, which the sidebar filter interpreted as
+  // "absent" and hid Flux children.
+  it("keeps Flux child entries visible when the probe has not completed yet ('unknown')", () => {
+    mocks.probeStatus.current = 'unknown';
+    const filter = getSidebarFilter();
+    const entry = { name: 'kustomizations', parent: 'flux' };
+    expect(filter(entry)).toEqual(entry);
+  });
+
+  it("keeps Flux child entries visible when Flux is 'installed'", () => {
+    mocks.probeStatus.current = 'installed';
+    const filter = getSidebarFilter();
+    const entry = { name: 'helmreleases', parent: 'flux' };
+    expect(filter(entry)).toEqual(entry);
+  });
+
+  // The actual fix for issue #972: a failed probe must NOT hide the entries.
+  it("keeps Flux child entries visible when the probe errored ('error') — issue #972", () => {
+    mocks.probeStatus.current = 'error';
+    const filter = getSidebarFilter();
+    const entry = { name: 'sources', parent: 'flux' };
+    expect(filter(entry)).toEqual(entry);
+  });
+
+  it('triggers a probe each time the filter runs for a Flux child entry', () => {
+    mocks.probeStatus.current = 'unknown';
+    const filter = getSidebarFilter();
+    filter({ name: 'sources', parent: 'flux' });
+    filter({ name: 'helmreleases', parent: 'flux' });
+    expect(mocks.ensureChecked).toHaveBeenCalled();
+  });
+
+  it('does not trigger a probe for non-Flux-parent or always-visible entries', () => {
+    mocks.probeStatus.current = 'unknown';
+    const filter = getSidebarFilter();
+    filter({ name: 'workloads', parent: 'cluster-menu' });
+    filter({ name: 'flux', parent: null });
+    filter({ name: 'overview', parent: 'flux' });
+    expect(mocks.ensureChecked).not.toHaveBeenCalled();
+  });
+
+  it('passes the current cluster from Utils.getCluster() to the probe', () => {
+    mocks.probeStatus.current = 'unknown';
+    mocks.getCluster.mockImplementation(() => 'cluster-b');
+    const filter = getSidebarFilter();
+    filter({ name: 'sources', parent: 'flux' });
+    expect(mocks.ensureChecked).toHaveBeenCalledWith('cluster-b');
+  });
+});
+
+describe('flux plugin registration smoke tests', () => {
+  it('registers the top-level Flux sidebar entry', () => {
+    expect(mocks.registerSidebarEntry).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'flux', label: 'Flux', parent: null })
+    );
+  });
+
+  it('registers core Flux routes', () => {
+    const registeredPaths = mocks.registerRoute.mock.calls.map(
+      c => (c[0] as { path: string }).path
+    );
+    expect(registeredPaths).toContain('/flux/overview');
+    expect(registeredPaths).toContain('/flux/kustomizations');
+    expect(registeredPaths).toContain('/flux/sources');
+  });
+
+  it('registers the Flux icon for plugin settings and the Flux map source', () => {
+    expect(mocks.addIcon).toHaveBeenCalledWith(
+      'simple-icons:flux',
+      expect.objectContaining({ width: 24, height: 24 })
+    );
+    expect(mocks.registerMapSource).toHaveBeenCalled();
+    expect(mocks.registerPluginSettings).toHaveBeenCalledWith(
+      '@headlamp-k8s/flux',
+      expect.anything(),
+      false
+    );
+    expect(mocks.registerFluxHeaderActionsProcessor).toHaveBeenCalled();
+    expect(mocks.registerHelmRelease).toHaveBeenCalled();
+  });
+});

--- a/flux/src/index.tsx
+++ b/flux/src/index.tsx
@@ -1,6 +1,5 @@
 import { addIcon, Icon } from '@iconify/react';
 import {
-  K8s,
   registerKindIcon,
   registerMapSource,
   registerPluginSettings,
@@ -10,6 +9,7 @@ import {
   Utils,
 } from '@kinvolk/headlamp-plugin/lib';
 import { registerFluxHeaderActionsProcessor } from './actions/headerActionsProcessor';
+import { checkFluxInstalled, getFluxInstallStatus } from './checkFluxInstalled';
 import Canaries from './flagger/canaries';
 import CanaryDetails from './flagger/canarydetails';
 import { HelmReleases } from './helm-releases/HelmReleaseList';
@@ -32,41 +32,10 @@ import { TerraformDetailView } from './terraforms/TerraformSingle';
 registerHelmRelease();
 registerFluxHeaderActionsProcessor();
 
-// Track whether Flux CRDs exist per cluster to hide sidebar children.
-// The watch callback keeps `fluxInstalledByCluster` fresh while the page is open;
-// the TTL re-arms the check after `CHECK_TTL_MS` so the sidebar reflects
-// install/uninstall events that happen between sessions or after a watch drops.
-const fluxInstalledByCluster: Record<string, boolean> = {};
-const lastCheckedAt: Record<string, number> = {};
-const inFlight: Record<string, boolean> = {};
-const CHECK_TTL_MS = 30 * 1000;
-
-function checkFluxInstalled(cluster: string) {
-  const now = Date.now();
-  const fresh = now - (lastCheckedAt[cluster] ?? 0) < CHECK_TTL_MS;
-  if (inFlight[cluster] || fresh) {
-    return;
-  }
-  inFlight[cluster] = true;
-
-  const listFn = K8s.ResourceClasses.CustomResourceDefinition.apiList(
-    crds => {
-      fluxInstalledByCluster[cluster] = crds.some(crd =>
-        crd.jsonData?.metadata?.name?.includes('fluxcd.')
-      );
-      lastCheckedAt[cluster] = Date.now();
-      inFlight[cluster] = false;
-    },
-    () => {
-      fluxInstalledByCluster[cluster] = false;
-      lastCheckedAt[cluster] = Date.now();
-      inFlight[cluster] = false;
-    },
-    { cluster }
-  );
-  listFn();
-}
-
+// Top-level Flux sidebar entries that must remain reachable even when
+// the CRD probe reports Flux as absent. This keeps the parent entry
+// and the Overview page (which renders its own "not installed" empty
+// state) accessible to the user.
 const FLUX_SIDEBAR_ALWAYS_VISIBLE = new Set(['flux', 'overview']);
 
 registerSidebarEntryFilter(entry => {
@@ -80,7 +49,13 @@ registerSidebarEntryFilter(entry => {
   const cluster = Utils.getCluster() ?? '';
   checkFluxInstalled(cluster);
 
-  if (fluxInstalledByCluster[cluster] === false) {
+  // Hide Flux sidebar children ONLY when the CRD probe has confirmed
+  // Flux is genuinely absent on this cluster.
+  //
+  // 'error' (RBAC denial, transient API failure, network blip, 5xx, etc.)
+  // and 'unknown' (no completed probe yet) intentionally keep the entries
+  // visible. See issue #972.
+  if (getFluxInstallStatus(cluster) === 'absent') {
     return null;
   }
   return entry;


### PR DESCRIPTION
## Summary

The Flux sidebar install-detection probe was treating every CRD-list failure as "Flux is not installed". The error callback of `K8s.ResourceClasses.CustomResourceDefinition.apiList` set the cache to `false`, so `registerSidebarEntryFilter` hid Flux child entries on RBAC 403s, transient 5xxs, network blips, etc. — even though we had no evidence Flux was actually missing.

This PR replaces the boolean cache with a typed status (`unknown | installed | absent | error`) and updates the sidebar filter to hide entries only when the probe confirms `absent`. On `error` (and while a probe is still pending) entries remain visible so the user can still navigate to the Overview page, which renders its own `useFluxCheck`-based empty state when Flux is genuinely absent.

The probe logic is extracted into a new `flux/src/checkFluxInstalled.ts` module with an injectable `apiList` for unit testing. Two new test files cover both the probe semantics and the sidebar filter behavior across all four states, including the regression test for #972.

## Changes

- **`flux/src/index.tsx`** — sidebar filter hides entries only when probe status is `'absent'`; removes the now-unused `K8s` import. (-37 / +12 lines.)
- **`flux/src/checkFluxInstalled.ts`** (new) — extracted probe + tri-state-→-quad-state result with `createCheckFluxInstalled(apiList?)` factory.
- **`flux/src/checkFluxInstalled.test.ts`** (new) — 9 unit tests including the error regression.
- **`flux/src/index.test.tsx`** (new) — 12 tests verifying the sidebar filter across all four probe states plus registration smoke tests.

## Why this is correct

- Minimal: only the predicate `'absent'` was changed; behavior for `installed`, `absent`, and `unknown` is unchanged.
- Matches the intent stated in #972: "sidebar entries only [hidden] when a successful CRD probe determines that Flux CRDs are absent".
- Preserves UX: `FLUX_SIDEBAR_ALWAYS_VISIBLE` still keeps the `flux` and `overview` parent entries reachable so users land on the Overview page regardless of probe state.

## Verification

```
npm run lint    # 0 errors, 0 warnings (--max-warnings 0)
npm test        # 27 passed, 1 skipped (pre-existing storybook), 0 failed
npm run tsc     # clean
npm run build   # dist/main.js built (235 kB)
```

## Related

- Fixes #972
- Follow-up: Argo CD and Knative have analogous `error → false` patterns. They are intentionally out of scope here since #972 is filed against Flux only.

