### PR TITLE
knative: require cluster match for DomainMapping claims

### DIFF
--- a/knative/src/utils/domain.test.ts
+++ b/knative/src/utils/domain.test.ts
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ClusterDomainClaim, KnativeDomainMapping } from '../resources/knative';
+import { getClusterDomainClaim } from './domain';
+
+vi.mock('../resources/knative', () => ({
+  ClusterDomainClaim: class {},
+  KnativeDomainMapping: class {},
+}));
+
+const HOST = 'app.example.com';
+const NAMESPACE = 'tenant-a';
+
+function makeDomainMapping(cluster = 'cluster-b', host = HOST): KnativeDomainMapping {
+  const jsonData = {
+    apiVersion: 'serving.knative.dev/v1beta1',
+    kind: 'DomainMapping',
+    metadata: { name: host, namespace: NAMESPACE },
+    spec: {
+      ref: {
+        apiVersion: 'serving.knative.dev/v1',
+        kind: 'Service',
+        name: 'app',
+        namespace: NAMESPACE,
+      },
+    },
+  };
+
+  return {
+    cluster,
+    jsonData,
+    metadata: jsonData.metadata,
+    spec: jsonData.spec,
+    get host() {
+      return jsonData.metadata.name;
+    },
+  } as unknown as KnativeDomainMapping;
+}
+
+function makeClaim(cluster?: string): ClusterDomainClaim {
+  const jsonData = {
+    apiVersion: 'networking.internal.knative.dev/v1alpha1',
+    kind: 'ClusterDomainClaim',
+    metadata: { name: HOST },
+    spec: { namespace: NAMESPACE },
+  };
+
+  return {
+    cluster: cluster ?? '',
+    jsonData,
+    metadata: jsonData.metadata,
+    spec: jsonData.spec,
+    get targetNamespace() {
+      return jsonData.spec.namespace;
+    },
+  } as unknown as ClusterDomainClaim;
+}
+
+describe('getClusterDomainClaim', () => {
+  it('does not match a claim from another cluster', () => {
+    const domainMapping = makeDomainMapping('cluster-b');
+    const claim = makeClaim('cluster-a');
+
+    expect(getClusterDomainClaim(domainMapping, [claim], 'cluster-b', NAMESPACE)).toEqual({
+      state: 'missing',
+      claim: null,
+    });
+  });
+
+  it('matches a claim from the DomainMapping cluster', () => {
+    const domainMapping = makeDomainMapping('cluster-b');
+    const claim = makeClaim('cluster-b');
+
+    expect(getClusterDomainClaim(domainMapping, [claim], 'cluster-b', NAMESPACE)).toEqual({
+      state: 'present',
+      claim,
+    });
+  });
+
+  it('selects the matching cluster when both clusters use the same host and namespace', () => {
+    const domainMapping = makeDomainMapping('cluster-b');
+    const clusterAClaim = makeClaim('cluster-a');
+    const clusterBClaim = makeClaim('cluster-b');
+
+    expect(
+      getClusterDomainClaim(domainMapping, [clusterAClaim, clusterBClaim], 'cluster-b', NAMESPACE)
+    ).toEqual({ state: 'present', claim: clusterBClaim });
+  });
+
+  it('does not assign a clusterless claim to a known DomainMapping cluster', () => {
+    const domainMapping = makeDomainMapping('cluster-b');
+    const claim = makeClaim();
+
+    expect(getClusterDomainClaim(domainMapping, [claim], 'cluster-b', NAMESPACE)).toEqual({
+      state: 'missing',
+      claim: null,
+    });
+    expect(claim.cluster).toBe('');
+  });
+
+  it('uses the caller cluster when the DomainMapping has no cluster', () => {
+    const domainMapping = makeDomainMapping('');
+    const claim = makeClaim('cluster-b');
+
+    expect(getClusterDomainClaim(domainMapping, [claim], 'cluster-b', NAMESPACE)).toEqual({
+      state: 'present',
+      claim,
+    });
+    expect(claim.cluster).toBe('cluster-b');
+  });
+
+  it('returns unknown when claims have not loaded', () => {
+    expect(getClusterDomainClaim(makeDomainMapping(), null, 'cluster-b', NAMESPACE)).toEqual({
+      state: 'unknown',
+      claim: null,
+    });
+  });
+
+  it('returns unknown for a blank DomainMapping host', () => {
+    expect(
+      getClusterDomainClaim(makeDomainMapping('cluster-b', '   '), [], 'cluster-b', NAMESPACE)
+    ).toEqual({ state: 'unknown', claim: null });
+  });
+
+  it('returns unknown for an absent DomainMapping host', () => {
+    const domainMapping = makeDomainMapping();
+    Reflect.deleteProperty(domainMapping.metadata, 'name');
+
+    expect(getClusterDomainClaim(domainMapping, [], 'cluster-b', NAMESPACE)).toEqual({
+      state: 'unknown',
+      claim: null,
+    });
+  });
+});

--- a/knative/src/utils/domain.ts
+++ b/knative/src/utils/domain.ts
@@ -25,7 +25,6 @@ export function getClusterDomainClaim(
   state: 'unknown' | 'missing' | 'present';
   claim: ClusterDomainClaim | null;
 } {
-  const clusters = [cluster];
   if (!clusterDomainClaims) {
     return { state: 'unknown', claim: null };
   }
@@ -34,22 +33,15 @@ export function getClusterDomainClaim(
     return { state: 'unknown', claim: null };
   }
 
-  // DomainMappingSection is single-cluster today, but keep this safe if it ever becomes multi-cluster.
   const effectiveCluster = dm.cluster || cluster;
-  const requireClusterMatch = clusters.length > 1;
 
   const claim =
     clusterDomainClaims.find(
       cdc =>
-        (!requireClusterMatch || cdc.cluster === effectiveCluster) &&
+        cdc.cluster === effectiveCluster &&
         cdc.metadata?.name === host &&
         cdc.targetNamespace === namespace
     ) ?? null;
-
-  if (claim && !claim.cluster && effectiveCluster) {
-    claim.cluster = effectiveCluster;
-  }
-
   return claim ? { state: 'present', claim } : { state: 'missing', claim: null };
 }
 


### PR DESCRIPTION
## Summary

Require a `ClusterDomainClaim` to belong to the same cluster as the
`DomainMapping` before treating it as the corresponding claim.

## Problem

The DomainMapping list can display resources from multiple selected clusters.
It also loads ClusterDomainClaims across those clusters.

`getClusterDomainClaim()` previously decided whether cluster matching was
needed from a locally created one-element array:

```ts
const clusters = [cluster];
const requireClusterMatch = clusters.length > 1;
```

Because that condition was always false, the lookup matched only the hostname
and target namespace.

If cluster A contained a claim for `shop.example.com` targeting namespace
`store`, an identically named DomainMapping in cluster B could incorrectly
display that claim as present. The action for creating the actually missing
claim in cluster B could consequently be hidden.

## Fix

Match claims using all three relationship dimensions:

* cluster
* hostname
* target namespace

The helper remains compatible with callers where the DomainMapping does not
carry a cluster directly by using the caller-provided cluster as its effective
cluster.

The lookup no longer mutates the returned claim.

## Testing

Added focused tests covering:

* rejection of a claim from another cluster;
* successful same-cluster matching;
* correct selection when both clusters contain the same hostname and namespace;
* rejection and non-mutation of a clusterless claim;
* fallback to the caller cluster when the DomainMapping has no cluster;
* unloaded claims;
* blank and absent DomainMapping hosts.

The cross-cluster regression test fails against the previous implementation
and passes with this change.

## Verification

* `npm run tsc`
* `npm run lint`
* `npm run format`
* `npm run test`
* `npm run build`
* `git diff --check`

All checks passed.