### PR TITLE
kyverno: Fix JSONPatch mutation expression display

### DIFF
--- a/kyverno/src/components/CELPolicyViewer.tsx
+++ b/kyverno/src/components/CELPolicyViewer.tsx
@@ -34,6 +34,7 @@ import {
   MutatingPolicy,
   ValidatingPolicy,
 } from '../resources/celPolicies';
+import { getMutationExpression } from './mutationExpression';
 
 type CELPolicy = ValidatingPolicy | MutatingPolicy | GeneratingPolicy | DeletingPolicy;
 
@@ -272,7 +273,7 @@ export function CELPolicyViewer({ policy }: CELPolicyViewerProps) {
             { label: t('Patch Type'), getter: i => i.patchType || 'JSONPatch' },
             {
               label: t('Expression'),
-              getter: i => i.applyConfiguration?.expression || i.rfc6902?.expression,
+              getter: getMutationExpression,
             },
           ]}
         />

--- a/kyverno/src/components/mutationExpression.test.ts
+++ b/kyverno/src/components/mutationExpression.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'vitest';
+import { getMutationExpression } from './mutationExpression';
+
+describe('getMutationExpression', () => {
+  test('reads the expression from a JSONPatch mutation', () => {
+    expect(
+      getMutationExpression({
+        jsonPatch: { expression: '[JSONPatch{op: "add", path: "/metadata/labels/x", value: "y"}]' },
+      })
+    ).toBe('[JSONPatch{op: "add", path: "/metadata/labels/x", value: "y"}]');
+  });
+
+  test('reads the expression from an ApplyConfiguration mutation', () => {
+    expect(
+      getMutationExpression({ applyConfiguration: { expression: 'Object{spec: object.spec}' } })
+    ).toBe('Object{spec: object.spec}');
+  });
+
+  test('uses a placeholder when the mutation has no expression', () => {
+    expect(getMutationExpression({})).toBe('-');
+  });
+});

--- a/kyverno/src/components/mutationExpression.ts
+++ b/kyverno/src/components/mutationExpression.ts
@@ -1,0 +1,8 @@
+export interface MutationExpressionSource {
+  applyConfiguration?: { expression: string };
+  jsonPatch?: { expression: string };
+}
+
+export function getMutationExpression(mutation: MutationExpressionSource): string {
+  return mutation.applyConfiguration?.expression ?? mutation.jsonPatch?.expression ?? '-';
+}

--- a/kyverno/src/resources/celPolicies.ts
+++ b/kyverno/src/resources/celPolicies.ts
@@ -117,7 +117,7 @@ export class ValidatingPolicy extends KubeObject<ValidatingPolicyInterface> {
 export interface CELMutation {
   patchType?: string;
   applyConfiguration?: { expression: string };
-  rfc6902?: { expression: string };
+  jsonPatch?: { expression: string };
 }
 
 export interface MutatingPolicySpec {


### PR DESCRIPTION
## Summary

Fix JSONPatch expressions being empty in the Kyverno MutatingPolicy details view.

Kyverno exposes these expressions as `jsonPatch.expression`, while the plugin was looking for `rfc6902.expression`.

Fixes #1058

## Changes

- align the `CELMutation` type with Kyverno's `jsonPatch` field
- use a small SDK-free helper to select ApplyConfiguration or JSONPatch expressions
- add regression coverage for both mutation types and the empty fallback

## Testing

- `npm run format -- --check`
- `npm run lint`
- `npm run tsc`
- `npm test` — 8 tests passed
- `npm run build`

## Screenshots

Not applicable; this corrects the value shown in an existing table without changing its layout.
