### PR TITLE
prometheus: Fix a11y violations

### DIFF
--- a/prometheus/locales/cs/translation.json
+++ b/prometheus/locales/cs/translation.json
@@ -16,6 +16,8 @@
   "write": "",
   "Pause": "",
   "Resume": "",
+  "Timespan": "",
+  "Resolution": "",
   "CPU": "",
   "Memory": "",
   "Network": "",

--- a/prometheus/locales/de/translation.json
+++ b/prometheus/locales/de/translation.json
@@ -16,6 +16,8 @@
   "write": "",
   "Pause": "",
   "Resume": "",
+  "Timespan": "",
+  "Resolution": "",
   "CPU": "",
   "Memory": "",
   "Network": "",

--- a/prometheus/locales/en/translation.json
+++ b/prometheus/locales/en/translation.json
@@ -16,6 +16,8 @@
   "write": "write",
   "Pause": "Pause",
   "Resume": "Resume",
+  "Timespan": "Timespan",
+  "Resolution": "Resolution",
   "CPU": "CPU",
   "Memory": "Memory",
   "Network": "Network",

--- a/prometheus/locales/es/translation.json
+++ b/prometheus/locales/es/translation.json
@@ -16,6 +16,8 @@
   "write": "",
   "Pause": "",
   "Resume": "",
+  "Timespan": "",
+  "Resolution": "",
   "CPU": "",
   "Memory": "",
   "Network": "",

--- a/prometheus/locales/fr/translation.json
+++ b/prometheus/locales/fr/translation.json
@@ -16,6 +16,8 @@
   "write": "",
   "Pause": "",
   "Resume": "",
+  "Timespan": "",
+  "Resolution": "",
   "CPU": "",
   "Memory": "",
   "Network": "",

--- a/prometheus/locales/hu/translation.json
+++ b/prometheus/locales/hu/translation.json
@@ -16,6 +16,8 @@
   "write": "",
   "Pause": "",
   "Resume": "",
+  "Timespan": "",
+  "Resolution": "",
   "CPU": "",
   "Memory": "",
   "Network": "",

--- a/prometheus/locales/id/translation.json
+++ b/prometheus/locales/id/translation.json
@@ -16,6 +16,8 @@
   "write": "",
   "Pause": "",
   "Resume": "",
+  "Timespan": "",
+  "Resolution": "",
   "CPU": "",
   "Memory": "",
   "Network": "",

--- a/prometheus/locales/it/translation.json
+++ b/prometheus/locales/it/translation.json
@@ -16,6 +16,8 @@
   "write": "",
   "Pause": "",
   "Resume": "",
+  "Timespan": "",
+  "Resolution": "",
   "CPU": "",
   "Memory": "",
   "Network": "",

--- a/prometheus/locales/ja/translation.json
+++ b/prometheus/locales/ja/translation.json
@@ -16,6 +16,8 @@
   "write": "",
   "Pause": "",
   "Resume": "",
+  "Timespan": "",
+  "Resolution": "",
   "CPU": "",
   "Memory": "",
   "Network": "",

--- a/prometheus/locales/ko/translation.json
+++ b/prometheus/locales/ko/translation.json
@@ -16,6 +16,8 @@
   "write": "",
   "Pause": "",
   "Resume": "",
+  "Timespan": "",
+  "Resolution": "",
   "CPU": "",
   "Memory": "",
   "Network": "",

--- a/prometheus/locales/nl/translation.json
+++ b/prometheus/locales/nl/translation.json
@@ -16,6 +16,8 @@
   "write": "",
   "Pause": "",
   "Resume": "",
+  "Timespan": "",
+  "Resolution": "",
   "CPU": "",
   "Memory": "",
   "Network": "",

--- a/prometheus/locales/pl/translation.json
+++ b/prometheus/locales/pl/translation.json
@@ -16,6 +16,8 @@
   "write": "",
   "Pause": "",
   "Resume": "",
+  "Timespan": "",
+  "Resolution": "",
   "CPU": "",
   "Memory": "",
   "Network": "",

--- a/prometheus/locales/pt-BR/translation.json
+++ b/prometheus/locales/pt-BR/translation.json
@@ -16,6 +16,8 @@
   "write": "",
   "Pause": "",
   "Resume": "",
+  "Timespan": "",
+  "Resolution": "",
   "CPU": "",
   "Memory": "",
   "Network": "",

--- a/prometheus/locales/pt-PT/translation.json
+++ b/prometheus/locales/pt-PT/translation.json
@@ -16,6 +16,8 @@
   "write": "",
   "Pause": "",
   "Resume": "",
+  "Timespan": "",
+  "Resolution": "",
   "CPU": "",
   "Memory": "",
   "Network": "",

--- a/prometheus/locales/ru/translation.json
+++ b/prometheus/locales/ru/translation.json
@@ -16,6 +16,8 @@
   "write": "",
   "Pause": "",
   "Resume": "",
+  "Timespan": "",
+  "Resolution": "",
   "CPU": "",
   "Memory": "",
   "Network": "",

--- a/prometheus/locales/sv/translation.json
+++ b/prometheus/locales/sv/translation.json
@@ -16,6 +16,8 @@
   "write": "",
   "Pause": "",
   "Resume": "",
+  "Timespan": "",
+  "Resolution": "",
   "CPU": "",
   "Memory": "",
   "Network": "",

--- a/prometheus/locales/tr/translation.json
+++ b/prometheus/locales/tr/translation.json
@@ -16,6 +16,8 @@
   "write": "",
   "Pause": "",
   "Resume": "",
+  "Timespan": "",
+  "Resolution": "",
   "CPU": "",
   "Memory": "",
   "Network": "",

--- a/prometheus/locales/zh-Hans/translation.json
+++ b/prometheus/locales/zh-Hans/translation.json
@@ -16,6 +16,8 @@
   "write": "",
   "Pause": "",
   "Resume": "",
+  "Timespan": "",
+  "Resolution": "",
   "CPU": "",
   "Memory": "",
   "Network": "",

--- a/prometheus/locales/zh-Hant/translation.json
+++ b/prometheus/locales/zh-Hant/translation.json
@@ -16,6 +16,8 @@
   "write": "",
   "Pause": "",
   "Resume": "",
+  "Timespan": "",
+  "Resolution": "",
   "CPU": "",
   "Memory": "",
   "Network": "",

--- a/prometheus/src/components/Chart/CapiChart/CapiChart.tsx
+++ b/prometheus/src/components/Chart/CapiChart/CapiChart.tsx
@@ -148,7 +148,7 @@ export function CapiChart(props: CapiChartProps) {
                 <ToggleButtonGroup
                   onChange={handleChartVariantChange}
                   size="small"
-                  aria-label="metric chooser"
+                  aria-label={t('metric chooser')}
                   value={selectedChart}
                   exclusive
                 >
@@ -176,6 +176,7 @@ export function CapiChart(props: CapiChartProps) {
                 </Button>
                 <Box>
                   <Select
+                    inputProps={{ 'aria-label': t('Timespan') }}
                     variant="outlined"
                     size="small"
                     name="Time"
@@ -200,6 +201,7 @@ export function CapiChart(props: CapiChartProps) {
                 </Box>
                 <Box>
                   <Select
+                    inputProps={{ 'aria-label': t('Resolution') }}
                     variant="outlined"
                     size="small"
                     name="Time"

--- a/prometheus/src/components/Chart/DiskMetricsChart/DiskMetricsChart.tsx
+++ b/prometheus/src/components/Chart/DiskMetricsChart/DiskMetricsChart.tsx
@@ -94,6 +94,7 @@ export function DiskMetricsChart(props: DiskMetricsChartProps) {
             <Box>{t('Disk')}</Box>
             <Box pl={2}>
               <IconButton
+                aria-label={refresh ? t('Pause') : t('Resume')}
                 onClick={() => {
                   setRefresh(prev => !prev);
                 }}

--- a/prometheus/src/components/Chart/GenericMetricsChart/GenericMetricsChart.tsx
+++ b/prometheus/src/components/Chart/GenericMetricsChart/GenericMetricsChart.tsx
@@ -125,7 +125,7 @@ export function GenericMetricsChart(props: GenericMetricsChartProps) {
             <ToggleButtonGroup
               onChange={handleChartVariantChange}
               size="small"
-              aria-label="metric chooser"
+              aria-label={t('metric chooser')}
               value={chartVariant}
               exclusive
             >
@@ -140,6 +140,7 @@ export function GenericMetricsChart(props: GenericMetricsChartProps) {
             </ToggleButtonGroup>
             <Box>
               <Select
+                inputProps={{ 'aria-label': t('Timespan') }}
                 variant="outlined"
                 size="small"
                 name="Time"
@@ -164,6 +165,7 @@ export function GenericMetricsChart(props: GenericMetricsChartProps) {
             </Box>
             <Box>
               <Select
+                inputProps={{ 'aria-label': t('Resolution') }}
                 variant="outlined"
                 size="small"
                 name="Time"

--- a/prometheus/src/components/Chart/KarpenterChart/KarpenterChart.tsx
+++ b/prometheus/src/components/Chart/KarpenterChart/KarpenterChart.tsx
@@ -139,7 +139,7 @@ export function KarpenterChart(props: KarpenterChartProps) {
                 <ToggleButtonGroup
                   onChange={handleChartVariantChange}
                   size="small"
-                  aria-label="metric chooser"
+                  aria-label={t('metric chooser')}
                   value={selectedChart}
                   exclusive
                 >
@@ -167,6 +167,7 @@ export function KarpenterChart(props: KarpenterChartProps) {
                 </Button>
                 <Box>
                   <Select
+                    inputProps={{ 'aria-label': t('Timespan') }}
                     variant="outlined"
                     size="small"
                     name="Time"
@@ -191,6 +192,7 @@ export function KarpenterChart(props: KarpenterChartProps) {
                 </Box>
                 <Box>
                   <Select
+                    inputProps={{ 'aria-label': t('Resolution') }}
                     variant="outlined"
                     size="small"
                     name="Time"

--- a/prometheus/src/components/Chart/KedaChart/KedaChart.tsx
+++ b/prometheus/src/components/Chart/KedaChart/KedaChart.tsx
@@ -179,6 +179,7 @@ export function KedaChart(props: KedaChartProps) {
             </Button>
             <Box>
               <Select
+                inputProps={{ 'aria-label': t('Timespan') }}
                 variant="outlined"
                 size="small"
                 name="Time"
@@ -203,6 +204,7 @@ export function KedaChart(props: KedaChartProps) {
             </Box>
             <Box>
               <Select
+                inputProps={{ 'aria-label': t('Resolution') }}
                 variant="outlined"
                 size="small"
                 name="Time"

--- a/prometheus/src/components/Chart/KnativeChart/KnativeChart.tsx
+++ b/prometheus/src/components/Chart/KnativeChart/KnativeChart.tsx
@@ -215,7 +215,7 @@ export function KnativeChart({
                 <ToggleButtonGroup
                   onChange={handleChartVariantChange}
                   size="small"
-                  aria-label="metric chooser"
+                  aria-label={t('metric chooser')}
                   value={selectedChart}
                   exclusive
                 >
@@ -243,6 +243,7 @@ export function KnativeChart({
                 </Button>
                 <Box>
                   <Select
+                    inputProps={{ 'aria-label': t('Timespan') }}
                     variant="outlined"
                     size="small"
                     name="Time"
@@ -267,6 +268,7 @@ export function KnativeChart({
                 </Box>
                 <Box>
                   <Select
+                    inputProps={{ 'aria-label': t('Resolution') }}
                     variant="outlined"
                     size="small"
                     name="Resolution"

--- a/prometheus/src/components/Chart/StrimziChart/StrimziChart.tsx
+++ b/prometheus/src/components/Chart/StrimziChart/StrimziChart.tsx
@@ -276,6 +276,7 @@ export function StrimziChart(props: StrimziChartProps) {
                 </Button>
                 <Box>
                   <Select
+                    inputProps={{ 'aria-label': t('Timespan') }}
                     variant="outlined"
                     size="small"
                     name="Time"
@@ -300,6 +301,7 @@ export function StrimziChart(props: StrimziChartProps) {
                 </Box>
                 <Box>
                   <Select
+                    inputProps={{ 'aria-label': t('Resolution') }}
                     variant="outlined"
                     size="small"
                     name="Resolution"

--- a/prometheus/src/components/Chart/VolcanoChart/VolcanoChart.tsx
+++ b/prometheus/src/components/Chart/VolcanoChart/VolcanoChart.tsx
@@ -243,6 +243,7 @@ export function VolcanoChart(props: VolcanoChartProps) {
                   {refresh ? t('Pause') : t('Resume')}
                 </Button>
                 <Select
+                  inputProps={{ 'aria-label': t('Timespan') }}
                   variant="outlined"
                   size="small"
                   name="Time"
@@ -265,6 +266,7 @@ export function VolcanoChart(props: VolcanoChartProps) {
                   <MenuItem value={'14d'}>{t('14 days')}</MenuItem>
                 </Select>
                 <Select
+                  inputProps={{ 'aria-label': t('Resolution') }}
                   variant="outlined"
                   size="small"
                   name="Resolution"

--- a/prometheus/src/components/Chart/common.tsx
+++ b/prometheus/src/components/Chart/common.tsx
@@ -52,6 +52,8 @@ export function PrometheusNotFoundBanner() {
       <Grid item>
         <Typography>
           <Link
+            component="button"
+            type="button"
             onClick={() => history.push(`/settings/plugins/${encodeURIComponent(PLUGIN_NAME)}`)}
           >
             {t('Configure Prometheus plugin.')}
@@ -60,7 +62,7 @@ export function PrometheusNotFoundBanner() {
       </Grid>
       <Grid item>
         <Typography>
-          <Link href={learnMoreLink} target="_blank">
+          <Link href={learnMoreLink} target="_blank" rel="noopener noreferrer">
             {t('Learn more about enabling advanced charts.')}
           </Link>
         </Typography>

--- a/prometheus/src/components/Settings/Settings.tsx
+++ b/prometheus/src/components/Settings/Settings.tsx
@@ -136,6 +136,7 @@ export function Settings(props: SettingsProps) {
       name: t('Enable Metrics'),
       value: (
         <Switch
+          inputProps={{ 'aria-label': t('Enable Metrics') }}
           checked={isMetricsEnabled}
           onChange={e => {
             const newMetricsEnabled = e.target.checked;
@@ -155,6 +156,7 @@ export function Settings(props: SettingsProps) {
       name: t('Auto detect'),
       value: (
         <Switch
+          inputProps={{ 'aria-label': t('Auto detect') }}
           disabled={!isMetricsEnabled}
           checked={isAutoDetectEnabled}
           onChange={e =>
@@ -175,6 +177,7 @@ export function Settings(props: SettingsProps) {
         <Box display="flex" flexDirection="column" width="100%">
           <Box display="flex" gap={2} alignItems="flex-start">
             <TextField
+              inputProps={{ 'aria-label': t('Prometheus Service Address') }}
               disabled={!isAddressFieldEnabled}
               helperText={
                 addressError
@@ -226,6 +229,7 @@ export function Settings(props: SettingsProps) {
       name: t('Prometheus Service Subpath'),
       value: (
         <TextField
+          inputProps={{ 'aria-label': t('Prometheus Service Subpath') }}
           value={selectedClusterData.subPath || ''}
           disabled={!isAddressFieldEnabled}
           helperText={t(
@@ -245,6 +249,7 @@ export function Settings(props: SettingsProps) {
       name: t('Default Timespan'),
       value: (
         <Select
+          inputProps={{ 'aria-label': t('Default Timespan') }}
           disabled={!isMetricsEnabled}
           value={data?.[selectedCluster]?.defaultTimespan || '24h'}
           onChange={e =>
@@ -278,6 +283,7 @@ export function Settings(props: SettingsProps) {
       name: t('Default Resolution'),
       value: (
         <Select
+          inputProps={{ 'aria-label': t('Default Resolution') }}
           disabled={!isMetricsEnabled}
           value={data?.[selectedCluster]?.defaultResolution || 'medium'}
           onChange={e =>
@@ -311,7 +317,11 @@ export function Settings(props: SettingsProps) {
     <Box width={'80%'}>
       <Box display="flex" alignItems="center" justifyContent="space-between" mb={2}>
         <Typography variant="h6">{t('Select Cluster')}</Typography>
-        <Select value={selectedCluster} onChange={e => setSelectedCluster(e.target.value)}>
+        <Select
+          inputProps={{ 'aria-label': t('Select Cluster') }}
+          value={selectedCluster}
+          onChange={e => setSelectedCluster(e.target.value)}
+        >
           {Object.keys(clusters).map(clusterName => (
             <MenuItem key={clusterName} value={clusterName}>
               {clusterName}


### PR DESCRIPTION
These changes fix accessibility (a11y) violations in the Prometheus plugin surfaced by an axe-core pass over the components. The plugin looks and behaves exactly as before for sighted mouse users, while becoming more usable for keyboard and screen-reader users.

### Changes

- Add translated accessible names to settings controls and chart selectors
- Add an accessible name to the disk chart pause/resume button
- Make the Prometheus configuration control keyboard-accessible
- Secure external links opened in a new tab with `rel="noopener noreferrer"`