### PR TITLE
fix(kueue): update route names to formatted strings

### DIFF
--- a/kueue/src/index.tsx
+++ b/kueue/src/index.tsx
@@ -39,7 +39,7 @@ registerSidebarEntry({
 registerRoute({
   path: kueueRoutePaths.clusterQueuesList,
   sidebar: 'kueue-clusterqueues',
-  name: kueueRouteNames.clusterQueuesList,
+  name: 'Cluster Queues',
   exact: true,
   component: () => <ClusterQueueList />,
 });
@@ -47,7 +47,7 @@ registerRoute({
 registerRoute({
   path: kueueRoutePaths.clusterQueueDetail,
   sidebar: 'kueue-clusterqueues',
-  name: kueueRouteNames.clusterQueueDetail,
+  name: 'Cluster Queue Detail',
   exact: true,
   component: () => <ClusterQueueDetail />,
 });
@@ -55,7 +55,7 @@ registerRoute({
 registerRoute({
   path: kueueRoutePaths.localQueuesList,
   sidebar: 'kueue-localqueues',
-  name: kueueRouteNames.localQueuesList,
+  name: 'Local Queues',
   exact: true,
   component: () => <LocalQueueList />,
 });
@@ -63,7 +63,7 @@ registerRoute({
 registerRoute({
   path: kueueRoutePaths.localQueueDetail,
   sidebar: 'kueue-localqueues',
-  name: kueueRouteNames.localQueueDetail,
+  name: 'Local Queue Detail',
   exact: true,
   component: () => <LocalQueueDetail />,
 });
@@ -71,7 +71,7 @@ registerRoute({
 registerRoute({
   path: kueueRoutePaths.resourceFlavorsList,
   sidebar: 'kueue-resourceflavors',
-  name: kueueRouteNames.resourceFlavorsList,
+  name: 'Resource Flavors',
   exact: true,
   component: () => <ResourceFlavorList />,
 });
@@ -79,7 +79,7 @@ registerRoute({
 registerRoute({
   path: kueueRoutePaths.resourceFlavorDetail,
   sidebar: 'kueue-resourceflavors',
-  name: kueueRouteNames.resourceFlavorDetail,
+  name: 'Resource Flavor Detail',
   exact: true,
   component: () => <ResourceFlavorDetail />,
 });


### PR DESCRIPTION
### What this PR does / why we need it:
This PR updates the raw route IDs in the Kueue plugin to human-readable formatted strings. This fixes the top window titles and breadcrumb navigation to display clean names like "Cluster Queues" instead of `kueue-clusterqueues-list`. It also updates the sidebar entries to correctly link to these new route names.

### Which issue(s) this PR fixes:
Fixes #1041

screeshot  

<img width="1846" height="1038" alt="image" src="https://github.com/user-attachments/assets/1cf12738-c2a8-460a-9de4-6fada5157ec8" />


### Special notes for your reviewer:
Tested locally via AppImage against a minikube cluster to ensure sidebar navigation remains intact and title bars format correctly.