### PR TITLE
minikube: Fix TypeScript type errors in cluster UI components

### DIFF
--- a/minikube/src/ClusterStatus.tsx
+++ b/minikube/src/ClusterStatus.tsx
@@ -3,7 +3,7 @@ import { Box, IconButton, Tooltip, Typography, useTheme } from '@mui/material';
 import React from 'react';
 import CommandCluster from './CommandCluster/CommandCluster';
 
-export default function ClusterStatus({ cluster, error }) {
+export default function ClusterStatus({ cluster, error }: { cluster: any; error: any }) {
   const theme = useTheme() as any;
   const stateUnknown = error === undefined;
   const hasReachError = error && error.status !== 401 && error.status !== 403;

--- a/minikube/src/CommandCluster/CommandCluster.tsx
+++ b/minikube/src/CommandCluster/CommandCluster.tsx
@@ -73,7 +73,7 @@ type RunningCommandType = {
   props: CommandClusterProps;
 };
 
-const commandsRunning = [];
+const commandsRunning: RunningCommandType[] = [];
 
 /**
  * Runs a command on a cluster, and shows the output in a dialog.
@@ -101,7 +101,12 @@ export default function CommandCluster(props: CommandClusterProps) {
   const [minikubeAvailable, setMinikubeAvailable] = React.useState<boolean | null>(null);
 
   const allDataRef = React.useRef<string[]>([]);
-  const processRef = React.useRef<{ kill?: () => void } | null>(null);
+  const processRef = React.useRef<{
+    kill?: () => void;
+    stdout: { on: (event: string, listener: (chunk: any) => void) => void };
+    stderr: { on: (event: string, listener: (chunk: any) => void) => void };
+    on: (event: string, listener: (code: number | null) => void) => void;
+  } | null>(null);
 
   function killProcess() {
     try {

--- a/minikube/src/CommandCluster/DriverSelect.tsx
+++ b/minikube/src/CommandCluster/DriverSelect.tsx
@@ -192,7 +192,7 @@ export default function DriverSelect({ setDriver, driver, info }: DriverSelectPr
           <Select
             labelId="driver-select-label"
             id="driver-select"
-            value={driver}
+            value={driver ?? ''}
             label="Driver"
             displayEmpty
             onChange={handleChange}


### PR DESCRIPTION
Fixes #1025 

## Summary

Adds TypeScript type annotations and null-coalescing fixes in three minikube plugin files. No runtime behavior changes.

## Changes

### `minikube/src/ClusterStatus.tsx`
- Type component props: `{ cluster: any; error: any }`

### `minikube/src/CommandCluster/CommandCluster.tsx`
- Type module-level `commandsRunning` as `RunningCommandType[]`
- Expand `processRef` type to include `stdout`, `stderr`, and `on` in addition to optional `kill`

### `minikube/src/CommandCluster/DriverSelect.tsx`
- Use `value={driver ?? ''}` so MUI `Select` receives a `string` when `driver` is `null`

## What it does

Resolves TypeScript errors when running `npm run tsc` in the minikube plugin and improves IDE type checking for contributors.

## Test plan

- [ ] `cd minikube && npm run tsc` passes
- [ ] `cd minikube && npm run lint` passes
- [ ] Manual smoke test: open minikube cluster create/stop/delete dialogs; driver select still shows "Autodetect" and command output still streams correctly

<img width="1035" height="377" alt="pass" src="https://github.com/user-attachments/assets/4d7fed3b-a8a4-4990-867b-0dc7763d5938" />
