### PR TITLE
kyverno: Fix Results column stuck on loading placeholder

### DIFF
--- a/kyverno/src/hooks/usePolicyResultCounts.test.ts
+++ b/kyverno/src/hooks/usePolicyResultCounts.test.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ClusterPolicyReport, PolicyReport } from '../resources/policyReport';
+import { usePolicyResultCounts } from './usePolicyResultCounts';
+
+vi.mock('../resources/policyReport', () => ({
+  PolicyReport: { useList: vi.fn() },
+  ClusterPolicyReport: { useList: vi.fn() },
+}));
+
+/** Mimics the shape `KubeObject.useList` returns for a still-in-flight query. */
+function pendingList() {
+  return { items: null, errors: null, isLoading: true, isError: false };
+}
+
+/** A list that settled with an error, e.g. the CRD is absent or RBAC denied it. */
+function erroredList() {
+  return { items: null, errors: [new Error('not found')], isLoading: false, isError: true };
+}
+
+function resolvedList(items: unknown[]) {
+  return { items, errors: null, isLoading: false, isError: false };
+}
+
+describe('usePolicyResultCounts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('stops loading once a list settles with an error', () => {
+    // Regression: loading used to be derived from `items === null`, which never
+    // becomes non-null for an errored list, leaving callers on a spinner forever.
+    vi.mocked(PolicyReport.useList).mockReturnValue(erroredList() as any);
+    vi.mocked(ClusterPolicyReport.useList).mockReturnValue(erroredList() as any);
+
+    const { result } = renderHook(() => usePolicyResultCounts());
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.forCluster('require-labels')).toBeUndefined();
+  });
+
+  it('reports loading while a list is still in flight', () => {
+    vi.mocked(PolicyReport.useList).mockReturnValue(pendingList() as any);
+    vi.mocked(ClusterPolicyReport.useList).mockReturnValue(resolvedList([]) as any);
+
+    const { result } = renderHook(() => usePolicyResultCounts());
+
+    expect(result.current.loading).toBe(true);
+  });
+
+  it('still aggregates the lists that did resolve', () => {
+    vi.mocked(PolicyReport.useList).mockReturnValue(
+      resolvedList([
+        {
+          results: [
+            { policy: 'default/require-labels', result: 'fail' },
+            { policy: 'default/require-labels', result: 'pass' },
+          ],
+        },
+      ]) as any
+    );
+    vi.mocked(ClusterPolicyReport.useList).mockReturnValue(erroredList() as any);
+
+    const { result } = renderHook(() => usePolicyResultCounts());
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.forNamespaced('require-labels', 'default')).toEqual({
+      fail: 1,
+      total: 2,
+    });
+  });
+});

--- a/kyverno/src/hooks/usePolicyResultCounts.ts
+++ b/kyverno/src/hooks/usePolicyResultCounts.ts
@@ -34,8 +34,18 @@ export interface PolicyResultLookup {
  * unit-tested without the Headlamp SDK shim.
  */
 export function usePolicyResultCounts(): PolicyResultLookup {
-  const { items: policyReports } = PolicyReport.useList();
-  const { items: clusterPolicyReports } = ClusterPolicyReport.useList();
+  const policyReportQuery = PolicyReport.useList();
+  const clusterPolicyReportQuery = ClusterPolicyReport.useList();
+
+  const policyReports = policyReportQuery.items;
+  const clusterPolicyReports = clusterPolicyReportQuery.items;
+
+  // `items` stays null when a list never resolves — including when the
+  // PolicyReport CRDs are absent or RBAC denies them — so deriving loading from
+  // `items === null` would leave callers stuck on a spinner forever. Use the
+  // query's own state instead, which settles on error too; an errored list then
+  // contributes no results and the caller can fall back to its empty state.
+  const loading = policyReportQuery.isLoading || clusterPolicyReportQuery.isLoading;
 
   return useMemo(() => {
     const { cluster, namespaced } = bucketReportResults([
@@ -46,8 +56,7 @@ export function usePolicyResultCounts(): PolicyResultLookup {
     return {
       forCluster: name => cluster.get(name),
       forNamespaced: (name, namespace) => namespaced.get(`${namespace}/${name}`),
-      // Loading until BOTH streams resolve — partial data would undercount per-row totals.
-      loading: policyReports === null || clusterPolicyReports === null,
+      loading,
     };
-  }, [policyReports, clusterPolicyReports]);
+  }, [policyReports, clusterPolicyReports, loading]);
 }


### PR DESCRIPTION
## What broke

`usePolicyResultCounts` decided it was still loading by checking whether the report lists were `null`:

```ts
loading: policyReports === null || clusterPolicyReports === null,
```

`KubeObject.useList` leaves `items` at `null` when a query settles with an error, not just while it's in flight — the failure is reported alongside it via `errors` / `isError` on the same `QueryListResponse`. So if the `wgpolicyk8s.io/v1alpha2` CRDs aren't readable, the lists never become non-null and the flag stays `true` for good.

`ClusterPolicyList.tsx:106` and `PolicyList.tsx:119` both branch on it:

```ts
if (counts.loading && !c) return <Typography variant="body2">…</Typography>;
if (!c || c.total === 0) return <Typography variant="body2">—</Typography>;
```

so every row keeps rendering the `…` placeholder and never reaches the `—` empty state on the following line. Reported in #992, with the situations that trigger it (reports controller disabled, `--openreportsEnabled` moving reporting to `openreports.io/v1alpha1`, or RBAC not granting list on policyreports).

## Fix

Take loading from the queries' own `isLoading` rather than inferring it from `items`. A list that settled with an error is then treated as resolved and contributes no results, so the existing `—` fallback renders. The aggregation itself is unchanged — it already tolerates a missing list via `?? []`.

## Testing

Added `usePolicyResultCounts.test.ts` (there were no tests for this hook) covering:
- both lists settled with an error → `loading` is `false` (the regression; fails on the previous logic with `expected true to be false`)
- one list still in flight → `loading` is `true`
- one list resolved, the other errored → still aggregates the good one and reports `{ fail: 1, total: 2 }`

I confirmed the first and third cases fail against the old derivation before applying the fix.

Ran locally in the `kyverno` plugin directory:
- `tsc --noEmit`: clean
- `eslint --max-warnings 0`: clean
- `vitest run`: 11 tests pass across 3 files
- `headlamp-plugin build`: succeeds

Fixes #992