### PR TITLE
kueue: Extract and test resourceFlavor formatters

### DIFF
--- a/kueue/src/resources/resourceFlavor.test.ts
+++ b/kueue/src/resources/resourceFlavor.test.ts
@@ -1,0 +1,100 @@
+import {
+  renderNodeLabels,
+  renderTaint,
+  renderTaints,
+  renderToleration,
+  renderTolerations,
+} from './resourceFlavorFormatters';
+import type { ResourceFlavorTaint, ResourceFlavorToleration } from './resourceFlavor';
+
+describe('ResourceFlavor Formatters', () => {
+  describe('renderNodeLabels', () => {
+    it('returns "-" for an empty object', () => {
+      expect(renderNodeLabels({})).toBe('-');
+    });
+
+    it('formats a single label correctly', () => {
+      expect(renderNodeLabels({ 'region': 'us-west' })).toBe('region=us-west');
+    });
+
+    it('formats multiple labels joined by commas', () => {
+      expect(renderNodeLabels({ 'region': 'us-west', 'zone': 'a' })).toBe('region=us-west, zone=a');
+    });
+  });
+
+  describe('renderTaint', () => {
+    it('formats a taint with key, value, and effect', () => {
+      const taint: ResourceFlavorTaint = { key: 'gpu', value: 'true', effect: 'NoSchedule' };
+      expect(renderTaint(taint)).toBe('gpu=true:NoSchedule');
+    });
+
+    it('formats a taint without a value', () => {
+      const taint: ResourceFlavorTaint = { key: 'gpu', effect: 'NoExecute' };
+      expect(renderTaint(taint)).toBe('gpu:NoExecute');
+    });
+  });
+
+  describe('renderTaints', () => {
+    it('returns "-" for an empty array', () => {
+      expect(renderTaints([])).toBe('-');
+    });
+
+    it('formats multiple taints joined by commas', () => {
+      const taints: ResourceFlavorTaint[] = [
+        { key: 'gpu', value: 'true', effect: 'NoSchedule' },
+        { key: 'dedicated', effect: 'NoExecute' },
+      ];
+      expect(renderTaints(taints)).toBe('gpu=true:NoSchedule, dedicated:NoExecute');
+    });
+  });
+
+  describe('renderToleration', () => {
+    it('formats a toleration with key, value, effect, and seconds', () => {
+      const toleration: ResourceFlavorToleration = {
+        key: 'node.kubernetes.io/not-ready',
+        operator: 'Equal',
+        value: 'true',
+        effect: 'NoExecute',
+        tolerationSeconds: 300,
+      };
+      expect(renderToleration(toleration)).toBe('node.kubernetes.io/not-ready=true:NoExecute (300s)');
+    });
+
+    it('ignores value when operator is Exists', () => {
+      const toleration: ResourceFlavorToleration = {
+        key: 'gpu',
+        operator: 'Exists',
+        value: 'true', // Should be ignored
+        effect: 'NoSchedule',
+      };
+      expect(renderToleration(toleration)).toBe('gpu:NoSchedule');
+    });
+
+    it('defaults key to "*" when missing', () => {
+      const toleration: ResourceFlavorToleration = {
+        operator: 'Exists',
+        effect: 'NoExecute',
+      };
+      expect(renderToleration(toleration)).toBe('*:NoExecute');
+    });
+
+    it('formats a minimal toleration with just a key', () => {
+      const toleration: ResourceFlavorToleration = { key: 'gpu' };
+      expect(renderToleration(toleration)).toBe('gpu');
+    });
+  });
+
+  describe('renderTolerations', () => {
+    it('returns "-" for an empty array', () => {
+      expect(renderTolerations([])).toBe('-');
+    });
+
+    it('formats multiple tolerations joined by commas', () => {
+      const tolerations: ResourceFlavorToleration[] = [
+        { key: 'gpu', operator: 'Exists', effect: 'NoSchedule' },
+        { key: 'dedicated', value: 'true', effect: 'NoExecute' },
+      ];
+      expect(renderTolerations(tolerations)).toBe('gpu:NoSchedule, dedicated=true:NoExecute');
+    });
+  });
+});

--- a/kueue/src/resources/resourceFlavor.ts
+++ b/kueue/src/resources/resourceFlavor.ts
@@ -1,6 +1,7 @@
 import { KubeObject, KubeObjectInterface } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
 import { kueueApiVersions } from '../utils/kueueApi';
 import { kueueRoutePaths } from '../utils/kueueRoutes';
+import { renderNodeLabels, renderTaints, renderTolerations } from './resourceFlavorFormatters';
 
 /**
  * Node label selector values associated with a Kueue ResourceFlavor.
@@ -153,13 +154,7 @@ export class ResourceFlavor extends KubeObject<KubeResourceFlavor> {
   }
 
   get nodeLabelsDisplay() {
-    const labels = Object.entries(this.nodeLabels);
-
-    if (labels.length === 0) {
-      return '-';
-    }
-
-    return labels.map(([key, value]) => `${key}=${value}`).join(', ');
+    return renderNodeLabels(this.nodeLabels);
   }
 
   get nodeTaints() {
@@ -181,39 +176,4 @@ export class ResourceFlavor extends KubeObject<KubeResourceFlavor> {
   get topologyName() {
     return this.spec.topologyName || '-';
   }
-}
-
-function renderTaints(taints: ResourceFlavorTaint[]) {
-  if (taints.length === 0) {
-    return '-';
-  }
-
-  return taints.map(renderTaint).join(', ');
-}
-
-function renderTaint(taint: ResourceFlavorTaint) {
-  const value = taint.value ? `=${taint.value}` : '';
-
-  return `${taint.key}${value}:${taint.effect}`;
-}
-
-function renderTolerations(tolerations: ResourceFlavorToleration[]) {
-  if (tolerations.length === 0) {
-    return '-';
-  }
-
-  return tolerations.map(renderToleration).join(', ');
-}
-
-function renderToleration(toleration: ResourceFlavorToleration) {
-  const key = toleration.key || '*';
-  const value =
-    toleration.operator === 'Exists' || toleration.value === undefined
-      ? ''
-      : `=${toleration.value}`;
-  const effect = toleration.effect ? `:${toleration.effect}` : '';
-  const seconds =
-    toleration.tolerationSeconds === undefined ? '' : ` (${toleration.tolerationSeconds}s)`;
-
-  return `${key}${value}${effect}${seconds}`;
 }

--- a/kueue/src/resources/resourceFlavorFormatters.ts
+++ b/kueue/src/resources/resourceFlavorFormatters.ts
@@ -1,0 +1,46 @@
+import type { NodeLabels, ResourceFlavorTaint, ResourceFlavorToleration } from './resourceFlavor';
+
+export function renderNodeLabels(nodeLabels: NodeLabels) {
+  const labels = Object.entries(nodeLabels);
+
+  if (labels.length === 0) {
+    return '-';
+  }
+
+  return labels.map(([key, value]) => `${key}=${value}`).join(', ');
+}
+
+export function renderTaints(taints: ResourceFlavorTaint[]) {
+  if (taints.length === 0) {
+    return '-';
+  }
+
+  return taints.map(renderTaint).join(', ');
+}
+
+export function renderTaint(taint: ResourceFlavorTaint) {
+  const value = taint.value ? `=${taint.value}` : '';
+
+  return `${taint.key}${value}:${taint.effect}`;
+}
+
+export function renderTolerations(tolerations: ResourceFlavorToleration[]) {
+  if (tolerations.length === 0) {
+    return '-';
+  }
+
+  return tolerations.map(renderToleration).join(', ');
+}
+
+export function renderToleration(toleration: ResourceFlavorToleration) {
+  const key = toleration.key || '*';
+  const value =
+    toleration.operator === 'Exists' || toleration.value === undefined
+      ? ''
+      : `=${toleration.value}`;
+  const effect = toleration.effect ? `:${toleration.effect}` : '';
+  const seconds =
+    toleration.tolerationSeconds === undefined ? '' : ` (${toleration.tolerationSeconds}s)`;
+
+  return `${key}${value}${effect}${seconds}`;
+}


### PR DESCRIPTION
**Summary:**
Extracts ResourceFlavor formatters into a separate file and adds unit test coverage. Fixes #988.

**Changes:**
- Extracted `renderNodeLabels`, `renderTaints`, and `renderTolerations` to `resourceFlavorFormatters.ts`.
- Updated `ResourceFlavor` class to use the extracted formatters.
- Added comprehensive unit tests in `resourceFlavor.test.ts`.

**Steps to Test:**
- Run `npm run test` in the `kueue` plugin directory to verify that all the extracted logic passes perfectly.
- Run `npm run tsc --noEmit` to verify type safety.