### PR TITLE
kyverno: reports: Remove pages for nonexistent CRDs

### DIFF
--- a/kyverno/src/components/CRDGuard.tsx
+++ b/kyverno/src/components/CRDGuard.tsx
@@ -39,9 +39,6 @@ export function CRDGuard({ requires, children, message }: CRDGuardProps) {
     cleanup: t('Kyverno cleanup policies (kyverno.io/v2) were not detected on this cluster.'),
     reports: t('Policy Reports (wgpolicyk8s.io/v1alpha2) were not detected on this cluster.'),
     exceptions: t('Policy Exceptions (kyverno.io/v2) were not detected on this cluster.'),
-    kyvernoV2Reports: t(
-      'Kyverno admission/background-scan reports (kyverno.io/v2) were not detected on this cluster.'
-    ),
     ephemeralReports: t(
       'Kyverno ephemeral reports (reports.kyverno.io/v1) were not detected on this cluster. Kyverno 1.11+ is required.'
     ),

--- a/kyverno/src/components/KyvernoReportList.tsx
+++ b/kyverno/src/components/KyvernoReportList.tsx
@@ -18,24 +18,11 @@ import { Icon } from '@iconify/react';
 import { Activity, useTranslation } from '@kinvolk/headlamp-plugin/lib';
 import { ResourceListView } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 import { Link as MuiLink } from '@mui/material';
-import {
-  AdmissionReport,
-  BackgroundScanReport,
-  ClusterAdmissionReport,
-  ClusterBackgroundScanReport,
-  ClusterEphemeralReport,
-  EphemeralReport,
-} from '../resources/kyvernoReports';
+import { ClusterEphemeralReport, EphemeralReport } from '../resources/kyvernoReports';
 import { SummaryChips } from './common';
 import { ReportClass, ReportLike, ReportViewer } from './ReportViewer';
 
-export type AnyKyvernoReportClass =
-  | typeof AdmissionReport
-  | typeof ClusterAdmissionReport
-  | typeof BackgroundScanReport
-  | typeof ClusterBackgroundScanReport
-  | typeof EphemeralReport
-  | typeof ClusterEphemeralReport;
+export type AnyKyvernoReportClass = typeof EphemeralReport | typeof ClusterEphemeralReport;
 
 interface KyvernoReportListProps<T extends AnyKyvernoReportClass> {
   /** Untranslated title key, fed through useTranslation. */

--- a/kyverno/src/components/ReportViewer.tsx
+++ b/kyverno/src/components/ReportViewer.tsx
@@ -27,7 +27,7 @@ import {
 import { SummaryChips } from './common';
 import { ResultsTable } from './ResultsTable';
 
-// Any report class (PolicyReport, ClusterPolicyReport, AdmissionReport, EphemeralReport, ...)
+// Any report class (PolicyReport, ClusterPolicyReport, EphemeralReport, ...)
 // must expose these accessors. They normalise the wgpolicyk8s and kyverno.io schema differences.
 export interface ReportLike {
   jsonData: PolicyReportInterface;
@@ -37,7 +37,7 @@ export interface ReportLike {
 }
 
 // Generic over the item type so we don't need an `unknown as ReportLike` cast at the
-// use site. Each concrete class (PolicyReport, AdmissionReport, ...) exposes the
+// use site. Each concrete class (PolicyReport, EphemeralReport, ...) exposes the
 // required summary/results/scope getters via a shared base — they all satisfy
 // `ReportClass<T extends ReportLike>`.
 export interface ReportClass<T extends ReportLike> {
@@ -48,7 +48,7 @@ interface ReportViewerProps<T extends ReportLike = ReportLike> {
   name: string;
   namespace?: string;
   isClusterScoped?: boolean;
-  /** Override the resource class (e.g. for AdmissionReport / EphemeralReport). */
+  /** Override the resource class (e.g. for ClusterEphemeralReport / EphemeralReport). */
   resourceClass?: ReportClass<T>;
 }
 

--- a/kyverno/src/hooks/useKyvernoCRDs.ts
+++ b/kyverno/src/hooks/useKyvernoCRDs.ts
@@ -23,7 +23,6 @@ export interface KyvernoCRDStatus {
   cleanup: boolean; // kyverno.io/v2 (CleanupPolicy, ClusterCleanupPolicy)
   reports: boolean; // wgpolicyk8s.io/v1alpha2 (PolicyReport, ClusterPolicyReport)
   exceptions: boolean; // kyverno.io/v2 (PolicyException)
-  kyvernoV2Reports: boolean; // kyverno.io/v2 (Admission/BackgroundScan reports)
   ephemeralReports: boolean; // reports.kyverno.io/v1 (EphemeralReport, ClusterEphemeralReport)
   loading: boolean;
 }
@@ -34,7 +33,6 @@ const initialStatus: KyvernoCRDStatus = {
   cleanup: false,
   reports: false,
   exceptions: false,
-  kyvernoV2Reports: false,
   ephemeralReports: false,
   loading: true,
 };
@@ -71,18 +69,16 @@ async function probeCluster(cluster: string): Promise<KyvernoCRDStatus> {
       checkAPIGroup('/apis/reports.kyverno.io/v1'),
     ]);
 
-    // kyverno.io/v2 hosts cleanup, exceptions, and admission/background scan reports.
-    // The API-group-level probe doesn't tell us *which* CRDs are inside, so we treat
-    // all v2 features as available together, matching what stock Kyverno installs.
+    // kyverno.io/v2 hosts cleanup and exceptions. The API-group-level probe
+    // doesn't tell us *which* CRDs are inside, so we treat both v2 features
+    // as available together, matching what stock Kyverno installs.
     let cleanup = false;
     let exceptions = false;
-    let kyvernoV2Reports = false;
     if (legacy) {
       const v2 = await checkAPIGroup('/apis/kyverno.io/v2');
       if (v2) {
         cleanup = true;
         exceptions = true;
-        kyvernoV2Reports = true;
       }
     }
 
@@ -92,7 +88,6 @@ async function probeCluster(cluster: string): Promise<KyvernoCRDStatus> {
       cleanup,
       reports,
       exceptions,
-      kyvernoV2Reports,
       ephemeralReports,
       loading: false,
     };

--- a/kyverno/src/index.tsx
+++ b/kyverno/src/index.tsx
@@ -38,14 +38,7 @@ import { PolicyList } from './components/PolicyList';
 import { PolicyReportList } from './components/PolicyReportList';
 import { ViolationsView } from './components/ViolationsView';
 import { registerKyvernoIcon } from './kyvernoIcon';
-import {
-  AdmissionReport,
-  BackgroundScanReport,
-  ClusterAdmissionReport,
-  ClusterBackgroundScanReport,
-  ClusterEphemeralReport,
-  EphemeralReport,
-} from './resources/kyvernoReports';
+import { ClusterEphemeralReport, EphemeralReport } from './resources/kyvernoReports';
 
 registerKyvernoIcon();
 
@@ -223,66 +216,6 @@ registerKyvernoPage({
   path: '/kyverno/clusterpolicyreports',
   requires: 'reports',
   component: () => <ClusterPolicyReportList />,
-});
-
-registerKyvernoPage({
-  name: 'AdmissionReports',
-  parent: 'KyvernoReports',
-  label: 'Admission Reports',
-  path: '/kyverno/admissionreports',
-  requires: 'kyvernoV2Reports',
-  component: () => (
-    <KyvernoReportList
-      titleKey="Admission Reports"
-      resourceClass={AdmissionReport}
-      activityIdPrefix="kyverno-admrpt"
-    />
-  ),
-});
-
-registerKyvernoPage({
-  name: 'ClusterAdmissionReports',
-  parent: 'KyvernoReports',
-  label: 'Cluster Admission Reports',
-  path: '/kyverno/clusteradmissionreports',
-  requires: 'kyvernoV2Reports',
-  component: () => (
-    <KyvernoReportList
-      titleKey="Cluster Admission Reports"
-      resourceClass={ClusterAdmissionReport}
-      activityIdPrefix="kyverno-cadmrpt"
-    />
-  ),
-});
-
-registerKyvernoPage({
-  name: 'BackgroundScanReports',
-  parent: 'KyvernoReports',
-  label: 'Background Scan Reports',
-  path: '/kyverno/backgroundscanreports',
-  requires: 'kyvernoV2Reports',
-  component: () => (
-    <KyvernoReportList
-      titleKey="Background Scan Reports"
-      resourceClass={BackgroundScanReport}
-      activityIdPrefix="kyverno-bgscan"
-    />
-  ),
-});
-
-registerKyvernoPage({
-  name: 'ClusterBackgroundScanReports',
-  parent: 'KyvernoReports',
-  label: 'Cluster Background Scan Reports',
-  path: '/kyverno/clusterbackgroundscanreports',
-  requires: 'kyvernoV2Reports',
-  component: () => (
-    <KyvernoReportList
-      titleKey="Cluster Background Scan Reports"
-      resourceClass={ClusterBackgroundScanReport}
-      activityIdPrefix="kyverno-cbgscan"
-    />
-  ),
 });
 
 registerKyvernoPage({

--- a/kyverno/src/resources/kyvernoReports.ts
+++ b/kyverno/src/resources/kyvernoReports.ts
@@ -70,33 +70,13 @@ abstract class KyvernoReportBase extends KubeObject<KyvernoReportInterface> {
   }
 }
 
-export class AdmissionReport extends KyvernoReportBase {
-  static kind = 'AdmissionReport';
-  static apiName = 'admissionreports';
-  static apiVersion = 'kyverno.io/v2';
-  static isNamespaced = true;
-}
-
-export class ClusterAdmissionReport extends KyvernoReportBase {
-  static kind = 'ClusterAdmissionReport';
-  static apiName = 'clusteradmissionreports';
-  static apiVersion = 'kyverno.io/v2';
-  static isNamespaced = false;
-}
-
-export class BackgroundScanReport extends KyvernoReportBase {
-  static kind = 'BackgroundScanReport';
-  static apiName = 'backgroundscanreports';
-  static apiVersion = 'kyverno.io/v2';
-  static isNamespaced = true;
-}
-
-export class ClusterBackgroundScanReport extends KyvernoReportBase {
-  static kind = 'ClusterBackgroundScanReport';
-  static apiName = 'clusterbackgroundscanreports';
-  static apiVersion = 'kyverno.io/v2';
-  static isNamespaced = false;
-}
+// Kyverno does not expose AdmissionReport / BackgroundScanReport as separate,
+// listable API resources. Both the admission controller and the background
+// controller write their intermediate results as EphemeralReport /
+// ClusterEphemeralReport (reports.kyverno.io/v1), distinguished only by the
+// `audit.kyverno.io/source: admission|background-scan` label. Confirmed live:
+// `kubectl get --raw /apis/kyverno.io/v2` never lists admissionreports or
+// backgroundscanreports, and requesting either path returns a 404.
 
 export class EphemeralReport extends KyvernoReportBase {
   static kind = 'EphemeralReport';


### PR DESCRIPTION
## What this fixes

The Kyverno plugin registers four sidebar pages: Admission Reports, Cluster Admission Reports, Background Scan Reports and Cluster Background Scan Reports. All four read from `kyverno.io/v2`, a resource that does not exist. On every real Kyverno install these pages load forever and never show data.

## Root cause

`kyvernoReports.ts` declares `AdmissionReport`, `ClusterAdmissionReport`, `BackgroundScanReport` and `ClusterBackgroundScanReport` under `apiVersion: kyverno.io/v2`. I checked this against a kind cluster running Kyverno v1.18.2:

```
$ kubectl get --raw /apis/kyverno.io/v2 | jq -r '.resources[].name' | sort -u
cleanuppolicies
clustercleanuppolicies
globalcontextentries
policyexceptions
updaterequests

$ kubectl get --raw /apis/kyverno.io/v2/admissionreports
Error from server (NotFound): the server could not find the requested resource

$ kubectl get --raw /apis/kyverno.io/v2/backgroundscanreports
Error from server (NotFound): the server could not find the requested resource
```

`kyverno.io/v2` only ever held CleanupPolicy, ClusterCleanupPolicy, PolicyException, UpdateRequest and GlobalContextEntry. Admission and background scan results live in `EphemeralReport` and `ClusterEphemeralReport` under `reports.kyverno.io/v1`, told apart only by an `audit.kyverno.io/source` label. I confirmed this by running a pod and reading the EphemeralReport it produced, which carries `audit.kyverno.io/source: admission`.

The CRD guard that should hide these pages when unsupported never catches it either. `useKyvernoCRDs` sets `kyvernoV2Reports` to true whenever the `kyverno.io/v2` group exists at all, which it does, because CleanupPolicy and PolicyException are real. The guard checks group existence, not resource existence, so it passes and the four broken pages render on every install.

## What changed

- Removed `AdmissionReport`, `ClusterAdmissionReport`, `BackgroundScanReport` and `ClusterBackgroundScanReport` from `resources/kyvernoReports.ts`.
- Removed their four sidebar pages and routes from `index.tsx`.
- Removed the `kyvernoV2Reports` field from `useKyvernoCRDs` and its entry in `CRDGuard`'s message map, since nothing needs it anymore.
- Updated the two illustrative comments in `ReportViewer.tsx` that used `AdmissionReport` as an example.

`EphemeralReport` and `ClusterEphemeralReport`, which are real, are untouched.

## Verification

- `npm run tsc`, `npm run lint` and `npm run test` all pass.
- `npm run build` succeeds.
- Ran the built plugin against the same local kind cluster, before and after. Before, the Reports submenu lists all eight entries and Background Scan Reports spins forever. After, the submenu lists only Policy Reports, Cluster Policy Reports, Ephemeral Reports and Cluster Ephemeral Reports, all of which load correctly.

**Before, sidebar with the four dead entries:**
<img width="1400" height="900" alt="1-before-sidebar-broken-entries" src="https://github.com/user-attachments/assets/2e278a7e-9040-41cd-a98c-47a106ffdb8b" />


**Before, Background Scan Reports stuck on a permanent spinner:**
<img width="1400" height="900" alt="2-before-stuck-loading" src="https://github.com/user-attachments/assets/b1d84b9e-e0e7-4f53-bb2b-39944e258b54" />


**Terminal proof the resource does not exist:**
<img width="1005" height="410" alt="3-terminal-404-proof" src="https://github.com/user-attachments/assets/14ba0d5b-1685-43bf-b563-e0dfb025ab70" />


**After, sidebar showing only the real report types:**
<img width="1400" height="900" alt="4-after-sidebar-fixed" src="https://github.com/user-attachments/assets/fcf864f4-58c1-44e7-9326-15b2c93202f3" />
