### PR TITLE
feat(kueue): implement Workload CRD resource model and list/detail views

### DIFF
--- a/kueue/package-lock.json
+++ b/kueue/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.1.0-alpha",
       "devDependencies": {
         "@headlamp-k8s/eslint-config": "^0.7.0",
-        "@kinvolk/headlamp-plugin": "^0.14.0"
+        "@kinvolk/headlamp-plugin": "^0.14.0",
+        "happy-dom": "^20.11.1"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -4650,12 +4651,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/wrap-ansi": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
       "integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.26.0",
@@ -6220,6 +6238,19 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
+    },
+    "node_modules/buffer-image-size": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+      "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
     },
     "node_modules/buffer-xor": {
       "version": "1.0.3",
@@ -9705,6 +9736,48 @@
       "license": "MIT",
       "dependencies": {
         "through2": "^2.0.1"
+      }
+    },
+    "node_modules/happy-dom": {
+      "version": "20.11.1",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.11.1.tgz",
+      "integrity": "sha512-XSt8tMzbW9ymE7687xztkO1ckR7qJNQ3LywY9vlYGhGi3zXrGBHuUo2Cl1ztZaICW+1eAGdkLbj6iwVqDT33kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "buffer-image-size": "^0.6.4",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/happy-dom/node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/has-bigints": {

--- a/kueue/package.json
+++ b/kueue/package.json
@@ -33,7 +33,8 @@
   },
   "devDependencies": {
     "@headlamp-k8s/eslint-config": "^0.7.0",
-    "@kinvolk/headlamp-plugin": "^0.14.0"
+    "@kinvolk/headlamp-plugin": "^0.14.0",
+    "happy-dom": "^20.11.1"
   },
   "overrides": {
     "ws": "8.21.0"

--- a/kueue/src/components/workloads/Detail.tsx
+++ b/kueue/src/components/workloads/Detail.tsx
@@ -1,0 +1,94 @@
+import {
+  ConditionsSection,
+  DetailsGrid,
+  SectionBox,
+  SimpleTable,
+} from '@kinvolk/headlamp-plugin/lib/components/common';
+import { useParams } from 'react-router-dom';
+import { PodSet, Workload } from '../../resources/workload';
+import { renderWorkloadStatus } from '../../resources/workloadFormatters';
+
+function getPodSetsSection(workload: Workload) {
+  const podSets = workload.podSets;
+  if (!podSets || podSets.length === 0) {
+    return null;
+  }
+
+  return {
+    id: 'pod-sets',
+    section: (
+      <SectionBox title="Pod Sets">
+        <SimpleTable
+          data={podSets}
+          columns={[
+            {
+              label: 'Name',
+              getter: (row: PodSet) => row.name,
+            },
+            {
+              label: 'Count',
+              getter: (row: PodSet) => row.count,
+            },
+          ]}
+        />
+      </SectionBox>
+    ),
+  };
+}
+
+function getConditionsSection(workload: Workload) {
+  if (!workload.conditions.length) {
+    return null;
+  }
+
+  return {
+    id: 'conditions',
+    section: <ConditionsSection resource={workload.jsonData} />,
+  };
+}
+
+export default function WorkloadDetail() {
+  const { namespace, name } = useParams<{ namespace: string; name: string }>();
+
+  return (
+    <DetailsGrid
+      resourceType={Workload}
+      namespace={namespace}
+      name={name}
+      withEvents
+      extraInfo={workload =>
+        workload
+          ? [
+              {
+                name: 'Local Queue',
+                value: workload.queueName,
+              },
+              {
+                name: 'Cluster Queue',
+                value: workload.clusterQueueName,
+              },
+              {
+                name: 'Priority Class',
+                value: workload.priorityClassName,
+              },
+              {
+                name: 'Priority',
+                value: workload.priority,
+              },
+              {
+                name: 'Status',
+                value: renderWorkloadStatus(workload.conditions),
+              },
+            ]
+          : []
+      }
+      extraSections={workload =>
+        workload
+          ? [getPodSetsSection(workload), getConditionsSection(workload)].filter(
+              (s): s is NonNullable<typeof s> => s !== null
+            )
+          : []
+      }
+    />
+  );
+}

--- a/kueue/src/components/workloads/List.tsx
+++ b/kueue/src/components/workloads/List.tsx
@@ -1,0 +1,42 @@
+import { ResourceListView } from '@kinvolk/headlamp-plugin/lib/components/common';
+import { Workload } from '../../resources/workload';
+import { renderPodSetsSummary, renderWorkloadStatus } from '../../resources/workloadFormatters';
+
+export default function WorkloadList() {
+  return (
+    <ResourceListView
+      title="Workloads"
+      resourceClass={Workload}
+      columns={[
+        'name',
+        'namespace',
+        {
+          id: 'queueName',
+          label: 'Queue',
+          getValue: (workload: Workload) => workload.queueName,
+        },
+        {
+          id: 'clusterQueue',
+          label: 'ClusterQueue',
+          getValue: (workload: Workload) => workload.clusterQueueName,
+        },
+        {
+          id: 'priority',
+          label: 'Priority',
+          getValue: (workload: Workload) => workload.priority,
+        },
+        {
+          id: 'podSets',
+          label: 'Pod Sets',
+          getValue: (workload: Workload) => renderPodSetsSummary(workload.podSets),
+        },
+        {
+          id: 'status',
+          label: 'Status',
+          getValue: (workload: Workload) => renderWorkloadStatus(workload.conditions),
+        },
+        'age',
+      ]}
+    />
+  );
+}

--- a/kueue/src/index.tsx
+++ b/kueue/src/index.tsx
@@ -5,6 +5,8 @@ import LocalQueueDetail from './components/localqueues/Detail';
 import LocalQueueList from './components/localqueues/List';
 import ResourceFlavorDetail from './components/resourceflavors/Detail';
 import ResourceFlavorList from './components/resourceflavors/List';
+import WorkloadDetail from './components/workloads/Detail';
+import WorkloadList from './components/workloads/List';
 import { kueueRouteNames, kueueRoutePaths } from './utils/kueueRoutes';
 
 registerSidebarEntry({
@@ -34,6 +36,13 @@ registerSidebarEntry({
   name: 'kueue-resourceflavors',
   label: 'ResourceFlavors',
   url: kueueRoutePaths.resourceFlavorsList,
+});
+
+registerSidebarEntry({
+  parent: 'kueue',
+  name: 'kueue-workloads',
+  label: 'Workloads',
+  url: kueueRoutePaths.workloadsList,
 });
 
 registerRoute({
@@ -82,4 +91,20 @@ registerRoute({
   name: kueueRouteNames.resourceFlavorDetail,
   exact: true,
   component: () => <ResourceFlavorDetail />,
+});
+
+registerRoute({
+  path: kueueRoutePaths.workloadsList,
+  sidebar: 'kueue-workloads',
+  name: kueueRouteNames.workloadsList,
+  exact: true,
+  component: () => <WorkloadList />,
+});
+
+registerRoute({
+  path: kueueRoutePaths.workloadDetail,
+  sidebar: 'kueue-workloads',
+  name: kueueRouteNames.workloadDetail,
+  exact: true,
+  component: () => <WorkloadDetail />,
 });

--- a/kueue/src/resources/workload.test.ts
+++ b/kueue/src/resources/workload.test.ts
@@ -1,0 +1,81 @@
+if (typeof globalThis.localStorage === 'undefined') {
+  const store: Record<string, string> = {};
+  globalThis.localStorage = {
+    getItem: (key: string) => store[key] || null,
+    setItem: (key: string, value: string) => {
+      store[key] = value.toString();
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      for (const k of Object.keys(store)) {
+        delete store[k];
+      }
+    },
+    length: 0,
+    key: (index: number) => Object.keys(store)[index] || null,
+  };
+}
+
+import { describe, expect, it } from 'vitest';
+import { Workload } from './workload';
+import { getWorkloadDetailRouteParams, renderPodSetsSummary, renderWorkloadStatus } from './workloadFormatters';
+
+describe('Workload resource and formatters', () => {
+  it('formats podSets summary correctly', () => {
+    const podSets = [
+      { name: 'main', count: 2 },
+      { name: 'workers', count: 8 },
+    ];
+    expect(renderPodSetsSummary(podSets)).toBe('main: 2, workers: 8');
+    expect(renderPodSetsSummary([])).toBe('-');
+    expect(renderPodSetsSummary(undefined)).toBe('-');
+  });
+
+  it('evaluates status label from conditions', () => {
+    expect(renderWorkloadStatus([{ type: 'Finished', status: 'True' }])).toBe('Finished');
+    expect(renderWorkloadStatus([{ type: 'Evicted', status: 'True' }])).toBe('Evicted');
+    expect(renderWorkloadStatus([{ type: 'Admitted', status: 'True' }])).toBe('Admitted');
+    expect(renderWorkloadStatus([])).toBe('Pending');
+    expect(renderWorkloadStatus(undefined)).toBe('Pending');
+  });
+
+  it('correctly parses Workload KubeObject instances', () => {
+    const rawWorkload = {
+      apiVersion: 'kueue.x-k8s.io/v1beta2',
+      kind: 'Workload',
+      metadata: { name: 'test-wl', namespace: 'default' },
+      spec: {
+        queueName: 'user-queue',
+        priority: 100,
+        podSets: [{ name: 'main', count: 4 }],
+      },
+      status: {
+        admission: {
+          clusterQueue: 'cq-main',
+        },
+        conditions: [{ type: 'Admitted', status: 'True' }],
+      },
+    };
+
+    const wl = new Workload(rawWorkload as any);
+    expect(wl.queueName).toBe('user-queue');
+    expect(wl.priority).toBe(100);
+    expect(wl.clusterQueueName).toBe('cq-main');
+    expect(wl.isAdmitted).toBe(true);
+    expect(wl.isFinished).toBe(false);
+    expect(wl.statusLabel).toBe('Admitted');
+  });
+
+  it('handles missing route parameters safely', () => {
+    expect(getWorkloadDetailRouteParams('team-a', 'job-wl')).toEqual({
+      namespace: 'team-a',
+      name: 'job-wl',
+    });
+    expect(getWorkloadDetailRouteParams(undefined, undefined)).toEqual({
+      namespace: '',
+      name: '',
+    });
+  });
+});

--- a/kueue/src/resources/workload.ts
+++ b/kueue/src/resources/workload.ts
@@ -1,0 +1,159 @@
+import { K8s } from '@kinvolk/headlamp-plugin/lib';
+import type { KubeObjectInterface } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import { kueueApiVersions } from '../utils/kueueApi';
+import { kueueRoutePaths } from '../utils/kueueRoutes';
+import type { KueueCondition, ResourceQuantity } from './clusterQueue';
+
+const KubeObject = K8s.cluster.KubeObject;
+
+/**
+ * Pod set defined in a Kueue Workload spec.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#podset
+ */
+export interface PodSet {
+  /** PodSet identifier, for example `main` or `workers`. */
+  name: string;
+  /** Number of pods in the pod set. */
+  count: number;
+}
+
+/**
+ * Quotas allocated to a PodSet upon admission.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#podsetassignment
+ */
+export interface PodSetAssignment {
+  /** Name of the PodSet assigned. */
+  name: string;
+  /** ResourceFlavor names assigned for each resource. */
+  flavors?: Record<string, string>;
+  /** Total resources requested by this PodSet. */
+  resourceUsage?: Record<string, ResourceQuantity>;
+}
+
+/**
+ * Admission decision details recorded in Workload status.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#admission
+ */
+export interface Admission {
+  /** ClusterQueue that admitted this Workload. */
+  clusterQueue: string;
+  /** Per-PodSet flavor and resource allocations. */
+  podSetAssignments?: PodSetAssignment[];
+}
+
+/**
+ * Desired state of a Kueue Workload.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#workloadspec
+ */
+export interface WorkloadSpec {
+  /** LocalQueue name where the Workload was submitted. */
+  queueName?: string;
+  /** Whether the Workload is active for admission. */
+  active?: boolean;
+  /** Priority class name controlling queuing order. */
+  priorityClassName?: string;
+  /** Numeric priority value evaluated by Kueue. */
+  priority?: number;
+  /** Pod sets wrapped by this Workload. */
+  podSets?: PodSet[];
+}
+
+/**
+ * Observed state of a Kueue Workload.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#workloadstatus
+ */
+export interface WorkloadStatus {
+  /** Admission information if the Workload has been admitted. */
+  admission?: Admission;
+  /** Conditions observing Workload lifecycle states. */
+  conditions?: KueueCondition[];
+}
+
+/**
+ * Kubernetes Workload object returned by the Kueue API.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#workload
+ */
+export interface KubeWorkload extends KubeObjectInterface {
+  metadata: KubeObjectInterface['metadata'];
+  spec?: WorkloadSpec;
+  status?: WorkloadStatus;
+}
+
+export class Workload extends KubeObject<KubeWorkload> {
+  static kind = 'Workload';
+  static apiName = 'workloads';
+  static apiVersion = kueueApiVersions;
+  static isNamespaced = true;
+
+  static get detailsRoute() {
+    return kueueRoutePaths.workloadDetail;
+  }
+
+  get spec(): WorkloadSpec {
+    return this.jsonData.spec ?? {};
+  }
+
+  get status(): WorkloadStatus {
+    return this.jsonData.status ?? {};
+  }
+
+  get queueName(): string {
+    return this.spec.queueName || '-';
+  }
+
+  get priority(): number | string {
+    return this.spec.priority ?? '-';
+  }
+
+  get priorityClassName(): string {
+    return this.spec.priorityClassName || '-';
+  }
+
+  get podSets(): PodSet[] {
+    return this.spec.podSets || [];
+  }
+
+  get conditions(): KueueCondition[] {
+    return this.status.conditions || [];
+  }
+
+  get admission(): Admission | undefined {
+    return this.status.admission;
+  }
+
+  get clusterQueueName(): string {
+    return this.admission?.clusterQueue || '-';
+  }
+
+  get isAdmitted(): boolean {
+    return (
+      this.conditions.some(c => c.type === 'Admitted' && c.status === 'True') ||
+      Boolean(this.admission)
+    );
+  }
+
+  get isFinished(): boolean {
+    return this.conditions.some(c => c.type === 'Finished' && c.status === 'True');
+  }
+
+  get isEvicted(): boolean {
+    return this.conditions.some(c => c.type === 'Evicted' && c.status === 'True');
+  }
+
+  get isQuotaReserved(): boolean {
+    return this.conditions.some(c => c.type === 'QuotaReserved' && c.status === 'True');
+  }
+
+  get statusLabel(): 'Admitted' | 'Finished' | 'Evicted' | 'Pending' {
+    if (this.isFinished) return 'Finished';
+    if (this.isEvicted) return 'Evicted';
+    if (this.isAdmitted) return 'Admitted';
+    return 'Pending';
+  }
+}

--- a/kueue/src/resources/workloadFormatters.ts
+++ b/kueue/src/resources/workloadFormatters.ts
@@ -1,0 +1,38 @@
+import type { KueueCondition } from './clusterQueue';
+import type { PodSet } from './workload';
+
+/** Minimal condition shape for workload lifecycle checks. */
+export type WorkloadConditionLike = Pick<KueueCondition, 'type' | 'status' | 'reason' | 'message'>;
+
+/** Format a compact summary string of pod sets (e.g., "main: 4, workers: 8"). */
+export function renderPodSetsSummary(podSets?: PodSet[]): string {
+  const sets = podSets || [];
+  if (sets.length === 0) {
+    return '-';
+  }
+
+  return sets.map(ps => `${ps.name}: ${ps.count}`).join(', ');
+}
+
+/** Format user-readable status label for a Workload from conditions. */
+export function renderWorkloadStatus(conditions?: WorkloadConditionLike[]): 'Admitted' | 'Finished' | 'Evicted' | 'Pending' {
+  const list = conditions || [];
+  if (list.some(c => c.type === 'Finished' && c.status === 'True')) {
+    return 'Finished';
+  }
+  if (list.some(c => c.type === 'Evicted' && c.status === 'True')) {
+    return 'Evicted';
+  }
+  if (list.some(c => c.type === 'Admitted' && c.status === 'True')) {
+    return 'Admitted';
+  }
+  return 'Pending';
+}
+
+/** Format route parameters for Workload detail page links. */
+export function getWorkloadDetailRouteParams(namespace?: string, name?: string) {
+  return {
+    namespace: namespace || '',
+    name: name || '',
+  };
+}

--- a/kueue/src/utils/kueueRoutes.ts
+++ b/kueue/src/utils/kueueRoutes.ts
@@ -5,6 +5,8 @@ export const kueueRouteNames = {
   localQueueDetail: 'kueue-localqueue-detail',
   resourceFlavorsList: 'kueue-resourceflavors-list',
   resourceFlavorDetail: 'kueue-resourceflavor-detail',
+  workloadsList: 'kueue-workloads-list',
+  workloadDetail: 'kueue-workload-detail',
 } as const;
 
 export const kueueRoutePaths = {
@@ -14,4 +16,6 @@ export const kueueRoutePaths = {
   localQueueDetail: '/kueue/localqueues/:namespace/:name',
   resourceFlavorsList: '/kueue/resourceflavors',
   resourceFlavorDetail: '/kueue/resourceflavors/:name',
+  workloadsList: '/kueue/workloads',
+  workloadDetail: '/kueue/workloads/:namespace/:name',
 } as const;


### PR DESCRIPTION
## Description
This PR introduces full support for Kueue `Workload` custom resources (`kueue.x-k8s.io/v1beta2`) in the Headlamp Kueue plugin (`plugins/kueue`).

### Problem
Previously, the Headlamp Kueue plugin only displayed `ClusterQueue`, `LocalQueue`, and `ResourceFlavor` configurations, but lacked any representation for `Workload` custom resources. As a result, users and cluster administrators could not view or inspect individual batch, AI/ML, or HPC workloads submitted to Kueue, their podSets resource allocations, or their admission lifecycle status.

### Solution & Changes
- **Typed Workload Model (`src/resources/workload.ts`)**:
  - Implemented `Workload` class extending `KubeObject<KubeWorkload>` supporting the `kueue.x-k8s.io/v1beta2` schema.
  - Added getter properties for `queueName`, `clusterQueueName`, `priority`, `podSets`, and condition state helpers (`isAdmitted`, `isFinished`, `isEvicted`, `isQuotaReserved`, `statusLabel`).
- **Workload Formatters (`src/resources/workloadFormatters.ts`)**:
  - Added helper functions for formatting podSet summaries and workload status labels.
- **Workload List View (`src/components/workloads/List.tsx`)**:
  - Built namespaced table displaying Workload name, namespace, LocalQueue, ClusterQueue, priority, podSets summary, status badge, and age.
- **Workload Detail View (`src/components/workloads/Detail.tsx`)**:
  - Built detail view displaying Workload spec, podSets breakdown table, conditions section, and Kubernetes event logs.
- **Routing & Navigation (`src/index.tsx` & `src/utils/kueueRoutes.ts`)**:
  - Registered **Workloads** entry under the main `Kueue` sidebar menu and attached `/kueue/workloads` and `/kueue/workloads/:namespace/:name` routes.
- **Unit Test Suite (`src/resources/workload.test.ts`)**:
  - Added test suite verifying Workload instantiation, status condition parsing, and formatter fallbacks.

This PR fills the largest functional gap in the Kueue plugin, giving users complete visibility into their batch workloads directly inside the Headlamp web interface.