### PR TITLE
kyverno: Hide sidebar entries for missing CRDs

### DIFF
--- a/kyverno/src/hooks/kyvernoSidebarVisibility.test.ts
+++ b/kyverno/src/hooks/kyvernoSidebarVisibility.test.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { shouldHideSidebarEntry } from './kyvernoSidebarVisibility';
+import { KyvernoCRDStatus } from './useKyvernoCRDs';
+
+function status(overrides: Partial<KyvernoCRDStatus>): KyvernoCRDStatus {
+  return {
+    legacy: false,
+    cel: false,
+    cleanup: false,
+    reports: false,
+    exceptions: false,
+    kyvernoV2Reports: false,
+    ephemeralReports: false,
+    loading: false,
+    ...overrides,
+  };
+}
+
+describe('shouldHideSidebarEntry', () => {
+  it('stays visible when the cluster has not been probed yet', () => {
+    expect(shouldHideSidebarEntry(undefined, 'cleanup')).toBe(false);
+  });
+
+  it('stays visible while the probe is still in flight, even if the group is false', () => {
+    expect(shouldHideSidebarEntry(status({ loading: true, cleanup: false }), 'cleanup')).toBe(
+      false
+    );
+  });
+
+  it('hides once the probe resolved and the required group is absent', () => {
+    expect(shouldHideSidebarEntry(status({ cleanup: false }), 'cleanup')).toBe(true);
+  });
+
+  it('stays visible once the probe resolved and the required group is present', () => {
+    expect(shouldHideSidebarEntry(status({ cleanup: true }), 'cleanup')).toBe(false);
+  });
+
+  it('checks the specific group asked for, not any other group on the same status', () => {
+    const s = status({ legacy: true, cleanup: false });
+    expect(shouldHideSidebarEntry(s, 'legacy')).toBe(false);
+    expect(shouldHideSidebarEntry(s, 'cleanup')).toBe(true);
+  });
+});

--- a/kyverno/src/hooks/kyvernoSidebarVisibility.ts
+++ b/kyverno/src/hooks/kyvernoSidebarVisibility.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CRDGroup } from '../components/CRDGuard';
+import { KyvernoCRDStatus } from './useKyvernoCRDs';
+
+/**
+ * Decides whether a Kyverno sidebar entry should be hidden for the current
+ * cluster.
+ *
+ * Kept SDK-free (no Headlamp imports) so it can be unit-tested without the
+ * host shim, same as bucketReportResults in policyResultBucket.ts.
+ *
+ * We only hide once the probe has actually resolved. While it's still
+ * loading, or hasn't run for this cluster yet, the entry stays visible —
+ * hiding on missing data would flash every entry away for a moment on
+ * every cluster switch.
+ */
+export function shouldHideSidebarEntry(
+  status: KyvernoCRDStatus | undefined,
+  requires: CRDGroup
+): boolean {
+  return !!status && !status.loading && !status[requires];
+}

--- a/kyverno/src/hooks/useKyvernoCRDs.ts
+++ b/kyverno/src/hooks/useKyvernoCRDs.ts
@@ -59,7 +59,7 @@ function notify(cluster: string, status: KyvernoCRDStatus) {
   listeners.get(cluster)?.forEach(fn => fn(status));
 }
 
-async function probeCluster(cluster: string): Promise<KyvernoCRDStatus> {
+export async function probeCluster(cluster: string): Promise<KyvernoCRDStatus> {
   const existing = inFlight.get(cluster);
   if (existing) return existing;
 
@@ -104,6 +104,16 @@ async function probeCluster(cluster: string): Promise<KyvernoCRDStatus> {
 
   inFlight.set(cluster, promise);
   return promise;
+}
+
+/**
+ * Synchronously returns the last known CRD status for a cluster, or undefined
+ * if it hasn't been probed yet. registerSidebarEntryFilter runs outside React
+ * (Headlamp calls it directly while building the sidebar tree), so it can't
+ * use the useKyvernoCRDs hook — this is how it reads the same cache instead.
+ */
+export function peekKyvernoCRDs(cluster: string): KyvernoCRDStatus | undefined {
+  return probeCache.get(cluster);
 }
 
 export function useKyvernoCRDs(): KyvernoCRDStatus {

--- a/kyverno/src/index.tsx
+++ b/kyverno/src/index.tsx
@@ -18,6 +18,8 @@ import {
   registerAppBarAction,
   registerRoute,
   registerSidebarEntry,
+  registerSidebarEntryFilter,
+  Utils,
 } from '@kinvolk/headlamp-plugin/lib';
 import {
   DeletingPolicyList,
@@ -37,6 +39,8 @@ import { PolicyExceptionList } from './components/PolicyExceptionList';
 import { PolicyList } from './components/PolicyList';
 import { PolicyReportList } from './components/PolicyReportList';
 import { ViolationsView } from './components/ViolationsView';
+import { shouldHideSidebarEntry } from './hooks/kyvernoSidebarVisibility';
+import { peekKyvernoCRDs, probeCluster } from './hooks/useKyvernoCRDs';
 import { registerKyvernoIcon } from './kyvernoIcon';
 import {
   AdmissionReport,
@@ -70,6 +74,11 @@ interface KyvernoPageOptions {
   requires?: CRDGroup;
 }
 
+// Which CRD group each sidebar entry needs, so the filter below can hide
+// entries for groups that aren't on the cluster without every call site
+// having to register its own filter.
+const sidebarRequirements = new Map<string, CRDGroup>();
+
 // Centralises the sidebar + route pair that every Kyverno page needs so each
 // call site stays one block. `requires` makes CRDGuard wrapping a single field
 // instead of a per-call-site `<CRDGuard>` block.
@@ -85,11 +94,30 @@ export function registerKyvernoPage({
   requires,
 }: KyvernoPageOptions) {
   registerSidebarEntry({ name, url: url ?? path, parent, label, icon });
+  if (requires) {
+    sidebarRequirements.set(name, requires);
+  }
   const wrapped = requires
     ? () => <CRDGuard requires={requires}>{component()}</CRDGuard>
     : component;
   registerRoute({ path, sidebar: name, name, exact, component: wrapped });
 }
+
+// CRDGuard (above) only gates what renders once you're on a page — the
+// sidebar entry that links to it is registered unconditionally and stays
+// there either way. This hides entries for CRD groups confirmed absent on
+// the current cluster, once probeCluster has actually resolved for it.
+registerSidebarEntryFilter(entry => {
+  const requires = sidebarRequirements.get(entry.name);
+  if (!requires) {
+    return entry;
+  }
+
+  const cluster = Utils.getCluster() ?? '';
+  void probeCluster(cluster);
+
+  return shouldHideSidebarEntry(peekKyvernoCRDs(cluster), requires) ? null : entry;
+});
 
 registerSidebarEntry({
   name: 'Kyverno',


### PR DESCRIPTION
## Problem

Kyverno sidebar links all show up regardless of what's on the cluster — `CRDGuard` only gates what renders on the page, not the sidebar entry that links to it (details in #1034). Knative and flux already solve this for their own plugins with `registerSidebarEntryFilter`; Kyverno never calls it.

## Fix

- `registerKyvernoPage` now records each page's `requires` group as it registers, in a `name → CRDGroup` map.
- One `registerSidebarEntryFilter` looks up that map per entry and hides it once the probe confirms the group is absent, reusing the existing cache/probe in `useKyvernoCRDs.ts` (no new polling).
- Entries stay visible while still loading or unprobed, so nothing flashes away on cluster switch.
- Decision logic lives in `kyvernoSidebarVisibility.ts` as a plain function, same split as `policyResultBucket.ts`, so it's unit-testable without the SDK.

## Before / after

**Before:** open the sidebar on a CEL-only cluster (no legacy engine, no cleanup CRDs) — Cluster Policies, Policies, Cleanup Policies, Cluster Cleanup Policies, Exceptions all still show up. Click one, get a "not detected on this cluster" banner.

**After:** those entries don't show up at all once the probe resolves; Validating/Mutating/etc. policies (which the cluster does have) stay visible.

## Testing

Ran locally in the `kyverno` plugin directory:
- `tsc --noEmit`: clean
- `eslint --max-warnings 0`: clean
- `vitest run`: 10 tests pass, including 5 new ones in `kyvernoSidebarVisibility.test.ts` covering not-yet-probed, still-loading, resolved-absent, resolved-present, and per-group isolation
- `headlamp-plugin build`: succeeds

Fixes #1034