### PR TITLE
flux: Clear the RemainingTimeDisplay timeout on unmount

### DIFF
--- a/flux/src/common/RemainingTimeDisplay.tsx
+++ b/flux/src/common/RemainingTimeDisplay.tsx
@@ -138,7 +138,7 @@ export default function RemainingTimeDisplay(props: RemainingTimeDisplayProps) {
     }
 
     if (!!timeoutRef.current) {
-      window.clearInterval(timeoutRef.current);
+      window.clearTimeout(timeoutRef.current);
     }
 
     // The trigger projection is not perfect, so if our remaining time is getting negative,
@@ -153,11 +153,15 @@ export default function RemainingTimeDisplay(props: RemainingTimeDisplayProps) {
   }, [nextAttemptStatus, timeRemaining]);
 
   React.useEffect(() => {
-    // Just to clear out any remaining timeouts when the component is unmounted
-    if (!!timeoutRef.current) {
-      window.clearInterval(timeoutRef.current);
-      timeoutRef.current = undefined;
-    }
+    // Just to clear out any remaining timeouts when the component is unmounted.
+    // This has to be returned as the cleanup function, otherwise it only runs on
+    // mount, when there is no timeout to clear yet.
+    return () => {
+      if (!!timeoutRef.current) {
+        window.clearTimeout(timeoutRef.current);
+        timeoutRef.current = undefined;
+      }
+    };
   }, []);
 
   return (


### PR DESCRIPTION
Fixes #1006

## What this changes

`RemainingTimeDisplay` schedules a `setTimeout` to refresh the countdown and keeps the handle in `timeoutRef`. The effect meant to clear it looked like this:

```js
React.useEffect(() => {
  // Just to clear out any remaining timeouts when the component is unmounted
  if (!!timeoutRef.current) {
    window.clearInterval(timeoutRef.current);
    timeoutRef.current = undefined;
  }
}, []);
```

The clearing code sits in the effect body instead of a returned cleanup. With an empty dependency array the body runs once on mount, when `timeoutRef.current` is still `undefined`, so the `if` is false and nothing happens. There is no `return`, so React has no cleanup to call and the effect never runs again. The comment says what was intended, but the timeout has never actually been cleared on unmount.

The pending timeout outlives the component and fires `setTimeRemaining` on an unmounted tree. Every Flux list row with a `spec.interval` renders one of these, so leaving a list of any size leaks a timer per row.

## The fix

- Return the cleanup from the effect so React runs it on unmount.
- Use `window.clearTimeout` to match the `window.setTimeout` that produced the handle, here and at the other call site. The old `clearInterval` worked only because browsers share a single id space for timeouts and intervals.

## Testing

`build`, `tsc`, `lint`, `format --check` and `test` all pass for the flux plugin.
