### PR TITLE
feat(kueue): implement MultiKueueCluster resource model and multi-cluster dashboard

### DIFF
--- a/kueue/src/components/multikueue/Detail.tsx
+++ b/kueue/src/components/multikueue/Detail.tsx
@@ -1,0 +1,50 @@
+import { ConditionsSection, DetailsGrid } from '@kinvolk/headlamp-plugin/lib/components/common';
+import { useParams } from 'react-router-dom';
+import { MultiKueueCluster } from '../../resources/multiKueueCluster';
+import { renderMultiKueueConnectionStatus } from '../../resources/multiKueueClusterFormatters';
+
+function getConditionsSection(cluster: MultiKueueCluster) {
+  if (!cluster.conditions.length) {
+    return null;
+  }
+
+  return {
+    id: 'conditions',
+    section: <ConditionsSection resource={cluster.jsonData} />,
+  };
+}
+
+export default function MultiKueueClusterDetail() {
+  const { name } = useParams<{ name: string }>();
+
+  return (
+    <DetailsGrid
+      resourceType={MultiKueueCluster}
+      name={name}
+      withEvents
+      extraInfo={cluster =>
+        cluster
+          ? [
+              {
+                name: 'KubeConfig Location',
+                value: cluster.kubeConfigLocation,
+              },
+              {
+                name: 'Location Type',
+                value: cluster.kubeConfigType,
+              },
+              {
+                name: 'Connection Status',
+                value: renderMultiKueueConnectionStatus(cluster.activeCondition),
+              },
+            ]
+          : []
+      }
+      extraSections={cluster =>
+        cluster
+          ? [getConditionsSection(cluster)].filter((s): s is NonNullable<typeof s> => s !== null)
+          : []
+      }
+    />
+  );
+}

--- a/kueue/src/components/multikueue/List.tsx
+++ b/kueue/src/components/multikueue/List.tsx
@@ -1,0 +1,32 @@
+import { ResourceListView } from '@kinvolk/headlamp-plugin/lib/components/common';
+import { MultiKueueCluster } from '../../resources/multiKueueCluster';
+import { renderMultiKueueConnectionStatus } from '../../resources/multiKueueClusterFormatters';
+
+export default function MultiKueueClusterList() {
+  return (
+    <ResourceListView
+      title="MultiKueue Clusters"
+      resourceClass={MultiKueueCluster}
+      columns={[
+        'name',
+        {
+          id: 'kubeConfigLocation',
+          label: 'KubeConfig Secret',
+          getValue: (cluster: MultiKueueCluster) => cluster.kubeConfigLocation,
+        },
+        {
+          id: 'locationType',
+          label: 'Location Type',
+          getValue: (cluster: MultiKueueCluster) => cluster.kubeConfigType,
+        },
+        {
+          id: 'connectionStatus',
+          label: 'Connection Status',
+          getValue: (cluster: MultiKueueCluster) =>
+            renderMultiKueueConnectionStatus(cluster.activeCondition),
+        },
+        'age',
+      ]}
+    />
+  );
+}

--- a/kueue/src/index.tsx
+++ b/kueue/src/index.tsx
@@ -3,6 +3,8 @@ import ClusterQueueDetail from './components/clusterqueues/Detail';
 import ClusterQueueList from './components/clusterqueues/List';
 import LocalQueueDetail from './components/localqueues/Detail';
 import LocalQueueList from './components/localqueues/List';
+import MultiKueueClusterDetail from './components/multikueue/Detail';
+import MultiKueueClusterList from './components/multikueue/List';
 import ResourceFlavorDetail from './components/resourceflavors/Detail';
 import ResourceFlavorList from './components/resourceflavors/List';
 import WorkloadDetail from './components/workloads/Detail';
@@ -43,6 +45,13 @@ registerSidebarEntry({
   name: 'kueue-workloads',
   label: 'Workloads',
   url: kueueRoutePaths.workloadsList,
+});
+
+registerSidebarEntry({
+  parent: 'kueue',
+  name: 'kueue-multikueueclusters',
+  label: 'MultiKueue Clusters',
+  url: kueueRoutePaths.multiKueueClustersList,
 });
 
 registerRoute({
@@ -107,4 +116,20 @@ registerRoute({
   name: kueueRouteNames.workloadDetail,
   exact: true,
   component: () => <WorkloadDetail />,
+});
+
+registerRoute({
+  path: kueueRoutePaths.multiKueueClustersList,
+  sidebar: 'kueue-multikueueclusters',
+  name: kueueRouteNames.multiKueueClustersList,
+  exact: true,
+  component: () => <MultiKueueClusterList />,
+});
+
+registerRoute({
+  path: kueueRoutePaths.multiKueueClusterDetail,
+  sidebar: 'kueue-multikueueclusters',
+  name: kueueRouteNames.multiKueueClusterDetail,
+  exact: true,
+  component: () => <MultiKueueClusterDetail />,
 });

--- a/kueue/src/resources/multiKueueCluster.test.ts
+++ b/kueue/src/resources/multiKueueCluster.test.ts
@@ -1,0 +1,63 @@
+if (typeof globalThis.localStorage === 'undefined') {
+  const store: Record<string, string> = {};
+  globalThis.localStorage = {
+    getItem: (key: string) => store[key] || null,
+    setItem: (key: string, value: string) => {
+      store[key] = value.toString();
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      for (const k of Object.keys(store)) {
+        delete store[k];
+      }
+    },
+    length: 0,
+    key: (index: number) => Object.keys(store)[index] || null,
+  };
+}
+
+import { describe, expect, it } from 'vitest';
+import { MultiKueueCluster } from './multiKueueCluster';
+import { getMultiKueueClusterDetailRouteParams, renderMultiKueueConnectionStatus } from './multiKueueClusterFormatters';
+
+describe('MultiKueueCluster resource and formatters', () => {
+  it('renders connection status correctly', () => {
+    expect(renderMultiKueueConnectionStatus({ type: 'Active', status: 'True' })).toBe('Connected');
+    expect(renderMultiKueueConnectionStatus({ type: 'Active', status: 'False' })).toBe('Disconnected');
+    expect(renderMultiKueueConnectionStatus(undefined)).toBe('Unknown');
+  });
+
+  it('correctly parses MultiKueueCluster KubeObject instances', () => {
+    const rawCluster = {
+      apiVersion: 'kueue.x-k8s.io/v1beta2',
+      kind: 'MultiKueueCluster',
+      metadata: { name: 'worker-us-east' },
+      spec: {
+        kubeConfig: {
+          location: 'worker-us-east-secret',
+          locationType: 'Secret',
+        },
+      },
+      status: {
+        conditions: [{ type: 'Active', status: 'True', reason: 'Connected' }],
+      },
+    };
+
+    const cluster = new MultiKueueCluster(rawCluster as any);
+    expect(cluster.kubeConfigLocation).toBe('worker-us-east-secret');
+    expect(cluster.kubeConfigType).toBe('Secret');
+    expect(cluster.isConnected).toBe(true);
+    expect(cluster.connectionStatus).toBe('Connected');
+  });
+
+  it('handles missing detail route parameters safely', () => {
+    expect(getMultiKueueClusterDetailRouteParams('worker-us-east')).toEqual({
+      name: 'worker-us-east',
+    });
+    expect(getMultiKueueClusterDetailRouteParams(undefined)).toEqual({
+      name: '',
+    });
+  });
+});

--- a/kueue/src/resources/multiKueueCluster.ts
+++ b/kueue/src/resources/multiKueueCluster.ts
@@ -1,0 +1,78 @@
+import { K8s } from '@kinvolk/headlamp-plugin/lib';
+import type { KubeObjectInterface } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import { kueueApiVersions } from '../utils/kueueApi';
+import { kueueRoutePaths } from '../utils/kueueRoutes';
+import type { KueueCondition } from './clusterQueue';
+
+const KubeObject = K8s.cluster.KubeObject;
+
+/** KubeConfig reference defined in MultiKueueCluster spec. */
+export interface MultiKueueKubeConfig {
+  /** Location string, for example secret name or path. */
+  location: string;
+  /** Location type, for example `Secret`. */
+  locationType?: string;
+}
+
+/** Desired state of a MultiKueueCluster. */
+export interface MultiKueueClusterSpec {
+  /** KubeConfig settings used to connect to the remote worker cluster. */
+  kubeConfig?: MultiKueueKubeConfig;
+}
+
+/** Observed status of a MultiKueueCluster. */
+export interface MultiKueueClusterStatus {
+  /** Conditions observing remote worker cluster connectivity and readiness. */
+  conditions?: KueueCondition[];
+}
+
+/** Kubernetes MultiKueueCluster object returned by the Kueue API. */
+export interface KubeMultiKueueCluster extends KubeObjectInterface {
+  metadata: KubeObjectInterface['metadata'];
+  spec?: MultiKueueClusterSpec;
+  status?: MultiKueueClusterStatus;
+}
+
+export class MultiKueueCluster extends KubeObject<KubeMultiKueueCluster> {
+  static kind = 'MultiKueueCluster';
+  static apiName = 'multikueueclusters';
+  static apiVersion = kueueApiVersions;
+  static isNamespaced = false;
+
+  static get detailsRoute() {
+    return kueueRoutePaths.multiKueueClusterDetail;
+  }
+
+  get spec(): MultiKueueClusterSpec {
+    return this.jsonData.spec ?? {};
+  }
+
+  get status(): MultiKueueClusterStatus {
+    return this.jsonData.status ?? {};
+  }
+
+  get conditions(): KueueCondition[] {
+    return this.status.conditions || [];
+  }
+
+  get kubeConfigLocation(): string {
+    return this.spec.kubeConfig?.location || '-';
+  }
+
+  get kubeConfigType(): string {
+    return this.spec.kubeConfig?.locationType || 'Secret';
+  }
+
+  get activeCondition(): KueueCondition | undefined {
+    return this.conditions.find(c => c.type === 'Active');
+  }
+
+  get isConnected(): boolean {
+    return this.activeCondition?.status === 'True';
+  }
+
+  get connectionStatus(): 'Connected' | 'Disconnected' | 'Unknown' {
+    if (!this.activeCondition) return 'Unknown';
+    return this.activeCondition.status === 'True' ? 'Connected' : 'Disconnected';
+  }
+}

--- a/kueue/src/resources/multiKueueClusterFormatters.ts
+++ b/kueue/src/resources/multiKueueClusterFormatters.ts
@@ -1,0 +1,28 @@
+import type { KueueCondition } from './clusterQueue';
+
+/** Minimal condition shape for MultiKueueCluster status rendering. */
+export type MultiKueueConditionLike = Pick<KueueCondition, 'type' | 'status' | 'reason' | 'message'>;
+
+/** Render user-readable connection status string. */
+export function renderMultiKueueConnectionStatus(activeCondition?: MultiKueueConditionLike): 'Connected' | 'Disconnected' | 'Unknown' {
+  if (!activeCondition) {
+    return 'Unknown';
+  }
+
+  if (activeCondition.status === 'True') {
+    return 'Connected';
+  }
+
+  if (activeCondition.status === 'False') {
+    return 'Disconnected';
+  }
+
+  return 'Unknown';
+}
+
+/** Render route params for cluster detail links. */
+export function getMultiKueueClusterDetailRouteParams(name?: string) {
+  return {
+    name: name || '',
+  };
+}

--- a/kueue/src/utils/kueueRoutes.ts
+++ b/kueue/src/utils/kueueRoutes.ts
@@ -7,6 +7,8 @@ export const kueueRouteNames = {
   resourceFlavorDetail: 'kueue-resourceflavor-detail',
   workloadsList: 'kueue-workloads-list',
   workloadDetail: 'kueue-workload-detail',
+  multiKueueClustersList: 'kueue-multikueueclusters-list',
+  multiKueueClusterDetail: 'kueue-multikueuecluster-detail',
 } as const;
 
 export const kueueRoutePaths = {
@@ -18,4 +20,6 @@ export const kueueRoutePaths = {
   resourceFlavorDetail: '/kueue/resourceflavors/:name',
   workloadsList: '/kueue/workloads',
   workloadDetail: '/kueue/workloads/:namespace/:name',
+  multiKueueClustersList: '/kueue/multikueueclusters',
+  multiKueueClusterDetail: '/kueue/multikueueclusters/:name',
 } as const;


### PR DESCRIPTION
## Description
This PR adds a **MultiKueue Clusters** dashboard to Headlamp, allowing cluster operators to monitor multi-cluster job dispatching - showing the connection status (**Connected**, **Disconnected**, **Unknown**) and secret credentials for every remote worker cluster.

### Problem
MultiKueue enables multi-cluster workload dispatching across Kubernetes clusters. Previously, Headlamp had zero visibility into MultiKueue cluster resources, remote worker cluster connection health, or KubeConfig secret locations.

### Solution & Changes
- **Data Model (`src/resources/multiKueueCluster.ts`)**: Reads worker cluster data and checks connection status.
- **Status Helpers (`src/resources/multiKueueClusterFormatters.ts`)**: Formats statuses into badges like `Connected` or `Disconnected`.
- **List Page (`src/components/multikueue/List.tsx`)**: Displays a dashboard table of all worker clusters and secret credentials.
- **Detail Page (`src/components/multikueue/Detail.tsx`)**: Shows detailed settings and live event logs for a selected cluster.
- **Sidebar & Navigation (`src/index.tsx` & `src/utils/kueueRoutes.ts`)**: Adds **MultiKueue Clusters** to the Headlamp sidebar.
- **Unit Tests (`src/resources/multiKueueCluster.test.ts`)**: Adds automated tests to verify cluster data parsing.

### Live UI Verification
Verified that `MultiKueueCluster` resources, routes, and sidebar navigation load cleanly in Headlamp connected to a live Kubernetes cluster:
- Sidebar: `kueue.x-k8s.io` with MultiKueueCluster entry
- Object routing: `/c/:cluster/kueue/multikueueclusters`

<img width="1208" height="563" alt="image" src="https://github.com/user-attachments/assets/80bd2e20-8566-4452-b6e4-00220b68355b" />


<img width="1198" height="565" alt="image" src="https://github.com/user-attachments/assets/baaebf90-2c4c-4239-93b1-7147fa2b1219" />


<img width="1199" height="567" alt="image" src="https://github.com/user-attachments/assets/c300b66a-5a1c-4598-b421-dcfe6a489e0f" />

