### PR TITLE
test(kyverno): add unit tests for PolicyException resource

### DIFF
--- a/kyverno/src/resources/policyException.test.ts
+++ b/kyverno/src/resources/policyException.test.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, test } from 'vitest';
+import { PolicyException } from './policyException';
+
+function makePolicyException(spec: Record<string, unknown>) {
+  return new PolicyException({
+    kind: 'PolicyException',
+    apiVersion: 'kyverno.io/v2',
+    metadata: {
+      name: 'test-exception',
+      namespace: 'default',
+      uid: 'abc-123',
+    },
+    spec,
+  } as any);
+}
+
+describe('PolicyException', () => {
+  test('exceptions returns the list from spec', () => {
+    const pe = makePolicyException({
+      match: {},
+      exceptions: [
+        { policyName: 'restrict-images', ruleNames: ['check-tag'] },
+        { policyName: 'require-labels', ruleNames: ['check-team-label'] },
+      ],
+    });
+
+    expect(pe.exceptions).toHaveLength(2);
+    expect(pe.exceptions[0]).toEqual({
+      policyName: 'restrict-images',
+      ruleNames: ['check-tag'],
+    });
+  });
+
+  test('exceptions returns an empty array when spec.exceptions is missing', () => {
+    const pe = makePolicyException({ match: {} });
+    expect(pe.exceptions).toEqual([]);
+  });
+
+  test('policyNames maps exceptions to their policy names', () => {
+    const pe = makePolicyException({
+      match: {},
+      exceptions: [
+        { policyName: 'restrict-images', ruleNames: ['check-tag'] },
+        { policyName: 'require-labels', ruleNames: ['check-team-label'] },
+      ],
+    });
+
+    expect(pe.policyNames).toEqual(['restrict-images', 'require-labels']);
+  });
+
+  test('policyNames is empty when there are no exceptions', () => {
+    const pe = makePolicyException({ match: {} });
+    expect(pe.policyNames).toEqual([]);
+  });
+
+  test('background defaults to true when not set in spec', () => {
+    const pe = makePolicyException({ match: {}, exceptions: [] });
+    expect(pe.background).toBe(true);
+  });
+
+  test('background reflects an explicit false value', () => {
+    const pe = makePolicyException({ match: {}, exceptions: [], background: false });
+    expect(pe.background).toBe(false);
+  });
+
+  test('background reflects an explicit true value', () => {
+    const pe = makePolicyException({ match: {}, exceptions: [], background: true });
+    expect(pe.background).toBe(true);
+  });
+});

--- a/kyverno/src/test-utils/kubeObjectStub.ts
+++ b/kyverno/src/test-utils/kubeObjectStub.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Minimal stand-in for @kinvolk/headlamp-plugin's KubeObject, used only in tests.
+//
+// The real KubeObject lives under lib/lib/k8s/cluster.js, but importing it (even
+// via an alias) pulls in the full k8s module barrel (ClusterRole, Pod, etc.),
+// which fails to load outside of a full Headlamp app bootstrap. Resource classes
+// only need jsonData/cluster bookkeeping from KubeObject, so this stub provides
+// just that, letting resource classes (which mostly add typed getters over
+// jsonData) be unit tested directly.
+export class KubeObject<T = any> {
+  jsonData: T;
+  private _clusterName: string;
+
+  constructor(json: T, cluster?: string) {
+    this.jsonData = json;
+    this._clusterName = cluster || '';
+  }
+
+  get cluster() {
+    return this._clusterName;
+  }
+
+  set cluster(cluster: string) {
+    this._clusterName = cluster;
+  }
+}
+
+export type KubeObjectInterface = Record<string, unknown>;

--- a/kyverno/vitest.config.ts
+++ b/kyverno/vitest.config.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import baseConfig from '@kinvolk/headlamp-plugin/config/vite.config.mjs';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+import { defineConfig, mergeConfig } from 'vitest/config';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// The shared headlamp-plugin vite config marks '@kinvolk/headlamp-plugin/lib/k8s/*'
+// as an external module for the *build* step, so that the real Headlamp app can
+// supply it at runtime via the global pluginLib object. That path does not exist
+// on disk under a single "lib" (the real files live under lib/lib/k8s/*), which
+// means any test that imports a resource class (e.g. one extending KubeObject)
+// fails to resolve, even though the build itself works fine.
+//
+// Aliasing straight to the real lib/lib/k8s/cluster.js pulls in the full k8s
+// module barrel (every resource class Headlamp ships), which fails to load
+// outside of a full app bootstrap. Resource classes only need the small bit of
+// jsonData/cluster bookkeeping KubeObject provides, so we alias to a local
+// stub (src/test-utils/kubeObjectStub.ts) instead, letting resource classes be
+// unit tested directly without needing the whole app running.
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    resolve: {
+      alias: {
+        '@kinvolk/headlamp-plugin/lib/k8s/cluster': resolve(
+          __dirname,
+          'src/test-utils/kubeObjectStub.ts'
+        ),
+      },
+    },
+  })
+);


### PR DESCRIPTION
## What this PR does

Adds unit tests for the "PolicyException" resource class in the kyverno plugin (7 tests, all passing).

## Test infrastructure fix

While adding these tests, I hit an existing gap: the shared "headlamp-plugin" vite config marks
`@kinvolk/headlamp-plugin/lib/k8s/*` as an external module for the build step, so the real Headlamp
app can supply it at runtime. That path doesn't exist on disk as a single `lib` (the real files live
under `lib/lib/k8s/*`), so any test importing a resource class that extends `KubeObject` failed to
resolve outside a full app bootstrap.

Aliasing directly to the real `lib/lib/k8s/cluster.js` pulls in the entire k8s module barrel (every
resource class Headlamp ships), which also fails to load outside a full app bootstrap — not something
worth chasing further for a test.

Fix: added a small local stub (`src/test-utils/kubeObjectStub.ts`) providing just the `jsonData`/
`cluster` bookkeeping that resource classes need, and a project-local `vitest.config.ts` that aliases
the import to it. This unblocks unit testing for `PolicyException` and should unblock any other
resource class going forward.

## Files changed
- `src/resources/policyException.test.ts` — new, 7 tests
- `src/test-utils/kubeObjectStub.ts` — new, local test stub for `KubeObject`
- `vitest.config.ts` — new, project-local vitest config with the alias

## Testing
✓ 12 tests passed (2 files, including the 7 new ones)

Also verified clean with `eslint` and `tsc --noEmit`.-