### PR TITLE
fix(opencost): support direct OpenCost URL fallback

### DIFF
--- a/opencost/README.md
+++ b/opencost/README.md
@@ -13,3 +13,13 @@ This plugins needs the following projects running in your cluster:
 
 Once the plugin is installed, go to the plugin's settings page and configure the service's URL
 and any other desired customizations.
+
+By default, the plugin talks to OpenCost through the Kubernetes apiserver's service-proxy path
+(`/api/v1/namespaces/<namespace>/services/<service>/proxy/...`). Some clusters (for example, EKS
+with certain CNI/networking configurations) reject this kind of apiserver proxying with
+`error trying to reach service: Address is not allowed`. If you hit that error, set the
+**Service URL** setting to a full `http(s)://` URL that OpenCost is reachable at directly (e.g. an
+Ingress or Gateway API address) instead of a `<service-name>:<port-name>` value, and the plugin
+will query it directly instead of going through the apiserver proxy. Note that the URL must be
+directly reachable from your browser, including CORS if OpenCost is exposed on a different origin
+than Headlamp.

--- a/opencost/src/detail.tsx
+++ b/opencost/src/detail.tsx
@@ -71,6 +71,7 @@ export function OpencostDetailSection({ resource, type }) {
   const [tsData, setTsData] = useState(null);
   const [installed, setInstalled] = useState(true);
   const [displayTimespan, setDisplayTimespan] = useState(getDisplayTimespan());
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -86,53 +87,68 @@ export function OpencostDetailSection({ resource, type }) {
       return;
     }
     const fetchData = async () => {
-      const [namespace, serviceName] = await getServiceDetails();
-      const accumulatedData = await fetchOpencostData(
-        namespace,
-        serviceName,
-        displayTimespan,
-        type,
-        true
-      );
-      if (accumulatedData?.data[0]?.[resource.jsonData?.metadata?.name]) {
-        setAccumulatedData(accumulatedData?.data[0]?.[resource.jsonData?.metadata?.name]);
-      } else {
-        setAccumulatedData({});
-      }
-      const tsData = await fetchOpencostData(namespace, serviceName, displayTimespan, type, false);
-      const processedData = [];
-      const currentDate = new Date();
-      let startDate = new Date(currentDate);
-      if (displayTimespan === 'yesterday') {
-        startDate = new Date(currentDate.setDate(currentDate.getDate() - 1));
-      } else if (displayTimespan === 'lastweek') {
-        // find last saturday
-        startDate = new Date(currentDate.setDate(currentDate.getDate() - currentDate.getDay() - 1));
-        // startDate = new Date(currentDate.setDate(currentDate.getDate() - 7));
-      }
-
-      startDate.setDate(currentDate.getDate() - tsData.data.length + 1);
-      tsData.data.forEach(day => {
-        if (day.hasOwnProperty(resource.jsonData?.metadata?.name)) {
-          processedData.push({
-            date: new Date(startDate.getTime()),
-            cpuCost: day[resource.jsonData?.metadata?.name].cpuCost,
-            ramCost: day[resource.jsonData?.metadata?.name].ramCost,
-            pvCost: day[resource.jsonData?.metadata?.name].pvCost,
-            gpuCost: day[resource.jsonData?.metadata?.name].gpuCost,
-          });
-        } else if (Object.keys(day).length === 0) {
-          processedData.push({
-            date: new Date(startDate.getTime()),
-            cpuCost: 0,
-            ramCost: 0,
-            pvCost: 0,
-            gpuCost: 0,
-          });
+      setError(null);
+      try {
+        const [namespace, serviceName] = await getServiceDetails();
+        const accumulatedData = await fetchOpencostData(
+          namespace,
+          serviceName,
+          displayTimespan,
+          type,
+          true
+        );
+        if (accumulatedData?.data[0]?.[resource.jsonData?.metadata?.name]) {
+          setAccumulatedData(accumulatedData?.data[0]?.[resource.jsonData?.metadata?.name]);
+        } else {
+          setAccumulatedData({});
         }
-        startDate.setDate(startDate.getDate() + 1);
-      });
-      setTsData(processedData);
+        const tsData = await fetchOpencostData(
+          namespace,
+          serviceName,
+          displayTimespan,
+          type,
+          false
+        );
+        const processedData = [];
+        const currentDate = new Date();
+        let startDate = new Date(currentDate);
+        if (displayTimespan === 'yesterday') {
+          startDate = new Date(currentDate.setDate(currentDate.getDate() - 1));
+        } else if (displayTimespan === 'lastweek') {
+          // find last saturday
+          startDate = new Date(
+            currentDate.setDate(currentDate.getDate() - currentDate.getDay() - 1)
+          );
+          // startDate = new Date(currentDate.setDate(currentDate.getDate() - 7));
+        }
+
+        startDate.setDate(currentDate.getDate() - tsData.data.length + 1);
+        tsData.data.forEach(day => {
+          if (day.hasOwnProperty(resource.jsonData?.metadata?.name)) {
+            processedData.push({
+              date: new Date(startDate.getTime()),
+              cpuCost: day[resource.jsonData?.metadata?.name].cpuCost,
+              ramCost: day[resource.jsonData?.metadata?.name].ramCost,
+              pvCost: day[resource.jsonData?.metadata?.name].pvCost,
+              gpuCost: day[resource.jsonData?.metadata?.name].gpuCost,
+            });
+          } else if (Object.keys(day).length === 0) {
+            processedData.push({
+              date: new Date(startDate.getTime()),
+              cpuCost: 0,
+              ramCost: 0,
+              pvCost: 0,
+              gpuCost: 0,
+            });
+          }
+          startDate.setDate(startDate.getDate() + 1);
+        });
+        setTsData(processedData);
+      } catch (err) {
+        setAccumulatedData({});
+        setTsData([]);
+        setError(err instanceof Error ? err.message : String(err));
+      }
     };
 
     fetchData();
@@ -142,6 +158,7 @@ export function OpencostDetailSection({ resource, type }) {
     setDisplayTimespan(timespan);
     setTsData(null);
     setAccumulatedData(null);
+    setError(null);
   };
 
   return (
@@ -153,6 +170,7 @@ export function OpencostDetailSection({ resource, type }) {
       learnMoreLink={learnMoreLink}
       displayCurrency={getDisplayCurrency()}
       handleDisplayTimespanChange={handleDisplayTimespanChange}
+      error={error}
     />
   );
 }
@@ -174,6 +192,7 @@ interface OpencostDetailSectionPureProps {
   learnMoreLink: string;
   displayCurrency: string;
   handleDisplayTimespanChange: (timespan: string) => void;
+  error?: string | null;
 }
 
 export function OpencostDetailSectionPure(props: OpencostDetailSectionPureProps) {
@@ -185,12 +204,19 @@ export function OpencostDetailSectionPure(props: OpencostDetailSectionPureProps)
     learnMoreLink,
     displayCurrency,
     handleDisplayTimespanChange,
+    error,
   } = props;
 
   let content = null;
 
   if (installed) {
-    if (
+    if (error) {
+      content = (
+        <Paper variant="outlined">
+          <EmptyContent color="error">{`Couldn't fetch cost data: ${error}`}</EmptyContent>
+        </Paper>
+      );
+    } else if (
       (accumulatedData === null || Object.keys(accumulatedData).length === 0) &&
       tsData?.length === 0
     ) {

--- a/opencost/src/index.tsx
+++ b/opencost/src/index.tsx
@@ -100,17 +100,24 @@ const useOpenCostData = () => {
     }
     setIsLoading(true);
     const fetchData = async () => {
-      const [namespace, serviceName] = await getServiceDetails();
-      const result = await fetchOpencostData(
-        namespace,
-        serviceName,
-        getDisplayTimespan(),
-        resourceType,
-        true
-      );
-      openCostDataCache = result;
-      setData(result);
-      setIsLoading(false);
+      try {
+        const [namespace, serviceName] = await getServiceDetails();
+        const result = await fetchOpencostData(
+          namespace,
+          serviceName,
+          getDisplayTimespan(),
+          resourceType,
+          true
+        );
+        openCostDataCache = result;
+        setData(result);
+      } catch (err) {
+        console.error('Failed to fetch OpenCost data', err);
+        openCostDataCache = null;
+        setData(null);
+      } finally {
+        setIsLoading(false);
+      }
     };
 
     fetchData();

--- a/opencost/src/request.test.ts
+++ b/opencost/src/request.test.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fetchOpencostData } from './request';
+
+const mockRequest = vi.fn();
+
+vi.mock('@kinvolk/headlamp-plugin/lib', () => ({
+  ApiProxy: {
+    request: (...args: unknown[]) => mockRequest(...args),
+  },
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('fetchOpencostData', () => {
+  it('goes through the kube-apiserver service proxy for a plain service name', async () => {
+    mockRequest.mockResolvedValue({ data: [] });
+
+    await fetchOpencostData('opencost', 'http:opencost:9003', '1d', 'pod', true);
+
+    expect(mockRequest).toHaveBeenCalledWith(
+      '/api/v1/namespaces/opencost/services/http:opencost:9003/proxy/allocation?window=1d&aggregate=pod&step=1d&accumulate=true'
+    );
+  });
+
+  it('fetches a configured http(s) URL directly, bypassing the apiserver proxy', async () => {
+    const mockJson = vi.fn().mockResolvedValue({ data: [] });
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true, json: mockJson });
+    vi.stubGlobal('fetch', mockFetch);
+
+    await fetchOpencostData('opencost', 'https://opencost.example.com', '1d', 'pod', true);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://opencost.example.com/allocation?window=1d&aggregate=pod&step=1d&accumulate=true'
+    );
+    expect(mockRequest).not.toHaveBeenCalled();
+  });
+
+  it('strips a trailing slash from a configured direct URL', async () => {
+    const mockJson = vi.fn().mockResolvedValue({ data: [] });
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true, json: mockJson });
+    vi.stubGlobal('fetch', mockFetch);
+
+    await fetchOpencostData('opencost', 'https://opencost.example.com/', '1d', 'pod', true);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://opencost.example.com/allocation?window=1d&aggregate=pod&step=1d&accumulate=true'
+    );
+  });
+
+  it('rejects with a descriptive error when the direct URL request fails', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      statusText: 'Service Unavailable',
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    await expect(
+      fetchOpencostData('opencost', 'https://opencost.example.com', '1d', 'pod', true)
+    ).rejects.toThrow(/503/);
+  });
+});

--- a/opencost/src/request.tsx
+++ b/opencost/src/request.tsx
@@ -22,6 +22,17 @@ export async function isOpenCostInstalled() {
   return [false, null, null];
 }
 
+/**
+ * Some clusters (e.g. EKS with certain CNI configurations) reject
+ * kube-apiserver service-proxy requests to the OpenCost backend with
+ * "error trying to reach service: Address is not allowed". When the
+ * configured service value is itself a full URL, talk to it directly
+ * instead of going through the apiserver proxy.
+ */
+function isDirectUrl(serviceName: string): boolean {
+  return /^https?:\/\//i.test(serviceName);
+}
+
 export function fetchOpencostData(
   namespace: string,
   serviceName: string,
@@ -29,9 +40,20 @@ export function fetchOpencostData(
   resource: string,
   accumulate: boolean
 ) {
-  const url = `/api/v1/namespaces/${namespace}/services/${serviceName}/proxy/allocation?window=${window}&aggregate=${resource}&step=1d&accumulate=${accumulate.toString()}`;
+  const queryString = `window=${window}&aggregate=${resource}&step=1d&accumulate=${accumulate.toString()}`;
 
-  return request(url).then(data => {
-    return data;
-  });
+  if (isDirectUrl(serviceName)) {
+    const baseUrl = serviceName.replace(/\/+$/, '');
+    return fetch(`${baseUrl}/allocation?${queryString}`).then(response => {
+      if (!response.ok) {
+        throw new Error(
+          `Request to OpenCost URL ${baseUrl} failed with status ${response.status} ${response.statusText}`
+        );
+      }
+      return response.json();
+    });
+  }
+
+  const url = `/api/v1/namespaces/${namespace}/services/${serviceName}/proxy/allocation?${queryString}`;
+  return request(url);
 }

--- a/opencost/src/settings.tsx
+++ b/opencost/src/settings.tsx
@@ -24,7 +24,7 @@ export function Settings(props) {
       name: 'Namespace',
       value: (
         <TextField
-          helperText="Please enter the namespace where Opencost is Installed"
+          helperText="Please enter the namespace where Opencost is Installed. Not used when Service URL below is a direct http(s) URL."
           defaultValue={data?.namespace ? data.namespace : ''}
           onChange={e => onDataChange({ ...data, namespace: e.target.value })}
           variant="standard"
@@ -36,7 +36,7 @@ export function Settings(props) {
       value: (
         <TextField
           fullWidth
-          helperText="Please enter the service URL of Opencost web UI service"
+          helperText="Either <service-name>:<port-name> to reach OpenCost through the Kubernetes apiserver proxy (default), or a direct http(s):// URL if your cluster rejects apiserver service-proxy requests to OpenCost."
           defaultValue={data?.serviceURL ? data.serviceURL : ''}
           onChange={e => onDataChange({ ...data, serviceURL: e.target.value })}
           variant="standard"


### PR DESCRIPTION
## Summary

- OpenCost plugin only talks to OpenCost through the kube-apiserver service-proxy path. On clusters that reject that kind of proxying (e.g. some EKS/CNI setups), this fails with `error trying to reach service: Address is not allowed`, and the cost panel/column hangs forever because the failure was never caught.

## Fix

- `request.tsx`: if the configured Service URL is a full `http(s)://` URL, fetch OpenCost directly instead of going through the apiserver proxy. Existing `<namespace>/<service:port>` configs are unaffected.
- `detail.tsx` / `index.tsx`: catch fetch errors instead of leaving the UI stuck in a loading state — the detail panel now shows a clear error message, and the list-view column falls back to `N/A`.
- `settings.tsx` / `README.md`: document the direct-URL option and its CORS caveat (the URL must be reachable directly from the browser).

## Test plan

- Added `request.test.ts` covering the default proxy path, the new direct-URL path, trailing-slash handling, and error propagation on a failed direct request.
- Verified these tests fail against the old code and pass with the fix.
- `tsc`, `eslint --max-warnings 0`, `vitest run`, and `headlamp-plugin build` all pass.

Fixes #733
