### PR TITLE
cluster-api: add accessible names to filter selects and copy button

### DIFF
--- a/cluster-api/src/components/overview/ClusterDetailsErrorOverview.tsx
+++ b/cluster-api/src/components/overview/ClusterDetailsErrorOverview.tsx
@@ -186,7 +186,15 @@ function InlineSolutionPanel({
                   <Typography variant="caption" color="text.secondary">
                     {cmd.description}
                   </Typography>
-                  <IconButton size="small" onClick={() => handleCopy(cmd.command)}>
+                  <IconButton
+                    size="small"
+                    aria-label={
+                      copiedCommand === cmd.command
+                        ? `Copied command: ${cmd.description}`
+                        : `Copy command: ${cmd.description}`
+                    }
+                    onClick={() => handleCopy(cmd.command)}
+                  >
                     <Icon
                       icon={copiedCommand === cmd.command ? 'mdi:check' : 'mdi:content-copy'}
                       width="14px"
@@ -690,6 +698,7 @@ export default function ClusterDetailsErrorOverview({
           </Box>
           <Select
             size="small"
+            inputProps={{ 'aria-label': 'Filter clusters' }}
             value={clusterFilter}
             onChange={e => setClusterFilter(e.target.value)}
             sx={{ minWidth: 220 }}

--- a/cluster-api/src/components/overview/Overview.tsx
+++ b/cluster-api/src/components/overview/Overview.tsx
@@ -864,6 +864,7 @@ export default function ClusterApiOverview() {
         <Box sx={{ mb: 2, display: 'flex', justifyContent: 'flex-end', gap: 1, flexWrap: 'wrap' }}>
           <Select
             size="small"
+            inputProps={{ 'aria-label': 'Filter conditions by cluster' }}
             value={clusterErrorFilter}
             onChange={e => setClusterErrorFilter(e.target.value)}
             sx={{ minWidth: 200 }}
@@ -876,6 +877,7 @@ export default function ClusterApiOverview() {
           </Select>
           <Select
             size="small"
+            inputProps={{ 'aria-label': 'Filter conditions by resource' }}
             value={errorResourceFilter}
             onChange={e => setErrorResourceFilter(e.target.value)}
             sx={{ minWidth: 220 }}
@@ -889,6 +891,7 @@ export default function ClusterApiOverview() {
           </Select>
           <Select
             size="small"
+            inputProps={{ 'aria-label': 'Filter conditions by severity' }}
             value={severityFilter}
             onChange={e => setSeverityFilter(e.target.value as 'All' | ErrorSeverity)}
             sx={{ minWidth: 160 }}


### PR DESCRIPTION
Four Select controls in the cluster-api overview render with no accessible name. They sit directly inside a `Box` with no `FormControl`, `InputLabel`, `label` or `aria-label`, so assistive technology announces them as unlabeled comboboxes and cannot tell the cluster, resource and severity filters apart.

- `Overview.tsx`: cluster, resource and severity filters under "Conditions"
- `ClusterDetailsErrorOverview.tsx`: cluster filter under "Clusters"

The copy button in the inline solution panel has the same problem. Its only child is an `Icon`, so it exposes no name. Its label now also reflects the copied state, which was previously conveyed only by the icon swapping to a checkmark.

Uses `aria-label` via `inputProps` on the selects, following the pattern in prometheus (#999). `lint`, `tsc --noEmit` and prettier are clean.

Found by reading the source, not by an automated audit. I do not have a Cluster API cluster to run the plugin against, so these have not been confirmed against axe in a browser.
