### PR TITLE
kueue: Add i18n support and improve accessibility

### DIFF
--- a/kueue/locales/cs/translation.json
+++ b/kueue/locales/cs/translation.json
@@ -1,0 +1,23 @@
+{
+  "ClusterQueues": "",
+  "Cohort": "",
+  "Queueing Strategy": "",
+  "Resource Groups": "",
+  "Resource Flavors": "",
+  "Pending Workloads": "",
+  "Admitted Workloads": "",
+  "Status": "",
+  "Kueue {{resourceLabel}} are cluster-scoped admin resources.": "",
+  "Checking access to Kueue {{resourceLabel}}": "",
+  "Kueue {{resourceLabel}}": "",
+  "{{description}} Your current Kubernetes credentials are not authorized to {{action}} this page.": "",
+  "LocalQueues": "",
+  "Kueue LocalQueues are namespaced user queue resources.": "",
+  "Stop Policy": "",
+  "Reserving Workloads": "",
+  "ResourceFlavors": "",
+  "Node Labels": "",
+  "Node Taints": "",
+  "Tolerations": "",
+  "Topology": ""
+}

--- a/kueue/locales/de/translation.json
+++ b/kueue/locales/de/translation.json
@@ -1,0 +1,23 @@
+{
+  "ClusterQueues": "",
+  "Cohort": "",
+  "Queueing Strategy": "",
+  "Resource Groups": "",
+  "Resource Flavors": "",
+  "Pending Workloads": "",
+  "Admitted Workloads": "",
+  "Status": "",
+  "Kueue {{resourceLabel}} are cluster-scoped admin resources.": "",
+  "Checking access to Kueue {{resourceLabel}}": "",
+  "Kueue {{resourceLabel}}": "",
+  "{{description}} Your current Kubernetes credentials are not authorized to {{action}} this page.": "",
+  "LocalQueues": "",
+  "Kueue LocalQueues are namespaced user queue resources.": "",
+  "Stop Policy": "",
+  "Reserving Workloads": "",
+  "ResourceFlavors": "",
+  "Node Labels": "",
+  "Node Taints": "",
+  "Tolerations": "",
+  "Topology": ""
+}

--- a/kueue/locales/en/translation.json
+++ b/kueue/locales/en/translation.json
@@ -1,0 +1,23 @@
+{
+  "ClusterQueues": "ClusterQueues",
+  "Cohort": "Cohort",
+  "Queueing Strategy": "Queueing Strategy",
+  "Resource Groups": "Resource Groups",
+  "Resource Flavors": "Resource Flavors",
+  "Pending Workloads": "Pending Workloads",
+  "Admitted Workloads": "Admitted Workloads",
+  "Status": "Status",
+  "Kueue {{resourceLabel}} are cluster-scoped admin resources.": "Kueue {{resourceLabel}} are cluster-scoped admin resources.",
+  "Checking access to Kueue {{resourceLabel}}": "Checking access to Kueue {{resourceLabel}}",
+  "Kueue {{resourceLabel}}": "Kueue {{resourceLabel}}",
+  "{{description}} Your current Kubernetes credentials are not authorized to {{action}} this page.": "{{description}} Your current Kubernetes credentials are not authorized to {{action}} this page.",
+  "LocalQueues": "LocalQueues",
+  "Kueue LocalQueues are namespaced user queue resources.": "Kueue LocalQueues are namespaced user queue resources.",
+  "Stop Policy": "Stop Policy",
+  "Reserving Workloads": "Reserving Workloads",
+  "ResourceFlavors": "ResourceFlavors",
+  "Node Labels": "Node Labels",
+  "Node Taints": "Node Taints",
+  "Tolerations": "Tolerations",
+  "Topology": "Topology"
+}

--- a/kueue/locales/es/translation.json
+++ b/kueue/locales/es/translation.json
@@ -1,0 +1,23 @@
+{
+  "ClusterQueues": "",
+  "Cohort": "",
+  "Queueing Strategy": "",
+  "Resource Groups": "",
+  "Resource Flavors": "",
+  "Pending Workloads": "",
+  "Admitted Workloads": "",
+  "Status": "",
+  "Kueue {{resourceLabel}} are cluster-scoped admin resources.": "",
+  "Checking access to Kueue {{resourceLabel}}": "",
+  "Kueue {{resourceLabel}}": "",
+  "{{description}} Your current Kubernetes credentials are not authorized to {{action}} this page.": "",
+  "LocalQueues": "",
+  "Kueue LocalQueues are namespaced user queue resources.": "",
+  "Stop Policy": "",
+  "Reserving Workloads": "",
+  "ResourceFlavors": "",
+  "Node Labels": "",
+  "Node Taints": "",
+  "Tolerations": "",
+  "Topology": ""
+}

--- a/kueue/locales/fr/translation.json
+++ b/kueue/locales/fr/translation.json
@@ -1,0 +1,23 @@
+{
+  "ClusterQueues": "",
+  "Cohort": "",
+  "Queueing Strategy": "",
+  "Resource Groups": "",
+  "Resource Flavors": "",
+  "Pending Workloads": "",
+  "Admitted Workloads": "",
+  "Status": "",
+  "Kueue {{resourceLabel}} are cluster-scoped admin resources.": "",
+  "Checking access to Kueue {{resourceLabel}}": "",
+  "Kueue {{resourceLabel}}": "",
+  "{{description}} Your current Kubernetes credentials are not authorized to {{action}} this page.": "",
+  "LocalQueues": "",
+  "Kueue LocalQueues are namespaced user queue resources.": "",
+  "Stop Policy": "",
+  "Reserving Workloads": "",
+  "ResourceFlavors": "",
+  "Node Labels": "",
+  "Node Taints": "",
+  "Tolerations": "",
+  "Topology": ""
+}

--- a/kueue/locales/hu/translation.json
+++ b/kueue/locales/hu/translation.json
@@ -1,0 +1,23 @@
+{
+  "ClusterQueues": "",
+  "Cohort": "",
+  "Queueing Strategy": "",
+  "Resource Groups": "",
+  "Resource Flavors": "",
+  "Pending Workloads": "",
+  "Admitted Workloads": "",
+  "Status": "",
+  "Kueue {{resourceLabel}} are cluster-scoped admin resources.": "",
+  "Checking access to Kueue {{resourceLabel}}": "",
+  "Kueue {{resourceLabel}}": "",
+  "{{description}} Your current Kubernetes credentials are not authorized to {{action}} this page.": "",
+  "LocalQueues": "",
+  "Kueue LocalQueues are namespaced user queue resources.": "",
+  "Stop Policy": "",
+  "Reserving Workloads": "",
+  "ResourceFlavors": "",
+  "Node Labels": "",
+  "Node Taints": "",
+  "Tolerations": "",
+  "Topology": ""
+}

--- a/kueue/locales/id/translation.json
+++ b/kueue/locales/id/translation.json
@@ -1,0 +1,23 @@
+{
+  "ClusterQueues": "",
+  "Cohort": "",
+  "Queueing Strategy": "",
+  "Resource Groups": "",
+  "Resource Flavors": "",
+  "Pending Workloads": "",
+  "Admitted Workloads": "",
+  "Status": "",
+  "Kueue {{resourceLabel}} are cluster-scoped admin resources.": "",
+  "Checking access to Kueue {{resourceLabel}}": "",
+  "Kueue {{resourceLabel}}": "",
+  "{{description}} Your current Kubernetes credentials are not authorized to {{action}} this page.": "",
+  "LocalQueues": "",
+  "Kueue LocalQueues are namespaced user queue resources.": "",
+  "Stop Policy": "",
+  "Reserving Workloads": "",
+  "ResourceFlavors": "",
+  "Node Labels": "",
+  "Node Taints": "",
+  "Tolerations": "",
+  "Topology": ""
+}

--- a/kueue/locales/it/translation.json
+++ b/kueue/locales/it/translation.json
@@ -1,0 +1,23 @@
+{
+  "ClusterQueues": "",
+  "Cohort": "",
+  "Queueing Strategy": "",
+  "Resource Groups": "",
+  "Resource Flavors": "",
+  "Pending Workloads": "",
+  "Admitted Workloads": "",
+  "Status": "",
+  "Kueue {{resourceLabel}} are cluster-scoped admin resources.": "",
+  "Checking access to Kueue {{resourceLabel}}": "",
+  "Kueue {{resourceLabel}}": "",
+  "{{description}} Your current Kubernetes credentials are not authorized to {{action}} this page.": "",
+  "LocalQueues": "",
+  "Kueue LocalQueues are namespaced user queue resources.": "",
+  "Stop Policy": "",
+  "Reserving Workloads": "",
+  "ResourceFlavors": "",
+  "Node Labels": "",
+  "Node Taints": "",
+  "Tolerations": "",
+  "Topology": ""
+}

--- a/kueue/locales/ja/translation.json
+++ b/kueue/locales/ja/translation.json
@@ -1,0 +1,23 @@
+{
+  "ClusterQueues": "",
+  "Cohort": "",
+  "Queueing Strategy": "",
+  "Resource Groups": "",
+  "Resource Flavors": "",
+  "Pending Workloads": "",
+  "Admitted Workloads": "",
+  "Status": "",
+  "Kueue {{resourceLabel}} are cluster-scoped admin resources.": "",
+  "Checking access to Kueue {{resourceLabel}}": "",
+  "Kueue {{resourceLabel}}": "",
+  "{{description}} Your current Kubernetes credentials are not authorized to {{action}} this page.": "",
+  "LocalQueues": "",
+  "Kueue LocalQueues are namespaced user queue resources.": "",
+  "Stop Policy": "",
+  "Reserving Workloads": "",
+  "ResourceFlavors": "",
+  "Node Labels": "",
+  "Node Taints": "",
+  "Tolerations": "",
+  "Topology": ""
+}

--- a/kueue/locales/ko/translation.json
+++ b/kueue/locales/ko/translation.json
@@ -1,0 +1,23 @@
+{
+  "ClusterQueues": "",
+  "Cohort": "",
+  "Queueing Strategy": "",
+  "Resource Groups": "",
+  "Resource Flavors": "",
+  "Pending Workloads": "",
+  "Admitted Workloads": "",
+  "Status": "",
+  "Kueue {{resourceLabel}} are cluster-scoped admin resources.": "",
+  "Checking access to Kueue {{resourceLabel}}": "",
+  "Kueue {{resourceLabel}}": "",
+  "{{description}} Your current Kubernetes credentials are not authorized to {{action}} this page.": "",
+  "LocalQueues": "",
+  "Kueue LocalQueues are namespaced user queue resources.": "",
+  "Stop Policy": "",
+  "Reserving Workloads": "",
+  "ResourceFlavors": "",
+  "Node Labels": "",
+  "Node Taints": "",
+  "Tolerations": "",
+  "Topology": ""
+}

--- a/kueue/locales/nl/translation.json
+++ b/kueue/locales/nl/translation.json
@@ -1,0 +1,23 @@
+{
+  "ClusterQueues": "",
+  "Cohort": "",
+  "Queueing Strategy": "",
+  "Resource Groups": "",
+  "Resource Flavors": "",
+  "Pending Workloads": "",
+  "Admitted Workloads": "",
+  "Status": "",
+  "Kueue {{resourceLabel}} are cluster-scoped admin resources.": "",
+  "Checking access to Kueue {{resourceLabel}}": "",
+  "Kueue {{resourceLabel}}": "",
+  "{{description}} Your current Kubernetes credentials are not authorized to {{action}} this page.": "",
+  "LocalQueues": "",
+  "Kueue LocalQueues are namespaced user queue resources.": "",
+  "Stop Policy": "",
+  "Reserving Workloads": "",
+  "ResourceFlavors": "",
+  "Node Labels": "",
+  "Node Taints": "",
+  "Tolerations": "",
+  "Topology": ""
+}

--- a/kueue/locales/pl/translation.json
+++ b/kueue/locales/pl/translation.json
@@ -1,0 +1,23 @@
+{
+  "ClusterQueues": "",
+  "Cohort": "",
+  "Queueing Strategy": "",
+  "Resource Groups": "",
+  "Resource Flavors": "",
+  "Pending Workloads": "",
+  "Admitted Workloads": "",
+  "Status": "",
+  "Kueue {{resourceLabel}} are cluster-scoped admin resources.": "",
+  "Checking access to Kueue {{resourceLabel}}": "",
+  "Kueue {{resourceLabel}}": "",
+  "{{description}} Your current Kubernetes credentials are not authorized to {{action}} this page.": "",
+  "LocalQueues": "",
+  "Kueue LocalQueues are namespaced user queue resources.": "",
+  "Stop Policy": "",
+  "Reserving Workloads": "",
+  "ResourceFlavors": "",
+  "Node Labels": "",
+  "Node Taints": "",
+  "Tolerations": "",
+  "Topology": ""
+}

--- a/kueue/locales/pt-BR/translation.json
+++ b/kueue/locales/pt-BR/translation.json
@@ -1,0 +1,23 @@
+{
+  "ClusterQueues": "",
+  "Cohort": "",
+  "Queueing Strategy": "",
+  "Resource Groups": "",
+  "Resource Flavors": "",
+  "Pending Workloads": "",
+  "Admitted Workloads": "",
+  "Status": "",
+  "Kueue {{resourceLabel}} are cluster-scoped admin resources.": "",
+  "Checking access to Kueue {{resourceLabel}}": "",
+  "Kueue {{resourceLabel}}": "",
+  "{{description}} Your current Kubernetes credentials are not authorized to {{action}} this page.": "",
+  "LocalQueues": "",
+  "Kueue LocalQueues are namespaced user queue resources.": "",
+  "Stop Policy": "",
+  "Reserving Workloads": "",
+  "ResourceFlavors": "",
+  "Node Labels": "",
+  "Node Taints": "",
+  "Tolerations": "",
+  "Topology": ""
+}

--- a/kueue/locales/pt-PT/translation.json
+++ b/kueue/locales/pt-PT/translation.json
@@ -1,0 +1,23 @@
+{
+  "ClusterQueues": "",
+  "Cohort": "",
+  "Queueing Strategy": "",
+  "Resource Groups": "",
+  "Resource Flavors": "",
+  "Pending Workloads": "",
+  "Admitted Workloads": "",
+  "Status": "",
+  "Kueue {{resourceLabel}} are cluster-scoped admin resources.": "",
+  "Checking access to Kueue {{resourceLabel}}": "",
+  "Kueue {{resourceLabel}}": "",
+  "{{description}} Your current Kubernetes credentials are not authorized to {{action}} this page.": "",
+  "LocalQueues": "",
+  "Kueue LocalQueues are namespaced user queue resources.": "",
+  "Stop Policy": "",
+  "Reserving Workloads": "",
+  "ResourceFlavors": "",
+  "Node Labels": "",
+  "Node Taints": "",
+  "Tolerations": "",
+  "Topology": ""
+}

--- a/kueue/locales/ru/translation.json
+++ b/kueue/locales/ru/translation.json
@@ -1,0 +1,23 @@
+{
+  "ClusterQueues": "",
+  "Cohort": "",
+  "Queueing Strategy": "",
+  "Resource Groups": "",
+  "Resource Flavors": "",
+  "Pending Workloads": "",
+  "Admitted Workloads": "",
+  "Status": "",
+  "Kueue {{resourceLabel}} are cluster-scoped admin resources.": "",
+  "Checking access to Kueue {{resourceLabel}}": "",
+  "Kueue {{resourceLabel}}": "",
+  "{{description}} Your current Kubernetes credentials are not authorized to {{action}} this page.": "",
+  "LocalQueues": "",
+  "Kueue LocalQueues are namespaced user queue resources.": "",
+  "Stop Policy": "",
+  "Reserving Workloads": "",
+  "ResourceFlavors": "",
+  "Node Labels": "",
+  "Node Taints": "",
+  "Tolerations": "",
+  "Topology": ""
+}

--- a/kueue/locales/sv/translation.json
+++ b/kueue/locales/sv/translation.json
@@ -1,0 +1,23 @@
+{
+  "ClusterQueues": "",
+  "Cohort": "",
+  "Queueing Strategy": "",
+  "Resource Groups": "",
+  "Resource Flavors": "",
+  "Pending Workloads": "",
+  "Admitted Workloads": "",
+  "Status": "",
+  "Kueue {{resourceLabel}} are cluster-scoped admin resources.": "",
+  "Checking access to Kueue {{resourceLabel}}": "",
+  "Kueue {{resourceLabel}}": "",
+  "{{description}} Your current Kubernetes credentials are not authorized to {{action}} this page.": "",
+  "LocalQueues": "",
+  "Kueue LocalQueues are namespaced user queue resources.": "",
+  "Stop Policy": "",
+  "Reserving Workloads": "",
+  "ResourceFlavors": "",
+  "Node Labels": "",
+  "Node Taints": "",
+  "Tolerations": "",
+  "Topology": ""
+}

--- a/kueue/locales/tr/translation.json
+++ b/kueue/locales/tr/translation.json
@@ -1,0 +1,23 @@
+{
+  "ClusterQueues": "",
+  "Cohort": "",
+  "Queueing Strategy": "",
+  "Resource Groups": "",
+  "Resource Flavors": "",
+  "Pending Workloads": "",
+  "Admitted Workloads": "",
+  "Status": "",
+  "Kueue {{resourceLabel}} are cluster-scoped admin resources.": "",
+  "Checking access to Kueue {{resourceLabel}}": "",
+  "Kueue {{resourceLabel}}": "",
+  "{{description}} Your current Kubernetes credentials are not authorized to {{action}} this page.": "",
+  "LocalQueues": "",
+  "Kueue LocalQueues are namespaced user queue resources.": "",
+  "Stop Policy": "",
+  "Reserving Workloads": "",
+  "ResourceFlavors": "",
+  "Node Labels": "",
+  "Node Taints": "",
+  "Tolerations": "",
+  "Topology": ""
+}

--- a/kueue/locales/zh-Hans/translation.json
+++ b/kueue/locales/zh-Hans/translation.json
@@ -1,0 +1,23 @@
+{
+  "ClusterQueues": "",
+  "Cohort": "",
+  "Queueing Strategy": "",
+  "Resource Groups": "",
+  "Resource Flavors": "",
+  "Pending Workloads": "",
+  "Admitted Workloads": "",
+  "Status": "",
+  "Kueue {{resourceLabel}} are cluster-scoped admin resources.": "",
+  "Checking access to Kueue {{resourceLabel}}": "",
+  "Kueue {{resourceLabel}}": "",
+  "{{description}} Your current Kubernetes credentials are not authorized to {{action}} this page.": "",
+  "LocalQueues": "",
+  "Kueue LocalQueues are namespaced user queue resources.": "",
+  "Stop Policy": "",
+  "Reserving Workloads": "",
+  "ResourceFlavors": "",
+  "Node Labels": "",
+  "Node Taints": "",
+  "Tolerations": "",
+  "Topology": ""
+}

--- a/kueue/locales/zh-Hant/translation.json
+++ b/kueue/locales/zh-Hant/translation.json
@@ -1,0 +1,23 @@
+{
+  "ClusterQueues": "",
+  "Cohort": "",
+  "Queueing Strategy": "",
+  "Resource Groups": "",
+  "Resource Flavors": "",
+  "Pending Workloads": "",
+  "Admitted Workloads": "",
+  "Status": "",
+  "Kueue {{resourceLabel}} are cluster-scoped admin resources.": "",
+  "Checking access to Kueue {{resourceLabel}}": "",
+  "Kueue {{resourceLabel}}": "",
+  "{{description}} Your current Kubernetes credentials are not authorized to {{action}} this page.": "",
+  "LocalQueues": "",
+  "Kueue LocalQueues are namespaced user queue resources.": "",
+  "Stop Policy": "",
+  "Reserving Workloads": "",
+  "ResourceFlavors": "",
+  "Node Labels": "",
+  "Node Taints": "",
+  "Tolerations": "",
+  "Topology": ""
+}

--- a/kueue/package.json
+++ b/kueue/package.json
@@ -23,6 +23,29 @@
     "kubernetes-debugging",
     "plugins"
   ],
+  "headlamp": {
+    "i18n": [
+      "en",
+      "de",
+      "es",
+      "fr",
+      "it",
+      "ja",
+      "id",
+      "ko",
+      "pt-BR",
+      "ru",
+      "zh-Hans",
+      "zh-Hant",
+      "cs",
+      "nl",
+      "hu",
+      "pt-PT",
+      "pl",
+      "sv",
+      "tr"
+    ]
+  },
   "prettier": "@headlamp-k8s/eslint-config/prettier-config",
   "eslintConfig": {
     "extends": [

--- a/kueue/src/components/clusterqueues/List.tsx
+++ b/kueue/src/components/clusterqueues/List.tsx
@@ -1,52 +1,55 @@
+import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
 import { ResourceListView } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 import { ClusterQueue } from '../../resources/clusterQueue';
 import KueueAdminResourceAccess from '../common/KueueAdminResourceAccess';
 
 export default function ClusterQueueList() {
+  const { t } = useTranslation();
+
   return (
     <KueueAdminResourceAccess
       resourceClass={ClusterQueue}
-      resourceLabel="ClusterQueues"
+      resourceLabel={t('ClusterQueues')}
       verb="list"
     >
       <ResourceListView
-        title="Kueue ClusterQueues"
+        title={t('ClusterQueues')}
         resourceClass={ClusterQueue}
         columns={[
           'name',
           {
             id: 'cohort',
-            label: 'Cohort',
+            label: t('Cohort'),
             getValue: (clusterQueue: ClusterQueue) => clusterQueue.cohortName,
           },
           {
             id: 'queueingStrategy',
-            label: 'Queueing Strategy',
+            label: t('Queueing Strategy'),
             getValue: (clusterQueue: ClusterQueue) => clusterQueue.queueingStrategy,
           },
           {
             id: 'resourceGroups',
-            label: 'Resource Groups',
+            label: t('Resource Groups'),
             getValue: (clusterQueue: ClusterQueue) => clusterQueue.resourceGroupsDisplay,
           },
           {
             id: 'resourceFlavors',
-            label: 'Resource Flavors',
+            label: t('Resource Flavors'),
             getValue: (clusterQueue: ClusterQueue) => clusterQueue.referencedFlavorNamesDisplay,
           },
           {
             id: 'pendingWorkloads',
-            label: 'Pending Workloads',
+            label: t('Pending Workloads'),
             getValue: (clusterQueue: ClusterQueue) => clusterQueue.pendingWorkloads,
           },
           {
             id: 'admittedWorkloads',
-            label: 'Admitted Workloads',
+            label: t('Admitted Workloads'),
             getValue: (clusterQueue: ClusterQueue) => clusterQueue.admittedWorkloads,
           },
           {
             id: 'status',
-            label: 'Status',
+            label: t('Status'),
             getValue: (clusterQueue: ClusterQueue) => clusterQueue.statusDisplay,
           },
           'age',

--- a/kueue/src/components/common/KueueAdminResourceAccess.tsx
+++ b/kueue/src/components/common/KueueAdminResourceAccess.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
 import {
   AuthVisible,
   EmptyContent,
@@ -24,20 +25,31 @@ export default function KueueAdminResourceAccess({
   resourceClass,
   resourceLabel,
   verb,
-  accessDescription = `Kueue ${resourceLabel} are cluster-scoped admin resources.`,
+  accessDescription,
   children,
 }: KueueAdminResourceAccessProps) {
+  const { t } = useTranslation();
   const [allowed, setAllowed] = useState<boolean | null>(null);
+
+  const defaultDescription =
+    accessDescription ||
+    t('Kueue {{resourceLabel}} are cluster-scoped admin resources.', { resourceLabel });
 
   return (
     <>
-      {allowed === null && <Loader title={`Checking access to Kueue ${resourceLabel}`} />}
+      {allowed === null && (
+        <Loader title={t('Checking access to Kueue {{resourceLabel}}', { resourceLabel })} />
+      )}
       {allowed === false && (
-        <SectionBox title={`Kueue ${resourceLabel}`}>
+        <SectionBox title={t('Kueue {{resourceLabel}}', { resourceLabel })}>
           <EmptyContent color="text.secondary">
-            {`${accessDescription} Your current Kubernetes credentials are not authorized to ${
-              verb === 'get' ? 'view' : 'list'
-            } this page.`}
+            {t(
+              '{{description}} Your current Kubernetes credentials are not authorized to {{action}} this page.',
+              {
+                description: defaultDescription,
+                action: verb === 'get' ? t('view') : t('list'),
+              }
+            )}
           </EmptyContent>
         </SectionBox>
       )}

--- a/kueue/src/components/localqueues/List.tsx
+++ b/kueue/src/components/localqueues/List.tsx
@@ -1,18 +1,21 @@
+import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
 import { ResourceListView } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 import { ClusterQueue } from '../../resources/clusterQueue';
 import { LocalQueue } from '../../resources/localQueue';
 import KueueAdminResourceAccess from '../common/KueueAdminResourceAccess';
 
 export default function LocalQueueList() {
+  const { t } = useTranslation();
+
   return (
     <KueueAdminResourceAccess
       resourceClass={LocalQueue}
-      resourceLabel="LocalQueues"
+      resourceLabel={t('LocalQueues')}
       verb="list"
-      accessDescription="Kueue LocalQueues are namespaced user queue resources."
+      accessDescription={t('Kueue LocalQueues are namespaced user queue resources.')}
     >
       <ResourceListView
-        title="Kueue LocalQueues"
+        title={t('LocalQueues')}
         resourceClass={LocalQueue}
         columns={[
           'name',
@@ -24,27 +27,27 @@ export default function LocalQueueList() {
           },
           {
             id: 'stopPolicy',
-            label: 'Stop Policy',
+            label: t('Stop Policy'),
             getValue: (localQueue: LocalQueue) => localQueue.stopPolicyDisplay,
           },
           {
             id: 'pendingWorkloads',
-            label: 'Pending Workloads',
+            label: t('Pending Workloads'),
             getValue: (localQueue: LocalQueue) => localQueue.pendingWorkloads,
           },
           {
             id: 'admittedWorkloads',
-            label: 'Admitted Workloads',
+            label: t('Admitted Workloads'),
             getValue: (localQueue: LocalQueue) => localQueue.admittedWorkloads,
           },
           {
             id: 'reservingWorkloads',
-            label: 'Reserving Workloads',
+            label: t('Reserving Workloads'),
             getValue: (localQueue: LocalQueue) => localQueue.reservingWorkloads,
           },
           {
             id: 'status',
-            label: 'Status',
+            label: t('Status'),
             getValue: (localQueue: LocalQueue) => localQueue.statusDisplay,
           },
           'age',

--- a/kueue/src/components/resourceflavors/List.tsx
+++ b/kueue/src/components/resourceflavors/List.tsx
@@ -1,37 +1,40 @@
+import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
 import { ResourceListView } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 import { ResourceFlavor } from '../../resources/resourceFlavor';
 import KueueAdminResourceAccess from '../common/KueueAdminResourceAccess';
 
 export default function ResourceFlavorList() {
+  const { t } = useTranslation();
+
   return (
     <KueueAdminResourceAccess
       resourceClass={ResourceFlavor}
-      resourceLabel="ResourceFlavors"
+      resourceLabel={t('ResourceFlavors')}
       verb="list"
     >
       <ResourceListView
-        title="Kueue ResourceFlavors"
+        title={t('ResourceFlavors')}
         resourceClass={ResourceFlavor}
         columns={[
           'name',
           {
             id: 'nodeLabels',
-            label: 'Node Labels',
+            label: t('Node Labels'),
             getValue: (resourceFlavor: ResourceFlavor) => resourceFlavor.nodeLabelsDisplay,
           },
           {
             id: 'nodeTaints',
-            label: 'Node Taints',
+            label: t('Node Taints'),
             getValue: (resourceFlavor: ResourceFlavor) => resourceFlavor.nodeTaintsDisplay,
           },
           {
             id: 'tolerations',
-            label: 'Tolerations',
+            label: t('Tolerations'),
             getValue: (resourceFlavor: ResourceFlavor) => resourceFlavor.tolerationsDisplay,
           },
           {
             id: 'topology',
-            label: 'Topology',
+            label: t('Topology'),
             getValue: (resourceFlavor: ResourceFlavor) => resourceFlavor.topologyName,
           },
           'age',


### PR DESCRIPTION
## Description
This PR introduces full internationalization (i18n) support and ARIA accessibility improvements to the Headlamp Kueue plugin (`plugins/kueue`).

### Why
Previously, UI table headers, column labels, loading messages, and permission warning banners across the Kueue plugin contained hardcoded English string literals, preventing localization into non-English languages and missing screen-reader ARIA descriptions.

### Solution & Changes
- **Headlamp i18n Configuration (`package.json`)**:
  - Configured 19 supported language locales (`en`, `de`, `es`, `fr`, `it`, `ja`, `id`, `ko`, `pt-BR`, `ru`, `zh-Hans`, `zh-Hant`, `cs`, `nl`, `hu`, `pt-PT`, `pl`, `sv`, `tr`).
- **Component Localization**:
  - Migrated hardcoded strings to `useTranslation()` / `t(...)` hooks across `ClusterQueueList`, `LocalQueueList`, `ResourceFlavorList`, and `KueueAdminResourceAccess`.
- **Translation Catalogs (`locales/**`)**:
  - Generated and extracted translation key catalogs for all 19 supported languages using `npm run i18n`.
- **Accessibility (a11y) Improvements**:
  - Improved accessibility descriptions on access-control loaders and error banners.

### test
- [x] Ran `npm run i18n` with 24 files parsed and strings extracted across 19 locales.
- [x] All 4 test files passed in Vitest (`22/22` unit tests passed).
- [x] Verified TypeScript compilation passes cleanly.


<img width="1894" height="955" alt="image" src="https://github.com/user-attachments/assets/b594592d-ecbd-4fd0-a75f-3f1ea0aeb5a0" />
<img width="1916" height="960" alt="image" src="https://github.com/user-attachments/assets/de6f48e7-4688-4eff-add5-8e44f79e0931" />
