### PR TITLE
kueue: extract resourceFlavor formatters and add tests

### DIFF
--- a/kueue/src/resources/resourceFlavor.test.ts
+++ b/kueue/src/resources/resourceFlavor.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { kueueRoutePaths } from '../utils/kueueRoutes';
+import { renderNodeLabels, renderTaints, renderTolerations } from './resourceFlavorFormatters';
+
+describe('ResourceFlavor formatters', () => {
+  it('formats node labels', () => {
+    expect(renderNodeLabels({})).toBe('-');
+    expect(renderNodeLabels({ 'kubernetes.io/arch': 'amd64' })).toBe('kubernetes.io/arch=amd64');
+    expect(
+      renderNodeLabels({ 'kubernetes.io/arch': 'amd64', 'cloud.provider/spot': 'true' })
+    ).toBe('kubernetes.io/arch=amd64, cloud.provider/spot=true');
+  });
+
+  it('formats node taints', () => {
+    expect(renderTaints([])).toBe('-');
+    expect(renderTaints([{ key: 'spot', effect: 'NoSchedule' }])).toBe('spot:NoSchedule');
+    expect(renderTaints([{ key: 'spot', value: 'true', effect: 'NoSchedule' }])).toBe(
+      'spot=true:NoSchedule'
+    );
+    expect(
+      renderTaints([
+        { key: 'spot', effect: 'NoSchedule' },
+        { key: 'gpu', value: 'nvidia', effect: 'NoExecute' },
+      ])
+    ).toBe('spot:NoSchedule, gpu=nvidia:NoExecute');
+  });
+
+  it('formats tolerations, including an empty/omitted key as a wildcard', () => {
+    expect(renderTolerations([])).toBe('-');
+    expect(renderTolerations([{ operator: 'Exists' }])).toBe('*');
+    expect(renderTolerations([{ key: 'spot', operator: 'Exists' }])).toBe('spot');
+    expect(
+      renderTolerations([{ key: 'spot', operator: 'Equal', value: 'true', effect: 'NoSchedule' }])
+    ).toBe('spot=true:NoSchedule');
+  });
+
+  it('renders tolerationSeconds while preserving an explicit zero', () => {
+    expect(
+      renderTolerations([
+        { key: 'spot', operator: 'Equal', value: 'true', effect: 'NoExecute', tolerationSeconds: 0 },
+      ])
+    ).toBe('spot=true:NoExecute (0s)');
+    expect(
+      renderTolerations([
+        {
+          key: 'spot',
+          operator: 'Equal',
+          value: 'true',
+          effect: 'NoExecute',
+          tolerationSeconds: 300,
+        },
+      ])
+    ).toBe('spot=true:NoExecute (300s)');
+  });
+
+  it('ignores value when operator is Exists, even if a value is also set', () => {
+    // Not a valid Kubernetes manifest (Exists ignores value), but the API doesn't
+    // reject it, so the display behavior should still be well-defined and tested.
+    expect(
+      renderTolerations([{ key: 'spot', operator: 'Exists', value: 'true', effect: 'NoSchedule' }])
+    ).toBe('spot:NoSchedule');
+  });
+
+  it('builds the resource flavor detail route path', () => {
+    expect(kueueRoutePaths.resourceFlavorDetail).toBe('/kueue/resourceflavors/:name');
+  });
+});

--- a/kueue/src/resources/resourceFlavor.ts
+++ b/kueue/src/resources/resourceFlavor.ts
@@ -1,6 +1,7 @@
 import { KubeObject, KubeObjectInterface } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
 import { kueueApiVersions } from '../utils/kueueApi';
 import { kueueRoutePaths } from '../utils/kueueRoutes';
+import { renderNodeLabels, renderTaints, renderTolerations } from './resourceFlavorFormatters';
 
 /**
  * Node label selector values associated with a Kueue ResourceFlavor.
@@ -153,13 +154,7 @@ export class ResourceFlavor extends KubeObject<KubeResourceFlavor> {
   }
 
   get nodeLabelsDisplay() {
-    const labels = Object.entries(this.nodeLabels);
-
-    if (labels.length === 0) {
-      return '-';
-    }
-
-    return labels.map(([key, value]) => `${key}=${value}`).join(', ');
+    return renderNodeLabels(this.nodeLabels);
   }
 
   get nodeTaints() {
@@ -181,39 +176,4 @@ export class ResourceFlavor extends KubeObject<KubeResourceFlavor> {
   get topologyName() {
     return this.spec.topologyName || '-';
   }
-}
-
-function renderTaints(taints: ResourceFlavorTaint[]) {
-  if (taints.length === 0) {
-    return '-';
-  }
-
-  return taints.map(renderTaint).join(', ');
-}
-
-function renderTaint(taint: ResourceFlavorTaint) {
-  const value = taint.value ? `=${taint.value}` : '';
-
-  return `${taint.key}${value}:${taint.effect}`;
-}
-
-function renderTolerations(tolerations: ResourceFlavorToleration[]) {
-  if (tolerations.length === 0) {
-    return '-';
-  }
-
-  return tolerations.map(renderToleration).join(', ');
-}
-
-function renderToleration(toleration: ResourceFlavorToleration) {
-  const key = toleration.key || '*';
-  const value =
-    toleration.operator === 'Exists' || toleration.value === undefined
-      ? ''
-      : `=${toleration.value}`;
-  const effect = toleration.effect ? `:${toleration.effect}` : '';
-  const seconds =
-    toleration.tolerationSeconds === undefined ? '' : ` (${toleration.tolerationSeconds}s)`;
-
-  return `${key}${value}${effect}${seconds}`;
 }

--- a/kueue/src/resources/resourceFlavorFormatters.ts
+++ b/kueue/src/resources/resourceFlavorFormatters.ts
@@ -1,0 +1,82 @@
+/** Node taint entry used by ResourceFlavor node selection. */
+export interface ResourceFlavorTaintLike {
+  /** Taint key applied to matching nodes. */
+  key: string;
+  /** Optional taint value. */
+  value?: string;
+  /** Taint effect; Kueue evaluates NoSchedule and NoExecute. */
+  effect: string;
+}
+
+/** Extra pod toleration entry added to workloads admitted with a ResourceFlavor. */
+export interface ResourceFlavorTolerationLike {
+  /** Toleration key. Empty key with Exists matches all taint keys. */
+  key?: string;
+  /** Relationship between the key and value, such as Equal or Exists. */
+  operator?: string;
+  /** Toleration value matched against the taint value. */
+  value?: string;
+  /** Taint effect tolerated by this entry. */
+  effect?: string;
+  /** Time period in seconds for which a NoExecute taint is tolerated. */
+  tolerationSeconds?: number;
+}
+
+/** Render a Kubernetes node label map as compact "key=value" detail text. */
+export function renderNodeLabels(nodeLabels: Record<string, string>) {
+  const labels = Object.entries(nodeLabels);
+
+  if (labels.length === 0) {
+    return '-';
+  }
+
+  return labels.map(([key, value]) => `${key}=${value}`).join(', ');
+}
+
+/** Render all node taints for a ResourceFlavor as compact detail text. */
+export function renderTaints(taints: ResourceFlavorTaintLike[]) {
+  if (taints.length === 0) {
+    return '-';
+  }
+
+  return taints.map(renderTaint).join(', ');
+}
+
+/** Render one node taint entry as "key=value:effect". */
+export function renderTaint(taint: ResourceFlavorTaintLike) {
+  const value = taint.value ? `=${taint.value}` : '';
+
+  return `${taint.key}${value}:${taint.effect}`;
+}
+
+/** Render all extra tolerations for a ResourceFlavor as compact detail text. */
+export function renderTolerations(tolerations: ResourceFlavorTolerationLike[]) {
+  if (tolerations.length === 0) {
+    return '-';
+  }
+
+  return tolerations.map(renderToleration).join(', ');
+}
+
+/**
+ * Render one toleration entry as "key=value:effect (Ns)".
+ *
+ * An empty/omitted key renders as "*" (matches all taint keys, the standard
+ * Kubernetes convention for a key-less toleration). When `operator` is
+ * `Exists`, any configured `value` is ignored for display, matching how the
+ * Kubernetes API itself treats `value` as meaningless for that operator even
+ * if a manifest sets both (this is technically an invalid combination, but
+ * the API does not reject it).
+ */
+export function renderToleration(toleration: ResourceFlavorTolerationLike) {
+  const key = toleration.key || '*';
+  const value =
+    toleration.operator === 'Exists' || toleration.value === undefined
+      ? ''
+      : `=${toleration.value}`;
+  const effect = toleration.effect ? `:${toleration.effect}` : '';
+  const seconds =
+    toleration.tolerationSeconds === undefined ? '' : ` (${toleration.tolerationSeconds}s)`;
+
+  return `${key}${value}${effect}${seconds}`;
+}


### PR DESCRIPTION
Fixes #988

## PR Summary

This PR brings `resourceFlavor.ts` in line with the pattern already used by `clusterQueue.ts` and `localQueue.ts`, where display-formatting logic lives in a separate, exported, and independently-tested file.

## Problem

`clusterQueue.ts` and `localQueue.ts` both extract their rendering logic into dedicated formatter files (`clusterQueueFormatters.ts`, `localQueueFormatters.ts`), which are exported and covered by their own test files (`clusterQueue.test.ts`, `localQueue.test.ts`).

`resourceFlavor.ts` didn't follow this pattern `renderTaints`,`renderTaint`,`renderTolerations`, and `renderToleration` were defined as unexported functions directly inside the resource file. Because they weren't exported, they couldn't be unit tested, and no test file existed for this resource.

While reading through the logic, I also found that `renderToleration()` had no defined or tested behavior for the case where a toleration sets `operator: 'Exists'` *and* also sets a `value`. This isn't a valid Kubernetes manifest (the API ignores `value` when `operator` is `Exists`), but since the Kubernetes API doesn't reject it outright, the display behavior is worth locking down with a test rather than leaving it implicit.

## Changes

* **Added** `resourceFlavorFormatters.ts` — exported `renderNodeLabels`, `renderTaints`, `renderTaint`, `renderTolerations`, and `renderToleration`, along with `ResourceFlavorTaintLike` / `ResourceFlavorTolerationLike` types, following the same structure as the existing `clusterQueueFormatters.ts`.
* **Added** `resourceFlavor.test.ts` — covers node label formatting, taint formatting (single and multiple), toleration formatting (including the key-less/wildcard case), `tolerationSeconds` handling (including an explicit `0`), and the `Exists` + `value` edge case described above.
* **Updated** `resourceFlavor.ts` — now imports and uses the extracted functions instead of defining them privately; no behavior change for existing use cases.

## Testing

* `npx tsc --noEmit` — no errors
* `npx headlamp-plugin lint` — no warnings
* `npx vitest run` — 17/17 tests passing 
* `npx headlamp-plugin build` — builds cleanly
