### PR TITLE
flux: Fix parseDuration for millisecond and fractional intervals

### DIFF
--- a/flux/src/common/RemainingTimeDisplay.tsx
+++ b/flux/src/common/RemainingTimeDisplay.tsx
@@ -46,6 +46,12 @@ function getNextReconciliationAttempt(item: KubeObject) {
 
   const intervalInMs = parseDuration(interval);
 
+  // Without a usable interval there is nothing to project the next attempt from.
+  // This also keeps a zero interval from turning the division below into NaN.
+  if (!(intervalInMs > 0)) {
+    return -1;
+  }
+
   // Calculate the last reconciliation attempt assuming there was an attempt at every interval,
   // starting from the last ready state.
   const nowAndLastReadyDiff = new Date().getTime() - lastRecordedCheck.getTime();

--- a/flux/src/helpers/duration.ts
+++ b/flux/src/helpers/duration.ts
@@ -1,0 +1,38 @@
+const DURATION_UNITS_IN_MS = {
+  ns: 1e-6,
+  us: 1e-3,
+  µs: 1e-3,
+  ms: 1,
+  s: 1000,
+  m: 60 * 1000,
+  h: 60 * 60 * 1000,
+};
+
+// Flux intervals are metav1.Duration, so they are parsed by Go's
+// time.ParseDuration. That accepts fractional values and the ns, us, ms, s, m
+// and h units. The two character units have to come first in the alternation,
+// otherwise "500ms" matches "500m" and is read as 500 minutes.
+const DURATION_REGEX = /(\d+(?:\.\d+)?)(ns|us|µs|ms|s|m|h)/g;
+
+/**
+ * Converts a Go style duration such as "5m", "1m30s" or "500ms" to milliseconds.
+ *
+ * @param duration - The duration string to parse.
+ * @returns The duration in milliseconds, or NaN if nothing could be parsed.
+ */
+export function parseDuration(duration) {
+  let totalMilliseconds = 0;
+  let matched = false;
+  let match;
+
+  DURATION_REGEX.lastIndex = 0;
+
+  while ((match = DURATION_REGEX.exec(duration)) !== null) {
+    matched = true;
+    totalMilliseconds += parseFloat(match[1]) * DURATION_UNITS_IN_MS[match[2]];
+  }
+
+  // Returning 0 here would look like a valid interval to callers and make them
+  // divide by zero, so report an unparsable duration instead.
+  return matched ? totalMilliseconds : NaN;
+}

--- a/flux/src/helpers/index.tsx
+++ b/flux/src/helpers/index.tsx
@@ -153,30 +153,7 @@ export function ObjectEventsRenderer(props: { events?: Event[] }) {
   );
 }
 
-export function parseDuration(duration) {
-  const regex = /(\d+)([hms])/g; // Match numbers followed by h, m, or s
-  let totalMilliseconds = 0;
-  let match;
-
-  while ((match = regex.exec(duration)) !== null) {
-    const value = parseInt(match[1], 10);
-    const unit = match[2];
-
-    switch (unit) {
-      case 'h':
-        totalMilliseconds += value * 60 * 60 * 1000; // Convert hours to milliseconds
-        break;
-      case 'm':
-        totalMilliseconds += value * 60 * 1000; // Convert minutes to milliseconds
-        break;
-      case 's':
-        totalMilliseconds += value * 1000; // Convert seconds to milliseconds
-        break;
-    }
-  }
-
-  return totalMilliseconds;
-}
+export { parseDuration } from './duration';
 
 export function NameLink(resourceClass: KubeObjectClass) {
   const apiVersion = new String(resourceClass.apiVersion); // explicit String cast is needed for string methods

--- a/flux/src/helpers/parseDuration.test.ts
+++ b/flux/src/helpers/parseDuration.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { parseDuration } from './duration';
+
+describe('parseDuration', () => {
+  it('parses single unit durations', () => {
+    expect(parseDuration('30s')).toBe(30 * 1000);
+    expect(parseDuration('5m')).toBe(5 * 60 * 1000);
+    expect(parseDuration('1h')).toBe(60 * 60 * 1000);
+  });
+
+  it('adds up compound durations', () => {
+    expect(parseDuration('1m30s')).toBe(90 * 1000);
+    expect(parseDuration('1h0m0s')).toBe(60 * 60 * 1000);
+  });
+
+  it('reads milliseconds as milliseconds and not as minutes', () => {
+    expect(parseDuration('500ms')).toBe(500);
+    expect(parseDuration('250ms')).toBe(250);
+  });
+
+  it('keeps the fractional part', () => {
+    expect(parseDuration('1.5s')).toBe(1500);
+    expect(parseDuration('2.5m')).toBe(150 * 1000);
+  });
+
+  it('supports the sub millisecond units', () => {
+    expect(parseDuration('100us')).toBeCloseTo(0.1);
+    expect(parseDuration('100µs')).toBeCloseTo(0.1);
+    expect(parseDuration('1000ns')).toBeCloseTo(0.001);
+  });
+
+  it('returns NaN when there is nothing to parse', () => {
+    expect(parseDuration('')).toBeNaN();
+    expect(parseDuration('later')).toBeNaN();
+    expect(parseDuration(undefined)).toBeNaN();
+  });
+});


### PR DESCRIPTION
Fixes #1005

## What this changes

`parseDuration` used `/(\d+)([hms])/g`, which had two problems:

- `500ms` matched `500m` first, so it was read as 500 minutes rather than 500 milliseconds, out by a factor of 60000.
- `\d+` does not match `.`, so `1.5s` skipped past `1.` and was read as 5 seconds.

Units outside `h`, `m` and `s` matched nothing at all and the function returned `0`. The only caller then divided by it:

```js
Math.floor(nowAndLastReadyDiff / intervalInMs) * intervalInMs
```

`Infinity * 0` is `NaN`, so `getNextReconciliationAttempt` returned `NaN`. Since `lastReconcileUnknown` is set from `nextAttempt === -1` and `NaN === -1` is false, the "Unable to calculate" fallback never ran, and the row rendered `formatRemainingTime(NaN)` with a hover label of `new Date(NaN)`, showing Invalid Date.

Flux intervals are `metav1.Duration`, parsed by Go's `time.ParseDuration`, so `ms`, `us`, `ns` and fractional values are all legal input.

## The fix

- Match the two character units before the single character ones so `ms` wins over `m`.
- Allow a fractional part.
- Return `NaN` instead of `0` when nothing parses, so callers can tell an unparsable interval from a genuine zero.
- Guard in `getNextReconciliationAttempt` so an unusable interval returns `-1` and reaches the existing "Unable to calculate" path.

`parseDuration` moves to `helpers/duration.ts`. It was in `helpers/index.tsx`, which imports the Headlamp component library, and importing that from a test fails to resolve under vitest. The re-export from `helpers/index.tsx` keeps existing imports working.

## Before and after

| input | before | after |
| --- | --- | --- |
| `30s` | 30000 | 30000 |
| `1m30s` | 90000 | 90000 |
| `500ms` | 30000000 | 500 |
| `1.5s` | 5000 | 1500 |
| `100us` | 0 | 0.1 |
| `later` | 0 | NaN |

## Testing

Added `helpers/parseDuration.test.ts` covering each of the above. Full `build`, `tsc`, `lint`, `format --check` and `test` pass for the flux plugin.
