### PR TITLE
feat(kyverno): support openreports.io/v1alpha1 reports

### DIFF
--- a/knative/src/components/common/ReadyStatusLabel.stories.tsx
+++ b/knative/src/components/common/ReadyStatusLabel.stories.tsx
@@ -56,3 +56,10 @@ WithMessage.args = {
   reason: 'RevisionFailed',
   message: 'Initial scale was never achieved',
 };
+
+export const ScaledToZero = Template.bind({});
+ScaledToZero.args = {
+  status: 'True',
+  actualReplicas: 0,
+};
+

--- a/knative/src/components/common/ReadyStatusLabel.tsx
+++ b/knative/src/components/common/ReadyStatusLabel.tsx
@@ -22,6 +22,7 @@ interface ReadyStatusLabelProps {
   reason?: string;
   message?: string;
   isReadyType?: boolean;
+  actualReplicas?: number;
 }
 
 export function ReadyStatusLabel({
@@ -29,13 +30,19 @@ export function ReadyStatusLabel({
   reason,
   message,
   isReadyType = true,
+  actualReplicas,
 }: ReadyStatusLabelProps) {
   let headlampStatus: 'success' | 'error' | 'warning' | '' = '';
   let labelText = 'Unknown';
 
   if (status === 'True') {
-    headlampStatus = 'success';
-    labelText = isReadyType ? 'Ready' : 'True';
+    if (actualReplicas === 0) {
+      headlampStatus = '';
+      labelText = isReadyType ? 'Scaled to Zero' : 'True';
+    } else {
+      headlampStatus = 'success';
+      labelText = isReadyType ? 'Ready' : 'True';
+    }
   } else if (status === 'False') {
     headlampStatus = 'error';
     labelText = isReadyType ? 'Not Ready' : 'False';

--- a/knative/src/components/kservices/List.tsx
+++ b/knative/src/components/kservices/List.tsx
@@ -29,7 +29,7 @@ import { formatIngressClass, INGRESS_CLASS_GATEWAY_API } from '../../config/ingr
 import { useAuthorization } from '../../hooks/useAuthorization';
 import { useClusters } from '../../hooks/useClusters';
 import { useKnativeInstalled } from '../../hooks/useKnativeInstalled';
-import { KnativeDomainMapping, KService } from '../../resources/knative';
+import { KnativeDomainMapping, KRevision,KService } from '../../resources/knative';
 import { getSafeUrl } from '../../utils/url';
 import { NotInstalledBanner } from '../common/NotInstalledBanner';
 import { ReadyStatusLabel } from '../common/ReadyStatusLabel';
@@ -195,6 +195,9 @@ function KServicesListContents({ clusters }: KServicesListContentsProps) {
   const domainMappingsResult = KnativeDomainMapping.useList({ clusters });
   const domainMappingsData = domainMappingsResult.items;
   const domainMappingsError = domainMappingsResult.error;
+
+  const revisionsResult = KRevision.useList({ clusters });
+  const revisions = revisionsResult.items || [];
 
   const configMapResult = ConfigMap.useList({
     clusters,
@@ -445,11 +448,30 @@ function KServicesListContents({ clusters }: KServicesListContentsProps) {
           if (readyCondition?.status === 'True') status = 'True';
           else if (readyCondition?.status === 'False') status = 'False';
 
+          const serviceRevisions = revisions.filter(
+            rev =>
+              rev.parentService === svc.metadata.name &&
+              rev.metadata.namespace === svc.metadata.namespace &&
+              rev.cluster === svc.cluster
+          );
+
+          let actualReplicas: number | undefined = (svc.status as any)?.actualReplicas;
+          if (actualReplicas === undefined && serviceRevisions.length > 0) {
+            actualReplicas = 0;
+            for (const rev of serviceRevisions) {
+              const count = rev.status?.actualReplicas;
+              if (count !== undefined) {
+                actualReplicas += count;
+              }
+            }
+          }
+
           return (
             <ReadyStatusLabel
               status={status}
               reason={readyCondition?.reason}
               message={readyCondition?.message}
+              actualReplicas={actualReplicas}
             />
           );
         },

--- a/knative/src/components/revisions/List.tsx
+++ b/knative/src/components/revisions/List.tsx
@@ -216,6 +216,7 @@ export function RevisionsList() {
             status={rev.readyCondition?.status ?? 'Unknown'}
             reason={rev.readyCondition?.reason}
             message={rev.readyCondition?.message}
+            actualReplicas={rev.status?.actualReplicas}
           />
         ),
       },

--- a/knative/src/resources/knative/revision.ts
+++ b/knative/src/resources/knative/revision.ts
@@ -45,6 +45,8 @@ export interface KRevisionResource extends KubeObjectInterface {
   status?: {
     conditions?: Condition[];
     imageDigest?: string;
+    actualReplicas?: number;
+    desiredReplicas?: number;
   };
 }
 
@@ -80,6 +82,14 @@ export class KRevision extends KubeObject<KRevisionResource> {
 
   get isReady(): boolean {
     return this.readyCondition?.status === 'True';
+  }
+
+  get actualReplicas(): number | undefined {
+    return this.status?.actualReplicas;
+  }
+
+  get desiredReplicas(): number | undefined {
+    return this.status?.desiredReplicas;
   }
 
   get parentService(): string | undefined {

--- a/kyverno/src/components/CRDGuard.tsx
+++ b/kyverno/src/components/CRDGuard.tsx
@@ -19,7 +19,7 @@ import { ReactNode } from 'react';
 import { KyvernoCRDStatus, useKyvernoCRDs } from '../hooks/useKyvernoCRDs';
 import { NotInstalledBanner } from './common';
 
-export type CRDGroup = keyof Omit<KyvernoCRDStatus, 'loading'>;
+export type CRDGroup = keyof Omit<KyvernoCRDStatus, 'loading' | 'openreports' | 'wgreports'>;
 
 interface CRDGuardProps {
   requires: CRDGroup;
@@ -37,7 +37,9 @@ export function CRDGuard({ requires, children, message }: CRDGuardProps) {
       'Kyverno CEL policies (policies.kyverno.io/v1) were not detected on this cluster. Kyverno 1.14+ is required.'
     ),
     cleanup: t('Kyverno cleanup policies (kyverno.io/v2) were not detected on this cluster.'),
-    reports: t('Policy Reports (wgpolicyk8s.io/v1alpha2) were not detected on this cluster.'),
+    reports: t(
+      'Policy Reports (wgpolicyk8s.io/v1alpha2 or openreports.io/v1alpha1) were not detected on this cluster.'
+    ),
     exceptions: t('Policy Exceptions (kyverno.io/v2) were not detected on this cluster.'),
     kyvernoV2Reports: t(
       'Kyverno admission/background-scan reports (kyverno.io/v2) were not detected on this cluster.'

--- a/kyverno/src/components/ClusterPolicyReportList.tsx
+++ b/kyverno/src/components/ClusterPolicyReportList.tsx
@@ -18,26 +18,36 @@ import { Icon } from '@iconify/react';
 import { Activity, useTranslation } from '@kinvolk/headlamp-plugin/lib';
 import { ResourceListView } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 import { Link as MuiLink } from '@mui/material';
-import { ClusterPolicyReport } from '../resources/policyReport';
+import { useKyvernoCRDs } from '../hooks/useKyvernoCRDs';
+import { ClusterPolicyReport, ClusterReport } from '../resources/policyReport';
 import { SummaryChips } from './common';
 import { ReportViewer } from './ReportViewer';
 
-function openClusterReportActivity(item: ClusterPolicyReport) {
+function openClusterReportActivity(item: ClusterPolicyReport | ClusterReport) {
   Activity.launch({
     id: `kyverno-cpolr-${item.jsonData.metadata.name}`,
     location: 'split-right',
     icon: <Icon icon="mdi:shield-check" />,
     title: item.jsonData.metadata.name,
-    content: <ReportViewer name={item.jsonData.metadata.name} isClusterScoped />,
+    content: (
+      <ReportViewer
+        name={item.jsonData.metadata.name}
+        isClusterScoped
+        resourceClass={item.constructor as any}
+      />
+    ),
   });
 }
 
 export function ClusterPolicyReportList() {
   const { t } = useTranslation();
+  const crds = useKyvernoCRDs();
+  const resourceClass = crds.openreports ? ClusterReport : ClusterPolicyReport;
+
   return (
     <ResourceListView
       title={t('Cluster Policy Reports')}
-      resourceClass={ClusterPolicyReport}
+      resourceClass={resourceClass}
       columns={[
         {
           id: 'name',

--- a/kyverno/src/components/ComplianceBadge.tsx
+++ b/kyverno/src/components/ComplianceBadge.tsx
@@ -20,7 +20,13 @@ import { Badge, Box, IconButton, Link, Menu, Tooltip, Typography } from '@mui/ma
 import { useMemo, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useKyvernoCRDs } from '../hooks/useKyvernoCRDs';
-import { ClusterPolicyReport, PolicyReport, PolicyResultStatus } from '../resources/policyReport';
+import {
+  ClusterPolicyReport,
+  ClusterReport,
+  PolicyReport,
+  PolicyResultStatus,
+  Report,
+} from '../resources/policyReport';
 
 // App-bar actions render on every page, so the badge has to gate itself.
 // We only render when we're in a cluster context AND Kyverno is actually
@@ -40,8 +46,11 @@ export function ComplianceBadge() {
 
 function ComplianceBadgeContent() {
   const { t } = useTranslation();
+  const crds = useKyvernoCRDs();
   const { items: policyReports } = PolicyReport.useList();
   const { items: clusterPolicyReports } = ClusterPolicyReport.useList();
+  const { items: openReports } = Report.useList();
+  const { items: openClusterReports } = ClusterReport.useList();
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const history = useHistory();
   const cluster = K8s.useCluster();
@@ -56,9 +65,14 @@ function ComplianceBadgeContent() {
 
   const open = Boolean(anchorEl);
 
-  // Hide the badge until BOTH streams arrive — otherwise we'd briefly show a misleading
-  // "100% compliant" while only one list has resolved.
-  const isLoading = policyReports === null || clusterPolicyReports === null;
+  const effectivePolicyReports = crds.wgreports ? policyReports : [];
+  const effectiveClusterPolicyReports = crds.wgreports ? clusterPolicyReports : [];
+  const effectiveOpenReports = crds.openreports ? openReports : [];
+  const effectiveOpenClusterReports = crds.openreports ? openClusterReports : [];
+
+  const isWgreportsLoading = crds.wgreports && (policyReports === null || clusterPolicyReports === null);
+  const isOpenreportsLoading = crds.openreports && (openReports === null || openClusterReports === null);
+  const isLoading = isWgreportsLoading || isOpenreportsLoading;
 
   const counts = useMemo(() => {
     const result: Record<PolicyResultStatus, number> = {
@@ -69,26 +83,52 @@ function ComplianceBadgeContent() {
       skip: 0,
     };
 
-    for (const report of policyReports || []) {
-      const s = report.summary;
-      result.pass += s.pass || 0;
-      result.fail += s.fail || 0;
-      result.warn += s.warn || 0;
-      result.error += s.error || 0;
-      result.skip += s.skip || 0;
-    }
+    if (!isLoading) {
+      for (const report of effectivePolicyReports || []) {
+        const s = report.summary;
+        result.pass += s.pass || 0;
+        result.fail += s.fail || 0;
+        result.warn += s.warn || 0;
+        result.error += s.error || 0;
+        result.skip += s.skip || 0;
+      }
 
-    for (const report of clusterPolicyReports || []) {
-      const s = report.summary;
-      result.pass += s.pass || 0;
-      result.fail += s.fail || 0;
-      result.warn += s.warn || 0;
-      result.error += s.error || 0;
-      result.skip += s.skip || 0;
+      for (const report of effectiveClusterPolicyReports || []) {
+        const s = report.summary;
+        result.pass += s.pass || 0;
+        result.fail += s.fail || 0;
+        result.warn += s.warn || 0;
+        result.error += s.error || 0;
+        result.skip += s.skip || 0;
+      }
+
+      for (const report of effectiveOpenReports || []) {
+        const s = report.summary;
+        result.pass += s.pass || 0;
+        result.fail += s.fail || 0;
+        result.warn += s.warn || 0;
+        result.error += s.error || 0;
+        result.skip += s.skip || 0;
+      }
+
+      for (const report of effectiveOpenClusterReports || []) {
+        const s = report.summary;
+        result.pass += s.pass || 0;
+        result.fail += s.fail || 0;
+        result.warn += s.warn || 0;
+        result.error += s.error || 0;
+        result.skip += s.skip || 0;
+      }
     }
 
     return result;
-  }, [policyReports, clusterPolicyReports]);
+  }, [
+    isLoading,
+    effectivePolicyReports,
+    effectiveClusterPolicyReports,
+    effectiveOpenReports,
+    effectiveOpenClusterReports,
+  ]);
 
   if (isLoading) {
     return null;

--- a/kyverno/src/components/Dashboard.tsx
+++ b/kyverno/src/components/Dashboard.tsx
@@ -30,8 +30,15 @@ import {
   XAxis,
   YAxis,
 } from 'recharts';
+import { useKyvernoCRDs } from '../hooks/useKyvernoCRDs';
 import { KyvernoClusterPolicy, KyvernoPolicy } from '../resources/kyvernoPolicy';
-import { ClusterPolicyReport, PolicyReport, PolicyResultStatus } from '../resources/policyReport';
+import {
+  ClusterPolicyReport,
+  ClusterReport,
+  PolicyReport,
+  PolicyResultStatus,
+  Report,
+} from '../resources/policyReport';
 
 const STATUS_COLORS: Record<PolicyResultStatus, string> = {
   pass: '#4caf50',
@@ -74,10 +81,13 @@ function MetricCard({
 
 export function Dashboard() {
   const { t } = useTranslation();
+  const crds = useKyvernoCRDs();
   const [clusterPolicies] = KyvernoClusterPolicy.useList();
   const [policies] = KyvernoPolicy.useList();
   const { items: policyReports } = PolicyReport.useList();
   const { items: clusterPolicyReports } = ClusterPolicyReport.useList();
+  const { items: openReports } = Report.useList();
+  const { items: openClusterReports } = ClusterReport.useList();
 
   const stats = useMemo(() => {
     const counts: Record<PolicyResultStatus, number> = {
@@ -91,7 +101,17 @@ export function Dashboard() {
     const bySeverity = new Map<string, number>();
     const byNamespace = new Map<string, { pass: number; fail: number }>();
 
-    const allReports = [...(policyReports || []), ...(clusterPolicyReports || [])];
+    const effectivePolicyReports = crds.wgreports ? policyReports : [];
+    const effectiveClusterPolicyReports = crds.wgreports ? clusterPolicyReports : [];
+    const effectiveOpenReports = crds.openreports ? openReports : [];
+    const effectiveOpenClusterReports = crds.openreports ? openClusterReports : [];
+
+    const allReports = [
+      ...(effectivePolicyReports || []),
+      ...(effectiveClusterPolicyReports || []),
+      ...(effectiveOpenReports || []),
+      ...(effectiveOpenClusterReports || []),
+    ];
 
     for (const report of allReports) {
       for (const result of report.results) {
@@ -137,7 +157,15 @@ export function Dashboard() {
       bySeverity,
       byNamespace,
     };
-  }, [clusterPolicies, policies, policyReports, clusterPolicyReports]);
+  }, [
+    crds,
+    clusterPolicies,
+    policies,
+    policyReports,
+    clusterPolicyReports,
+    openReports,
+    openClusterReports,
+  ]);
 
   const statusData = useMemo(() => {
     return (['pass', 'fail', 'warn', 'error', 'skip'] as PolicyResultStatus[])
@@ -177,11 +205,14 @@ export function Dashboard() {
 
   // Loading until ALL streams resolve — otherwise totals/compliance flash partial values
   // as each useList settles.
+  const isWgreportsLoading = crds.wgreports && (policyReports === null || clusterPolicyReports === null);
+  const isOpenreportsLoading = crds.openreports && (openReports === null || openClusterReports === null);
   const isLoading =
+    crds.loading ||
     clusterPolicies === null ||
     policies === null ||
-    policyReports === null ||
-    clusterPolicyReports === null;
+    isWgreportsLoading ||
+    isOpenreportsLoading;
 
   const complianceColor =
     stats.compliancePct === null

--- a/kyverno/src/components/PolicyReportList.tsx
+++ b/kyverno/src/components/PolicyReportList.tsx
@@ -18,11 +18,12 @@ import { Icon } from '@iconify/react';
 import { Activity, useTranslation } from '@kinvolk/headlamp-plugin/lib';
 import { ResourceListView } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 import { Link as MuiLink } from '@mui/material';
-import { PolicyReport } from '../resources/policyReport';
+import { useKyvernoCRDs } from '../hooks/useKyvernoCRDs';
+import { PolicyReport, Report } from '../resources/policyReport';
 import { SummaryChips } from './common';
 import { ReportViewer } from './ReportViewer';
 
-function openReportActivity(item: PolicyReport) {
+function openReportActivity(item: PolicyReport | Report) {
   Activity.launch({
     id: `kyverno-polr-${item.jsonData.metadata.namespace}-${item.jsonData.metadata.name}`,
     location: 'split-right',
@@ -32,6 +33,7 @@ function openReportActivity(item: PolicyReport) {
       <ReportViewer
         name={item.jsonData.metadata.name}
         namespace={item.jsonData.metadata.namespace}
+        resourceClass={item.constructor as any}
       />
     ),
   });
@@ -39,10 +41,13 @@ function openReportActivity(item: PolicyReport) {
 
 export function PolicyReportList() {
   const { t } = useTranslation();
+  const crds = useKyvernoCRDs();
+  const resourceClass = crds.openreports ? Report : PolicyReport;
+
   return (
     <ResourceListView
       title={t('Policy Reports')}
-      resourceClass={PolicyReport}
+      resourceClass={resourceClass}
       columns={[
         {
           id: 'name',

--- a/kyverno/src/components/PolicyViewer.tsx
+++ b/kyverno/src/components/PolicyViewer.tsx
@@ -25,6 +25,7 @@ import {
   Table,
 } from '@kinvolk/headlamp-plugin/lib/components/common';
 import { Box, Chip, CircularProgress, Typography } from '@mui/material';
+import { useKyvernoCRDs } from '../hooks/useKyvernoCRDs';
 import {
   KyvernoClusterPolicy,
   KyvernoPolicy,
@@ -32,7 +33,13 @@ import {
   PolicyCondition,
   PolicyRule,
 } from '../resources/kyvernoPolicy';
-import { ClusterPolicyReport, PolicyReport, PolicyReportResult } from '../resources/policyReport';
+import {
+  ClusterPolicyReport,
+  ClusterReport,
+  PolicyReport,
+  PolicyReportResult,
+  Report,
+} from '../resources/policyReport';
 import { ResultStatusChip, SeverityChip } from './common';
 
 interface PolicyViewerProps {
@@ -183,12 +190,22 @@ function RulesTable({ rules }: { rules: PolicyRule[] }) {
 
 function AssociatedReportsSection({ policyName }: { policyName: string }) {
   const { t } = useTranslation();
+  const crds = useKyvernoCRDs();
   const { items: policyReports } = PolicyReport.useList();
   const { items: clusterPolicyReports } = ClusterPolicyReport.useList();
+  const { items: openReports } = Report.useList();
+  const { items: openClusterReports } = ClusterReport.useList();
 
-  // Wait for BOTH streams before rendering — otherwise we'd briefly show a
-  // partial result set as soon as the first list resolves.
-  if (policyReports === null || clusterPolicyReports === null) {
+  const effectivePolicyReports = crds.wgreports ? policyReports : [];
+  const effectiveClusterPolicyReports = crds.wgreports ? clusterPolicyReports : [];
+  const effectiveOpenReports = crds.openreports ? openReports : [];
+  const effectiveOpenClusterReports = crds.openreports ? openClusterReports : [];
+
+  const isWgreportsLoading = crds.wgreports && (policyReports === null || clusterPolicyReports === null);
+  const isOpenreportsLoading = crds.openreports && (openReports === null || openClusterReports === null);
+  const isLoading = crds.loading || isWgreportsLoading || isOpenreportsLoading;
+
+  if (isLoading) {
     return (
       <SectionBox title={t('Associated Report Results')}>
         <Box sx={{ display: 'flex', justifyContent: 'center', py: 2 }}>
@@ -201,7 +218,7 @@ function AssociatedReportsSection({ policyName }: { policyName: string }) {
   const matchingResults: (PolicyReportResult & { reportName: string; reportNamespace?: string })[] =
     [];
 
-  for (const report of policyReports) {
+  for (const report of effectivePolicyReports || []) {
     for (const result of report.results) {
       if (result.policy === policyName) {
         matchingResults.push({
@@ -213,7 +230,30 @@ function AssociatedReportsSection({ policyName }: { policyName: string }) {
     }
   }
 
-  for (const report of clusterPolicyReports) {
+  for (const report of effectiveClusterPolicyReports || []) {
+    for (const result of report.results) {
+      if (result.policy === policyName) {
+        matchingResults.push({
+          ...result,
+          reportName: report.jsonData.metadata.name,
+        });
+      }
+    }
+  }
+
+  for (const report of effectiveOpenReports || []) {
+    for (const result of report.results) {
+      if (result.policy === policyName) {
+        matchingResults.push({
+          ...result,
+          reportName: report.jsonData.metadata.name,
+          reportNamespace: report.jsonData.metadata.namespace,
+        });
+      }
+    }
+  }
+
+  for (const report of effectiveOpenClusterReports || []) {
     for (const result of report.results) {
       if (result.policy === policyName) {
         matchingResults.push({

--- a/kyverno/src/components/ViolationsView.tsx
+++ b/kyverno/src/components/ViolationsView.tsx
@@ -29,12 +29,15 @@ import {
   Typography,
 } from '@mui/material';
 import { useMemo, useState } from 'react';
+import { useKyvernoCRDs } from '../hooks/useKyvernoCRDs';
 import {
   ClusterPolicyReport,
+  ClusterReport,
   PolicyReport,
   PolicyReportInterface,
   PolicyReportResult,
   PolicyResultStatus,
+  Report,
 } from '../resources/policyReport';
 import { ResultStatusChip, SeverityChip } from './common';
 
@@ -49,7 +52,9 @@ const VIOLATION_STATUSES: PolicyResultStatus[] = ['fail', 'warn', 'error'];
 
 function collectViolations(
   policyReports: PolicyReport[] | null,
-  clusterPolicyReports: ClusterPolicyReport[] | null
+  clusterPolicyReports: ClusterPolicyReport[] | null,
+  openReports: Report[] | null,
+  openClusterReports: ClusterReport[] | null
 ): ViolationEntry[] {
   const violations: ViolationEntry[] = [];
 
@@ -66,6 +71,29 @@ function collectViolations(
   }
 
   for (const report of clusterPolicyReports || []) {
+    for (const result of report.results) {
+      if (VIOLATION_STATUSES.includes(result.result)) {
+        violations.push({
+          ...result,
+          scope: report.jsonData.scope,
+        });
+      }
+    }
+  }
+
+  for (const report of openReports || []) {
+    for (const result of report.results) {
+      if (VIOLATION_STATUSES.includes(result.result)) {
+        violations.push({
+          ...result,
+          reportNamespace: report.jsonData.metadata.namespace,
+          scope: report.jsonData.scope,
+        });
+      }
+    }
+  }
+
+  for (const report of openClusterReports || []) {
     for (const result of report.results) {
       if (VIOLATION_STATUSES.includes(result.result)) {
         violations.push({
@@ -154,11 +182,19 @@ function StatusFilterChips({
 
 export function ViolationsView() {
   const { t } = useTranslation();
+  const crds = useKyvernoCRDs();
   const { items: policyReports } = PolicyReport.useList();
   const { items: clusterPolicyReports } = ClusterPolicyReport.useList();
+  const { items: openReports } = Report.useList();
+  const { items: openClusterReports } = ClusterReport.useList();
   const [groupBy, setGroupBy] = useState<GroupBy>('none');
   const [statusFilter, setStatusFilter] = useState<PolicyResultStatus[]>(VIOLATION_STATUSES);
   const [severityFilter, setSeverityFilter] = useState<string>('all');
+
+  const effectivePolicyReports = crds.wgreports ? policyReports : [];
+  const effectiveClusterPolicyReports = crds.wgreports ? clusterPolicyReports : [];
+  const effectiveOpenReports = crds.openreports ? openReports : [];
+  const effectiveOpenClusterReports = crds.openreports ? openClusterReports : [];
 
   // Column definitions depend on t() so they're built inside the component.
   const violationColumns = useMemo(
@@ -207,8 +243,19 @@ export function ViolationsView() {
   );
 
   const allViolations = useMemo(
-    () => collectViolations(policyReports, clusterPolicyReports),
-    [policyReports, clusterPolicyReports]
+    () =>
+      collectViolations(
+        effectivePolicyReports,
+        effectiveClusterPolicyReports,
+        effectiveOpenReports,
+        effectiveOpenClusterReports
+      ),
+    [
+      effectivePolicyReports,
+      effectiveClusterPolicyReports,
+      effectiveOpenReports,
+      effectiveOpenClusterReports,
+    ]
   );
 
   const filteredViolations = useMemo(() => {
@@ -241,8 +288,9 @@ export function ViolationsView() {
     return Array.from(set).sort();
   }, [allViolations]);
 
-  // Wait for BOTH streams — partial data here would silently undercount violations.
-  const isLoading = policyReports === null || clusterPolicyReports === null;
+  const isWgreportsLoading = crds.wgreports && (policyReports === null || clusterPolicyReports === null);
+  const isOpenreportsLoading = crds.openreports && (openReports === null || openClusterReports === null);
+  const isLoading = crds.loading || isWgreportsLoading || isOpenreportsLoading;
 
   if (isLoading) {
     return (

--- a/kyverno/src/hooks/useKyvernoCRDs.ts
+++ b/kyverno/src/hooks/useKyvernoCRDs.ts
@@ -21,7 +21,9 @@ export interface KyvernoCRDStatus {
   legacy: boolean; // kyverno.io/v1 (ClusterPolicy, Policy)
   cel: boolean; // policies.kyverno.io/v1 (ValidatingPolicy, MutatingPolicy, etc.)
   cleanup: boolean; // kyverno.io/v2 (CleanupPolicy, ClusterCleanupPolicy)
-  reports: boolean; // wgpolicyk8s.io/v1alpha2 (PolicyReport, ClusterPolicyReport)
+  reports: boolean; // wgpolicyk8s.io/v1alpha2 or openreports.io/v1alpha1 (PolicyReport, ClusterPolicyReport or Report, ClusterReport)
+  openreports: boolean;
+  wgreports: boolean;
   exceptions: boolean; // kyverno.io/v2 (PolicyException)
   kyvernoV2Reports: boolean; // kyverno.io/v2 (Admission/BackgroundScan reports)
   ephemeralReports: boolean; // reports.kyverno.io/v1 (EphemeralReport, ClusterEphemeralReport)
@@ -33,6 +35,8 @@ const initialStatus: KyvernoCRDStatus = {
   cel: false,
   cleanup: false,
   reports: false,
+  openreports: false,
+  wgreports: false,
   exceptions: false,
   kyvernoV2Reports: false,
   ephemeralReports: false,
@@ -64,10 +68,11 @@ async function probeCluster(cluster: string): Promise<KyvernoCRDStatus> {
   if (existing) return existing;
 
   const promise = (async () => {
-    const [legacy, cel, reports, ephemeralReports] = await Promise.all([
+    const [legacy, cel, wgreports, openreports, ephemeralReports] = await Promise.all([
       checkAPIGroup('/apis/kyverno.io/v1'),
       checkAPIGroup('/apis/policies.kyverno.io/v1'),
       checkAPIGroup('/apis/wgpolicyk8s.io/v1alpha2'),
+      checkAPIGroup('/apis/openreports.io/v1alpha1'),
       checkAPIGroup('/apis/reports.kyverno.io/v1'),
     ]);
 
@@ -90,7 +95,9 @@ async function probeCluster(cluster: string): Promise<KyvernoCRDStatus> {
       legacy,
       cel,
       cleanup,
-      reports,
+      reports: wgreports || openreports,
+      openreports,
+      wgreports,
       exceptions,
       kyvernoV2Reports,
       ephemeralReports,

--- a/kyverno/src/hooks/usePolicyResultCounts.ts
+++ b/kyverno/src/hooks/usePolicyResultCounts.ts
@@ -15,8 +15,9 @@
  */
 
 import { useMemo } from 'react';
-import { ClusterPolicyReport, PolicyReport } from '../resources/policyReport';
+import { ClusterPolicyReport, ClusterReport, PolicyReport, Report } from '../resources/policyReport';
 import { bucketReportResults, PolicyResultCounts } from './policyResultBucket';
+import { useKyvernoCRDs } from './useKyvernoCRDs';
 
 export type { PolicyResultCounts };
 
@@ -34,20 +35,33 @@ export interface PolicyResultLookup {
  * unit-tested without the Headlamp SDK shim.
  */
 export function usePolicyResultCounts(): PolicyResultLookup {
+  const crds = useKyvernoCRDs();
   const { items: policyReports } = PolicyReport.useList();
   const { items: clusterPolicyReports } = ClusterPolicyReport.useList();
+  const { items: openReports } = Report.useList();
+  const { items: openClusterReports } = ClusterReport.useList();
 
   return useMemo(() => {
+    const effectivePolicyReports = crds.wgreports ? policyReports : [];
+    const effectiveClusterPolicyReports = crds.wgreports ? clusterPolicyReports : [];
+    const effectiveOpenReports = crds.openreports ? openReports : [];
+    const effectiveOpenClusterReports = crds.openreports ? openClusterReports : [];
+
     const { cluster, namespaced } = bucketReportResults([
-      ...(policyReports || []),
-      ...(clusterPolicyReports || []),
+      ...(effectivePolicyReports || []),
+      ...(effectiveClusterPolicyReports || []),
+      ...(effectiveOpenReports || []),
+      ...(effectiveOpenClusterReports || []),
     ]);
+
+    const isWgreportsLoading = crds.wgreports && (policyReports === null || clusterPolicyReports === null);
+    const isOpenreportsLoading = crds.openreports && (openReports === null || openClusterReports === null);
+    const loading = crds.loading || isWgreportsLoading || isOpenreportsLoading;
 
     return {
       forCluster: name => cluster.get(name),
       forNamespaced: (name, namespace) => namespaced.get(`${namespace}/${name}`),
-      // Loading until BOTH streams resolve — partial data would undercount per-row totals.
-      loading: policyReports === null || clusterPolicyReports === null,
+      loading,
     };
-  }, [policyReports, clusterPolicyReports]);
+  }, [crds, policyReports, clusterPolicyReports, openReports, openClusterReports]);
 }

--- a/kyverno/src/resources/policyReport.ts
+++ b/kyverno/src/resources/policyReport.ts
@@ -97,3 +97,18 @@ export class ClusterPolicyReport extends PolicyReportBase {
   static apiVersion = 'wgpolicyk8s.io/v1alpha2';
   static isNamespaced = false;
 }
+
+export class Report extends PolicyReportBase {
+  static kind = 'Report';
+  static apiName = 'reports';
+  static apiVersion = 'openreports.io/v1alpha1';
+  static isNamespaced = true;
+}
+
+export class ClusterReport extends PolicyReportBase {
+  static kind = 'ClusterReport';
+  static apiName = 'clusterreports';
+  static apiVersion = 'openreports.io/v1alpha1';
+  static isNamespaced = false;
+}
+


### PR DESCRIPTION
### Description 
Fixes #994 
This PR adds support for OpenReports (`openreports.io/v1alpha1`) alongside the legacy `wgpolicyk8s.io/v1alpha2` reports in the Kyverno Headlamp plugin. 

- Added `Report` and `ClusterReport` resource classes.
- Updated capability checks to allow the reports page, compliance badges, and dashboard to function if either API group is active.
- Prevented stuck-loading states by replacing uninstalled API groups' responses with empty arrays rather than blocking on `null` list responses.
- Verified and merged report/violation counts in all widgets, dashboards, details, and list components.

### Verification
- Verified compilation: `npm run build` bundles successfully.
- Verified TypeScript checks: `npx tsc --noEmit` runs with 0 errors.
- Verified lint checks: `npx eslint` passes with 0 warnings/errors.
