### PR TITLE
fix(kyverno): make NotInstalledBanner accessible

### DIFF
--- a/kyverno/src/components/common.test.tsx
+++ b/kyverno/src/components/common.test.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+import { NotInstalledBanner } from './common';
+
+// No i18n resources are loaded in this test environment, so the real hook resolves
+// every key to ''. Mock it to return the key unchanged, matching what renders in the app.
+vi.mock('@kinvolk/headlamp-plugin/lib', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+describe('NotInstalledBanner', () => {
+  test('loading state renders a Loader with an accessible name', () => {
+    render(<NotInstalledBanner loading />);
+
+    expect(
+      screen.getByRole('progressbar', { name: 'Detecting Kyverno resources' })
+    ).toBeInTheDocument();
+  });
+
+  test('not-installed state is announced as a polite, atomic status region', () => {
+    render(<NotInstalledBanner message="Kyverno was not detected on this cluster." />);
+
+    const status = screen.getByRole('status');
+    expect(status).toHaveAttribute('aria-live', 'polite');
+    expect(status).toHaveAttribute('aria-atomic', 'true');
+    expect(status).toHaveTextContent('Kyverno was not detected on this cluster.');
+  });
+});

--- a/kyverno/src/components/common.tsx
+++ b/kyverno/src/components/common.tsx
@@ -15,7 +15,8 @@
  */
 
 import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
-import { Box, Chip, CircularProgress, Link, Tooltip, Typography } from '@mui/material';
+import { Loader } from '@kinvolk/headlamp-plugin/lib/components/common';
+import { Box, Chip, Link, Tooltip, Typography } from '@mui/material';
 import { Trans } from 'react-i18next';
 import { PolicyReportSummary, PolicyResultStatus } from '../resources/policyReport';
 
@@ -80,16 +81,27 @@ export function SummaryChips({ summary }: { summary: PolicyReportSummary }) {
 }
 
 export function NotInstalledBanner({ loading, message }: { loading?: boolean; message?: string }) {
+  const { t } = useTranslation();
+
   if (loading) {
     return (
       <Box display="flex" justifyContent="center" alignItems="center" p={2} minHeight="200px">
-        <CircularProgress />
+        <Loader title={t('Detecting Kyverno resources')} />
       </Box>
     );
   }
 
   return (
-    <Box display="flex" justifyContent="center" alignItems="center" p={2} minHeight="200px">
+    <Box
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      display="flex"
+      justifyContent="center"
+      alignItems="center"
+      p={2}
+      minHeight="200px"
+    >
       <Box textAlign="center">
         <Typography variant="h5" gutterBottom>
           {message}


### PR DESCRIPTION
### Summary

`NotInstalledBanner`'s loading and not-installed states gave assistive
technology nothing to work with — an unlabeled spinner and a message
that wasn't announced when it appeared.

### Why

Screen reader users got silence through both states: no accessible name
on the loading spinner, and no announcement when the "not detected"
message rendered.

### What changed

- Loading state now uses `Loader` with a `title`, giving the spinner an
  accessible name.
- Not-installed state is now a `role="status" aria-live="polite"
  aria-atomic="true"` region, so the message is announced when it
  appears.
- No visual or layout changes.
- Added focused unit tests covering both states.

### Testing

- `prettier --check` — clean
- `eslint --max-warnings 0` — clean
- `tsc --noEmit` — clean
- `vitest run` — 7/7 passing (5 pre-existing, 2 new)
- Manually verified both states render the expected ARIA attributes.
