### PR TITLE
metal3: Add a fleet overview landing page

### DIFF
--- a/metal3/src/BareMetalHost/Overview.tsx
+++ b/metal3/src/BareMetalHost/Overview.tsx
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2026 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  EmptyContent,
+  Link,
+  Loader,
+  NamespacesAutocomplete,
+  PageGrid,
+  SectionBox,
+  SimpleTable,
+} from '@kinvolk/headlamp-plugin/lib/components/common';
+import type { KubeObject } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import { Box, MenuItem, TextField } from '@mui/material';
+import { useMemo, useState } from 'react';
+import { useSelector } from 'react-redux';
+import { CRDGuard } from '../common/CRDGuard';
+import { HostStatusLabel } from './HostStatusLabel';
+import { bareMetalHostClass } from './List';
+import type { InProgressHost } from './overviewStats';
+import { computeOverview, groupByLabel, inProgressHosts, labelKeys } from './overviewStats';
+
+/**
+ * The globally selected namespaces (empty means all), read from Headlamp's shared
+ * filter store the way its list views do. Uses react-redux directly because the
+ * internal filter module is not exposed to plugins at runtime.
+ */
+function useSelectedNamespaces(): string[] | undefined {
+  const namespaces = useSelector(
+    (state: { filter?: { namespaces?: Set<string> } }) => state.filter?.namespaces
+  );
+  // Undefined means all namespaces; otherwise a stable array so it can be passed
+  // straight to useList as a query dependency without re-fetching every render.
+  return useMemo(() => (namespaces && namespaces.size ? [...namespaces] : undefined), [namespaces]);
+}
+
+/** A dwell time in ms as a short human string, or an em dash when unknown. */
+function formatDuration(ms: number | null): string {
+  if (ms === null) {
+    return '—';
+  }
+  const minutes = Math.floor(ms / 60000);
+  if (minutes < 60) {
+    return `${minutes}m`;
+  }
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) {
+    return `${hours}h ${minutes % 60}m`;
+  }
+  return `${Math.floor(hours / 24)}d ${hours % 24}h`;
+}
+
+/** One row of the fleets table: a fleet and its per-fleet counts. */
+interface FleetRow {
+  name: string;
+  total: number;
+  free: number;
+  claimed: number;
+  backing: number;
+  inProgress: number;
+  error: number;
+  poweredOn: number;
+}
+
+/** A link to a host's detail page. */
+function hostLink(host: KubeObject) {
+  return (
+    <Link
+      routeName="baremetalhost-detail"
+      params={{ namespace: host.metadata.namespace, name: host.metadata.name }}
+    >
+      {host.metadata.name}
+    </Link>
+  );
+}
+
+/** The overview body, rendered once the CRD is confirmed present. */
+function OverviewContent() {
+  const [groupKey, setGroupKey] = useState('');
+  const selectedNamespaces = useSelectedNamespaces();
+  // Scope the request to the selected namespaces so a user with namespace-only list
+  // permission is not forced into a cluster-wide request they cannot make.
+  const [hosts, error] = bareMetalHostClass().useList({ namespace: selectedNamespaces });
+  if (!hosts) {
+    return error ? (
+      <EmptyContent>
+        Could not load bare-metal hosts. You may not have permission to list them, or the request
+        failed.
+      </EmptyContent>
+    ) : (
+      <Loader title="Loading bare-metal hosts…" />
+    );
+  }
+  if (hosts.length === 0) {
+    return <EmptyContent>No bare-metal hosts found.</EmptyContent>;
+  }
+
+  const now = Date.now();
+  const keys = labelKeys(hosts);
+  // The chosen label can drop out when the namespace filter changes; fall back to no
+  // grouping so the select never carries an out-of-range value.
+  const effectiveGroupKey = keys.includes(groupKey) ? groupKey : '';
+  const fleets = groupByLabel(hosts, effectiveGroupKey);
+  const overall = computeOverview(hosts);
+  const allInProgress = inProgressHosts(hosts, now);
+
+  // Which fleet a host belongs to under the current grouping, for the list columns.
+  const fleetOf = (host: KubeObject): string =>
+    effectiveGroupKey
+      ? host.jsonData.metadata?.labels?.[effectiveGroupKey] ?? `(no ${effectiveGroupKey})`
+      : 'All hosts';
+
+  const fleetRows: FleetRow[] = fleets.map(fleet => {
+    const s = computeOverview(fleet.hosts);
+    return {
+      name: fleet.name,
+      total: s.total,
+      free: s.free,
+      claimed: s.claimed,
+      backing: s.backingMachine,
+      inProgress: inProgressHosts(fleet.hosts, now).length,
+      error: s.error,
+      poweredOn: s.poweredOn,
+    };
+  });
+
+  return (
+    <PageGrid>
+      <Box sx={{ display: 'flex', gap: 2, alignItems: 'center', flexWrap: 'wrap', mt: 1.5, mb: 1 }}>
+        <NamespacesAutocomplete />
+        {keys.length > 0 && (
+          <TextField
+            select
+            label="Group by label"
+            value={effectiveGroupKey}
+            onChange={e => setGroupKey(e.target.value)}
+            size="small"
+            sx={{ minWidth: 240 }}
+          >
+            <MenuItem value="">All hosts</MenuItem>
+            {keys.map(k => (
+              <MenuItem key={k} value={k}>
+                {k}
+              </MenuItem>
+            ))}
+          </TextField>
+        )}
+      </Box>
+      <SectionBox title="Fleets">
+        <SimpleTable
+          columns={[
+            { label: 'Fleet', getter: (row: FleetRow) => row.name, sort: true },
+            { label: 'Hosts', getter: (row: FleetRow) => row.total, sort: true },
+            { label: 'Free', getter: (row: FleetRow) => row.free, sort: true },
+            { label: 'Claimed', getter: (row: FleetRow) => row.claimed, sort: true },
+            { label: 'Backing a machine', getter: (row: FleetRow) => row.backing, sort: true },
+            { label: 'In progress', getter: (row: FleetRow) => row.inProgress, sort: true },
+            { label: 'In error', getter: (row: FleetRow) => row.error, sort: true },
+            {
+              label: 'Powered on',
+              getter: (row: FleetRow) => `${row.poweredOn}/${row.total}`,
+              sort: (row: FleetRow) => row.poweredOn,
+            },
+          ]}
+          data={fleetRows}
+        />
+      </SectionBox>
+
+      <SectionBox title="In progress">
+        {allInProgress.length === 0 ? (
+          <EmptyContent>No hosts are mid-operation right now.</EmptyContent>
+        ) : (
+          <SimpleTable
+            columns={[
+              { label: 'Name', getter: (row: InProgressHost) => hostLink(row.host) },
+              ...(effectiveGroupKey
+                ? [{ label: 'Fleet', getter: (row: InProgressHost) => fleetOf(row.host) }]
+                : []),
+              { label: 'State', getter: (row: InProgressHost) => row.state },
+              { label: 'For', getter: (row: InProgressHost) => formatDuration(row.durationMs) },
+            ]}
+            data={allInProgress}
+          />
+        )}
+      </SectionBox>
+
+      <SectionBox title="Needs attention">
+        {overall.attention.length === 0 ? (
+          <EmptyContent>No hosts need attention.</EmptyContent>
+        ) : (
+          <SimpleTable
+            columns={[
+              { label: 'Name', getter: (host: KubeObject) => hostLink(host) },
+              ...(effectiveGroupKey
+                ? [{ label: 'Fleet', getter: (host: KubeObject) => fleetOf(host) }]
+                : []),
+              { label: 'Namespace', getter: (host: KubeObject) => host.metadata.namespace },
+              { label: 'Status', getter: (host: KubeObject) => <HostStatusLabel host={host} /> },
+            ]}
+            data={overall.attention}
+          />
+        )}
+      </SectionBox>
+
+      <Box sx={{ height: 24 }} />
+    </PageGrid>
+  );
+}
+
+/**
+ * Fleet overview and landing page for the Metal3 section.
+ *
+ * Metal3 has no fleet resource, so hosts are grouped into fleets by a label the
+ * user picks, and each fleet is a row showing its allocation (free, claimed, and
+ * how many back a Metal3Machine), how many are in error or in progress, and how
+ * many are powered on. Below that, two lists across all fleets: the hosts
+ * currently mid-operation with how long they have been there, and the hosts
+ * needing attention. Namespace scoping is left to Headlamp's own namespace
+ * filter. It is pure aggregation over the host list, so no new data is fetched
+ * beyond what the list view already loads. Guarded by CRD presence.
+ */
+export function BareMetalHostOverview() {
+  return (
+    <CRDGuard crdName="baremetalhosts.metal3.io" resourceLabel="Bare Metal Host">
+      <OverviewContent />
+    </CRDGuard>
+  );
+}

--- a/metal3/src/BareMetalHost/overviewStats.test.ts
+++ b/metal3/src/BareMetalHost/overviewStats.test.ts
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2026 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { KubeObject } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import { describe, expect, it } from 'vitest';
+import {
+  computeOverview,
+  groupByLabel,
+  inProgressHosts,
+  labelKeys,
+  timeInState,
+} from './overviewStats';
+
+/** Builds a minimal BareMetalHost-shaped object for the aggregation. */
+function host(opts: {
+  name: string;
+  op?: string;
+  prov?: string;
+  online?: boolean;
+  consumer?: boolean;
+  consumerKind?: string;
+  errorType?: string;
+  labels?: Record<string, string>;
+}): KubeObject {
+  return {
+    metadata: { name: opts.name, uid: opts.name },
+    jsonData: {
+      metadata: { name: opts.name, ...(opts.labels ? { labels: opts.labels } : {}) },
+      spec: {
+        ...(opts.online !== undefined ? { online: opts.online } : {}),
+        ...(opts.consumer || opts.consumerKind
+          ? {
+              consumerRef: {
+                name: 'consumer',
+                ...(opts.consumerKind ? { kind: opts.consumerKind } : {}),
+              },
+            }
+          : {}),
+      },
+      status: {
+        operationalStatus: opts.op ?? 'OK',
+        provisioning: { state: opts.prov ?? 'provisioned' },
+        ...(opts.errorType ? { errorType: opts.errorType } : {}),
+      },
+    },
+  } as unknown as KubeObject;
+}
+
+describe('computeOverview', () => {
+  it('returns zeros for an empty fleet', () => {
+    const s = computeOverview([]);
+    expect(s.total).toBe(0);
+    expect(s.attention).toEqual([]);
+  });
+
+  it('aggregates counts across the status axes', () => {
+    const hosts = [
+      host({ name: 'h1', op: 'OK', prov: 'available', online: true }),
+      host({ name: 'h2', op: 'OK', prov: 'provisioned', online: true, consumer: true }),
+      host({
+        name: 'h3',
+        op: 'error',
+        prov: 'provisioned',
+        online: true,
+        consumer: true,
+        errorType: 'x',
+      }),
+      host({ name: 'h4', op: 'OK', prov: 'inspecting', online: true }),
+      host({ name: 'h5', op: 'error', prov: 'registering', online: false, errorType: 'y' }),
+    ];
+    const s = computeOverview(hosts);
+    expect(s.total).toBe(5);
+    expect(s.available).toBe(1);
+    expect(s.provisioned).toBe(2);
+    expect(s.error).toBe(2);
+    expect(s.offline).toBe(1);
+    expect(s.claimed).toBe(2);
+    expect(s.free).toBe(3);
+    expect(s.byOperationalStatus).toEqual({ OK: 3, error: 2 });
+    expect(s.byProvisioningState).toEqual({
+      available: 1,
+      provisioned: 2,
+      inspecting: 1,
+      registering: 1,
+    });
+  });
+
+  it('counts hosts backing a Metal3Machine', () => {
+    const s = computeOverview([
+      host({ name: 'a', consumerKind: 'Metal3Machine' }),
+      host({ name: 'b', consumerKind: 'HostClaim' }),
+      host({ name: 'c' }),
+    ]);
+    expect(s.claimed).toBe(2);
+    expect(s.free).toBe(1);
+    expect(s.backingMachine).toBe(1);
+  });
+
+  it('counts observed power state, not intent, and names empty vs missing labels distinctly', () => {
+    const h = (name: string, poweredOn: boolean, rack?: string) =>
+      ({
+        metadata: { name, uid: name },
+        jsonData: {
+          metadata: { name, ...(rack !== undefined ? { labels: { rack } } : {}) },
+          // spec.online is the opposite of the observed state, to prove we read status.
+          spec: { online: !poweredOn },
+          status: { operationalStatus: 'OK', provisioning: { state: 'provisioned' }, poweredOn },
+        },
+      } as unknown as KubeObject);
+
+    const hosts = [h('a', true, 'r1'), h('b', false, ''), h('c', true)];
+    expect(computeOverview(hosts).poweredOn).toBe(2);
+    expect(
+      groupByLabel(hosts, 'rack')
+        .map(f => f.name)
+        .sort()
+    ).toEqual(['(empty)', '(no rack)', 'r1']);
+  });
+
+  it('groups hosts into fleets by a label and lists the label keys', () => {
+    const hosts = [
+      host({ name: 'a', labels: { rack: 'r1' } }),
+      host({ name: 'b', labels: { rack: 'r1' } }),
+      host({ name: 'c', labels: { rack: 'r2' } }),
+      host({ name: 'd' }),
+    ];
+    expect(labelKeys(hosts)).toEqual(['rack']);
+    expect(groupByLabel(hosts, '').map(f => f.name)).toEqual(['All hosts']);
+    const fleets = groupByLabel(hosts, 'rack');
+    expect(fleets.map(f => `${f.name}:${f.hosts.length}`)).toEqual(['(no rack):1', 'r1:2', 'r2:1']);
+  });
+
+  it('measures time in state from the in-flight operation, longest first', () => {
+    const now = Date.parse('2026-08-04T12:00:00Z');
+    const inFlight = (name: string, state: string, key: string, start: string) =>
+      ({
+        metadata: { name, uid: name },
+        jsonData: {
+          metadata: { name },
+          spec: {},
+          status: {
+            operationalStatus: 'OK',
+            provisioning: { state },
+            operationHistory: { [key]: { start, end: null } },
+          },
+        },
+      } as unknown as KubeObject);
+
+    const inspecting = inFlight('insp', 'inspecting', 'inspect', '2026-08-04T09:00:00Z'); // 3h
+    const provisioning = inFlight('prov', 'provisioning', 'provision', '2026-08-04T11:30:00Z'); // 30m
+    const settled = host({ name: 'done', prov: 'provisioned' });
+
+    expect(timeInState(inspecting, now)).toBe(3 * 60 * 60 * 1000);
+    // A finished operation (end set) is not timeable, even in a transitional state.
+    const finished = {
+      ...inspecting,
+      jsonData: {
+        ...inspecting.jsonData,
+        status: {
+          ...inspecting.jsonData.status,
+          operationHistory: {
+            inspect: { start: '2026-08-04T09:00:00Z', end: '2026-08-04T09:05:00Z' },
+          },
+        },
+      },
+    } as unknown as KubeObject;
+    expect(timeInState(finished, now)).toBeNull();
+
+    const rows = inProgressHosts([settled, provisioning, inspecting], now);
+    expect(rows.map(r => r.host.metadata.name)).toEqual(['insp', 'prov']);
+    expect(rows[0].durationMs).toBe(3 * 60 * 60 * 1000);
+  });
+
+  it('lists hosts needing attention, errors first', () => {
+    const hosts = [
+      host({ name: 'ok', op: 'OK' }),
+      host({ name: 'delayed', op: 'delayed' }),
+      host({ name: 'broken', op: 'error', errorType: 'z' }),
+    ];
+    const s = computeOverview(hosts);
+    expect(s.attention.map(h => h.metadata.name)).toEqual(['broken', 'delayed']);
+  });
+
+  it('treats detached and servicing as informational, not attention', () => {
+    const hosts = [
+      host({ name: 'detached', op: 'detached' }),
+      host({ name: 'servicing', op: 'servicing' }),
+      host({ name: 'broken', op: 'error', errorType: 'z' }),
+    ];
+    const s = computeOverview(hosts);
+    expect(s.attention.map(h => h.metadata.name)).toEqual(['broken']);
+  });
+});

--- a/metal3/src/BareMetalHost/overviewStats.ts
+++ b/metal3/src/BareMetalHost/overviewStats.ts
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2026 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { KubeObject } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import { composeStatus } from './HostStatusLabel';
+
+/** Fleet-level counts derived from the BareMetalHost list, for the overview page. */
+export interface OverviewStats {
+  total: number;
+  /** Provisioning state is `available`, i.e. free to be provisioned. */
+  available: number;
+  /** Provisioning state is `provisioned`. */
+  provisioned: number;
+  /** Operational status is an error. */
+  error: number;
+  /** `spec.online` is explicitly false. */
+  offline: number;
+  /** Has a `spec.consumerRef`, i.e. claimed by a consumer. */
+  claimed: number;
+  /** No consumer, i.e. still allocatable. */
+  free: number;
+  /** Host count per provisioning state. */
+  byProvisioningState: Record<string, number>;
+  /** Host count per operational status. */
+  byOperationalStatus: Record<string, number>;
+  /**
+   * Hosts needing attention: an error severity, a delayed retry, or a set error type,
+   * error-first. `detached` (intentional) and `servicing` (a normal transient) are
+   * treated as informational, not problems.
+   */
+  attention: KubeObject[];
+  /** Hosts observed powered on (`status.poweredOn === true`), not the desired intent. */
+  poweredOn: number;
+  /** Hosts backing a Metal3Machine (`spec.consumerRef.kind === 'Metal3Machine'`). */
+  backingMachine: number;
+}
+
+function bump(counts: Record<string, number>, key: string): void {
+  counts[key] = (counts[key] ?? 0) + 1;
+}
+
+/**
+ * Aggregates a list of BareMetalHosts into the fleet counts the overview page shows.
+ * Pure over the four status axes and `spec` (via `composeStatus`), so it can be
+ * unit-tested without a running cluster.
+ *
+ * @param hosts - The BareMetalHost list.
+ * @returns Totals, per-axis breakdowns, and the error-first attention list.
+ */
+export function computeOverview(hosts: KubeObject[]): OverviewStats {
+  const stats: OverviewStats = {
+    total: hosts.length,
+    available: 0,
+    provisioned: 0,
+    error: 0,
+    offline: 0,
+    claimed: 0,
+    free: 0,
+    byProvisioningState: {},
+    byOperationalStatus: {},
+    attention: [],
+    poweredOn: 0,
+    backingMachine: 0,
+  };
+
+  hosts.forEach(host => {
+    const s = composeStatus(host.jsonData);
+    if (host.jsonData.status?.poweredOn === true) {
+      stats.poweredOn += 1;
+    }
+    if (host.jsonData.spec?.consumerRef?.kind === 'Metal3Machine') {
+      stats.backingMachine += 1;
+    }
+    bump(stats.byOperationalStatus, s.operationalStatus || 'Unknown');
+    bump(stats.byProvisioningState, s.provisioningState || 'Unknown');
+    if (s.provisioningState === 'available') {
+      stats.available += 1;
+    }
+    if (s.provisioningState === 'provisioned') {
+      stats.provisioned += 1;
+    }
+    if (s.severity === 'error') {
+      stats.error += 1;
+    }
+    if (host.jsonData.spec?.online === false) {
+      stats.offline += 1;
+    }
+    if (host.jsonData.spec?.consumerRef?.name) {
+      stats.claimed += 1;
+    } else {
+      stats.free += 1;
+    }
+    // Genuine problems only: an error, a delayed retry, or a set error type. The other
+    // warning states, detached and servicing, are informational and are left out.
+    if (s.severity === 'error' || s.errorType || s.operationalStatus === 'delayed') {
+      stats.attention.push(host);
+    }
+  });
+
+  // Errors first in the attention list; other non-OK states follow.
+  stats.attention.sort((a, b) => {
+    const rank = (h: KubeObject) => (composeStatus(h.jsonData).severity === 'error' ? 0 : 1);
+    return rank(a) - rank(b);
+  });
+
+  return stats;
+}
+
+/** Provisioning states that represent an operation in flight. */
+export const TRANSITIONAL_STATES = new Set([
+  'registering',
+  'inspecting',
+  'preparing',
+  'provisioning',
+  'deprovisioning',
+  'deleting',
+]);
+
+/** Maps a provisioning state to its `status.operationHistory` metric key, if any. */
+const HISTORY_KEY: Record<string, string> = {
+  registering: 'register',
+  inspecting: 'inspect',
+  provisioning: 'provision',
+  deprovisioning: 'deprovision',
+};
+
+/** A metav1.Time is unset when absent, null, or the Go zero time. */
+function isUnsetTime(t: unknown): boolean {
+  return !t || String(t).startsWith('0001-01-01');
+}
+
+/** Start time (ms) of the current in-flight operation, or null if not timeable. */
+function inFlightStartMs(host: KubeObject): number | null {
+  const state = host.jsonData.status?.provisioning?.state;
+  const key = state ? HISTORY_KEY[state] : undefined;
+  const metric = key ? host.jsonData.status?.operationHistory?.[key] : undefined;
+  if (!metric || isUnsetTime(metric.start) || !isUnsetTime(metric.end)) {
+    return null;
+  }
+  const t = Date.parse(metric.start);
+  return Number.isNaN(t) ? null : t;
+}
+
+/**
+ * How long, in milliseconds, the host has been in its current in-flight
+ * operation, or null when the state carries no operation we can time (no
+ * `operationHistory` entry, or the operation has already finished). Uses the
+ * operation's start rather than `status.lastUpdated`, which re-stamps on every
+ * reconcile and so cannot measure dwell.
+ *
+ * @param host - The BareMetalHost.
+ * @param nowMs - The current time in milliseconds, passed in so this stays pure.
+ */
+export function timeInState(host: KubeObject, nowMs: number): number | null {
+  const start = inFlightStartMs(host);
+  return start === null ? null : Math.max(0, nowMs - start);
+}
+
+/** A host currently mid-operation, with how long it has been there. */
+export interface InProgressHost {
+  host: KubeObject;
+  state: string;
+  durationMs: number | null;
+}
+
+/**
+ * The hosts in a transitional provisioning state, each with its dwell time,
+ * sorted longest first so a stalled host rises to the top.
+ *
+ * @param hosts - The BareMetalHost list.
+ * @param nowMs - The current time in milliseconds.
+ */
+export function inProgressHosts(hosts: KubeObject[], nowMs: number): InProgressHost[] {
+  return hosts
+    .filter(h => TRANSITIONAL_STATES.has(h.jsonData.status?.provisioning?.state))
+    .map(h => ({
+      host: h,
+      state: h.jsonData.status.provisioning.state as string,
+      durationMs: timeInState(h, nowMs),
+    }))
+    .sort((a, b) => (b.durationMs ?? -1) - (a.durationMs ?? -1));
+}
+
+/** A named group of hosts, treated as one fleet on the overview. */
+export interface Fleet {
+  name: string;
+  hosts: KubeObject[];
+}
+
+/** The distinct label keys present across the hosts, sorted, for the group-by control. */
+export function labelKeys(hosts: KubeObject[]): string[] {
+  const keys = new Set<string>();
+  hosts.forEach(h => {
+    Object.keys(h.jsonData.metadata?.labels ?? {}).forEach(k => keys.add(k));
+  });
+  return [...keys].sort();
+}
+
+/**
+ * Groups hosts into fleets by the value of a label key. Hosts missing the label
+ * fall into a "(no <key>)" fleet. An empty key returns a single "All hosts" fleet,
+ * since Metal3 has no fleet resource and a label is the only grouping we have.
+ *
+ * @param hosts - The BareMetalHost list.
+ * @param labelKey - The label whose values define the fleets, or '' for no grouping.
+ */
+export function groupByLabel(hosts: KubeObject[], labelKey: string): Fleet[] {
+  if (!labelKey) {
+    return [{ name: 'All hosts', hosts }];
+  }
+  const groups = new Map<string, KubeObject[]>();
+  hosts.forEach(h => {
+    const value = h.jsonData.metadata?.labels?.[labelKey];
+    // Missing label vs a present-but-empty value are distinct; both need a usable name.
+    const name = value === undefined ? `(no ${labelKey})` : value === '' ? '(empty)' : value;
+    if (!groups.has(name)) {
+      groups.set(name, []);
+    }
+    groups.get(name)!.push(h);
+  });
+  return [...groups.entries()]
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([name, hs]) => ({ name, hosts: hs }));
+}

--- a/metal3/src/index.tsx
+++ b/metal3/src/index.tsx
@@ -21,6 +21,7 @@ import {
 } from '@kinvolk/headlamp-plugin/lib';
 import { BareMetalHostDetail } from './BareMetalHost/Details';
 import { BareMetalHosts } from './BareMetalHost/List';
+import { BareMetalHostOverview } from './BareMetalHost/Overview';
 import { PowerActionButton } from './BareMetalHost/PowerActionButton';
 import { Metal3ClusterDetail } from './Metal3Cluster/Details';
 import { Metal3Clusters } from './Metal3Cluster/List';
@@ -37,14 +38,30 @@ import { Metal3Machines } from './Metal3Machine/List';
 import { Metal3MachineTemplateDetail } from './Metal3MachineTemplate/Details';
 import { Metal3MachineTemplates } from './Metal3MachineTemplate/List';
 
-// Parent Metal3 group. Its url points at the first child's list so the group
-// header is itself navigable.
+// Parent Metal3 group. Its url points at the Overview so the group header lands
+// on the fleet dashboard.
 registerSidebarEntry({
   parent: null,
   name: 'metal3',
   icon: 'mdi:server',
   label: 'Metal3',
-  url: '/metal3/baremetalhosts',
+  url: '/metal3/overview',
+});
+
+// Overview / fleet dashboard: the section's landing page.
+registerSidebarEntry({
+  parent: 'metal3',
+  name: 'metal3overview',
+  label: 'Overview',
+  url: '/metal3/overview',
+});
+
+registerRoute({
+  path: '/metal3/overview',
+  sidebar: 'metal3overview',
+  component: BareMetalHostOverview,
+  name: 'metal3-overview',
+  exact: true,
 });
 
 registerSidebarEntry({


### PR DESCRIPTION
## Summary

Adds a fleet overview as the Metal3 section's landing page, aimed at operators running many
bare-metal hosts at once.

Metal3 has no fleet resource, so hosts are grouped into fleets by a label you pick from a
dropdown, and namespace scoping uses Headlamp's shared namespace filter rather than a grouping of
its own. Each fleet is a row in a sortable table showing how many hosts it has and, of those, how
many are free, claimed, and specifically backing a Metal3Machine (the real "in use" number for
bare metal), how many are in error or currently in progress, and how many are powered on.

Below the table there are two lists across all fleets:

- In progress: hosts in a transitional state (registering, inspecting, preparing, provisioning, deprovisioning, or deleting), with how long each has been in that
  state, longest first, so a stalled host rises to the top. The duration comes from the operation
  start time in status.operationHistory, not status.lastUpdated, which re-stamps on every
  reconcile.
- Needs attention: hosts in error, delayed, or carrying an error type, error first. Detached and
  servicing are treated as informational, not problems.

Everything is pure aggregation over the BareMetalHost list, so no new data is fetched beyond what
the list view already loads, and the aggregation helpers (grouping, allocation counts,
time-in-state, attention) are unit-tested.


## Notes for reviewers

- I made the overview the section's landing page, so the Metal3 group header now lands here,
  matching the cluster-api and flux plugins. Happy to make it a plain entry instead if you prefer.
- The presentation, a sortable row per fleet plus two shared action lists, is one reading of
  "multiple fleets by label." Open to a different shape.
- The fleet view is only as useful as the labels operators put on their hosts. With no useful
  labels it shows a single "All hosts" fleet.
- The namespace selection is read with react-redux useSelector on filter.namespaces.

## How to test

1. A cluster with the Metal3 CRDs and a few BareMetalHosts.
2. cd metal3 && npm install && npm start, then run Headlamp.
3. Open Metal3 in the sidebar; it lands on the Overview.
4. Label some hosts (for example kubectl label bmh <name> rack=r1) and pick that label under
   "Group by label" to split into fleets. Click In error or In progress to sort, and use the
   namespace filter to scope.

## Media

Screenshot for the overview grouped into fleets by label (the fleets table, in progress, and
needs attention)
<img width="2330" height="1420" alt="image" src="https://github.com/user-attachments/assets/dad00f36-731b-4457-94d2-8a08ef5606a3" />

Screen recording for switching the group-by label, sorting a column, and scoping with the
namespace filter

https://github.com/user-attachments/assets/d22278a7-359a-4690-8ef0-778765df686c



