### PR TITLE
fix(knative): guard optional spec property access in service and domain claim lists

### DIFF
--- a/knative/src/components/clusterdomainclaims/List.tsx
+++ b/knative/src/components/clusterdomainclaims/List.tsx
@@ -41,7 +41,7 @@ export function useClusterDomainClaimColumns(
         gridTemplate: 'auto',
         getValue: item => {
           const cdc = item as ClusterDomainClaim;
-          return cdc.spec.namespace || '';
+          return cdc.spec?.namespace || '';
         },
         render: item => {
           const cdc = item as ClusterDomainClaim;

--- a/knative/src/components/kservices/List.tsx
+++ b/knative/src/components/kservices/List.tsx
@@ -209,9 +209,9 @@ function KServicesListContents({ clusters }: KServicesListContentsProps) {
     const domainMap: Record<string, string[]> = {};
     if (!domainMappingsData) return domainMap;
     for (const dm of domainMappingsData) {
-      const refName = dm.spec.ref.name;
+      const refName = dm.spec?.ref?.name;
       if (!refName) continue;
-      const svcNs = dm.spec.ref.namespace || dm.metadata.namespace!;
+      const svcNs = dm.spec?.ref?.namespace || dm.metadata?.namespace || '';
       const key = `${dm.cluster}/${svcNs}/${refName}`;
       const isReady = dm.status?.conditions?.find(c => c.type === 'Ready')?.status === 'True';
       const url = dm.status?.url || dm.status?.address?.url;


### PR DESCRIPTION
## Description

This PR fixes potential runtime `TypeError` crashes in the Knative plugin (`@headlamp-k8s/knative`) when rendering custom resource lists where `.spec` or nested `.spec.ref` fields are omitted or initializing.

### Problem
1. **`KServicesList` (`plugins/knative/src/components/kservices/List.tsx`)**:
   In `domainByServiceKey`, the loop accesses `dm.spec.ref.name` and `dm.spec.ref.namespace` directly without optional chaining on `spec` or `ref`. When a `DomainMapping` resource is in a syncing or partial state (missing `.spec` or `.spec.ref`), rendering the KServices list throws `TypeError: Cannot read properties of undefined (reading 'name')`, causing the entire view to crash.
2. **`ClusterDomainClaimsList` (`plugins/knative/src/components/clusterdomainclaims/List.tsx`)**:
   The `namespace` column `getValue` accessor reads `cdc.spec.namespace` without optional chaining, whereas the cell renderer correctly guards with `cdc.spec?.namespace`. If a `ClusterDomainClaim` payload lacks a `spec` field, table sorting/filtering crashes with `TypeError: Cannot read properties of undefined (reading 'namespace')`.

### Solution
- Applied optional chaining (`dm.spec?.ref?.name` and `dm.spec?.ref?.namespace`) in `KServicesList`.
- Applied optional chaining (`cdc.spec?.namespace || ''`) in `ClusterDomainClaimsList` column accessor.

---

## How Has This Been Tested?

- [x] **TypeScript Type Checking**: Verified compilation with `npx tsc --noEmit` (0 errors).
- [x] **ESLint / Formatting**: Verified formatting rules pass cleanly (`npx eslint`).
- [x] **Unit Testing**: Verified all 22 existing unit tests pass (`npx vitest run`).

---

