### PR TITLE
fix(argocd): don't hide sidebar on API/RBAC errors

### DIFF
--- a/argocd/src/index.tsx
+++ b/argocd/src/index.tsx
@@ -61,7 +61,7 @@ function checkArgoInstalled(cluster: string) {
       inFlight[cluster] = false;
     },
     () => {
-      argoInstalledByCluster[cluster] = false;
+      delete argoInstalledByCluster[cluster];
       lastCheckedAt[cluster] = Date.now();
       inFlight[cluster] = false;
     },


### PR DESCRIPTION
Fixes #1033

### What was the issue?
When the Argo CD plugin initializes, it runs a probe (`checkArgoInstalled`) to determine if the Argo CRDs exist on the cluster. Previously, if this API call failed for *any* reason (such as an RBAC 403 permission error or a network timeout), the error handler would explicitly set the cluster's install cache to `false`. Because of this false negative, the sidebar would completely hide the Argo CD navigation menu, even if Argo CD was actually installed on the cluster.

### What it provided
In `src/index.tsx`, the error callback for the `apiList` probe was updated. Instead of forcing the cache to `false` when a network/API error occurs, the code now deletes the cluster from the `argoInstalledByCluster` cache using `delete argoInstalledByCluster[cluster]`. 

### How it helps
This changes the fallback state on API errors from "definitely not installed" to "unknown". The sidebar filter only hides the menu if the cache is strictly `false`. By removing the false negative, users who experience transient API timeouts or strict RBAC restrictions will no longer have their Argo CD sidebar navigation completely hidden.