### PR TITLE
knative: stabilize Traffic section reset effect

### DIFF
--- a/knative/src/components/kservices/detail/sections/traffic/TrafficSplittingSection.test.tsx
+++ b/knative/src/components/kservices/detail/sections/traffic/TrafficSplittingSection.test.tsx
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from '@testing-library/react';
+import React from 'react';
+
+// Hoisted test state: survives vi.mock factory hoisting and is accessible
+// in both the mock body and test assertions.
+const testState = vi.hoisted(() => ({
+  tableRenderCount: 0,
+  latestData: [] as Array<{ id?: string; percent?: number }>,
+}));
+
+vi.mock('@kinvolk/headlamp-plugin/lib/CommonComponents', () => ({
+  Link: ({ children }: any) => children,
+  SectionBox: ({ children }: any) => children,
+  SimpleTable: ({ data }: any) => {
+    testState.tableRenderCount += 1;
+    testState.latestData = data;
+
+    if (testState.tableRenderCount > 20) {
+      throw new Error('TrafficSplittingSection render loop detected');
+    }
+
+    return null;
+  },
+}));
+
+vi.mock('../../hooks/useKServiceEditMode', () => ({
+  useKServiceEditMode: () => ({ isEditMode: false, setIsEditMode: () => {} }),
+}));
+
+vi.mock('../../permissions/KServicePermissionsProvider', () => ({
+  useKServicePermissions: () => ({ canPatchKService: true, isLoading: false }),
+}));
+
+vi.mock('../../../../common/notifications/useNotify', () => ({
+  useNotify: () => ({ notifySuccess: () => {}, notifyError: () => {} }),
+}));
+
+import TrafficSplittingSection from './TrafficSplittingSection';
+
+// Minimal KService fixture.
+function makeKService(): any {
+  return {
+    metadata: { name: 'hello', namespace: 'default', creationTimestamp: '2025-01-01T00:00:00Z' },
+    spec: {
+      traffic: [{ revisionName: 'hello-00001', percent: 100 }],
+    },
+    status: {
+      traffic: [{ revisionName: 'hello-00001', percent: 100 }],
+      latestReadyRevisionName: 'hello-00001',
+      conditions: [{ type: 'Ready', status: 'True' }],
+    },
+    patch: vi.fn().mockResolvedValue({}),
+  };
+}
+
+function makeRevisions(): any[] {
+  return [
+    {
+      metadata: { name: 'hello-00001', creationTimestamp: '2025-01-01T00:00:00Z' },
+      status: {
+        conditions: [{ type: 'Ready', status: 'True', reason: 'Ready' }],
+      },
+    },
+  ];
+}
+
+describe('TrafficSplittingSection', () => {
+  beforeEach(() => {
+    testState.tableRenderCount = 0;
+    testState.latestData = [];
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('settles in read-only mode without repeatedly resetting traffic state', () => {
+    expect(() =>
+      render(
+        <TrafficSplittingSection
+          cluster="test-cluster"
+          kservice={makeKService()}
+          revisions={makeRevisions()}
+        />
+      )
+    ).not.toThrow();
+
+    // The component rendered at least once and stayed below the loop guard.
+    expect(testState.tableRenderCount).toBeGreaterThan(0);
+    expect(testState.tableRenderCount).toBeLessThanOrEqual(20);
+
+    // The component settled with the expected initialized traffic data.
+    expect(testState.latestData).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'hello-00001',
+        }),
+      ])
+    );
+  });
+});

--- a/knative/src/components/kservices/detail/sections/traffic/TrafficSplittingSection.tsx
+++ b/knative/src/components/kservices/detail/sections/traffic/TrafficSplittingSection.tsx
@@ -204,7 +204,7 @@ export default function TrafficSplittingSection({ cluster, kservice, revisions }
   const combinedValidationError = trafficValidationError || pendingTagError;
   const isTrafficValid = !combinedValidationError;
 
-  function resetSection() {
+  const resetSection = React.useCallback(() => {
     initializeFromKService();
     setPendingTagInputs({});
 
@@ -218,7 +218,7 @@ export default function TrafficSplittingSection({ cluster, kservice, revisions }
     if (latestTagInputRef.current) {
       latestTagInputRef.current.value = '';
     }
-  }
+  }, [initializeFromKService]);
 
   async function onSaveTraffic() {
     if (!kservice || !revisions) return;


### PR DESCRIPTION
## Summary

Prevent the Knative Traffic section from repeatedly resetting its local state
while rendered in read-only mode.

## Problem

`resetSection` was declared as a normal function and was therefore recreated
on every render.

The read-only reset effect depended on that function:

```ts
React.useEffect(() => {
  if (!isEditMode) {
    resetSection();
  }
}, [isEditMode, resetSection]);
```

In the default read-only state, the effect called `resetSection()`, which
initialized new object and array state. That caused another render, produced a
new `resetSection` reference, and triggered the effect again.

The component consequently entered a repeated render/reset cycle.

## Fix

Wrap `resetSection` in `React.useCallback` using the existing memoized
`initializeFromKService` callback as its dependency.

The effect now reruns only when edit mode or the underlying KService/revision
initializer changes.

The existing Reset action and reset-on-edit-exit behavior remain in place.

## Regression test

Added a bounded component regression test that:

* renders the section in its default read-only state
* counts table renders
* fails deterministically if rendering exceeds a safe threshold
* confirms the expected revision row rendered after the component settled

Against the unfixed implementation, the guard fails quickly with:

```text
TrafficSplittingSection render loop detected
```

With the fix, the component settles normally.

## Verification

* `npm run test`
* `npm run tsc`
* `npm run lint`
* `npm run format -- --check`
* `npm run build`
* `git diff --check`

## Related work

PR #1066 changes the same component for internationalization but currently does
not modify `resetSection`, `initializeFromKService`, or the read-only reset
effect.

## Scope

No traffic validation, payload construction, tags, permissions, routes, edit
mode behavior, or user-facing strings were changed.

## AI assistance

AI-assisted tooling was used during investigation and implementation. I reviewed
the final diff and ran the listed validation locally.