### PR TITLE
fix(ai-assistant): redact Kubernetes Secret data before GET

### DIFF
--- a/ai-assistant/packages/ai-common/src/security/redactSecrets.test.ts
+++ b/ai-assistant/packages/ai-common/src/security/redactSecrets.test.ts
@@ -299,6 +299,32 @@ namespace: default`;
     expect(out).toContain('"name": "db-credentials"');
   });
 
+  it('redacts a real apiserver SecretList response in YAML (`-o yaml` shape)', () => {
+    // Same SecretList shape as above but as the YAML `kubectl get secrets -o
+    // yaml` would render it: a single document, top-level `kind: SecretList`,
+    // with secrets nested under `items` (no `---` document separators).
+    const secretList = [
+      'apiVersion: v1',
+      'kind: SecretList',
+      'metadata:',
+      '  resourceVersion: "12345"',
+      'items:',
+      '- metadata:',
+      '    name: db-credentials',
+      '    namespace: default',
+      '  data:',
+      '    DATABASE_PASSWORD: aHVudGVyMg==',
+      '    session: czNjcjN0LXNlc3Npb24ta2V5',
+      '  type: Opaque',
+    ].join('\n');
+    const out = redactSecrets(secretList);
+    expect(out).not.toContain('aHVudGVyMg==');
+    expect(out).not.toContain('czNjcjN0LXNlc3Npb24ta2V5');
+    expect(out).toContain('DATABASE_PASSWORD: [REDACTED]');
+    expect(out).toContain('session: [REDACTED]');
+    expect(out).toContain('name: db-credentials');
+  });
+
   it('does not over-redact ConfigMap data', () => {
     const cm = ['kind: ConfigMap', 'data:', '  app.conf: hello-world'].join('\n');
     expect(redactSecrets(cm)).toContain('app.conf: hello-world');

--- a/ai-assistant/packages/ai-common/src/security/redactSecrets.test.ts
+++ b/ai-assistant/packages/ai-common/src/security/redactSecrets.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { redactSecrets } from './redactSecrets';
+import { redactSecrets, redactSecretsInValue } from './redactSecrets';
 
 describe('redactSecrets', () => {
   it('returns the input unchanged when there are no secrets', () => {
@@ -274,6 +274,31 @@ namespace: default`;
     expect(redactSecrets(list)).not.toContain('YWJj');
   });
 
+  it('redacts a real apiserver SecretList response (items omit their own kind)', () => {
+    // This is the shape returned by `GET /api/v1/namespaces/{ns}/secrets`,
+    // as opposed to `kubectl -o json`'s generic `kind: List` wrapper above.
+    const secretList = JSON.stringify({
+      kind: 'SecretList',
+      apiVersion: 'v1',
+      metadata: { resourceVersion: '12345' },
+      items: [
+        {
+          metadata: { name: 'db-credentials', namespace: 'default' },
+          data: {
+            DATABASE_PASSWORD: 'aHVudGVyMg==',
+            session: 'czNjcjN0LXNlc3Npb24ta2V5',
+          },
+          type: 'Opaque',
+        },
+      ],
+    });
+    const out = redactSecrets(secretList);
+    expect(out).not.toContain('aHVudGVyMg==');
+    expect(out).not.toContain('czNjcjN0LXNlc3Npb24ta2V5');
+    expect(out).toContain('[REDACTED]');
+    expect(out).toContain('"name": "db-credentials"');
+  });
+
   it('does not over-redact ConfigMap data', () => {
     const cm = ['kind: ConfigMap', 'data:', '  app.conf: hello-world'].join('\n');
     expect(redactSecrets(cm)).toContain('app.conf: hello-world');
@@ -287,5 +312,34 @@ namespace: default`;
     expect(
       redactSecrets('DefaultEndpointsProtocol=https;AccountKey=abc123DEF456==;Rest=1')
     ).toContain('AccountKey=[REDACTED]');
+  });
+});
+
+describe('redactSecretsInValue', () => {
+  it('redacts data fields of a parsed Secret object', () => {
+    const value = {
+      kind: 'Secret',
+      metadata: { name: 'db-credentials' },
+      data: { DATABASE_PASSWORD: 'aHVudGVyMg==' },
+    };
+    const out = redactSecretsInValue(value) as any;
+    expect(out.data.DATABASE_PASSWORD).toBe('[REDACTED]');
+    expect(out.metadata.name).toBe('db-credentials');
+  });
+
+  it('redacts data fields of items in a parsed SecretList object', () => {
+    const value = {
+      kind: 'SecretList',
+      items: [
+        {
+          metadata: { name: 'db-credentials', namespace: 'default' },
+          data: { DATABASE_PASSWORD: 'aHVudGVyMg==', session: 'czNjcjN0LXNlc3Npb24ta2V5' },
+        },
+      ],
+    };
+    const out = redactSecretsInValue(value) as any;
+    expect(out.items[0].data.DATABASE_PASSWORD).toBe('[REDACTED]');
+    expect(out.items[0].data.session).toBe('[REDACTED]');
+    expect(out.items[0].metadata.name).toBe('db-credentials');
   });
 });

--- a/ai-assistant/packages/ai-common/src/security/redactSecrets.ts
+++ b/ai-assistant/packages/ai-common/src/security/redactSecrets.ts
@@ -142,8 +142,10 @@ export function redactSecrets(input: string): string {
  * @returns The input with Secret data values replaced by `[REDACTED]`.
  */
 function redactKubernetesSecretValues(input: string): string {
-  // Cheap early-out: only act when the text mentions a Secret kind.
-  if (!/\bkind\b["\s]*:\s*["']?Secret\b/i.test(input)) {
+  // Cheap early-out: only act when the text mentions a Secret kind. Matches
+  // both the singular `Secret` kind and the apiserver's list kind
+  // `SecretList` (returned by e.g. `GET /api/v1/namespaces/{ns}/secrets`).
+  if (!/\bkind\b["\s]*:\s*["']?Secret(List)?\b/i.test(input)) {
     return input;
   }
 
@@ -196,13 +198,16 @@ function redactSecretsInParsedJson(value: unknown): boolean {
     const obj = value as Record<string, unknown>;
 
     if (obj.kind === 'Secret') {
-      for (const field of ['data', 'stringData'] as const) {
-        const bag = obj[field];
-        if (bag && typeof bag === 'object' && !Array.isArray(bag)) {
-          for (const key of Object.keys(bag as Record<string, unknown>)) {
-            (bag as Record<string, unknown>)[key] = '[REDACTED]';
-            changed = true;
-          }
+      changed = redactSecretDataFields(obj) || changed;
+    }
+
+    // The apiserver's `SecretList` (e.g. `GET /api/v1/namespaces/{ns}/secrets`)
+    // nests bare Secret objects under `items` that omit their own `kind`,
+    // unlike `kubectl -o json`'s generic `List` wrapper used in tests below.
+    if (obj.kind === 'SecretList' && Array.isArray(obj.items)) {
+      for (const item of obj.items as unknown[]) {
+        if (item && typeof item === 'object') {
+          changed = redactSecretDataFields(item as Record<string, unknown>) || changed;
         }
       }
     }
@@ -212,6 +217,27 @@ function redactSecretsInParsedJson(value: unknown): boolean {
     }
   }
 
+  return changed;
+}
+
+/**
+ * Redacts the `data` / `stringData` fields of a single Secret-shaped object.
+ *
+ * @param obj - A parsed Secret object (or a `SecretList` item, which has the
+ *   same shape but omits its own `kind`).
+ * @returns Whether any redaction was applied.
+ */
+function redactSecretDataFields(obj: Record<string, unknown>): boolean {
+  let changed = false;
+  for (const field of ['data', 'stringData'] as const) {
+    const bag = obj[field];
+    if (bag && typeof bag === 'object' && !Array.isArray(bag)) {
+      for (const key of Object.keys(bag as Record<string, unknown>)) {
+        (bag as Record<string, unknown>)[key] = '[REDACTED]';
+        changed = true;
+      }
+    }
+  }
   return changed;
 }
 
@@ -297,14 +323,34 @@ export function redactSecretsInValue(value: unknown): unknown {
     copy[key] = redactSecretsInValue(item);
   }
   if (copy.kind === 'Secret') {
-    for (const field of ['data', 'stringData'] as const) {
-      const bag = copy[field];
-      if (bag && typeof bag === 'object' && !Array.isArray(bag)) {
-        copy[field] = Object.fromEntries(
-          Object.keys(bag as Record<string, unknown>).map(key => [key, '[REDACTED]'])
-        );
+    redactSecretDataFieldsInPlace(copy);
+  }
+  // The apiserver's `SecretList` nests bare Secret objects under `items` that
+  // omit their own `kind`, so they are not caught by the check above.
+  if (copy.kind === 'SecretList' && Array.isArray(copy.items)) {
+    for (const item of copy.items as unknown[]) {
+      if (item && typeof item === 'object') {
+        redactSecretDataFieldsInPlace(item as Record<string, unknown>);
       }
     }
   }
   return copy;
+}
+
+/**
+ * Replaces the `data` / `stringData` fields of a Secret-shaped object with
+ * `[REDACTED]` values, in place.
+ *
+ * @param obj - A Secret object (or a `SecretList` item, which has the same
+ *   shape but omits its own `kind`).
+ */
+function redactSecretDataFieldsInPlace(obj: Record<string, unknown>): void {
+  for (const field of ['data', 'stringData'] as const) {
+    const bag = obj[field];
+    if (bag && typeof bag === 'object' && !Array.isArray(bag)) {
+      obj[field] = Object.fromEntries(
+        Object.keys(bag as Record<string, unknown>).map(key => [key, '[REDACTED]'])
+      );
+    }
+  }
 }

--- a/ai-assistant/packages/ai-common/src/security/redactSecrets.ts
+++ b/ai-assistant/packages/ai-common/src/security/redactSecrets.ts
@@ -255,7 +255,13 @@ function redactKubernetesSecretValuesYaml(input: string): string {
     .map(document => {
       if (
         /^\s*---\s*$/.test(document) ||
-        !/^\s*(?:-\s*)?kind:\s*["']?Secret["']?\s*$/m.test(document)
+        // Matches both a single Secret document and a SecretList document
+        // (the `-o yaml` shape for `GET /api/.../secrets`, a single document
+        // with a top-level `kind: SecretList` and secrets nested under
+        // `items`). The line scanner below redacts `data`/`stringData`
+        // blocks wherever they appear, so no further List-specific handling
+        // is needed once the document passes this gate.
+        !/^\s*(?:-\s*)?kind:\s*["']?Secret(List)?["']?\s*$/m.test(document)
       ) {
         return document;
       }

--- a/ai-assistant/src/api/clusterActions.test.ts
+++ b/ai-assistant/src/api/clusterActions.test.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockClusterRequest = vi.fn();
+
+vi.mock('@kinvolk/headlamp-plugin/lib', () => ({
+  clusterAction: (fn: () => unknown) => fn(),
+}));
+
+vi.mock('@kinvolk/headlamp-plugin/lib/ApiProxy', () => ({
+  apply: vi.fn(),
+  clusterRequest: (...args: unknown[]) => mockClusterRequest(...args),
+}));
+
+vi.mock('@kinvolk/headlamp-plugin/lib/Utils', () => ({
+  getCluster: () => 'test-cluster',
+}));
+
+vi.mock('@headlamp-k8s/ai-ui/parsing/urlParsing', () => ({
+  isLogRequest: () => false,
+  isSpecificResourceRequestHelper: () => true,
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('handleActualApiRequest GET', () => {
+  it('redacts Secret data before pushing the response to history', async () => {
+    mockClusterRequest.mockResolvedValue({
+      kind: 'Secret',
+      apiVersion: 'v1',
+      metadata: { name: 'db-credentials', namespace: 'default' },
+      data: { DATABASE_PASSWORD: 'aHVudGVyMg==', 'tls.key': 'LS0tLXByaXZhdGUta2V5LS0tLQ==' },
+      type: 'Opaque',
+    });
+
+    const { handleActualApiRequest } = await import('./clusterActions');
+
+    const aiManager = { history: [] as Array<{ content: string }> };
+    await handleActualApiRequest(
+      '/api/v1/namespaces/default/secrets/db-credentials',
+      'GET',
+      '',
+      () => {},
+      aiManager,
+      'db-credentials'
+    );
+
+    const historyContent = aiManager.history.map(entry => entry.content).join('\n');
+    expect(historyContent).not.toContain('aHVudGVyMg==');
+    expect(historyContent).not.toContain('LS0tLXByaXZhdGUta2V5LS0tLQ==');
+    expect(historyContent).toContain('[REDACTED]');
+  });
+
+  it('redacts Secret data in SecretList responses (list of secrets)', async () => {
+    mockClusterRequest.mockResolvedValue({
+      kind: 'SecretList',
+      apiVersion: 'v1',
+      metadata: { resourceVersion: '12345' },
+      items: [
+        {
+          metadata: { name: 'db-credentials', namespace: 'default' },
+          data: { DATABASE_PASSWORD: 'aHVudGVyMg==' },
+          type: 'Opaque',
+        },
+      ],
+    });
+
+    const { handleActualApiRequest } = await import('./clusterActions');
+
+    const aiManager = { history: [] as Array<{ content: string }> };
+    await handleActualApiRequest(
+      '/api/v1/namespaces/default/secrets',
+      'GET',
+      '',
+      () => {},
+      aiManager,
+      'secrets'
+    );
+
+    const historyContent = aiManager.history.map(entry => entry.content).join('\n');
+    expect(historyContent).not.toContain('aHVudGVyMg==');
+    expect(historyContent).toContain('[REDACTED]');
+  });
+});

--- a/ai-assistant/src/api/clusterActions.tsx
+++ b/ai-assistant/src/api/clusterActions.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { redactSecrets } from '@headlamp-k8s/ai-common/security/redactSecrets';
 import {
   isLogRequest,
   isSpecificResourceRequestHelper,
@@ -543,6 +544,8 @@ export const handleActualApiRequest = async (
         // Fallback: if not a Response object, treat as string
         logText = String(response);
       }
+      // Logs routinely contain tokens/credentials printed by the workload.
+      logText = redactSecrets(logText);
 
       // Extract resource information from URL for better log button display
       const extractResourceFromUrl = (url: string) => {
@@ -702,7 +705,7 @@ export const handleActualApiRequest = async (
       aiManager.history.push({
         success: true,
         role: 'tool',
-        content: formattedResponse,
+        content: redactSecrets(formattedResponse),
       });
 
       // Call the success callback if provided
@@ -714,7 +717,7 @@ export const handleActualApiRequest = async (
       aiManager.history.push({
         success: true,
         role: 'tool',
-        content: formattedResponse,
+        content: redactSecrets(formattedResponse),
       });
 
       // Call the success callback if provided
@@ -726,7 +729,7 @@ export const handleActualApiRequest = async (
       aiManager.history.push({
         success: true,
         role: 'tool',
-        content: formattedResponse,
+        content: redactSecrets(formattedResponse),
       });
 
       // Call the success callback if provided


### PR DESCRIPTION
## Summary
- Kubernetes `GET` responses (including Secrets) were pushed into AI chat history without going through `redactSecrets()`, so Secret `data`/`stringData` values (passwords, tokens, TLS keys) could be sent to the configured LLM provider.
- `redactSecrets()` also failed to recognize `SecretList` responses (the shape the apiserver returns for a list of secrets), so even where it was called, list responses were not redacted.

## Fix

- `clusterActions.tsx`: redact the response content (Table, object, string, and log branches) before pushing it to `aiManager.history`.
- `redactSecrets.ts`: recognize `kind: "SecretList"` and redact `data`/`stringData` on each item, since list items omit their own `kind`.

## Test plan

- Added regression tests that fetch a Secret and a SecretList and assert the resulting chat history contains `[REDACTED]` instead of the real base64 values.
- Verified these tests fail against the old code and pass with the fix.
- Full `ai-assistant` and `ai-common` test suites pass; `tsc` and `eslint` clean.

Fixes #995
