### PR TITLE
knative: Fix a11y violations in PodsSection

### DIFF
--- a/knative/src/components/kservices/detail/sections/pods/PodsSection.tsx
+++ b/knative/src/components/kservices/detail/sections/pods/PodsSection.tsx
@@ -113,6 +113,7 @@ function getContainerDisplayStatus(container: PodContainerStatus) {
 
   return {
     color,
+    label,
     tooltip: <span style={{ whiteSpace: 'pre-line' }}>{tooltipLines.join('\n')}</span>,
   };
 }
@@ -126,11 +127,14 @@ function makePodStatusLabel(pod: Pod) {
     containerStatuses.length > 0 ? (
       <Box display="flex" gap={0.5}>
         {containerStatuses.map((cs, index) => {
-          const { color, tooltip } = getContainerDisplayStatus(cs);
+          const { color, label, tooltip } = getContainerDisplayStatus(cs);
           return (
             <LightTooltip title={tooltip} key={`${cs.name}-${index}`}>
               <Box
                 component="span"
+                role="img"
+                aria-label={`${cs.name}: ${label}`}
+                tabIndex={0}
                 sx={{
                   width: '0.9rem',
                   height: '0.9rem',


### PR DESCRIPTION
## Summary

The container status dots in the Knative KService pod detail view communicate state by color alone, violating WCAG 2.1 SC 1.4.1 (Use of Color). Screen readers announce nothing for these elements, and they are not keyboard-reachable.

This PR adds three attributes to each status dot <Box>:

- role="img" — marks the dot as a meaningful image for assistive technology
- `aria-label={`${cs.name}: ${label}`}` — gives it an accessible name (e.g. "user-container: Running")
- tabIndex={0} — makes it keyboard-focusable so the existing LightTooltip can be triggered without a mouse

The label variable was already being computed inside getContainerDisplayStatus() for the tooltip text — this PR adds it to the function's return object so the same value can be reused as the accessible name, rather than computing anything new.

## Changes

knative/src/components/kservices/detail/sections/pods/PodsSection.tsx (+5/−1)

- getContainerDisplayStatus() now returns label in its result object
- Status dot <Box> gets role="img", aria-label, and tabIndex={0}

## No new user-facing strings

The four status labels already existed at lines 73–102 and were already used in tooltip text. No new hardcoded strings were introduced. These labels should be wrapped in t() as part of the dedicated i18n effort.

## Follow-ups (not in this PR)

- A non-color visual differentiator (icon, shape, or pattern) for container status would strengthen this further, but it's a visual design change — open to maintainer input on direction before pursuing it.
- No component test added: the plugin has 4 pure-function unit test files and 9 Storybook stories, but the stories are render-only (no play functions, no @storybook/test`) and aren't picked up by the test runner, so there's no existing pattern for asserting component behavior. Verified manually per the test plan below. Happy to add a story or a `play function if that's the direction you'd prefer.

## Test plan

- [ ] Screen reader (NVDA/VoiceOver) announces container name and status when focusing a dot
- [ ] Tab key reaches each status dot; tooltip appears on focus
- [ ] Visual appearance is unchanged (dots remain the same size, color, and shape)
- [x] npm run lint passes
- [x] npm run tsc passes
- [x] npm run build succeeds
- [x] npm run format -- --check passes
- [x] tests: 22/22 (4 files)