### PR TITLE
knative: abort KService restart when safety checks fail

### DIFF
--- a/knative/src/components/kservices/detail/hooks/restartKServicePods.test.ts
+++ b/knative/src/components/kservices/detail/hooks/restartKServicePods.test.ts
@@ -1,0 +1,283 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { restartKServicePods } from './restartKServicePods';
+
+const mocks = {
+  clearProgress: vi.fn(),
+  listPodsByLabelSelector: vi.fn(),
+  notifyError: vi.fn(),
+  notifyInfo: vi.fn(),
+  setProgress: vi.fn(),
+};
+
+type MockPod = {
+  cluster: string;
+  delete: ReturnType<typeof vi.fn>;
+  metadata: {
+    creationTimestamp: string;
+    deletionTimestamp?: string;
+    name: string;
+  };
+  status: { phase: string };
+};
+
+type ListResponse = Error | MockPod[] | (() => MockPod[]);
+
+let listResponses: ListResponse[] = [];
+
+function makePod(name: string, createdAt: string): MockPod {
+  return {
+    cluster: 'cluster-a',
+    delete: vi.fn().mockResolvedValue(undefined),
+    metadata: { creationTimestamp: createdAt, name },
+    status: { phase: 'Running' },
+  };
+}
+
+function repeatResponse(pods: MockPod[], count: number): MockPod[][] {
+  return Array.from({ length: count }, () => pods);
+}
+
+function startRestart() {
+  const onDone = vi.fn();
+  const operation = restartKServicePods({
+    clearProgress: mocks.clearProgress,
+    cluster: 'cluster-a',
+    listPodsByLabelSelector: mocks.listPodsByLabelSelector,
+    namespace: 'default',
+    notifyError: mocks.notifyError,
+    notifyInfo: mocks.notifyInfo,
+    onDone,
+    serviceName: 'service-a',
+    setProgress: mocks.setProgress,
+  });
+
+  return { onDone, operation };
+}
+
+async function finishRestart(operation: Promise<void>, advanceMs = 0) {
+  await Promise.resolve();
+  await vi.advanceTimersByTimeAsync(advanceMs);
+  await operation;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  listResponses = [];
+  vi.clearAllMocks();
+  mocks.listPodsByLabelSelector.mockImplementation(async () => {
+    const next = listResponses.shift();
+    if (!next) {
+      throw new Error('Unexpected Pod list call');
+    }
+
+    const response = typeof next === 'function' ? next() : next;
+    if (response instanceof Error) {
+      throw response;
+    }
+
+    return response;
+  });
+});
+
+afterEach(() => {
+  vi.clearAllTimers();
+  vi.useRealTimers();
+});
+
+describe('restartKServicePods', () => {
+  it('aborts before deleting another Pod when replacement recovery times out', async () => {
+    const podA = makePod('pod-a', '2026-01-01T00:00:00Z');
+    const podB = makePod('pod-b', '2026-01-01T00:01:00Z');
+    const replacementB = makePod('pod-b-replacement', '2026-01-01T00:02:00Z');
+    listResponses = [
+      [podA, podB],
+      [podA, podB],
+      [podB],
+      ...repeatResponse([podB], 30),
+      [podB],
+      [],
+      [replacementB],
+    ];
+
+    const { onDone, operation } = startRestart();
+    await finishRestart(operation, 62_000);
+
+    expect(podA.delete).toHaveBeenCalledOnce();
+    expect(podB.delete).not.toHaveBeenCalled();
+    expect(mocks.notifyError).toHaveBeenCalledWith(
+      'Timed out waiting for replacement pod after deleting pod-a'
+    );
+    expect(mocks.notifyInfo).not.toHaveBeenCalledWith('Restart completed successfully');
+    expect(mocks.clearProgress).toHaveBeenCalledOnce();
+    expect(onDone).toHaveBeenCalledOnce();
+  });
+
+  it('aborts before recovery or another deletion when Pod deletion times out', async () => {
+    const podA = makePod('pod-a', '2026-01-01T00:00:00Z');
+    const podB = makePod('pod-b', '2026-01-01T00:01:00Z');
+    const replacementB = makePod('pod-b-replacement', '2026-01-01T00:02:00Z');
+    listResponses = [
+      [podA, podB],
+      [podA, podB],
+      ...repeatResponse([podA, podB], 600),
+      [podA, podB],
+      [podA, podB],
+      [podA],
+      [podA, replacementB],
+    ];
+
+    const { onDone, operation } = startRestart();
+    await finishRestart(operation, 602_000);
+
+    expect(podA.delete).toHaveBeenCalledOnce();
+    expect(podB.delete).not.toHaveBeenCalled();
+    expect(mocks.notifyError).toHaveBeenCalledOnce();
+    expect(mocks.notifyError).toHaveBeenCalledWith('Timed out waiting for pod deletion: pod-a');
+    expect(mocks.notifyInfo).not.toHaveBeenCalledWith('Restart completed successfully');
+    expect(onDone).toHaveBeenCalledOnce();
+  });
+
+  it('aborts before deleting another Pod when deletion throws', async () => {
+    const podA = makePod('pod-a', '2026-01-01T00:00:00Z');
+    const podB = makePod('pod-b', '2026-01-01T00:01:00Z');
+    const replacementB = makePod('pod-b-replacement', '2026-01-01T00:02:00Z');
+    podA.delete.mockRejectedValue(new Error('delete denied'));
+    listResponses = [
+      [podA, podB],
+      [podA, podB],
+      [podA, podB],
+      [podA, podB],
+      [podA],
+      [podA, replacementB],
+    ];
+
+    const { onDone, operation } = startRestart();
+    await finishRestart(operation, 2_000);
+
+    expect(podA.delete).toHaveBeenCalledOnce();
+    expect(podB.delete).not.toHaveBeenCalled();
+    expect(mocks.notifyError).toHaveBeenCalledWith('Failed to delete pod pod-a: delete denied');
+    expect(mocks.notifyInfo).not.toHaveBeenCalledWith('Restart completed successfully');
+    expect(onDone).toHaveBeenCalledOnce();
+  });
+
+  it('restarts Pods sequentially after each replacement recovers', async () => {
+    const events: string[] = [];
+    const podA = makePod('pod-a', '2026-01-01T00:00:00Z');
+    const podB = makePod('pod-b', '2026-01-01T00:01:00Z');
+    const replacementA = makePod('pod-a-replacement', '2026-01-01T00:02:00Z');
+    const replacementB = makePod('pod-b-replacement', '2026-01-01T00:03:00Z');
+    podB.delete.mockImplementation(async () => {
+      events.push('pod-b-deleted');
+    });
+    listResponses = [
+      [podA, podB],
+      [podA, podB],
+      [podB],
+      () => {
+        events.push('pod-a-recovered');
+        return [podB, replacementA];
+      },
+      [podB, replacementA],
+      [replacementA],
+      [replacementA, replacementB],
+    ];
+
+    const { onDone, operation } = startRestart();
+    await finishRestart(operation, 2_000);
+
+    expect(podA.delete).toHaveBeenCalledOnce();
+    expect(podB.delete).toHaveBeenCalledOnce();
+    expect(events).toEqual(['pod-a-recovered', 'pod-b-deleted']);
+    expect(mocks.notifyInfo).toHaveBeenCalledTimes(1);
+    expect(mocks.notifyInfo).toHaveBeenCalledWith('Restart completed successfully');
+    expect(mocks.notifyError).not.toHaveBeenCalled();
+    expect(onDone).toHaveBeenCalledOnce();
+  });
+
+  it('does not delete a Pod when its availability baseline cannot be established', async () => {
+    const podA = makePod('pod-a', '2026-01-01T00:00:00Z');
+    const podB = makePod('pod-b', '2026-01-01T00:01:00Z');
+    const replacementB = makePod('pod-b-replacement', '2026-01-01T00:02:00Z');
+    listResponses = [
+      [podA, podB],
+      new Error('list denied'),
+      [podB],
+      [podB],
+      [podB],
+      [],
+      [replacementB],
+    ];
+
+    const { onDone, operation } = startRestart();
+    await finishRestart(operation, 2_000);
+
+    expect(podA.delete).not.toHaveBeenCalled();
+    expect(podB.delete).not.toHaveBeenCalled();
+    expect(mocks.notifyError).toHaveBeenCalledWith(
+      'Failed to check pod availability before deleting pod-a: list denied'
+    );
+    expect(mocks.notifyInfo).not.toHaveBeenCalledWith('Restart completed successfully');
+    expect(onDone).toHaveBeenCalledOnce();
+  });
+
+  it('aborts when the target Pod disappears before deletion', async () => {
+    const podA = makePod('pod-a', '2026-01-01T00:00:00Z');
+    const podB = makePod('pod-b', '2026-01-01T00:01:00Z');
+    const replacementB = makePod('pod-b-replacement', '2026-01-01T00:02:00Z');
+    listResponses = [[podA, podB], [podB], [podB], [], [replacementB]];
+
+    const { onDone, operation } = startRestart();
+    await finishRestart(operation);
+
+    expect(podA.delete).not.toHaveBeenCalled();
+    expect(podB.delete).not.toHaveBeenCalled();
+    expect(mocks.notifyError).toHaveBeenCalledWith(
+      'Restart stopped because pod pod-a is no longer present'
+    );
+    expect(mocks.notifyInfo).not.toHaveBeenCalledWith('Restart completed successfully');
+    expect(mocks.clearProgress).toHaveBeenCalledOnce();
+    expect(onDone).toHaveBeenCalledOnce();
+  });
+
+  it('aborts when the target Pod is already terminating', async () => {
+    const podA = makePod('pod-a', '2026-01-01T00:00:00Z');
+    const podB = makePod('pod-b', '2026-01-01T00:01:00Z');
+    const terminatingPodA = {
+      ...podA,
+      metadata: { ...podA.metadata, deletionTimestamp: '2026-01-01T00:02:00Z' },
+    };
+    listResponses = [
+      [podA, podB],
+      [terminatingPodA, podB],
+    ];
+
+    const { onDone, operation } = startRestart();
+    await finishRestart(operation);
+
+    expect(podA.delete).not.toHaveBeenCalled();
+    expect(podB.delete).not.toHaveBeenCalled();
+    expect(mocks.notifyError).toHaveBeenCalledWith(
+      'Restart stopped because pod pod-a is already terminating'
+    );
+    expect(mocks.notifyInfo).not.toHaveBeenCalledWith('Restart completed successfully');
+    expect(mocks.clearProgress).toHaveBeenCalledOnce();
+    expect(onDone).toHaveBeenCalledOnce();
+  });
+});

--- a/knative/src/components/kservices/detail/hooks/restartKServicePods.ts
+++ b/knative/src/components/kservices/detail/hooks/restartKServicePods.ts
@@ -1,0 +1,269 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const POD_DELETE_DELAY_MS = 2000;
+const POD_DELETION_TIMEOUT_MS = 600_000;
+const POD_DELETION_POLL_INTERVAL_MS = 1_000;
+const POD_RECOVERY_TIMEOUT_MS = 60_000;
+const POD_RECOVERY_POLL_INTERVAL_MS = 2_000;
+
+type RestartPod = {
+  cluster: string;
+  delete: () => Promise<unknown>;
+  metadata: {
+    creationTimestamp: string;
+    deletionTimestamp?: string;
+    name?: string;
+  };
+  status?: { phase?: string };
+};
+
+type ListPodsByLabelSelector = (params: {
+  cluster: string;
+  namespace: string;
+  labelSelector: string;
+}) => Promise<RestartPod[]>;
+
+type RestartKServicePodsOptions = {
+  clearProgress: () => void;
+  cluster: string;
+  listPodsByLabelSelector: ListPodsByLabelSelector;
+  namespace: string;
+  notifyError: (message: string) => void;
+  notifyInfo: (message: string) => void;
+  onDone?: () => void;
+  serviceName: string;
+  setProgress: (message: string) => void;
+};
+
+function sleep(ms: number) {
+  return new Promise<void>(resolve => setTimeout(resolve, ms));
+}
+
+function countRunningPods(pods: RestartPod[]) {
+  return pods.filter(p => !p.metadata.deletionTimestamp && (p.status?.phase ?? '') === 'Running')
+    .length;
+}
+
+async function waitForPodDeletion(params: {
+  cluster: string;
+  namespace: string;
+  labelSelector: string;
+  podName: string;
+  listPodsByLabelSelector: ListPodsByLabelSelector;
+  timeoutMs?: number;
+  pollIntervalMs?: number;
+}) {
+  const {
+    cluster,
+    namespace,
+    labelSelector,
+    podName,
+    listPodsByLabelSelector,
+    timeoutMs = POD_DELETION_TIMEOUT_MS,
+    pollIntervalMs = POD_DELETION_POLL_INTERVAL_MS,
+  } = params;
+
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    try {
+      const pods = await listPodsByLabelSelector({ cluster, namespace, labelSelector });
+      const stillExists = pods.some(p => p.metadata.name === podName);
+      if (!stillExists) {
+        return true;
+      }
+    } catch {
+      // Ignore transient list errors and retry until timeout.
+    }
+
+    await sleep(pollIntervalMs);
+  }
+
+  return false;
+}
+
+async function waitForRunningPodRecovery(params: {
+  cluster: string;
+  namespace: string;
+  labelSelector: string;
+  targetRunningCount: number;
+  listPodsByLabelSelector: ListPodsByLabelSelector;
+  timeoutMs?: number;
+  pollIntervalMs?: number;
+  onTick?: (info: { runningCount: number }) => void;
+}) {
+  const {
+    cluster,
+    namespace,
+    labelSelector,
+    targetRunningCount,
+    listPodsByLabelSelector,
+    timeoutMs = POD_RECOVERY_TIMEOUT_MS,
+    pollIntervalMs = POD_RECOVERY_POLL_INTERVAL_MS,
+    onTick,
+  } = params;
+
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    try {
+      const pods = await listPodsByLabelSelector({ cluster, namespace, labelSelector });
+      const runningCount = countRunningPods(pods);
+      if (onTick) {
+        onTick({ runningCount });
+      }
+      if (runningCount >= targetRunningCount) {
+        return true;
+      }
+    } catch {
+      // Ignore transient list errors and retry until timeout.
+    }
+
+    await sleep(pollIntervalMs);
+  }
+
+  return false;
+}
+
+/**
+ * Restart a KService by deleting its Pods one by one.
+ *
+ * We intentionally avoid "rollout restart" via Deployment patching here, because the Knative
+ * control plane may reconcile it back quickly and it may not create an observable change.
+ * Deleting Pods directly triggers the controller to recreate them.
+ */
+export async function restartKServicePods(options: RestartKServicePodsOptions) {
+  const {
+    clearProgress,
+    cluster,
+    listPodsByLabelSelector,
+    namespace,
+    notifyError,
+    notifyInfo,
+    onDone,
+    serviceName,
+    setProgress,
+  } = options;
+
+  try {
+    // Knative sets this label on pods for all revisions of the KService.
+    const labelSelector = `serving.knative.dev/service=${serviceName}`;
+    const pods = await listPodsByLabelSelector({ cluster, namespace, labelSelector });
+    const deletablePods = pods
+      .filter(pod => !pod.metadata.deletionTimestamp)
+      .sort((a, b) => {
+        const aCreationTime = new Date(a.metadata.creationTimestamp).getTime();
+        const bCreationTime = new Date(b.metadata.creationTimestamp).getTime();
+        return aCreationTime - bCreationTime;
+      });
+
+    if (deletablePods.length === 0) {
+      notifyInfo('No pods found for KService');
+      return;
+    }
+
+    let restartFailed = false;
+
+    for (let i = 0; i < deletablePods.length; i += 1) {
+      const podName = deletablePods[i].metadata.name!;
+
+      let runningBefore = 0;
+      let podToDelete: RestartPod | null = null;
+      try {
+        const currentPods = await listPodsByLabelSelector({ cluster, namespace, labelSelector });
+        runningBefore = countRunningPods(currentPods);
+        podToDelete = currentPods.find(p => p.metadata.name === podName) ?? null;
+      } catch (err: unknown) {
+        const error = err as { message?: string } | undefined;
+        const detail = error?.message?.trim();
+        notifyError(
+          detail
+            ? `Failed to check pod availability before deleting ${podName}: ${detail}`
+            : `Failed to check pod availability before deleting ${podName}`
+        );
+        restartFailed = true;
+        break;
+      }
+
+      if (!podToDelete) {
+        notifyError(`Restart stopped because pod ${podName} is no longer present`);
+        restartFailed = true;
+        break;
+      }
+
+      if (podToDelete.metadata.deletionTimestamp) {
+        notifyError(`Restart stopped because pod ${podName} is already terminating`);
+        restartFailed = true;
+        break;
+      }
+
+      try {
+        setProgress(
+          `Restart in progress: deleting pod ${podName} (${i + 1}/${deletablePods.length})`
+        );
+        await podToDelete.delete();
+        const deleted = await waitForPodDeletion({
+          cluster,
+          namespace,
+          labelSelector,
+          podName,
+          listPodsByLabelSelector,
+        });
+        if (!deleted) {
+          notifyError(`Timed out waiting for pod deletion: ${podName}`);
+          restartFailed = true;
+          break;
+        }
+      } catch (err: unknown) {
+        const error = err as { message?: string } | undefined;
+        const detail = error?.message?.trim();
+        notifyError(
+          detail ? `Failed to delete pod ${podName}: ${detail}` : `Failed to delete pod ${podName}`
+        );
+        restartFailed = true;
+        break;
+      }
+
+      const recovered = await waitForRunningPodRecovery({
+        cluster,
+        namespace,
+        labelSelector,
+        targetRunningCount: runningBefore,
+        listPodsByLabelSelector,
+      });
+
+      if (!recovered) {
+        notifyError(`Timed out waiting for replacement pod after deleting ${podName}`);
+        restartFailed = true;
+        break;
+      }
+
+      if (i < deletablePods.length - 1) {
+        await sleep(POD_DELETE_DELAY_MS);
+      }
+    }
+
+    if (!restartFailed) {
+      notifyInfo('Restart completed successfully');
+    }
+    if (onDone) {
+      onDone();
+    }
+  } finally {
+    clearProgress();
+  }
+}

--- a/knative/src/components/kservices/detail/hooks/useKServiceActions.tsx
+++ b/knative/src/components/kservices/detail/hooks/useKServiceActions.tsx
@@ -20,111 +20,13 @@ import { useSnackbar } from 'notistack';
 import React from 'react';
 import type { KService } from '../../../../resources/knative';
 import { useNotify } from '../../../common/notifications/useNotify';
+import { restartKServicePods } from './restartKServicePods';
 
 type KServiceActionId = 'redeploy' | 'restart';
 
 type UseKServiceActionsOptions = {
   onDone?: () => void;
 };
-
-/**
- * Restart a KService by deleting its pods one by one.
- *
- * We intentionally avoid "rollout restart" via Deployment patching here, because the Knative
- * control plane may reconcile it back quickly and it may not create an observable change.
- * Deleting pods directly triggers the controller to recreate them.
- */
-const POD_DELETE_DELAY_MS = 2000;
-const POD_DELETION_TIMEOUT_MS = 600_000;
-const POD_DELETION_POLL_INTERVAL_MS = 1_000;
-const POD_RECOVERY_TIMEOUT_MS = 60_000;
-const POD_RECOVERY_POLL_INTERVAL_MS = 2_000;
-
-function sleep(ms: number) {
-  return new Promise<void>(resolve => setTimeout(resolve, ms));
-}
-
-function countRunningPods(pods: Pod[]) {
-  return pods.filter(p => !p.metadata.deletionTimestamp && (p.status?.phase ?? '') === 'Running')
-    .length;
-}
-
-async function waitForPodDeletion(params: {
-  cluster: string;
-  namespace: string;
-  labelSelector: string;
-  podName: string;
-  timeoutMs?: number;
-  pollIntervalMs?: number;
-}) {
-  const {
-    cluster,
-    namespace,
-    labelSelector,
-    podName,
-    timeoutMs = POD_DELETION_TIMEOUT_MS,
-    pollIntervalMs = POD_DELETION_POLL_INTERVAL_MS,
-  } = params;
-
-  const deadline = Date.now() + timeoutMs;
-
-  while (Date.now() < deadline) {
-    try {
-      const pods = await listPodsByLabelSelector({ cluster, namespace, labelSelector });
-      const stillExists = pods.some(p => p.metadata.name === podName);
-      if (!stillExists) {
-        return true;
-      }
-    } catch {
-      // Ignore transient list errors and retry until timeout.
-    }
-
-    await sleep(pollIntervalMs);
-  }
-
-  return false;
-}
-
-async function waitForRunningPodRecovery(params: {
-  cluster: string;
-  namespace: string;
-  labelSelector: string;
-  targetRunningCount: number;
-  timeoutMs?: number;
-  pollIntervalMs?: number;
-  onTick?: (info: { runningCount: number }) => void;
-}) {
-  const {
-    cluster,
-    namespace,
-    labelSelector,
-    targetRunningCount,
-    timeoutMs = POD_RECOVERY_TIMEOUT_MS,
-    pollIntervalMs = POD_RECOVERY_POLL_INTERVAL_MS,
-    onTick,
-  } = params;
-
-  const deadline = Date.now() + timeoutMs;
-
-  while (Date.now() < deadline) {
-    try {
-      const pods = await listPodsByLabelSelector({ cluster, namespace, labelSelector });
-      const runningCount = countRunningPods(pods);
-      if (onTick) {
-        onTick({ runningCount });
-      }
-      if (runningCount >= targetRunningCount) {
-        return true;
-      }
-    } catch {
-      // Ignore transient list errors and retry until timeout.
-    }
-
-    await sleep(pollIntervalMs);
-  }
-
-  return false;
-}
 
 async function listPodsByLabelSelector(params: {
   cluster: string;
@@ -271,107 +173,22 @@ export function useKServiceActions(
         return;
       }
 
-      // Knative sets this label on pods for all revisions of the KService.
-      const labelSelector = `serving.knative.dev/service=${serviceName}`;
-
-      const pods = await listPodsByLabelSelector({
+      await restartKServicePods({
+        clearProgress,
         cluster: kservice.cluster,
+        listPodsByLabelSelector,
         namespace,
-        labelSelector,
+        notifyError,
+        notifyInfo,
+        onDone,
+        serviceName,
+        setProgress,
       });
-
-      const deletablePods = pods
-        .filter(pod => !pod.metadata.deletionTimestamp)
-        .sort((a, b) => {
-          const aCreationTime = new Date(a.metadata.creationTimestamp).getTime();
-          const bCreationTime = new Date(b.metadata.creationTimestamp).getTime();
-          return aCreationTime - bCreationTime;
-        });
-
-      if (deletablePods.length === 0) {
-        notifyInfo('No pods found for KService');
-        return;
-      }
-
-      let failedCount = 0;
-
-      for (let i = 0; i < deletablePods.length; i += 1) {
-        const podName = deletablePods[i].metadata.name!;
-
-        let runningBefore = 0;
-        let podToDelete: Pod | null = null;
-        try {
-          const currentPods = await listPodsByLabelSelector({
-            cluster: kservice.cluster,
-            namespace,
-            labelSelector,
-          });
-          runningBefore = countRunningPods(currentPods);
-          podToDelete = currentPods.find(p => p.metadata.name === podName) ?? null;
-        } catch {
-          // Fall back to deleting the original instance if listing failed.
-          podToDelete = deletablePods[i];
-        }
-
-        if (!podToDelete || podToDelete.metadata.deletionTimestamp) {
-          continue;
-        }
-
-        try {
-          setProgress(
-            `Restart in progress: deleting pod ${podName} (${i + 1}/${deletablePods.length})`
-          );
-          await podToDelete.delete();
-          const deleted = await waitForPodDeletion({
-            cluster: kservice.cluster,
-            namespace,
-            labelSelector,
-            podName,
-          });
-          if (!deleted) {
-            notifyError(`Timed out waiting for pod deletion: ${podName}`);
-          }
-        } catch (err: unknown) {
-          failedCount += 1;
-          const error = err as { message?: string } | undefined;
-          const detail = error?.message?.trim();
-          notifyError(
-            detail
-              ? `Failed to delete pod ${podName}: ${detail}`
-              : `Failed to delete pod ${podName}`
-          );
-        }
-
-        const recovered = await waitForRunningPodRecovery({
-          cluster: kservice.cluster,
-          namespace,
-          labelSelector,
-          targetRunningCount: runningBefore,
-        });
-
-        if (!recovered) {
-          notifyError(`Timed out waiting for replacement pod after deleting ${podName}`);
-        }
-
-        if (i < deletablePods.length - 1) {
-          await sleep(POD_DELETE_DELAY_MS);
-        }
-      }
-
-      if (failedCount > 0) {
-        notifyError(`Restart completed with errors (${failedCount}/${deletablePods.length})`);
-      } else {
-        notifyInfo('Restart completed successfully');
-      }
-      if (onDone) {
-        onDone();
-      }
     } catch (err: unknown) {
       const error = err as { message?: string } | undefined;
       const detail = error?.message?.trim();
       notifyError(detail ? `Restart failed: ${detail}` : 'Restart failed');
     } finally {
-      clearProgress();
       setActing(null);
     }
   }


### PR DESCRIPTION
## Summary

Stop the sequential KService Pod restart as soon as a required safety gate fails.

The action no longer intentionally deletes a later Pod after the previous restart step fails, and it no longer reports a successful restart after a timeout or deletion failure.

## Problem

The restart action deletes KService Pods one at a time and waits for each replacement before moving to the next Pod. Previously, deletion errors, deletion-confirmation timeouts, and replacement-recovery timeouts only displayed an error and allowed the loop to continue.

Timeout-only failures could also leave the failure count at zero, causing the action to report `Restart completed successfully`.

A failed pre-deletion Pod list used an artificial running baseline of zero. Pods that disappeared or became terminating between the initial snapshot and their turn were skipped, allowing later Pods to be deleted without confirming recovered capacity.

## Fix

Require every Pod restart step to pass these gates before considering the next Pod:

- establish the pre-deletion running-Pod baseline;
- complete the deletion request;
- confirm that the deleted Pod disappeared;
- confirm recovery to at least the previous running count.

The restart now stops immediately when a gate fails, when the target Pod disappears, or when it is already terminating. Later Pods remain untouched, the error identifies the failed gate, and the success notification is suppressed.

The orchestration was extracted from `useKServiceActions()` into a focused helper so timeout polling and sequential ordering can be tested deterministically with fake timers. The public hook API and Redeploy action remain unchanged.

## Testing

Added regression and preservation coverage for:

- replacement recovery timing out;
- deletion confirmation timing out;
- the deletion request throwing;
- successful sequential restart of two Pods;
- failure to establish the running-Pod baseline;
- the target Pod disappearing before deletion;
- the target Pod already terminating.

The primary recovery-timeout and absent-Pod regressions fail against the previous behavior and pass with this change.

## Verification

- `npm run tsc`
- `npm run lint`
- `npm run format`
- `npm run format -- --check`
- `npm run test` — 5 files, 29 tests
- `npm run build`
- `git diff --check`

All checks passed.

Screenshots are not applicable because this change affects restart orchestration and notifications without changing the visual layout.