### PR TITLE
backstage: Guard "View in Backstage" button against unparseable URLs

### DIFF
--- a/backstage/src/components/BackstageButton/BackstageButtonPure.tsx
+++ b/backstage/src/components/BackstageButton/BackstageButtonPure.tsx
@@ -1,6 +1,7 @@
 import { Icon } from '@iconify/react';
 import { IconButton, Tooltip } from '@mui/material';
 import React from 'react';
+import { validateUrl } from '../../utils';
 
 /**
  * Props for the BackstageButtonPure component.
@@ -50,9 +51,10 @@ export function BackstageButtonPure({
     }
   };
 
-  // If we are not running in Backstage + the Backstage URL is not set up, then we
-  // do not display the button at all.
-  if (!isInIframe && !backstageUrl) {
+  // If we are not running in Backstage + the Backstage URL is not set up (or is not a
+  // usable URL), then we do not display the button at all, since clicking it would
+  // otherwise throw when building the redirect URL below.
+  if (!isInIframe && !validateUrl(backstageUrl)) {
     return null;
   }
 

--- a/backstage/src/components/Settings/Settings.tsx
+++ b/backstage/src/components/Settings/Settings.tsx
@@ -1,15 +1,7 @@
 import { useClustersConf } from '@kinvolk/headlamp-plugin/lib/k8s';
 import React, { useCallback, useEffect, useState } from 'react';
+import { validateUrl } from '../../utils';
 import { SettingsData, SettingsPure } from './SettingsPure';
-
-function validateUrl(url: string): boolean {
-  try {
-    new URL(url);
-    return true;
-  } catch (e) {
-    return false;
-  }
-}
 
 interface SettingsProps {
   data?: SettingsData;

--- a/backstage/src/utils.ts
+++ b/backstage/src/utils.ts
@@ -39,3 +39,18 @@ export function getClusterConfig(cluster: string): ClusterLevelConf | null {
   }
   return conf[cluster] || null;
 }
+
+/**
+ * Checks whether a string is a URL that the Backstage plugin can actually use
+ * (i.e. the WHATWG URL constructor can parse it).
+ * @param {string} url - The URL to validate.
+ * @returns {boolean} True if the URL can be parsed, false otherwise.
+ */
+export function validateUrl(url: string): boolean {
+  try {
+    new URL(url);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}


### PR DESCRIPTION
BackstageButtonPure's handleClick called new URL(backstageUrl) with no guard. Settings.tsx already validates the URL and shows an "Invalid URL" hint, but still saves the value regardless, so an unparseable URL (e.g. "example.com" with no scheme) could reach the button and throw an uncaught TypeError on click, silently doing nothing.

Extract validateUrl into utils.ts as a shared helper, and extend the button's existing empty-URL guard to also cover unparseable URLs, so the button simply isn't shown rather than crashing when clicked.

Fixes #1064 