### PR TITLE
test(knative): add unit test coverage for isKnativeInstalled helper

### DIFF
--- a/knative/src/isKnativeInstalled.test.ts
+++ b/knative/src/isKnativeInstalled.test.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { isKnativeInstalled } from './isKnativeInstalled';
+import { CustomResourceDefinition } from './resources/k8s/customResourceDefinition';
+
+vi.mock('./resources/k8s/customResourceDefinition', () => ({
+  CustomResourceDefinition: {
+    apiGet: vi.fn(),
+  },
+}));
+
+describe('isKnativeInstalled', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should return false when clusters is empty or invalid', async () => {
+    expect(await isKnativeInstalled([])).toBe(false);
+    expect(await isKnativeInstalled(null as unknown as string[])).toBe(false);
+    expect(await isKnativeInstalled(undefined as unknown as string[])).toBe(false);
+  });
+
+  it('should return true when Knative CRD exists in a single cluster', async () => {
+    vi.mocked(CustomResourceDefinition.apiGet).mockImplementation(
+      ((onSuccess: () => void) => {
+        return () => {
+          onSuccess();
+          return Promise.resolve(vi.fn());
+        };
+      }) as unknown as typeof CustomResourceDefinition.apiGet
+    );
+
+    const result = await isKnativeInstalled(['cluster-1']);
+    expect(result).toBe(true);
+  });
+
+  it('should return false when Knative CRD is missing in a single cluster', async () => {
+    vi.mocked(CustomResourceDefinition.apiGet).mockImplementation(
+      ((_onSuccess: unknown, _crdName: unknown, _override: unknown, onError: () => void) => {
+        return () => {
+          onError();
+          return Promise.resolve(vi.fn());
+        };
+      }) as unknown as typeof CustomResourceDefinition.apiGet
+    );
+
+    const result = await isKnativeInstalled(['cluster-1']);
+    expect(result).toBe(false);
+  });
+
+  it('should return true when Knative CRD exists across all multiple clusters', async () => {
+    vi.mocked(CustomResourceDefinition.apiGet).mockImplementation(
+      ((onSuccess: () => void) => {
+        return () => {
+          onSuccess();
+          return Promise.resolve(vi.fn());
+        };
+      }) as unknown as typeof CustomResourceDefinition.apiGet
+    );
+
+    const result = await isKnativeInstalled(['cluster-1', 'cluster-2']);
+    expect(result).toBe(true);
+  });
+
+  it('should return false when Knative CRD is missing in any of the clusters', async () => {
+    vi.mocked(CustomResourceDefinition.apiGet).mockImplementation(
+      (
+        (
+          onSuccess: () => void,
+          _crdName: unknown,
+          _override: unknown,
+          onError: () => void,
+          options?: { cluster?: string }
+        ) => {
+          return () => {
+            if (options?.cluster === 'cluster-1') {
+              onSuccess();
+            } else {
+              onError();
+            }
+            return Promise.resolve(vi.fn());
+          };
+        }
+      ) as unknown as typeof CustomResourceDefinition.apiGet
+    );
+
+    const result = await isKnativeInstalled(['cluster-1', 'cluster-2']);
+    expect(result).toBe(false);
+  });
+
+  it('should return false when apiGet request rejects with an error', async () => {
+    vi.mocked(CustomResourceDefinition.apiGet).mockImplementation(
+      (() => {
+        return () => Promise.reject(new Error('Network error'));
+      }) as unknown as typeof CustomResourceDefinition.apiGet
+    );
+
+    const result = await isKnativeInstalled(['cluster-1']);
+    expect(result).toBe(false);
+  });
+});


### PR DESCRIPTION
## Description

This PR adds a comprehensive unit test suite for the `isKnativeInstalled` helper function (`plugins/knative/src/isKnativeInstalled.ts`), which determines whether Knative CRDs exist on selected cluster(s) to conditionally display or hide Knative navigation in Headlamp.

Prior to this PR, `isKnativeInstalled.ts` had zero test coverage.

### Covered Test Scenarios (`plugins/knative/src/isKnativeInstalled.test.ts`):
1. **Empty / Invalid Inputs**: Returns `false` when `clusters` is an empty array, `null`, or `undefined`.
2. **Single Cluster (Installed)**: Returns `true` when the `services.serving.knative.dev` CRD exists in a single cluster.
3. **Single Cluster (Missing)**: Returns `false` when the Knative CRD is not found in the cluster.
4. **Multi-Cluster (All Installed)**: Returns `true` when Knative CRDs exist across all selected clusters in a multi-cluster setup.
5. **Multi-Cluster (Partial Installation)**: Returns `false` when Knative CRDs are missing in at least one cluster in a multi-cluster setup.
6. **Network Rejection Handling**: Handles API call failures/rejections gracefully and returns `false`.

---


## How Has This Been Tested?

- [x] **TypeScript Type Checking**: Verified compilation with `npx tsc --noEmit` (0 errors).
- [x] **ESLint / Formatting**: Verified formatting rules pass cleanly (`npx eslint`).
- [x] **Unit Testing**: Executed `npx vitest run` (All 28 unit tests passing across 5 test files).

---


