### PR TITLE
karpenter: NodePool: Fix CPU bar filling when no CPU limit is set

### DIFF
--- a/karpenter/src/NodePool/List.tsx
+++ b/karpenter/src/NodePool/List.tsx
@@ -84,16 +84,14 @@ function NodePoolsList() {
             const data: ChartDataPoint[] = [
               {
                 name: 'CPU',
-                value: used,
+                value: limit > 0 ? used : 0,
               },
             ];
-
-            const effectiveLimit = limit > 0 ? limit : used || 1;
 
             return (
               <PercentageBar
                 data={data}
-                total={effectiveLimit}
+                total={limit > 0 ? limit : 1}
                 tooltipFunc={() => CPUtooltip(used, limit, t)}
               />
             );


### PR DESCRIPTION
## Description

The CPU column of the NodePool list rendered a completely full PercentageBar for
any NodePool without `spec.limits.cpu`. `PercentageBar` fills as
`(value / total) * 100`, and the CPU column passed `used` as `value` while
falling back to `used || 1` for `total`, so the ratio was exactly 1 whenever no
limit was set.

The Memory column already handles this correctly since #371, which only touched
Memory. This applies the same two expressions to CPU so both columns of a row
agree:

    value: limit > 0 ? used : 0,
    total: limit > 0 ? limit : 1,

The `limit > 0` path computes identically to before, so only the unlimited case
changes. The tooltip already reported "No limit set" and is unchanged.

Fixes #1094 

## Steps to Test

1. Apply a NodePool with no `spec.limits.cpu` and let it provision a node.
2. Open Karpenter > NodePools.
3. The CPU bar is empty rather than full, matching the Memory bar in the same row.
4. Re-add `limits.cpu` and confirm the bar fills proportionally again.

Verified locally in `karpenter/`: `npm run build`, `npm run tsc`, `npm run lint`
and `npm run test` all pass.

