### PR TITLE
kueue: fix null-handling crashes in details views

### DIFF
--- a/kueue/src/components/clusterqueues/Detail.tsx
+++ b/kueue/src/components/clusterqueues/Detail.tsx
@@ -107,7 +107,10 @@ function getResourceGroupRows(resourceGroups: ResourceGroup[]): ResourceGroupRow
 }
 
 /** Convert status flavor usage or reservation entries into table rows. */
-function getFlavorUsageRows(flavorUsage: FlavorUsage[] = []): FlavorUsageRow[] {
+function getFlavorUsageRows(flavorUsage?: FlavorUsage[] | null): FlavorUsageRow[] {
+  if (!flavorUsage) {
+    return [];
+  }
   return flavorUsage.flatMap(flavor => {
     if (!flavor.resources?.length) {
       return [

--- a/kueue/src/components/workloads/Detail.tsx
+++ b/kueue/src/components/workloads/Detail.tsx
@@ -144,8 +144,11 @@ function getPodSetRows(podSets: PodSet[]): PodSetRow[] {
 
 /** Convert admission assignments into table rows. */
 function getAdmissionAssignmentRows(
-  assignments: PodSetAssignment[] = []
+  assignments?: PodSetAssignment[] | null
 ): AdmissionAssignmentRow[] {
+  if (!assignments) {
+    return [];
+  }
   return assignments.map(assignment => ({
     name: assignment.name || 'main',
     count: assignment.count ?? '-',
@@ -156,7 +159,12 @@ function getAdmissionAssignmentRows(
 }
 
 /** Convert admission checks into table rows. */
-function getAdmissionCheckRows(admissionChecks: AdmissionCheckState[] = []): AdmissionCheckRow[] {
+function getAdmissionCheckRows(
+  admissionChecks?: AdmissionCheckState[] | null
+): AdmissionCheckRow[] {
+  if (!admissionChecks) {
+    return [];
+  }
   return admissionChecks.map(admissionCheck => ({
     name: admissionCheck.name,
     state: renderText(admissionCheck.state),
@@ -168,7 +176,12 @@ function getAdmissionCheckRows(admissionChecks: AdmissionCheckState[] = []): Adm
 }
 
 /** Convert reclaimable pods into table rows. */
-function getReclaimablePodRows(reclaimablePods: ReclaimablePod[] = []): ReclaimablePodRow[] {
+function getReclaimablePodRows(
+  reclaimablePods?: ReclaimablePod[] | null
+): ReclaimablePodRow[] {
+  if (!reclaimablePods) {
+    return [];
+  }
   return reclaimablePods.map(reclaimablePod => ({
     name: reclaimablePod.name,
     count: reclaimablePod.count,
@@ -176,7 +189,12 @@ function getReclaimablePodRows(reclaimablePods: ReclaimablePod[] = []): Reclaima
 }
 
 /** Convert resource request status entries into table rows. */
-function getResourceRequestRows(resourceRequests: PodSetRequest[] = []): ResourceRequestRow[] {
+function getResourceRequestRows(
+  resourceRequests?: PodSetRequest[] | null
+): ResourceRequestRow[] {
+  if (!resourceRequests) {
+    return [];
+  }
   return resourceRequests.map(request => ({
     name: request.name,
     resources: renderResourceList(request.resources),
@@ -184,7 +202,12 @@ function getResourceRequestRows(resourceRequests: PodSetRequest[] = []): Resourc
 }
 
 /** Convert scheduling eviction stats into table rows. */
-function getEvictionRows(evictions: WorkloadSchedulingStatsEviction[] = []): EvictionRow[] {
+function getEvictionRows(
+  evictions?: WorkloadSchedulingStatsEviction[] | null
+): EvictionRow[] {
+  if (!evictions) {
+    return [];
+  }
   return evictions.map(eviction => ({
     reason: eviction.reason,
     underlyingCause: renderText(eviction.underlyingCause),


### PR DESCRIPTION
## What this PR does

This PR fixes a potential crash in the Kueue plugin details views when certain status array fields are returned as `null` by the Kubernetes API.

The affected helper functions now explicitly handle both `null` and `undefined` values before iterating over collections, preventing runtime `TypeError` exceptions and allowing the details pages to render correctly with empty states.

## Changes

- Handle `null` and `undefined` values in Workload detail helper functions:
  - `getAdmissionAssignmentRows`
  - `getAdmissionCheckRows`
  - `getReclaimablePodRows`
  - `getResourceRequestRows`
  - `getEvictionRows`
- Handle `null` and `undefined` values in the ClusterQueue detail helper function:
  - `getFlavorUsageRows`
- Prevent details pages from crashing when optional status array fields are absent.

## Why

The affected helper functions assumed status fields were always arrays and called `.map()` or `.flatMap()` directly. When the Kubernetes API returns `null` for these fields, the default parameter (`= []`) is bypassed, resulting in a runtime exception instead of rendering an empty state.

## Testing

- ✅ Verified TypeScript compilation (`npm run tsc`)
- ✅ Verified all unit tests pass (`22/22`)
- ✅ Verified details pages render correctly when status array fields are `null` or empty
- ✅ Ran frontend lint successfully

Closes #1072