### PR TITLE
flux: fix crashes when spec.force or spec.chart are missing

### DIFF
--- a/flux/src/helm-releases/HelmReleaseSingle.tsx
+++ b/flux/src/helm-releases/HelmReleaseSingle.tsx
@@ -126,7 +126,7 @@ function CustomResourceDetails(props) {
       },
       {
         name: t('Reconcile Strategy'),
-        value: cr?.jsonData?.spec.chart?.spec?.reconcileStrategy,
+        value: cr?.jsonData?.spec?.chart?.spec?.reconcileStrategy,
       },
     ];
 

--- a/flux/src/helm-releases/HelmReleaseSingle.tsx
+++ b/flux/src/helm-releases/HelmReleaseSingle.tsx
@@ -167,11 +167,11 @@ function CustomResourceDetails(props) {
     }
     extraInfo.push({
       name: t('Version'),
-      value: cr?.jsonData?.spec.chart?.spec?.version,
+      value: cr?.jsonData?.spec?.chart?.spec?.version,
     });
     extraInfo.push({
       name: t('Suspend'),
-      value: cr?.jsonData.spec?.suspend ? t('True') : t('False'),
+      value: cr?.jsonData?.spec?.suspend ? t('True') : t('False'),
     });
 
     const interval = cr?.jsonData.spec?.interval;

--- a/flux/src/helm-releases/HelmReleaseSingle.tsx
+++ b/flux/src/helm-releases/HelmReleaseSingle.tsx
@@ -174,13 +174,13 @@ function CustomResourceDetails(props) {
       value: cr?.jsonData?.spec?.suspend ? t('True') : t('False'),
     });
 
-    const interval = cr?.jsonData.spec?.interval;
+    const interval = cr?.jsonData?.spec?.interval;
     extraInfo.push({
       name: t('Interval'),
       value: interval,
     });
 
-    if (!cr?.jsonData.spec?.suspend) {
+    if (!cr?.jsonData?.spec?.suspend) {
       extraInfo.push({
         name: t('Next Reconciliation'),
         value: <RemainingTimeDisplay item={cr} />,

--- a/flux/src/kustomizations/KustomizationSingle.tsx
+++ b/flux/src/kustomizations/KustomizationSingle.tsx
@@ -60,11 +60,11 @@ function KustomizationDetails(props) {
       },
       {
         name: t('Path'),
-        value: cr?.jsonData.spec?.path,
+        value: cr?.jsonData?.spec?.path,
       },
       {
         name: t('Prune'),
-        value: cr?.jsonData.spec?.prune,
+        value: cr?.jsonData?.spec?.prune,
       },
       {
         name: t('SourceRef'),
@@ -84,16 +84,16 @@ function KustomizationDetails(props) {
     ];
     extraInfo.push({
       name: t('Suspend'),
-      value: cr?.jsonData.spec?.suspend ? t('True') : t('False'),
+      value: cr?.jsonData?.spec?.suspend ? t('True') : t('False'),
     });
 
-    const interval = cr?.jsonData.spec?.interval;
+    const interval = cr?.jsonData?.spec?.interval;
     extraInfo.push({
       name: t('Interval'),
       value: interval,
     });
 
-    if (!cr?.jsonData.spec?.suspend) {
+    if (!cr?.jsonData?.spec?.suspend) {
       extraInfo.push({
         name: t('Next Reconciliation'),
         value: <RemainingTimeDisplay item={cr} />,

--- a/flux/src/kustomizations/KustomizationSingle.tsx
+++ b/flux/src/kustomizations/KustomizationSingle.tsx
@@ -56,7 +56,7 @@ function KustomizationDetails(props) {
       },
       {
         name: t('Force'),
-        value: cr?.jsonData.spec?.force.toString(),
+        value: cr?.jsonData?.spec?.force?.toString() ?? 'false',
       },
       {
         name: t('Path'),


### PR DESCRIPTION
### Summary

Fixes runtime crashes in Flux plugin detail views when `spec` or `spec.force` are omitted:

1. **KustomizationSingle.tsx**: Accessing `force.toString()` crashes with a `TypeError` when `spec.force` is omitted in the resource manifest. Added optional chaining (`force?.toString()`) with a fallback to `'false'`.
2. **HelmReleaseSingle.tsx**: When `jsonData.spec` is absent (`jsonData: {}`), accessing `cr?.jsonData?.spec.chart` throws a `TypeError` on `.chart` because the dot after `spec` is unguarded. Added optional chaining for `spec?.chart` across `reconcileStrategy` and `version` fields.

### Steps to test

1. Open a Kustomization detail view for a resource without `spec.force` set.
2. Verify the page renders cleanly with `Force: false` instead of throwing a `TypeError` crash.
3. Open a HelmRelease detail view for a resource without a `spec` block (or empty `jsonData`).
4. Verify the page renders without crashing on `reconcileStrategy` or `version`.
