### PR TITLE
knative: status: Add Scaled to Zero status badge for idle KServices and Revisions

### DIFF
--- a/knative/src/components/common/ReadyStatusLabel.stories.tsx
+++ b/knative/src/components/common/ReadyStatusLabel.stories.tsx
@@ -56,3 +56,11 @@ WithMessage.args = {
   reason: 'RevisionFailed',
   message: 'Initial scale was never achieved',
 };
+
+export const ScaledToZero = Template.bind({});
+ScaledToZero.args = {
+  status: 'True',
+  isScaledToZero: true,
+  reason: 'NoTraffic',
+  message: 'Service is scaled to zero (idle)',
+};

--- a/knative/src/components/common/ReadyStatusLabel.tsx
+++ b/knative/src/components/common/ReadyStatusLabel.tsx
@@ -22,6 +22,7 @@ interface ReadyStatusLabelProps {
   reason?: string;
   message?: string;
   isReadyType?: boolean;
+  isScaledToZero?: boolean;
 }
 
 export function ReadyStatusLabel({
@@ -29,11 +30,15 @@ export function ReadyStatusLabel({
   reason,
   message,
   isReadyType = true,
+  isScaledToZero = false,
 }: ReadyStatusLabelProps) {
   let headlampStatus: 'success' | 'error' | 'warning' | '' = '';
   let labelText = 'Unknown';
 
-  if (status === 'True') {
+  if (isScaledToZero && status === 'True') {
+    headlampStatus = 'warning';
+    labelText = 'Scaled to Zero';
+  } else if (status === 'True') {
     headlampStatus = 'success';
     labelText = isReadyType ? 'Ready' : 'True';
   } else if (status === 'False') {
@@ -44,6 +49,9 @@ export function ReadyStatusLabel({
   }
 
   const tooltipLines = [labelText];
+  if (isScaledToZero) {
+    tooltipLines.push('Status: Idle (0 active pods, wakes on request)');
+  }
   if (reason) tooltipLines.push(`Reason: ${reason}`);
   if (message) tooltipLines.push(`Message: ${message}`);
 

--- a/knative/src/components/kservices/List.tsx
+++ b/knative/src/components/kservices/List.tsx
@@ -30,6 +30,7 @@ import { useAuthorization } from '../../hooks/useAuthorization';
 import { useClusters } from '../../hooks/useClusters';
 import { useKnativeInstalled } from '../../hooks/useKnativeInstalled';
 import { KnativeDomainMapping, KService } from '../../resources/knative';
+import { isScaledToZero } from '../../utils/status';
 import { getSafeUrl } from '../../utils/url';
 import { NotInstalledBanner } from '../common/NotInstalledBanner';
 import { ReadyStatusLabel } from '../common/ReadyStatusLabel';
@@ -450,6 +451,7 @@ function KServicesListContents({ clusters }: KServicesListContentsProps) {
               status={status}
               reason={readyCondition?.reason}
               message={readyCondition?.message}
+              isScaledToZero={isScaledToZero(svc)}
             />
           );
         },

--- a/knative/src/components/revisions/List.tsx
+++ b/knative/src/components/revisions/List.tsx
@@ -24,6 +24,7 @@ import React from 'react';
 import { useClusters } from '../../hooks/useClusters';
 import { useKnativeInstalled } from '../../hooks/useKnativeInstalled';
 import { KRevision, KService } from '../../resources/knative';
+import { isScaledToZero } from '../../utils/status';
 import { getSafeUrl } from '../../utils/url';
 import { NotInstalledBanner } from '../common/NotInstalledBanner';
 import { ReadyStatusLabel } from '../common/ReadyStatusLabel';
@@ -216,6 +217,7 @@ export function RevisionsList() {
             status={rev.readyCondition?.status ?? 'Unknown'}
             reason={rev.readyCondition?.reason}
             message={rev.readyCondition?.message}
+            isScaledToZero={isScaledToZero(rev)}
           />
         ),
       },

--- a/knative/src/utils/status.test.ts
+++ b/knative/src/utils/status.test.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { isScaledToZero } from './status';
+
+describe('isScaledToZero', () => {
+  it('returns false for null or undefined items', () => {
+    expect(isScaledToZero(null)).toBe(false);
+    expect(isScaledToZero(undefined)).toBe(false);
+  });
+
+  it('returns false when Ready condition is False or missing', () => {
+    const itemNotReady = {
+      status: {
+        conditions: [
+          { type: 'Ready', status: 'False', reason: 'RevisionFailed' },
+          { type: 'Active', status: 'False', reason: 'NoTraffic' },
+        ],
+      },
+    } as any;
+    expect(isScaledToZero(itemNotReady)).toBe(false);
+  });
+
+  it('returns true when Ready is True and Active is False (idle NoTraffic)', () => {
+    const idleItem = {
+      status: {
+        conditions: [
+          { type: 'Ready', status: 'True' },
+          { type: 'Active', status: 'False', reason: 'NoTraffic' },
+        ],
+      },
+    } as any;
+    expect(isScaledToZero(idleItem)).toBe(true);
+  });
+
+  it('returns true when Ready is True and actualReplicas is 0', () => {
+    const zeroReplicasItem = {
+      status: {
+        conditions: [{ type: 'Ready', status: 'True' }],
+        actualReplicas: 0,
+      },
+    } as any;
+    expect(isScaledToZero(zeroReplicasItem)).toBe(true);
+  });
+
+  it('returns false when Ready is True and active pods are running (actualReplicas > 0)', () => {
+    const activeItem = {
+      status: {
+        conditions: [
+          { type: 'Ready', status: 'True' },
+          { type: 'Active', status: 'True' },
+        ],
+        actualReplicas: 1,
+      },
+    } as any;
+    expect(isScaledToZero(activeItem)).toBe(false);
+  });
+});

--- a/knative/src/utils/status.ts
+++ b/knative/src/utils/status.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { KService } from '../resources/knative/kservice';
+import type { KRevision } from '../resources/knative/revision';
+
+/**
+ * Evaluates whether a Knative Service or Revision is currently scaled to zero (idle).
+ *
+ * In Knative Serving, a service or revision scales to zero when it has no active pod replicas:
+ * 1. The 'Active' condition has status === 'False' (e.g. reason 'NoTraffic' or 'TimedOut').
+ * 2. status.actualReplicas === 0 or status.desiredReplicas === 0 while readyCondition.status === 'True'.
+ */
+export function isScaledToZero(item: KService | KRevision | null | undefined): boolean {
+  if (!item || !item.status) {
+    return false;
+  }
+
+  const conditions = item.status.conditions || [];
+  const readyCond = conditions.find(c => c.type === 'Ready');
+  if (readyCond?.status !== 'True') {
+    return false;
+  }
+
+  // Check Active condition (KPA sets Active=False with reason NoTraffic/TimedOut when idle)
+  const activeCond = conditions.find(c => c.type === 'Active');
+  if (activeCond && activeCond.status === 'False') {
+    return true;
+  }
+
+  // Check actual / desired replica counts if present in status
+  const statusAny = item.status as any;
+  if (typeof statusAny?.actualReplicas === 'number' && statusAny.actualReplicas === 0) {
+    return true;
+  }
+  if (typeof statusAny?.desiredReplicas === 'number' && statusAny.desiredReplicas === 0) {
+    return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
### Description
Knative Services scale to zero when idle (`0/0` active pods). Previously, idle services rendered the generic `Ready` badge, making it difficult to distinguish active services (`1/1` pods) from idle services (`0/0` pods).

This PR introduces a distinct **`Scaled to Zero`** status badge for idle KServices and Revisions when `status.conditions[Ready]` is `True` and the service is in an idle state (condition `Active=False` or `actualReplicas=0`).

### Changes
* `knative: utils`: Add `isScaledToZero` helper to detect Knative scale-to-zero status.
* `knative: utils`: Add unit tests for `isScaledToZero`.
* `knative: common`: Update `ReadyStatusLabel` to support `isScaledToZero` badge & tooltip.
* `knative: common`: Add Storybook story for `ScaledToZero`.
* `knative: kservices & revisions`: Wire `isScaledToZero` into `KServicesList` and `RevisionsList` tables.

### Fixes
Fixes #1028 
