### PR TITLE
app-catalog: Fix rollback dialog allowing submission without a selected revision

### DIFF
--- a/app-catalog/src/components/releases/Detail.tsx
+++ b/app-catalog/src/components/releases/Detail.tsx
@@ -9,17 +9,9 @@ import {
   SimpleTable,
   StatusLabel,
 } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
-import {
-  Button,
-  DialogActions,
-  DialogContent,
-  DialogContentText,
-  InputLabel,
-  MenuItem,
-  Select,
-} from '@mui/material';
+import { Button, DialogActions, DialogContent, DialogContentText } from '@mui/material';
 import { useSnackbar } from 'notistack';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useHistory, useParams } from 'react-router';
 import {
   deleteRelease,
@@ -29,8 +21,12 @@ import {
   rollbackRelease,
 } from '../../api/releases';
 import { EditorDialog } from './EditorDialog';
+import { RollbackDialog } from './RollbackDialog';
 
 const { createRouteURL } = Router;
+const DELETE_STATUS_POLLING_INTERVAL = 1000;
+const DELETE_STATUS_MAX_RETRIES = 60;
+
 export default function ReleaseDetail() {
   const { t } = useTranslation();
   const [update, setUpdate] = useState<boolean>(false);
@@ -55,6 +51,9 @@ export default function ReleaseDetail() {
   useEffect(() => {
     getReleaseHistory(namespace, releaseName).then(response => {
       setReleaseHistory(response);
+      if (response?.releases?.length) {
+        setRevertVersion(response.releases[0].version.toString());
+      }
     });
   }, [update]);
 
@@ -87,6 +86,58 @@ export default function ReleaseDetail() {
     setIsEditorOpen(true);
     setIsUpdateRelease(true);
   }
+
+  const handleConfirmRollback = useCallback(() => {
+    if (release) {
+      rollbackRelease(release.namespace, releaseName, Number.parseInt(revertVersion, 10))
+        .then(() => {
+          setRollbackPopup(false);
+          enqueueSnackbar(`Rollback in progress for ${releaseName}`, {
+            variant: 'info',
+          });
+          const checkRollbackStatus = (retryCount = 0) => {
+            if (retryCount >= DELETE_STATUS_MAX_RETRIES) {
+              enqueueSnackbar(`Rollback status check timeout for ${releaseName}`, {
+                variant: 'warning',
+              });
+              setUpdate(prev => !prev);
+              return;
+            }
+            getActionStatus(releaseName, 'rollback')
+              .then(response => {
+                if (response.status === 'success') {
+                  enqueueSnackbar(`Rollback successful for ${releaseName}`, {
+                    variant: 'success',
+                  });
+                  setUpdate(prev => !prev);
+                } else if (response.status === 'failed') {
+                  enqueueSnackbar(`Rollback failed for ${releaseName}`, { variant: 'error' });
+                  setUpdate(prev => !prev);
+                } else {
+                  setTimeout(
+                    () => checkRollbackStatus(retryCount + 1),
+                    DELETE_STATUS_POLLING_INTERVAL
+                  );
+                }
+              })
+              .catch(() => {
+                setTimeout(
+                  () => checkRollbackStatus(retryCount + 1),
+                  DELETE_STATUS_POLLING_INTERVAL
+                );
+              });
+          };
+          checkRollbackStatus();
+        })
+        .catch(error => {
+          console.error('Failed to rollback release:', error);
+          setRollbackPopup(false);
+          enqueueSnackbar(`Failed to rollback ${releaseName}`, {
+            variant: 'error',
+          });
+        });
+    }
+  }, [release, releaseName, revertVersion, enqueueSnackbar]);
 
   return (
     <>
@@ -134,69 +185,15 @@ export default function ReleaseDetail() {
           </Button>
         </DialogActions>
       </Dialog>
-      <Dialog
+      <RollbackDialog
         open={rollbackPopup}
-        maxWidth="xs"
-        onClose={() => setRollbackPopup(false)}
-        title={t('Rollback')}
-      >
-        <DialogContent
-          style={{
-            width: '400px',
-            height: '100px',
-          }}
-        >
-          <InputLabel id="revert">{t('Select a version')}</InputLabel>
-          <Select
-            value={revertVersion}
-            defaultValue={releaseHistory?.releases[0]?.version}
-            onChange={event => setRevertVersion(event.target.value as string)}
-            id="revert"
-            fullWidth
-          >
-            {releaseHistory &&
-              releaseHistory.releases.map((release: any) => {
-                return (
-                  <MenuItem value={release?.version}>
-                    {release?.version} - {release?.info?.description || 'N/A'} (
-                    {new Date(release?.info.last_deployed).toLocaleString()})
-                  </MenuItem>
-                );
-              })}
-          </Select>
-        </DialogContent>
-        <DialogActions>
-          <Button
-            onClick={() => {
-              rollbackRelease(
-                release.namespace,
-                release.name,
-                Number.parseInt(revertVersion, 10)
-              ).then(() => {
-                setRollbackPopup(false);
-                setUpdate(!update);
-              });
-            }}
-            style={{
-              backgroundColor: '#000',
-              color: 'white',
-              textTransform: 'none',
-            }}
-          >
-            {t('Revert')}
-          </Button>
-          <Button
-            style={{
-              backgroundColor: '#000',
-              color: 'white',
-              textTransform: 'none',
-            }}
-            onClick={() => setRollbackPopup(false)}
-          >
-            {t('Cancel')}
-          </Button>
-        </DialogActions>
-      </Dialog>
+        releaseHistory={releaseHistory}
+        revertVersion={revertVersion}
+        onVersionChange={setRevertVersion}
+        onConfirm={handleConfirmRollback}
+        onCancel={() => setRollbackPopup(false)}
+        disabled={!revertVersion}
+      />
 
       {release && (
         <SectionBox

--- a/app-catalog/src/components/releases/RollbackDialog.tsx
+++ b/app-catalog/src/components/releases/RollbackDialog.tsx
@@ -27,6 +27,7 @@ interface RollbackDialogProps {
   onVersionChange: (version: string) => void;
   onConfirm: () => void;
   onCancel: () => void;
+  disabled?: boolean;
 }
 
 export function RollbackDialog({
@@ -36,6 +37,7 @@ export function RollbackDialog({
   onVersionChange,
   onConfirm,
   onCancel,
+  disabled = false,
 }: RollbackDialogProps) {
   return (
     <Dialog open={open} maxWidth="xs" onClose={onCancel} title="Rollback">
@@ -65,7 +67,7 @@ export function RollbackDialog({
         </Select>
       </DialogContent>
       <DialogActions>
-        <Button variant="contained" onClick={onConfirm}>
+        <Button variant="contained" onClick={onConfirm} disabled={disabled}>
           Revert
         </Button>
         <Button variant="outlined" onClick={onCancel}>


### PR DESCRIPTION
Fixes #1050

## Problem
The rollback dialog in `ReleaseDetail` could be submitted without a revision selected. `revertVersion` was initialized as an empty string and never populated, so clicking Revert without touching the version selector sent an invalid (NaN/null) revision to the rollback API. This only affected `ReleaseDetail` — `ReleaseList` was unaffected since it already initializes `revertVersion` correctly and uses a shared dialog component.

## Fix
- Replaced `ReleaseDetail`'s duplicated inline rollback dialog with the shared `RollbackDialog` component already used by `ReleaseList`, removing the duplicated JSX.
- `revertVersion` now initializes to the most recent revision once release history loads, instead of staying empty.
- Added an optional `disabled` prop to `RollbackDialog` (additive only, doesn't change `ReleaseList`'s existing usage) and wired it to disable the Revert button when no valid revision is selected, as defense in depth.
- Implemented rollback status polling in `ReleaseDetail`'s confirm handler, mirroring the existing pattern in `ReleaseList`, so the page correctly reflects rollback success/failure instead of assuming it succeeded immediately.

## Testing
- Verified locally that opening the rollback dialog now shows a pre-selected revision instead of a blank selector.
- Confirmed the Revert button is disabled when no revision is selected.
- `npm run format -- --check`, `npm run lint`, and `npm run build` all pass in `app-catalog`.