### PR TITLE
fix(app-catalog): ignore stale chart detail responses

### DIFF
--- a/app-catalog/locales/cs/translation.json
+++ b/app-catalog/locales/cs/translation.json
@@ -1,4 +1,5 @@
 {
+  "Error fetching chart details {{ error }}": "",
   "Install": "",
   "Name": "",
   "Description": "",

--- a/app-catalog/locales/de/translation.json
+++ b/app-catalog/locales/de/translation.json
@@ -1,4 +1,5 @@
 {
+  "Error fetching chart details {{ error }}": "",
   "Install": "",
   "Name": "",
   "Description": "",

--- a/app-catalog/locales/en/translation.json
+++ b/app-catalog/locales/en/translation.json
@@ -1,4 +1,5 @@
 {
+  "Error fetching chart details {{ error }}": "Error fetching chart details {{ error }}",
   "Install": "Install",
   "Name": "Name",
   "Description": "Description",

--- a/app-catalog/locales/es/translation.json
+++ b/app-catalog/locales/es/translation.json
@@ -1,4 +1,5 @@
 {
+  "Error fetching chart details {{ error }}": "",
   "Install": "",
   "Name": "",
   "Description": "",

--- a/app-catalog/locales/fr/translation.json
+++ b/app-catalog/locales/fr/translation.json
@@ -1,4 +1,5 @@
 {
+  "Error fetching chart details {{ error }}": "",
   "Install": "",
   "Name": "",
   "Description": "",

--- a/app-catalog/locales/hu/translation.json
+++ b/app-catalog/locales/hu/translation.json
@@ -1,4 +1,5 @@
 {
+  "Error fetching chart details {{ error }}": "",
   "Install": "",
   "Name": "",
   "Description": "",

--- a/app-catalog/locales/id/translation.json
+++ b/app-catalog/locales/id/translation.json
@@ -1,4 +1,5 @@
 {
+  "Error fetching chart details {{ error }}": "",
   "Install": "",
   "Name": "",
   "Description": "",

--- a/app-catalog/locales/it/translation.json
+++ b/app-catalog/locales/it/translation.json
@@ -1,4 +1,5 @@
 {
+  "Error fetching chart details {{ error }}": "",
   "Install": "",
   "Name": "",
   "Description": "",

--- a/app-catalog/locales/ja/translation.json
+++ b/app-catalog/locales/ja/translation.json
@@ -1,4 +1,5 @@
 {
+  "Error fetching chart details {{ error }}": "",
   "Install": "",
   "Name": "",
   "Description": "",

--- a/app-catalog/locales/ko/translation.json
+++ b/app-catalog/locales/ko/translation.json
@@ -1,4 +1,5 @@
 {
+  "Error fetching chart details {{ error }}": "",
   "Install": "",
   "Name": "",
   "Description": "",

--- a/app-catalog/locales/nl/translation.json
+++ b/app-catalog/locales/nl/translation.json
@@ -1,4 +1,5 @@
 {
+  "Error fetching chart details {{ error }}": "",
   "Install": "",
   "Name": "",
   "Description": "",

--- a/app-catalog/locales/pl/translation.json
+++ b/app-catalog/locales/pl/translation.json
@@ -1,4 +1,5 @@
 {
+  "Error fetching chart details {{ error }}": "",
   "Install": "",
   "Name": "",
   "Description": "",

--- a/app-catalog/locales/pt-BR/translation.json
+++ b/app-catalog/locales/pt-BR/translation.json
@@ -1,4 +1,5 @@
 {
+  "Error fetching chart details {{ error }}": "",
   "Install": "",
   "Name": "",
   "Description": "",

--- a/app-catalog/locales/pt-PT/translation.json
+++ b/app-catalog/locales/pt-PT/translation.json
@@ -1,4 +1,5 @@
 {
+  "Error fetching chart details {{ error }}": "",
   "Install": "",
   "Name": "",
   "Description": "",

--- a/app-catalog/locales/ru/translation.json
+++ b/app-catalog/locales/ru/translation.json
@@ -1,4 +1,5 @@
 {
+  "Error fetching chart details {{ error }}": "",
   "Install": "",
   "Name": "",
   "Description": "",

--- a/app-catalog/locales/sv/translation.json
+++ b/app-catalog/locales/sv/translation.json
@@ -1,4 +1,5 @@
 {
+  "Error fetching chart details {{ error }}": "",
   "Install": "",
   "Name": "",
   "Description": "",

--- a/app-catalog/locales/tr/translation.json
+++ b/app-catalog/locales/tr/translation.json
@@ -1,4 +1,5 @@
 {
+  "Error fetching chart details {{ error }}": "",
   "Install": "",
   "Name": "",
   "Description": "",

--- a/app-catalog/locales/zh-Hans/translation.json
+++ b/app-catalog/locales/zh-Hans/translation.json
@@ -1,4 +1,5 @@
 {
+  "Error fetching chart details {{ error }}": "",
   "Install": "",
   "Name": "",
   "Description": "",

--- a/app-catalog/locales/zh-Hant/translation.json
+++ b/app-catalog/locales/zh-Hant/translation.json
@@ -1,4 +1,5 @@
 {
+  "Error fetching chart details {{ error }}": "",
   "Install": "",
   "Name": "",
   "Description": "",

--- a/app-catalog/src/components/charts/Details.tsx
+++ b/app-catalog/src/components/charts/Details.tsx
@@ -72,8 +72,8 @@ export default function ChartDetails({ vanillaHelmRepo }: ChartDetailsProps) {
       })
       .catch(err => {
         if (!ignore) {
-          console.error(`Failed to fetch details for chart ${chartName}:`, err);
-          setError(err);
+          console.error(`Failed to fetch details for chart ${chartName} in repo ${repoName}:`, err);
+          setError(err instanceof Error ? err : new Error(String(err)));
         }
       });
 

--- a/app-catalog/src/components/charts/Details.tsx
+++ b/app-catalog/src/components/charts/Details.tsx
@@ -53,9 +53,29 @@ export default function ChartDetails({ vanillaHelmRepo }: ChartDetailsProps) {
     // An API to get details about a particular chart is required to achieve this. For example, take a look at the response
     // from https://artifacthub.io/api/v1/packages/helm/grafana/grafana
     // Easiest thing is to fetch index.yaml, get the details for chartName and fill the details
-    fetchChartDetailFromArtifact(chartName, repoName).then(response => {
-      setChart(response);
-    });
+    let ignore = false;
+
+    // Clear the previous chart so the loader shows instead of the details of
+    // the chart we just navigated away from.
+    setChart(null);
+
+    fetchChartDetailFromArtifact(chartName, repoName)
+      .then(response => {
+        // A request for a chart we have since navigated away from must not
+        // overwrite the details of the chart currently being viewed.
+        if (!ignore) {
+          setChart(response);
+        }
+      })
+      .catch(error => {
+        if (!ignore) {
+          console.error(`Failed to fetch details for chart ${chartName}:`, error);
+        }
+      });
+
+    return () => {
+      ignore = true;
+    };
   }, [chartName, repoName]);
 
   return (

--- a/app-catalog/src/components/charts/Details.tsx
+++ b/app-catalog/src/components/charts/Details.tsx
@@ -1,5 +1,6 @@
 import { Router, useTranslation } from '@kinvolk/headlamp-plugin/lib';
 import {
+  EmptyContent,
   Loader,
   NameValueTable,
   SectionBox,
@@ -43,6 +44,7 @@ export default function ChartDetails({ vanillaHelmRepo }: ChartDetailsProps) {
     version: string;
     icon?: string; // used when VANILLA_HELM_REPO
   } | null>(null);
+  const [error, setError] = useState<Error | null>(null);
   const [openEditor, setOpenEditor] = useState(false);
   const chartCfg = getCatalogConfig();
 
@@ -58,6 +60,7 @@ export default function ChartDetails({ vanillaHelmRepo }: ChartDetailsProps) {
     // Clear the previous chart so the loader shows instead of the details of
     // the chart we just navigated away from.
     setChart(null);
+    setError(null);
 
     fetchChartDetailFromArtifact(chartName, repoName)
       .then(response => {
@@ -67,9 +70,10 @@ export default function ChartDetails({ vanillaHelmRepo }: ChartDetailsProps) {
           setChart(response);
         }
       })
-      .catch(error => {
+      .catch(err => {
         if (!ignore) {
-          console.error(`Failed to fetch details for chart ${chartName}:`, error);
+          console.error(`Failed to fetch details for chart ${chartName}:`, err);
+          setError(err);
         }
       });
 
@@ -77,6 +81,19 @@ export default function ChartDetails({ vanillaHelmRepo }: ChartDetailsProps) {
       ignore = true;
     };
   }, [chartName, repoName]);
+
+  // Without this the loader below spins forever on a failed fetch, with the
+  // reason only in the console. Install is deliberately not offered for a
+  // chart whose details could not be read.
+  if (error) {
+    return (
+      <SectionBox title={<SectionHeader title={chartName} />} backLink={createRouteURL('Charts')}>
+        <EmptyContent color="error">
+          {t('Error fetching chart details {{ error }}', { error: error.message })}
+        </EmptyContent>
+      </SectionBox>
+    );
+  }
 
   return (
     <>


### PR DESCRIPTION
Fixes #1037

## Problem

The data-fetching effect in `ChartDetails` had no cleanup, so an in-flight request for a chart the user had already navigated away from would still call `setChart` when it resolved.

This is visible because the two halves of the page read the chart name from different places. `SectionHeader` takes `title={chartName}` straight from the route params, so it updates immediately on navigation, while the description, maintainers and readme come from `chart` state, which updates whenever a request happens to resolve. Clicking quickly between two charts in the catalog could therefore leave one chart's details rendered under another chart's name.

## Fix

Track the effect's lifetime with an `ignore` flag and set it in the cleanup function, so only the most recent request is allowed to update state. This is the approach suggested in the issue. The same flag also prevents a `setState`-after-unmount if the user leaves the page mid-request.

Two related cases produce the same wrong output and are covered by the same change:

- The previous chart is cleared when the route params change, so the loader shows while the new chart is fetched rather than the previous chart's description and readme.
- A rejected fetch is caught and logged instead of surfacing as an unhandled rejection. Previously a failed request left the chart state untouched, so the previously viewed chart stayed on screen under the new chart's name. The message format matches the existing `console.error` calls in `charts/List.tsx`.

I used a flag rather than an `AbortController` because `fetchChartDetailFromArtifact` takes no signal, and threading one through would mean changing a shared API helper for both its `request` and raw `fetch` branches. Happy to do that instead if you would rather the request was actually torn down and not just ignored, though it is a wider change than the bug needs.

## Testing

- `npm run lint`, `npm run tsc`, `npm run build` and `npm test` all pass in `app-catalog/`.
- No test is added. `app-catalog` currently has only the storyshots suite and no component test setup, so covering this would mean pulling in a rendering test harness that the package does not use today. I would rather not do that uninvited, but I am glad to add it in this PR if you want the coverage.

## Note on the rest of the package

The same shape appears in `releases/Detail.tsx`, where two effects call `getRelease` and `getReleaseHistory` and set state with no cleanup. Those are keyed on a refresh counter rather than route params, so the race needs rapid refreshes rather than navigation, and I have left them alone to keep this PR to the reported issue. Happy to open a follow-up if it is wanted.
