### PR TITLE
kueue: Use human-readable route names for title bar and breadcrumbs

### DIFF
--- a/kueue/src/components/clusterqueues/Detail.tsx
+++ b/kueue/src/components/clusterqueues/Detail.tsx
@@ -12,7 +12,7 @@ import {
   ResourceGroup,
   ResourceQuota,
 } from '../../resources/clusterQueue';
-import { kueueRouteNames } from '../../utils/kueueRoutes';
+import { kueueRoutePaths } from '../../utils/kueueRoutes';
 import KueueAdminResourceAccess from '../common/KueueAdminResourceAccess';
 
 /** Flattened row rendered in the ClusterQueue resource groups table. */
@@ -56,7 +56,7 @@ interface AdmissionCheckRow {
 /** Render a ResourceFlavor name as a Headlamp link to its detail page. */
 function renderFlavorLink(flavorName: string) {
   return (
-    <Link routeName={kueueRouteNames.resourceFlavorDetail} params={{ name: flavorName }}>
+    <Link routeName={kueueRoutePaths.resourceFlavorDetail} params={{ name: flavorName }}>
       {flavorName}
     </Link>
   );

--- a/kueue/src/components/localqueues/Detail.tsx
+++ b/kueue/src/components/localqueues/Detail.tsx
@@ -5,7 +5,7 @@ import {
 } from '@kinvolk/headlamp-plugin/lib/components/common';
 import { useParams } from 'react-router-dom';
 import { LocalQueue } from '../../resources/localQueue';
-import { kueueRouteNames } from '../../utils/kueueRoutes';
+import { kueueRoutePaths } from '../../utils/kueueRoutes';
 import KueueAdminResourceAccess from '../common/KueueAdminResourceAccess';
 
 /** Render a ClusterQueue reference as a detail-page link. */
@@ -17,7 +17,7 @@ function renderClusterQueueLink(localQueue: LocalQueue) {
   }
 
   return (
-    <Link routeName={kueueRouteNames.clusterQueueDetail} params={{ name: clusterQueueName }}>
+    <Link routeName={kueueRoutePaths.clusterQueueDetail} params={{ name: clusterQueueName }}>
       {clusterQueueName}
     </Link>
   );

--- a/kueue/src/index.tsx
+++ b/kueue/src/index.tsx
@@ -5,7 +5,7 @@ import LocalQueueDetail from './components/localqueues/Detail';
 import LocalQueueList from './components/localqueues/List';
 import ResourceFlavorDetail from './components/resourceflavors/Detail';
 import ResourceFlavorList from './components/resourceflavors/List';
-import { kueueRouteNames, kueueRoutePaths } from './utils/kueueRoutes';
+import { kueueRoutePaths } from './utils/kueueRoutes';
 
 registerSidebarEntry({
   parent: null,
@@ -39,7 +39,7 @@ registerSidebarEntry({
 registerRoute({
   path: kueueRoutePaths.clusterQueuesList,
   sidebar: 'kueue-clusterqueues',
-  name: kueueRouteNames.clusterQueuesList,
+  name: 'Cluster Queues',
   exact: true,
   component: () => <ClusterQueueList />,
 });
@@ -47,7 +47,7 @@ registerRoute({
 registerRoute({
   path: kueueRoutePaths.clusterQueueDetail,
   sidebar: 'kueue-clusterqueues',
-  name: kueueRouteNames.clusterQueueDetail,
+  name: 'Cluster Queue',
   exact: true,
   component: () => <ClusterQueueDetail />,
 });
@@ -55,7 +55,7 @@ registerRoute({
 registerRoute({
   path: kueueRoutePaths.localQueuesList,
   sidebar: 'kueue-localqueues',
-  name: kueueRouteNames.localQueuesList,
+  name: 'Local Queues',
   exact: true,
   component: () => <LocalQueueList />,
 });
@@ -63,7 +63,7 @@ registerRoute({
 registerRoute({
   path: kueueRoutePaths.localQueueDetail,
   sidebar: 'kueue-localqueues',
-  name: kueueRouteNames.localQueueDetail,
+  name: 'Local Queue',
   exact: true,
   component: () => <LocalQueueDetail />,
 });
@@ -71,7 +71,7 @@ registerRoute({
 registerRoute({
   path: kueueRoutePaths.resourceFlavorsList,
   sidebar: 'kueue-resourceflavors',
-  name: kueueRouteNames.resourceFlavorsList,
+  name: 'Resource Flavors',
   exact: true,
   component: () => <ResourceFlavorList />,
 });
@@ -79,7 +79,7 @@ registerRoute({
 registerRoute({
   path: kueueRoutePaths.resourceFlavorDetail,
   sidebar: 'kueue-resourceflavors',
-  name: kueueRouteNames.resourceFlavorDetail,
+  name: 'Resource Flavor',
   exact: true,
   component: () => <ResourceFlavorDetail />,
 });

--- a/kueue/src/utils/kueueRoutes.ts
+++ b/kueue/src/utils/kueueRoutes.ts
@@ -1,12 +1,3 @@
-export const kueueRouteNames = {
-  clusterQueuesList: 'kueue-clusterqueues-list',
-  clusterQueueDetail: 'kueue-clusterqueue-detail',
-  localQueuesList: 'kueue-localqueues-list',
-  localQueueDetail: 'kueue-localqueue-detail',
-  resourceFlavorsList: 'kueue-resourceflavors-list',
-  resourceFlavorDetail: 'kueue-resourceflavor-detail',
-} as const;
-
 export const kueueRoutePaths = {
   clusterQueuesList: '/kueue/clusterqueues',
   clusterQueueDetail: '/kueue/clusterqueues/:name',


### PR DESCRIPTION
Fixes #1041

Problem:
The Kueue plugin's top bar window title and breadcrumb navigation displayed raw internal route IDs (e.g. kueue-clusterqueues-list) instead of human-readable names, because the name field passed to registerRoute was reused from kueueRouteNames, which held routing-oriented string constants rather than display text.

Fix:
Replaced the name field in each of the 6 Kueue registerRoute calls with proper human-readable strings (Cluster Queues, Cluster Queue, Local Queues, Local Queue, Resource Flavors, Resource Flavor).
The kueueRouteNames constants were also used as routing aliases in a few <Link routeName={...}> calls (in clusterqueues/Detail.tsx and localqueues/Detail.tsx). Updated these to use kueueRoutePaths instead, decoupling route linking from display text — matching the pattern used in plugin-catalog.
Removed the now-unused kueueRouteNames export from kueueRoutes.ts.

Testing:
Verified locally that Cluster Queues, Local Queues, and Resource Flavors list/detail pages all show correct titles and breadcrumbs.
Confirmed navigation via the in-page links (Local Queue → Cluster Queue detail, Cluster Queue → Resource Flavor detail) still works correctly after the routing change.
grep -rn "kueueRouteNames" kueue/src confirms no remaining references.