### PR TITLE
Fix: clear close timer on unmount to prevent stale timeout

### DIFF
--- a/strimzi/src/components/Toast.tsx
+++ b/strimzi/src/components/Toast.tsx
@@ -26,6 +26,7 @@ export function Toast({ toast, onClose }: ToastProps) {
   const isDark = muiTheme.palette.mode === 'dark';
   const [isVisible, setIsVisible] = React.useState(false);
   const [isExiting, setIsExiting] = React.useState(false);
+  const closeTimerRef = React.useRef<ReturnType<typeof setTimeout>>();
 
   React.useEffect(() => {
     if (toast) {
@@ -45,12 +46,17 @@ export function Toast({ toast, onClose }: ToastProps) {
     }
   }, [toast]);
 
+  // Clear the fade-out timer if the component unmounts while it's in flight
+  React.useEffect(() => {
+    return () => clearTimeout(closeTimerRef.current);
+  }, []);
+
   const handleClose = () => {
     // Trigger fade-out animation
     setIsExiting(true);
 
     // Wait for animation to complete before removing
-    setTimeout(() => {
+    closeTimerRef.current = setTimeout(() => {
       setIsVisible(false);
       setIsExiting(false);
       onClose();


### PR DESCRIPTION
Closes #1016

## Problem
The `Toast` component's auto-dismiss timer (inside the main `useEffect`) is 
correctly captured and cleared on unmount. However, `handleClose()` starts a 
second, uncleared `setTimeout` for the fade-out animation. If the component 
unmounts while this 300ms window is in flight (e.g. the user navigates away 
right as a toast starts closing), the callback still fires and calls 
`setIsVisible`, `setIsExiting`, and `onClose` on an unmounted component — 
producing a React "state update on an unmounted component" warning and 
potentially triggering unexpected side effects in the parent via `onClose()`.

This is the same category of bug already fixed elsewhere in this repo for 
`Chart.tsx` (#978, #979).

## Fix
Stored the fade-out timeout id in `closeTimerRef` and added a cleanup 
`useEffect` that clears it on unmount — the same pattern already used for 
the auto-dismiss timer.

## Changes
- Added `closeTimerRef` (via `useRef`)
- `handleClose` now stores its timeout in `closeTimerRef.current` instead of 
  a local variable
- Added a new `useEffect(() => { return () => clearTimeout(closeTimerRef.current) }, [])` 
  to clear it on unmount

## Testing
- Manually verified toast still shows, fades out, and auto-dismisses correctly
- Verified no console warnings when triggering a toast and unmounting the 
  parent component before the fade-out timer fires