### PR TITLE
ai-assistant: Pin headlamp e2e image by digest

### DIFF
--- a/ai-assistant/e2e/Dockerfile.headlamp
+++ b/ai-assistant/e2e/Dockerfile.headlamp
@@ -1,4 +1,4 @@
-FROM ghcr.io/headlamp-k8s/headlamp:v0.43.0
+FROM ghcr.io/headlamp-k8s/headlamp:v0.43.0@sha256:5d03caa26df7a715079405df2949907160518750b9b62b6bf4de8d1a6142c541
 
 COPY --chown=100:101 dist/ /headlamp/plugins/ai-assistant/
 COPY --chown=100:101 package.json /headlamp/plugins/ai-assistant/package.json


### PR DESCRIPTION
This change pins the Headlamp e2e container image by digest to ensure reproducible builds.