### PR TITLE
fix(plugin-catalog): handle ArtifactHub fetch errors gracefully in PluginDetail

### DIFF
--- a/plugin-catalog/src/components/plugins/Detail.tsx
+++ b/plugin-catalog/src/components/plugins/Detail.tsx
@@ -460,7 +460,7 @@ export function PluginDetail() {
         } catch (error) {
           if (isMounted) {
             const message = error instanceof Error ? error.message : String(error);
-            setAlertMessage(`Failed to fetch plugin info from ArtifactHub: ${message}`);
+            setAlertMessage(t('Failed to fetch plugin info from {{url}}: {{message}}', { url, message }));
           }
           console.error('Error fetching plugin detail:', error);
           return;

--- a/plugin-catalog/src/components/plugins/Detail.tsx
+++ b/plugin-catalog/src/components/plugins/Detail.tsx
@@ -446,22 +446,29 @@ export function PluginDetail() {
 
   useEffect(() => {
     let isMounted = true;
-
     const initialize = async () => {
       if (isMounted) {
-        const data = await fetchHeadlampPluginDetail(repoName, pluginName);
-        const enrichedPluginData = await checkIfPluginIsInstalled(data);
-        setPluginDetail(enrichedPluginData);
-        // Default to the latest version, but don't override a version the user
-        // has already picked (this runs again whenever currentAction changes).
-        setSelectedVersion(prev => prev || enrichedPluginData.version);
+        try {
+          const data = await fetchHeadlampPluginDetail(repoName, pluginName);
+          const enrichedPluginData = await checkIfPluginIsInstalled(data);
+          if (isMounted) {
+            setPluginDetail(enrichedPluginData);
+            // Default to the latest version, but don't override a version the user has already picked
+            // keep user's version choice if already set
+            setSelectedVersion(prev => prev || enrichedPluginData.version);
+          }
+        } catch (error) {
+          if (isMounted) {
+            const message = error instanceof Error ? error.message : String(error);
+            setAlertMessage(`Failed to fetch plugin info from ArtifactHub: ${message}`);
+          }
+          console.error('Error fetching plugin detail:', error);
+          return;
+        }
       }
-
       fetchStatus();
     };
-
     initialize();
-
     return () => {
       isMounted = false;
     };


### PR DESCRIPTION
Fixes #866

## Problem
When fetching plugin info from ArtifactHub fails (network issue, proxy
error, ArtifactHub downtime, etc.), the error thrown inside
`fetchHeadlampPluginDetail()` was never caught in the `PluginDetail`
component's `useEffect`. This left the Plugin Detail page stuck on an
infinite loading spinner with no feedback to the user, instead of a
clear error message.

## Fix
Wrapped the fetch + install-status check in `initialize()` with a
try/catch block. On failure, the existing `alertMessage`/Snackbar UI
(already used elsewhere in this component for install/update/uninstall
actions) now surfaces a clear error message instead of failing silently.
Also added `isMounted` guards so state isn't updated after the component
unmounts.

## Testing
- `npm run build` passes cleanly with no errors
- Verified via direct `eslint` invocation that the code has zero
  lint errors/warnings (the `npm run lint` CLI wrapper has an unrelated
  Windows-specific issue running the command, but direct `eslint`
  confirms clean code)
- Manually verified the error path by simulating a failed fetch —
  the Snackbar now correctly displays the error message instead of an
  infinite spinner

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)