### PR TITLE
kyverno: add openreports.io/v1alpha1 support (resources, CRD probe)

### DIFF
--- a/kyverno/src/components/CRDGuard.tsx
+++ b/kyverno/src/components/CRDGuard.tsx
@@ -13,31 +13,34 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
 import { ReactNode } from 'react';
 import { KyvernoCRDStatus, useKyvernoCRDs } from '../hooks/useKyvernoCRDs';
 import { NotInstalledBanner } from './common';
-
 export type CRDGroup = keyof Omit<KyvernoCRDStatus, 'loading'>;
-
 interface CRDGuardProps {
   requires: CRDGroup;
   children: ReactNode;
   message?: string;
 }
-
 export function CRDGuard({ requires, children, message }: CRDGuardProps) {
   const { t } = useTranslation();
   const status = useKyvernoCRDs();
-
   const defaultMessages: Record<CRDGroup, string> = {
     legacy: t('Kyverno (kyverno.io/v1) was not detected on this cluster.'),
     cel: t(
       'Kyverno CEL policies (policies.kyverno.io/v1) were not detected on this cluster. Kyverno 1.14+ is required.'
     ),
     cleanup: t('Kyverno cleanup policies (kyverno.io/v2) were not detected on this cluster.'),
-    reports: t('Policy Reports (wgpolicyk8s.io/v1alpha2) were not detected on this cluster.'),
+    reports: t(
+      'Policy Reports (wgpolicyk8s.io/v1alpha2 or openreports.io/v1alpha1) were not detected on this cluster.'
+    ),
+    wgPolicyReports: t(
+      'Policy Reports (wgpolicyk8s.io/v1alpha2) were not detected on this cluster.'
+    ),
+    openReports: t(
+      'Policy Reports (openreports.io/v1alpha1) were not detected on this cluster.'
+    ),
     exceptions: t('Policy Exceptions (kyverno.io/v2) were not detected on this cluster.'),
     kyvernoV2Reports: t(
       'Kyverno admission/background-scan reports (kyverno.io/v2) were not detected on this cluster.'
@@ -46,14 +49,11 @@ export function CRDGuard({ requires, children, message }: CRDGuardProps) {
       'Kyverno ephemeral reports (reports.kyverno.io/v1) were not detected on this cluster. Kyverno 1.11+ is required.'
     ),
   };
-
   if (status.loading) {
     return <NotInstalledBanner loading />;
   }
-
   if (!status[requires]) {
     return <NotInstalledBanner message={message || defaultMessages[requires]} />;
   }
-
   return <>{children}</>;
 }

--- a/kyverno/src/hooks/useKyvernoCRDs.ts
+++ b/kyverno/src/hooks/useKyvernoCRDs.ts
@@ -21,7 +21,9 @@ export interface KyvernoCRDStatus {
   legacy: boolean; // kyverno.io/v1 (ClusterPolicy, Policy)
   cel: boolean; // policies.kyverno.io/v1 (ValidatingPolicy, MutatingPolicy, etc.)
   cleanup: boolean; // kyverno.io/v2 (CleanupPolicy, ClusterCleanupPolicy)
-  reports: boolean; // wgpolicyk8s.io/v1alpha2 (PolicyReport, ClusterPolicyReport)
+  reports: boolean; // true if EITHER wgpolicyk8s.io/v1alpha2 OR openreports.io/v1alpha1 is present
+  wgPolicyReports: boolean; // wgpolicyk8s.io/v1alpha2 (PolicyReport, ClusterPolicyReport)
+  openReports: boolean; // openreports.io/v1alpha1 (Report, ClusterReport)
   exceptions: boolean; // kyverno.io/v2 (PolicyException)
   kyvernoV2Reports: boolean; // kyverno.io/v2 (Admission/BackgroundScan reports)
   ephemeralReports: boolean; // reports.kyverno.io/v1 (EphemeralReport, ClusterEphemeralReport)
@@ -33,6 +35,8 @@ const initialStatus: KyvernoCRDStatus = {
   cel: false,
   cleanup: false,
   reports: false,
+  wgPolicyReports: false,
+  openReports: false,
   exceptions: false,
   kyvernoV2Reports: false,
   ephemeralReports: false,
@@ -64,10 +68,11 @@ async function probeCluster(cluster: string): Promise<KyvernoCRDStatus> {
   if (existing) return existing;
 
   const promise = (async () => {
-    const [legacy, cel, reports, ephemeralReports] = await Promise.all([
+    const [legacy, cel, wgPolicyReports, openReports, ephemeralReports] = await Promise.all([
       checkAPIGroup('/apis/kyverno.io/v1'),
       checkAPIGroup('/apis/policies.kyverno.io/v1'),
       checkAPIGroup('/apis/wgpolicyk8s.io/v1alpha2'),
+      checkAPIGroup('/apis/openreports.io/v1alpha1'),
       checkAPIGroup('/apis/reports.kyverno.io/v1'),
     ]);
 
@@ -90,7 +95,9 @@ async function probeCluster(cluster: string): Promise<KyvernoCRDStatus> {
       legacy,
       cel,
       cleanup,
-      reports,
+      reports: wgPolicyReports || openReports,
+      wgPolicyReports,
+      openReports,
       exceptions,
       kyvernoV2Reports,
       ephemeralReports,

--- a/kyverno/src/resources/policyReport.ts
+++ b/kyverno/src/resources/policyReport.ts
@@ -97,3 +97,16 @@ export class ClusterPolicyReport extends PolicyReportBase {
   static apiVersion = 'wgpolicyk8s.io/v1alpha2';
   static isNamespaced = false;
 }
+ export class Report extends PolicyReportBase {
+  static kind = 'Report';
+  static apiName = 'reports';
+  static apiVersion = 'openreports.io/v1alpha1';
+  static isNamespaced = true;
+}
+
+export class ClusterReport extends PolicyReportBase {
+  static kind = 'ClusterReport';
+  static apiName = 'clusterreports';
+  static apiVersion = 'openreports.io/v1alpha1';
+  static isNamespaced = false;
+}


### PR DESCRIPTION
## What

Adds support for Kyverno's `openreports.io/v1alpha1` reporting group, per #994.

This PR covers:
- New `Report` / `ClusterReport` resource classes reusing the existing
  `PolicyReportBase` (the wire format matches wgpolicyk8s.io, so no
  changes were needed to the base class or interfaces)
- `useKyvernoCRDs` now probes both `wgpolicyk8s.io/v1alpha2` and
  `openreports.io/v1alpha1`. The `reports` capability is now `true` if
  either group is present, with two new granular flags
  (`wgPolicyReports`, `openReports`) exposed for consumers that need to
  know which specific group(s) are installed
- Updated `CRDGuard`'s default messages to match the new fields, and
  reworded the `reports` message since it now covers both groups

## Deferred

Updating the consumption points (Dashboard, PolicyViewer, ViolationsView,
PolicyReportList, ClusterPolicyReportList, usePolicyResultCounts,
policyResultBucket) to actually read and merge reports from both API
groups is deferred to a follow-up PR, since:
- That work depends on #992 / #993 landing first (the list hooks
  currently can't distinguish "still loading" from "this group isn't
  installed", which matters more once there are two possible sources)
- #856 currently has open PRs touching ComplianceBadge, ViolationsView,
  PolicyReportList, and ClusterPolicyReportList — avoiding those files
  here to prevent conflicts

## Testing

- `npx tsc --noEmit` passes with no errors
- `npm run build` completes successfully
- ESLint passes with no errors/warnings

Related to #994 (partial — see Deferred section above)