### PR TITLE
flux: add Force Sync action for Kustomization and HelmRelease (#122)

### DIFF
--- a/flux/src/actions/index.tsx
+++ b/flux/src/actions/index.tsx
@@ -309,27 +309,41 @@ function SyncWithoutSourceAction(props) {
 function ForceSyncAction(props: { resource: KubeObject }) {
   const { resource } = props;
   const { enqueueSnackbar } = useSnackbar();
+  const [open, setOpen] = React.useState<boolean>(false);
 
   return (
-    <ActionButton
-      description="Force Sync"
-      icon="mdi:sync-alert"
-      onClick={() => {
-        const date = new Date().toISOString();
-        enqueueSnackbar(`Starting force sync for ${resource.metadata.name}`, { variant: 'info' });
-        syncRequest(resource, enqueueSnackbar, date, true)
-          .then(() => {
-            enqueueSnackbar(`Successfully requested force sync for ${resource.metadata.name}`, {
-              variant: 'success',
+    <>
+      <ActionButton
+        description="Force Sync"
+        icon="mdi:sync-alert"
+        onClick={() => {
+          setOpen(true);
+        }}
+      />
+      <ConfirmDialog
+        // @ts-ignore
+        open={open}
+        handleClose={() => setOpen(false)}
+        onConfirm={() => {
+          setOpen(false);
+          const date = new Date().toISOString();
+          enqueueSnackbar(`Starting force sync for ${resource.metadata.name}`, { variant: 'info' });
+          syncRequest(resource, enqueueSnackbar, date, true)
+            .then(() => {
+              enqueueSnackbar(`Successfully requested force sync for ${resource.metadata.name}`, {
+                variant: 'success',
+              });
+            })
+            .catch(error => {
+              enqueueSnackbar(`Failed force sync for ${resource.metadata.name}: ${error}`, {
+                variant: 'error',
+              });
             });
-          })
-          .catch(error => {
-            enqueueSnackbar(`Failed force sync for ${resource.metadata.name}: ${error}`, {
-              variant: 'error',
-            });
-          });
-      }}
-    />
+        }}
+        title="Force Sync"
+        description={`Are you sure you want to force reconciliation for ${resource.metadata.name}? This will trigger resource replacement.`}
+      />
+    </>
   );
 }
 

--- a/flux/src/actions/index.tsx
+++ b/flux/src/actions/index.tsx
@@ -55,11 +55,10 @@ function ForceReconciliationAction(props) {
             ? 'Disable Force Reconciliation'
             : 'Enable Force Reconciliation'
         }
-        description={`${
-          resource.jsonData.spec.force
+        description={`${resource.jsonData.spec.force
             ? 'Are you sure you want to disable force reconciliation for '
             : 'Are you sure you want to enable force reconciliation for '
-        }${resource.metadata.name}?`}
+          }${resource.metadata.name}?`}
       />
     </>
   );
@@ -167,17 +166,23 @@ function ResumeAction(props) {
   );
 }
 
-function syncRequest(resource: KubeObject, enqueueSnackbar, date) {
+function syncRequest(resource: KubeObject, enqueueSnackbar, date, force = false) {
   const name = resource.jsonData.metadata.name;
+
+  const annotations: Record<string, string> = {
+    ...resource.jsonData?.metadata?.annotations,
+    'reconcile.fluxcd.io/requestedAt': date,
+  };
+
+  if (force) {
+    annotations['reconcile.fluxcd.io/forceAt'] = date;
+  }
 
   const patch = (resource.constructor as any).apiEndpoint.patch;
   return patch(
     {
       metadata: {
-        annotations: {
-          ...resource.jsonData.metadata.annotations,
-          'reconcile.fluxcd.io/requestedAt': date,
-        },
+        annotations,
       },
     },
     resource.jsonData.metadata.namespace,
@@ -301,6 +306,33 @@ function SyncWithoutSourceAction(props) {
   );
 }
 
+function ForceSyncAction(props: { resource: KubeObject }) {
+  const { resource } = props;
+  const { enqueueSnackbar } = useSnackbar();
+
+  return (
+    <ActionButton
+      description="Force Sync"
+      icon="mdi:sync-alert"
+      onClick={() => {
+        const date = new Date().toISOString();
+        enqueueSnackbar(`Starting force sync for ${resource.metadata.name}`, { variant: 'info' });
+        syncRequest(resource, enqueueSnackbar, date, true)
+          .then(() => {
+            enqueueSnackbar(`Successfully requested force sync for ${resource.metadata.name}`, {
+              variant: 'success',
+            });
+          })
+          .catch(error => {
+            enqueueSnackbar(`Failed force sync for ${resource.metadata.name}: ${error}`, {
+              variant: 'error',
+            });
+          });
+      }}
+    />
+  );
+}
+
 export {
   SuspendAction,
   ResumeAction,
@@ -308,4 +340,5 @@ export {
   SyncWithSourceAction,
   SyncWithoutSourceAction,
   ForceReconciliationAction,
+  ForceSyncAction,
 };

--- a/flux/src/helm-releases/HelmReleaseSingle.tsx
+++ b/flux/src/helm-releases/HelmReleaseSingle.tsx
@@ -12,6 +12,7 @@ import { useParams } from 'react-router-dom';
 import YAML from 'yaml';
 import {
   ForceReconciliationAction,
+  ForceSyncAction,
   ResumeAction,
   SuspendAction,
   SyncWithoutSourceAction,
@@ -197,6 +198,7 @@ function CustomResourceDetails(props) {
     const actions = [];
     actions.push(<SyncWithSourceAction resource={cr} />);
     actions.push(<SyncWithoutSourceAction resource={cr} />);
+    actions.push(<ForceSyncAction resource={cr} />);
     actions.push(<SuspendAction resource={cr} />);
     actions.push(<ResumeAction resource={cr} />);
     actions.push(<ForceReconciliationAction resource={cr} />);

--- a/flux/src/kustomizations/KustomizationSingle.tsx
+++ b/flux/src/kustomizations/KustomizationSingle.tsx
@@ -11,7 +11,6 @@ import { useParams } from 'react-router-dom';
 import YAML from 'yaml';
 import {
   ForceReconciliationAction,
-  ForceSyncAction,
   ResumeAction,
   SuspendAction,
   SyncWithoutSourceAction,
@@ -111,7 +110,6 @@ function KustomizationDetails(props) {
     const actions = [];
     actions.push(<SyncWithSourceAction resource={cr} />);
     actions.push(<SyncWithoutSourceAction resource={cr} />);
-    actions.push(<ForceSyncAction resource={cr} />);
     actions.push(<SuspendAction resource={cr} />);
     actions.push(<ResumeAction resource={cr} />);
     actions.push(<ForceReconciliationAction resource={cr} />);

--- a/flux/src/kustomizations/KustomizationSingle.tsx
+++ b/flux/src/kustomizations/KustomizationSingle.tsx
@@ -11,6 +11,7 @@ import { useParams } from 'react-router-dom';
 import YAML from 'yaml';
 import {
   ForceReconciliationAction,
+  ForceSyncAction,
   ResumeAction,
   SuspendAction,
   SyncWithoutSourceAction,
@@ -110,6 +111,7 @@ function KustomizationDetails(props) {
     const actions = [];
     actions.push(<SyncWithSourceAction resource={cr} />);
     actions.push(<SyncWithoutSourceAction resource={cr} />);
+    actions.push(<ForceSyncAction resource={cr} />);
     actions.push(<SuspendAction resource={cr} />);
     actions.push(<ResumeAction resource={cr} />);
     actions.push(<ForceReconciliationAction resource={cr} />);


### PR DESCRIPTION
Fixes #122

### Problem
Flux CLI supports forcing reconciliation on-demand (`flux reconcile helmrelease <name> --force`), which instructs Flux controllers to force resource replacement when resources are stuck or out of sync.

Currently, the Flux Headlamp plugin provides standard `Sync` actions, but lacks an action button to trigger a forced reconciliation.

### Solution
According to [FluxCD documentation](https://fluxcd.io/flux/cmd/flux_reconcile_helmrelease/#options), triggering a one-off forced reconciliation requires attaching both metadata annotations:
- `reconcile.fluxcd.io/requestedAt: <timestamp>`
- `reconcile.fluxcd.io/forceAt: <timestamp>`

1. Updated `syncRequest` in `plugins/flux/src/actions/index.tsx` to support an optional `force` flag that attaches the `reconcile.fluxcd.io/forceAt` annotation.
2. Created `ForceSyncAction` component with an intuitive `"Force Sync"` action button (`mdi:sync-alert` icon).
3. Added `ForceSyncAction` to the action bars in `KustomizationSingle.tsx` and `HelmReleaseSingle.tsx`.

### Verification
- `npm run tsc` passed with 0 TypeScript errors.
- `npx eslint` passed with 0 warnings/errors.
