### PR TITLE
keda: Extract map edge logic and add tests

### DIFF
--- a/keda/src/mapEdges.test.ts
+++ b/keda/src/mapEdges.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+import { findAuthenticationEdges, makeKubeToKubeEdge } from './mapEdges';
+import type { ClusterTriggerAuthentication } from './resources/clusterTriggerAuthentication';
+import type { ScaledObject } from './resources/scaledobject';
+import type { TriggerAuthentication } from './resources/triggerAuthentication';
+
+/**
+ * findAuthenticationEdges only reads metadata and spec.triggers, so fixtures are
+ * plain objects rather than real KubeObjects. Building actual instances would
+ * pull in the cluster request layer for no added coverage.
+ */
+function scaledObject(namespace: string, uid: string, triggers: any[]): ScaledObject {
+  return {
+    metadata: { name: 'so', namespace, uid },
+    spec: { triggers },
+  } as unknown as ScaledObject;
+}
+
+function auth(namespace: string, name: string, uid: string): TriggerAuthentication {
+  return { metadata: { name, namespace, uid } } as unknown as TriggerAuthentication;
+}
+
+function clusterAuth(name: string, uid: string): ClusterTriggerAuthentication {
+  return { metadata: { name, uid } } as unknown as ClusterTriggerAuthentication;
+}
+
+describe('makeKubeToKubeEdge', () => {
+  it('derives the edge id from both uids so it is stable across renders', () => {
+    const from = { metadata: { uid: 'uid-a' } };
+    const to = { metadata: { uid: 'uid-b' } };
+
+    expect(makeKubeToKubeEdge(from, to)).toEqual({
+      id: 'uid-a-uid-b',
+      source: 'uid-a',
+      target: 'uid-b',
+    });
+  });
+});
+
+describe('findAuthenticationEdges', () => {
+  it('links a trigger to a TriggerAuthentication in the same namespace', () => {
+    const source = scaledObject('team-a', 'so-uid', [
+      { type: 'cron', authenticationRef: { name: 'creds' } },
+    ]);
+
+    const edges = findAuthenticationEdges(source, [auth('team-a', 'creds', 'auth-uid')], []);
+
+    expect(edges).toEqual([{ id: 'so-uid-auth-uid', source: 'so-uid', target: 'auth-uid' }]);
+  });
+
+  it('does not link a TriggerAuthentication of the same name in another namespace', () => {
+    const source = scaledObject('team-a', 'so-uid', [
+      { type: 'cron', authenticationRef: { name: 'creds' } },
+    ]);
+
+    // Same name, different namespace: namespaced refs must not cross namespaces.
+    const edges = findAuthenticationEdges(source, [auth('team-b', 'creds', 'auth-uid')], []);
+
+    expect(edges).toEqual([]);
+  });
+
+  it('treats a missing kind as TriggerAuthentication, matching KEDA default', () => {
+    const source = scaledObject('team-a', 'so-uid', [
+      { type: 'cron', authenticationRef: { name: 'creds' } },
+    ]);
+
+    // A cluster-scoped object of the same name must not satisfy an unqualified ref.
+    const edges = findAuthenticationEdges(source, [], [clusterAuth('creds', 'cluster-uid')]);
+
+    expect(edges).toEqual([]);
+  });
+
+  it('matches a ClusterTriggerAuthentication on name alone, ignoring namespace', () => {
+    const source = scaledObject('team-a', 'so-uid', [
+      {
+        type: 'cron',
+        authenticationRef: { name: 'shared', kind: 'ClusterTriggerAuthentication' },
+      },
+    ]);
+
+    const edges = findAuthenticationEdges(source, [], [clusterAuth('shared', 'cluster-uid')]);
+
+    expect(edges).toEqual([{ id: 'so-uid-cluster-uid', source: 'so-uid', target: 'cluster-uid' }]);
+  });
+
+  it('skips a reference that resolves to nothing', () => {
+    const source = scaledObject('team-a', 'so-uid', [
+      { type: 'cron', authenticationRef: { name: 'missing' } },
+    ]);
+
+    const edges = findAuthenticationEdges(source, [auth('team-a', 'other', 'auth-uid')], []);
+
+    expect(edges).toEqual([]);
+  });
+
+  it('skips triggers that carry no authenticationRef', () => {
+    const source = scaledObject('team-a', 'so-uid', [{ type: 'cron' }]);
+
+    const edges = findAuthenticationEdges(source, [auth('team-a', 'creds', 'auth-uid')], []);
+
+    expect(edges).toEqual([]);
+  });
+
+  it('returns one edge per resolving trigger', () => {
+    const source = scaledObject('team-a', 'so-uid', [
+      { type: 'cron', authenticationRef: { name: 'first' } },
+      { type: 'kafka', authenticationRef: { name: 'second' } },
+    ]);
+
+    const edges = findAuthenticationEdges(
+      source,
+      [auth('team-a', 'first', 'uid-1'), auth('team-a', 'second', 'uid-2')],
+      []
+    );
+
+    expect(edges).toHaveLength(2);
+    expect(edges.map(edge => edge.target)).toEqual(['uid-1', 'uid-2']);
+  });
+
+  it('returns no edges when the object has no triggers', () => {
+    const source = scaledObject('team-a', 'so-uid', undefined as any);
+
+    expect(findAuthenticationEdges(source, [auth('team-a', 'creds', 'auth-uid')], [])).toEqual([]);
+  });
+
+  it('returns no edges while the authentication lists are still loading', () => {
+    const source = scaledObject('team-a', 'so-uid', [
+      { type: 'cron', authenticationRef: { name: 'creds' } },
+    ]);
+
+    // useList returns null before the first response resolves.
+    expect(findAuthenticationEdges(source, null as any, [])).toEqual([]);
+    expect(findAuthenticationEdges(source, [], null as any)).toEqual([]);
+  });
+});

--- a/keda/src/mapEdges.ts
+++ b/keda/src/mapEdges.ts
@@ -1,0 +1,90 @@
+import type { ClusterTriggerAuthentication } from './resources/clusterTriggerAuthentication';
+import type { ScaledJob } from './resources/scaledjob';
+import type { ScaledObject } from './resources/scaledobject';
+import type { TriggerAuthentication } from './resources/triggerAuthentication';
+
+/**
+ * Kinds an `authenticationRef` can name.
+ *
+ * These mirror the `kind` statics on TriggerAuthentication and
+ * ClusterTriggerAuthentication. They are repeated here rather than imported so
+ * that this module carries no runtime dependency on the resource classes, which
+ * reach `@kinvolk/headlamp-plugin/lib/k8s/cluster`. That specifier is supplied
+ * by Headlamp at runtime and is not resolvable on disk, so importing it here
+ * would make this logic impossible to unit test.
+ */
+const TRIGGER_AUTHENTICATION_KIND = 'TriggerAuthentication';
+const CLUSTER_TRIGGER_AUTHENTICATION_KIND = 'ClusterTriggerAuthentication';
+
+/**
+ * Build a map edge between two Kubernetes objects.
+ *
+ * The id is derived from both uids so it stays stable across renders and does
+ * not collide with edges between other pairs.
+ *
+ * @param from - Source object.
+ * @param to - Target object.
+ * @returns An edge for the resource map.
+ */
+export const makeKubeToKubeEdge = (from: any, to: any): any => ({
+  id: `${from.metadata.uid}-${to.metadata.uid}`,
+  source: from.metadata.uid,
+  target: to.metadata.uid,
+});
+
+/**
+ * Build map edges from a ScaledObject or ScaledJob to the authentications its
+ * triggers reference.
+ *
+ * A trigger's `authenticationRef` carries a name and an optional kind, not a
+ * uid, so the target is resolved by lookup rather than by ownerReference. A
+ * TriggerAuthentication is matched on name within the source's own namespace;
+ * a ClusterTriggerAuthentication is matched on name alone because it is
+ * cluster scoped. `kind` defaults to TriggerAuthentication when omitted, which
+ * mirrors KEDA's own default.
+ *
+ * @param sourceObject - The ScaledObject or ScaledJob holding the triggers.
+ * @param triggerAuthentications - Namespaced authentications to match against;
+ *   null while the list is still loading.
+ * @param clusterTriggerAuthentications - Cluster-scoped authentications to
+ *   match against; null while the list is still loading.
+ * @returns One edge per trigger whose reference resolves. References that do
+ *   not resolve are skipped, so a dangling ref yields no edge rather than a
+ *   broken one.
+ */
+export const findAuthenticationEdges = (
+  sourceObject: ScaledObject | ScaledJob,
+  triggerAuthentications: TriggerAuthentication[],
+  clusterTriggerAuthentications: ClusterTriggerAuthentication[]
+) => {
+  const edges = [];
+  const { triggers } = sourceObject.spec;
+
+  if (!triggers || !triggerAuthentications || !clusterTriggerAuthentications) {
+    return edges;
+  }
+
+  triggers.forEach(trigger => {
+    if (trigger.authenticationRef) {
+      const authRefKind = trigger.authenticationRef.kind || TRIGGER_AUTHENTICATION_KIND;
+      const authRefName = trigger.authenticationRef.name;
+
+      let auth = null;
+      if (authRefKind === TRIGGER_AUTHENTICATION_KIND) {
+        auth = triggerAuthentications.find(
+          auth =>
+            auth.metadata.namespace === sourceObject.metadata.namespace &&
+            auth.metadata.name === authRefName
+        );
+      } else if (authRefKind === CLUSTER_TRIGGER_AUTHENTICATION_KIND) {
+        auth = clusterTriggerAuthentications.find(auth => auth.metadata.name === authRefName);
+      }
+
+      if (auth) {
+        edges.push(makeKubeToKubeEdge(sourceObject, auth));
+      }
+    }
+  });
+
+  return edges;
+};

--- a/keda/src/mapView.tsx
+++ b/keda/src/mapView.tsx
@@ -5,53 +5,11 @@ import { ClusterTriggerAuthenticationDetail } from './components/clustertriggera
 import { ScaledJobDetail } from './components/scaledjobs/Detail';
 import { ScaledObjectDetail } from './components/scaledobjects/Detail';
 import { TriggerAuthenticationDetail } from './components/triggerauthentication/Detail';
+import { findAuthenticationEdges, makeKubeToKubeEdge } from './mapEdges';
 import { ClusterTriggerAuthentication } from './resources/clusterTriggerAuthentication';
 import { ScaledJob } from './resources/scaledjob';
 import { ScaledObject } from './resources/scaledobject';
 import { TriggerAuthentication } from './resources/triggerAuthentication';
-
-export const makeKubeToKubeEdge = (from: any, to: any): any => ({
-  id: `${from.metadata.uid}-${to.metadata.uid}`,
-  source: from.metadata.uid,
-  target: to.metadata.uid,
-});
-
-const findAuthenticationEdges = (
-  sourceObject: ScaledObject | ScaledJob,
-  triggerAuthentications: TriggerAuthentication[],
-  clusterTriggerAuthentications: ClusterTriggerAuthentication[]
-) => {
-  const edges = [];
-  const { triggers } = sourceObject.spec;
-
-  if (!triggers || !triggerAuthentications || !clusterTriggerAuthentications) {
-    return edges;
-  }
-
-  triggers.forEach(trigger => {
-    if (trigger.authenticationRef) {
-      const authRefKind = trigger.authenticationRef.kind || TriggerAuthentication.kind;
-      const authRefName = trigger.authenticationRef.name;
-
-      let auth = null;
-      if (authRefKind === TriggerAuthentication.kind) {
-        auth = triggerAuthentications.find(
-          auth =>
-            auth.metadata.namespace === sourceObject.metadata.namespace &&
-            auth.metadata.name === authRefName
-        );
-      } else if (authRefKind === ClusterTriggerAuthentication.kind) {
-        auth = clusterTriggerAuthentications.find(auth => auth.metadata.name === authRefName);
-      }
-
-      if (auth) {
-        edges.push(makeKubeToKubeEdge(sourceObject, auth));
-      }
-    }
-  });
-
-  return edges;
-};
 
 const triggerAuthenticationSource = {
   id: 'keda-trigger-authentications',


### PR DESCRIPTION
## What Changed

`findAuthenticationEdges` builds the map edges from a ScaledObject or ScaledJob to the authentications its triggers reference. It had no test coverage.

This PR:

- Moves `findAuthenticationEdges` and `makeKubeToKubeEdge` from `mapView.tsx` into a new `mapEdges.ts`, with JSDoc on both
- Adds `mapEdges.test.ts` with ten tests
- Leaves the behaviour unchanged

## Why the code moved

The logic could not be tested where it was. `mapView.tsx` imports the four detail components, and the resource classes import `@kinvolk/headlamp-plugin/lib/k8s/cluster`.

That specifier does not resolve on disk. The published package has the module at `lib/lib/k8s/cluster`, and the import works because the build treats it as external and Headlamp supplies it at runtime. Under vitest it fails at transform time:

```
Failed to resolve import "@kinvolk/headlamp-plugin/lib/k8s/cluster"
```

`vi.mock` does not help, because resolution happens before mocking.

This appears to be why the repo's existing unit tests avoid that boundary. kro tests `instanceApi.ts` and never `instance.ts`, and `rgdGraph.test.ts` imports only a type from `resourceGraphDefinition`. `mapEdges.ts` follows the same split: type-only imports for the resource classes, so nothing is required at runtime.

The two kind strings are the one wrinkle. `findAuthenticationEdges` compares `authenticationRef.kind` against `TriggerAuthentication.kind` and `ClusterTriggerAuthentication.kind`, which are runtime values from the classes. They are declared as local constants in `mapEdges.ts` with a comment explaining why. That is duplication, and I would rather not have it, so I am happy to change the approach if you would prefer the constants live somewhere shared.

## What the tests cover

- A trigger resolves to a TriggerAuthentication in the same namespace
- A TriggerAuthentication with the same name in a different namespace does not match
- An omitted `kind` defaults to TriggerAuthentication, so a cluster-scoped object of the same name does not satisfy the reference
- `ClusterTriggerAuthentication` matches on name alone, ignoring namespace
- A reference naming something that does not exist yields no edge
- Triggers with no `authenticationRef` are skipped
- Two triggers that both resolve produce two edges
- An object with no triggers yields no edges
- Null authentication lists, the state before `useList` resolves, yield no edges
- `makeKubeToKubeEdge` derives its id from both uids

The namespace cases are the ones worth having. `authenticationRef` carries a name and an optional kind but no uid, so the target is resolved by lookup rather than by ownerReference, and the namespace check is what keeps a reference from resolving across namespaces.

## Verification

Run in `keda/`:

```
npx tsc --noEmit
npx eslint --cache -c package.json --max-warnings 0 --ext .js,.ts,.tsx src/
npx prettier --check "src/**/*.{js,ts,tsx}"
npx vitest run -c node_modules/@kinvolk/headlamp-plugin/config/vite.config.mjs
npx vite build -c node_modules/@kinvolk/headlamp-plugin/config/vite.config.mjs
```

Type check, lint and build pass, and the ten tests pass.

One note on formatting: `prettier --check` reports pre-existing issues in 21 files on my checkout, on `main` as well as on this branch, which I believe is a line-ending artifact local to me since CI is green. I ran prettier only on the three files this PR touches, to keep unrelated files out of the diff.