### PR TITLE
cert-manager: Fix Expires In column showing <invalid> for future notA…

### DIFF
--- a/cert-manager/src/components/certificates/List.tsx
+++ b/cert-manager/src/components/certificates/List.tsx
@@ -1,6 +1,6 @@
-import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
+import { useTranslation, Utils } from '@kinvolk/headlamp-plugin/lib';
 import { ResourceListView } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
-import { DateLabel } from '@kinvolk/headlamp-plugin/lib/components/common';
+import { HoverInfoLabel } from '@kinvolk/headlamp-plugin/lib/components/common';
 import { useCertManagerInstalled } from '../../hooks/useCertManagerInstalled';
 import { Certificate } from '../../resources/certificate';
 import { NotInstalledBanner } from '../common/CommonComponents';
@@ -30,9 +30,18 @@ export function CertificatesList() {
           id: 'expiresIn',
           label: t('Expires In (Not After)'),
           render: item => {
-            return item?.status?.notAfter ? (
-              <DateLabel date={item.status.notAfter} format="mini" />
-            ) : null;
+            const notAfter = item?.status?.notAfter;
+            if (!notAfter) {
+              return null;
+            }
+            // notAfter is a future expiry date, so we need the time remaining until it
+            // (not time elapsed since it, which is what DateLabel/TimeAgo compute).
+            const remainingMs = new Date(notAfter).getTime() - Date.now();
+            const label =
+              remainingMs <= 0 ? t('Expired') : Utils.formatDuration(remainingMs, { format: 'mini' });
+            return (
+              <HoverInfoLabel label={label} hoverInfo={Utils.localeDate(notAfter)} icon="mdi:calendar" />
+            );
           },
           getValue: item => item.status?.notAfter ?? '',
           sort: (a, b) => {


### PR DESCRIPTION
## Summary
- The Certificates list's "Expires In (Not After)" column always showed `<invalid>`, even for certificates with a valid, future `status.notAfter`.
- Root cause: the column used `DateLabel`/`TimeAgo` (headlamp core), which computes `now - date` — i.e. time elapsed since a *past* event. `notAfter` is a future date, so the diff is negative, and core's duration formatter treats any diff `< -1s` as `<invalid>`.
- Fix: compute `notAfter - now` directly and format that duration, falling back to "Expired" once it has passed, instead of feeding a future date into a component built for past ones.

Fixes #1020

## Test plan
- [x] `npx headlamp-plugin tsc`
- [x] `npx headlamp-plugin lint`
- [ ] Manually verify against a live cluster with a Certificate whose `status.notAfter` is in the future
