### PR TITLE
fix(backstage): restrict URL validation to http and https schemes (#1065)

### DIFF
--- a/backstage/src/components/BackstageButton/BackstageButtonPure.tsx
+++ b/backstage/src/components/BackstageButton/BackstageButtonPure.tsx
@@ -1,6 +1,7 @@
 import { Icon } from '@iconify/react';
 import { IconButton, Tooltip } from '@mui/material';
 import React from 'react';
+import { validateUrl } from '../../utils';
 
 /**
  * Props for the BackstageButtonPure component.
@@ -44,17 +45,21 @@ export function BackstageButtonPure({
         redirectPath,
       });
     } else {
+      if (!validateUrl(backstageUrl)) {
+        return;
+      }
       const redirectUrl = new URL(backstageUrl);
       redirectUrl.pathname = redirectUrl.pathname.replace(/\/$/, '') + redirectPath;
       window.open(redirectUrl.toString(), '_blank');
     }
   };
 
-  // If we are not running in Backstage + the Backstage URL is not set up, then we
+  // If we are not running in Backstage + the Backstage URL is not valid, then we
   // do not display the button at all.
-  if (!isInIframe && !backstageUrl) {
+  if (!isInIframe && !validateUrl(backstageUrl)) {
     return null;
   }
+
 
   return (
     <Tooltip title="View in Backstage">

--- a/backstage/src/components/Settings/Settings.tsx
+++ b/backstage/src/components/Settings/Settings.tsx
@@ -1,15 +1,8 @@
 import { useClustersConf } from '@kinvolk/headlamp-plugin/lib/k8s';
 import React, { useCallback, useEffect, useState } from 'react';
+import { validateUrl } from '../../utils';
 import { SettingsData, SettingsPure } from './SettingsPure';
 
-function validateUrl(url: string): boolean {
-  try {
-    new URL(url);
-    return true;
-  } catch (e) {
-    return false;
-  }
-}
 
 interface SettingsProps {
   data?: SettingsData;

--- a/backstage/src/utils.ts
+++ b/backstage/src/utils.ts
@@ -39,3 +39,7 @@ export function getClusterConfig(cluster: string): ClusterLevelConf | null {
   }
   return conf[cluster] || null;
 }
+
+export { validateUrl } from './utils/url';
+
+

--- a/backstage/src/utils/url.test.ts
+++ b/backstage/src/utils/url.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { validateUrl } from './url';
+
+describe('validateUrl', () => {
+  it('should return true for valid http and https URLs', () => {
+    expect(validateUrl('http://backstage.example.com')).toBe(true);
+    expect(validateUrl('https://backstage.example.com')).toBe(true);
+    expect(validateUrl('http://localhost:7007')).toBe(true);
+    expect(validateUrl('https://127.0.0.1:7007/path')).toBe(true);
+  });
+
+  it('should return false for non-http(s) schemes', () => {
+    expect(validateUrl('test:demo')).toBe(false);
+    expect(validateUrl('javascript:alert(1)')).toBe(false);
+    expect(validateUrl('file:///etc/passwd')).toBe(false);
+    expect(validateUrl('data:text/plain;base64,SGVsbG8=')).toBe(false);
+    expect(validateUrl('ftp://example.com')).toBe(false);
+  });
+
+  it('should return false for invalid, malformed, or empty URLs', () => {
+    expect(validateUrl('')).toBe(false);
+    expect(validateUrl(undefined)).toBe(false);
+    expect(validateUrl('not-a-url')).toBe(false);
+    expect(validateUrl('://missing-scheme')).toBe(false);
+  });
+});

--- a/backstage/src/utils/url.ts
+++ b/backstage/src/utils/url.ts
@@ -1,0 +1,19 @@
+/**
+ * Validates a URL string for Backstage.
+ * Only allows http and https schemes to prevent unsafe URI execution (e.g. javascript:, test:demo).
+ *
+ * @param url The URL string to validate
+ * @returns true if valid http/https URL, false otherwise
+ */
+export function validateUrl(url?: string): boolean {
+  if (!url) {
+    return false;
+  }
+
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "plugins",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
Fixes #1065

### Problem
The Backstage plugin settings allowed non-HTTP(S) URLs (such as `test:demo`, `javascript:`, `file:`, etc.) because `validateUrl` only checked if `new URL()` succeeded.

### Solution
- Restricted `validateUrl` to only accept `http:` and `https:` protocols (aligning with the Knative plugin pattern).
- Prevented `BackstageButton` from attempting unsafe navigation or rendering if the configured URL is invalid.
- Added unit tests in `src/utils/url.test.ts` to verify HTTP/HTTPS URL acceptance and rejection of invalid/unsafe schemes.

### Testing
- Ran `npx vitest run src/utils/url.test.ts` (3 tests passed).
- Verified TypeScript type checking with `tsc --noEmit`.
