### PR TITLE
opencost: Guard isOpenCostInstalled against a missing http-ui port

### DIFF
--- a/opencost/src/request.tsx
+++ b/opencost/src/request.tsx
@@ -12,10 +12,13 @@ export async function isOpenCostInstalled() {
 
   if (response.items && response.items.length > 0) {
     // find the service with name http-ui
-    const httpUIPort = response.items[0].spec.ports.filter(port => port.name === 'http-ui');
+    const httpUIPort = response.items[0].spec.ports.find(port => port.name === 'http-ui');
+    if (!httpUIPort) {
+      return [false, null, null];
+    }
     return [
       true,
-      `${response.items[0].metadata.name}:${httpUIPort[0].name}`,
+      `${response.items[0].metadata.name}:${httpUIPort.name}`,
       response.items[0].metadata.namespace,
     ];
   }


### PR DESCRIPTION
## Summary

Fixes `isOpenCostInstalled` crashing when the matched OpenCost Service doesn't expose a port literally named `http-ui`.

## Related Issue

Fixes #1086

## Changes

- `opencost/src/request.tsx`: `isOpenCostInstalled` used `.filter(...)[0].name`, which throws `TypeError: Cannot read properties of undefined (reading 'name')` when no port is named `http-ui` (different OpenCost Helm chart versions and custom installs commonly name it differently). Switched to `.find()` with an explicit `undefined` check, returning the same "not installed" tuple (`[false, null, null]`) used when no matching Service exists at all.
- No behavior change for the common case where the port is named `http-ui`.

## Why it matters

`isOpenCostInstalled` is only ever awaited inside `useEffect`s with no try/catch (`detail.tsx`, `index.tsx`), so the throw became an unhandled rejection. Downstream `installed`/`isLoading` state (both default to a "loading/installed" value) never got corrected, so the Cost section got stuck permanently on "Fetching Data" instead of falling back to the "Install Opencost" message.

## Steps to Test

1. Mock the Kubernetes API response for `isOpenCostInstalled` with a Service matching `app.kubernetes.io/name=opencost` but with `spec.ports: [{ name: 'http', port: 9003 }]` (no `http-ui` port).
2. Before the fix: `isOpenCostInstalled()` rejects with the TypeError above.
3. After the fix: `isOpenCostInstalled()` resolves to `[false, null, null]`, and the UI correctly falls back to "Install Opencost for accessing cost info" instead of an infinite loader — verified locally via a throwaway test against the mocked response.
