### PR TITLE
fix(kueue): Show Fair Sharing and Flavor Reservation/Usage on LocalQueue detail

### DIFF
--- a/kueue/src/components/localqueues/Detail.tsx
+++ b/kueue/src/components/localqueues/Detail.tsx
@@ -2,11 +2,87 @@ import {
   ConditionsSection,
   DetailsGrid,
   Link,
+  SectionBox,
+  SimpleTable,
 } from '@kinvolk/headlamp-plugin/lib/components/common';
 import { useParams } from 'react-router-dom';
-import { LocalQueue } from '../../resources/localQueue';
+import { LocalQueue, LocalQueueFlavorUsage } from '../../resources/localQueue';
 import { kueueRouteNames } from '../../utils/kueueRoutes';
 import KueueAdminResourceAccess from '../common/KueueAdminResourceAccess';
+
+/** Flattened row rendered for status flavor reservations or flavor usage. */
+interface FlavorUsageRow {
+  /** ResourceFlavor name reported by LocalQueue status. */
+  flavor: string;
+  /** Resource name reported under the flavor. */
+  resource: string;
+  /** Total reserved or used quantity for the resource. */
+  total?: string | number;
+}
+
+/** Render a ResourceFlavor name as a Headlamp link to its detail page. */
+function renderFlavorLink(flavorName: string) {
+  return (
+    <Link routeName={kueueRouteNames.resourceFlavorDetail} params={{ name: flavorName }}>
+      {flavorName}
+    </Link>
+  );
+}
+
+/** Convert status flavor usage or reservation entries into table rows. */
+function getFlavorUsageRows(flavorUsage: LocalQueueFlavorUsage[] = []): FlavorUsageRow[] {
+  return flavorUsage.flatMap(flavor => {
+    if (!flavor.resources?.length) {
+      return [
+        {
+          flavor: flavor.name,
+          resource: '-',
+        },
+      ];
+    }
+
+    return flavor.resources.map(resource => ({
+      flavor: flavor.name,
+      resource: resource.name,
+      total: resource.total,
+    }));
+  });
+}
+
+/** Build the extra detail section for LocalQueue status flavor reservations or usage. */
+function getFlavorUsageSection(title: string, id: string, flavorUsage?: LocalQueueFlavorUsage[]) {
+  const rows = getFlavorUsageRows(flavorUsage);
+
+  if (rows.length === 0) {
+    return null;
+  }
+
+  return {
+    id,
+    section: (
+      <SectionBox title={title}>
+        <SimpleTable
+          data={rows}
+          columns={[
+            {
+              label: 'ResourceFlavor',
+              getter: (row: FlavorUsageRow) =>
+                row.flavor === '-' ? '-' : renderFlavorLink(row.flavor),
+            },
+            {
+              label: 'Resource',
+              getter: (row: FlavorUsageRow) => row.resource,
+            },
+            {
+              label: 'Total',
+              getter: (row: FlavorUsageRow) => row.total ?? '-',
+            },
+          ]}
+        />
+      </SectionBox>
+    ),
+  };
+}
 
 /** Render a ClusterQueue reference as a detail-page link. */
 function renderClusterQueueLink(localQueue: LocalQueue) {
@@ -77,11 +153,29 @@ export default function LocalQueueDetail() {
                   name: 'Status',
                   value: localQueue.statusDisplay,
                 },
+                {
+                  name: 'Fair Sharing',
+                  value: localQueue.fairSharingDisplay,
+                },
               ]
             : []
         }
         extraSections={localQueue =>
-          localQueue ? [getConditionsSection(localQueue)].filter(Boolean) : []
+          localQueue
+            ? [
+                getConditionsSection(localQueue),
+                getFlavorUsageSection(
+                  'Flavor Reservations',
+                  'flavor-reservations',
+                  localQueue.status.flavorsReservation
+                ),
+                getFlavorUsageSection(
+                  'Flavor Usage',
+                  'flavor-usage',
+                  localQueue.status.flavorsUsage
+                ),
+              ].filter(Boolean)
+            : []
         }
       />
     </KueueAdminResourceAccess>

--- a/kueue/src/resources/localQueue.ts
+++ b/kueue/src/resources/localQueue.ts
@@ -2,6 +2,7 @@ import { KubeObject, KubeObjectInterface } from '@kinvolk/headlamp-plugin/lib/k8
 import { kueueApiVersions } from '../utils/kueueApi';
 import { kueueRoutePaths } from '../utils/kueueRoutes';
 import type { FairSharing, KueueCondition, ResourceQuantity, StopPolicy } from './clusterQueue';
+import { renderFairSharing } from './clusterQueueFormatters';
 import {
   getLocalQueueDetailRouteParams,
   renderClusterQueueName,
@@ -256,6 +257,10 @@ export class LocalQueue extends KubeObject<KubeLocalQueue> {
 
   get statusDisplay() {
     return renderLocalQueueStatus(this.activeCondition);
+  }
+
+  get fairSharingDisplay() {
+    return renderFairSharing(this.spec.fairSharing, this.status.fairSharing);
   }
 
   get detailRouteParams() {


### PR DESCRIPTION
Fixes #1055

## Summary

Adds the missing Fair Sharing and Flavor Reservation/Usage data to the LocalQueue detail view, bringing it in line with what ClusterQueue's detail view already shows.

## Problem

`resources/localQueue.ts` already typed `spec.fairSharing`, `status.fairSharing`, `status.flavorsReservation`, and 
`status.flavorsUsage` — these are real fields Kueue reports for LocalQueue — but there were no getters exposing them, and 
`LocalQueueDetail.tsx` never rendered them. The same kind of data is already fully displayed on ClusterQueue's detail page, so this data was silently missing for LocalQueue with no way to see it in the UI.

## Changes

* Added a `fairSharingDisplay` getter to `LocalQueue`, reusing the existing `renderFairSharing` formatter from `clusterQueueFormatters.ts` instead of duplicating it
* Added a "Fair Sharing" row to `extraInfo` in `LocalQueueDetail.tsx`
* Added "Flavor Reservations" and "Flavor Usage" sections to `extraSections`, following the same pattern already used in `ClusterQueueDetail.tsx`.

## Testing

* `npx tsc --noEmit -p .` — clean
* `npm run lint` — clean
* `npm run format` — clean