### PR TITLE
app-catalog: prevent stale chart data from race condition in ChartDet…

### DIFF
--- a/app-catalog/src/components/charts/Details.tsx
+++ b/app-catalog/src/components/charts/Details.tsx
@@ -46,6 +46,18 @@ export default function ChartDetails({ vanillaHelmRepo }: ChartDetailsProps) {
   const [openEditor, setOpenEditor] = useState(false);
   const chartCfg = getCatalogConfig();
 
+  // useEffect(() => {
+  //   // Note: This path is not enabled for vanilla helm repo. Please check the following comment in charts/List.tsx
+  //   // TODO: The app-catalog using artifacthub.io loads the details about the chart with an option to install the chart
+  //   //
+  //   // An API to get details about a particular chart is required to achieve this. For example, take a look at the response
+  //   // from https://artifacthub.io/api/v1/packages/helm/grafana/grafana
+  //   // Easiest thing is to fetch index.yaml, get the details for chartName and fill the details
+  //   fetchChartDetailFromArtifact(chartName, repoName).then(response => {
+  //     setChart(response);
+  //   });
+  // }, [chartName, repoName]);
+
   useEffect(() => {
     // Note: This path is not enabled for vanilla helm repo. Please check the following comment in charts/List.tsx
     // TODO: The app-catalog using artifacthub.io loads the details about the chart with an option to install the chart
@@ -53,9 +65,19 @@ export default function ChartDetails({ vanillaHelmRepo }: ChartDetailsProps) {
     // An API to get details about a particular chart is required to achieve this. For example, take a look at the response
     // from https://artifacthub.io/api/v1/packages/helm/grafana/grafana
     // Easiest thing is to fetch index.yaml, get the details for chartName and fill the details
+    let ignore = false;
+
     fetchChartDetailFromArtifact(chartName, repoName).then(response => {
-      setChart(response);
+      // Guard against a stale/out-of-order response overwriting state
+      // for a chart the user has since navigated away from.
+      if (!ignore) {
+        setChart(response);
+      }
     });
+
+    return () => {
+      ignore = true;
+    };
   }, [chartName, repoName]);
 
   return (


### PR DESCRIPTION
Fixes #<issue-number>

## What was broken
`ChartDetails`'s data-fetching useEffect had no cancellation guard.
If a user navigated quickly between charts, an older network response
could resolve after a newer one and overwrite state with the wrong
chart's data.

## Fix
Added an `ignore` flag that's set to `true` in the effect's cleanup,
so a stale response is ignored instead of overwriting state.

## Testing
- `npx tsc --noEmit` — clean, no errors
- `npx eslint` on the changed file — clean, no errors
- Manually verified by rapidly switching between two charts in the
  catalog list — details now stay consistent with the selected chart