### PR TITLE
fix(ai-assistant): use MCP server's manifest description in approval dialog instead of hardcoded "Inspektor Gadget" fallback

### DIFF
--- a/ai-assistant/packages/ai-common/src/assistant/LangChainAssistantSession.ts
+++ b/ai-assistant/packages/ai-common/src/assistant/LangChainAssistantSession.ts
@@ -639,10 +639,15 @@ export default class LangChainAssistantSession extends AssistantSession {
    *
    * @param toolName - Built-in or MCP tool name.
    * @param isMCPTool - Whether MCP-specific fallback wording should be used.
+   * @param catalogDescription - Optional description from the MCP server manifest.
    * @returns Human-readable tool description.
    */
-  private getToolDescription(toolName: string, isMCPTool: boolean): string {
-    return getToolDescription(toolName, isMCPTool);
+  private getToolDescription(
+    toolName: string,
+    isMCPTool: boolean,
+    catalogDescription?: string
+  ): string {
+    return getToolDescription(toolName, isMCPTool, catalogDescription);
   }
 
   /**
@@ -1512,7 +1517,8 @@ Please analyze this data and provide a specific, detailed response that directly
       toolCalls.map(async tc => {
         const toolName = tc.function.name;
         const mcpTools = this.toolManager.getMCPTools();
-        const isMCPTool = mcpTools.some(tool => tool.name === toolName);
+        const mcpToolEntry = mcpTools.find(tool => tool.name === toolName);
+        const isMCPTool = Boolean(mcpToolEntry);
         let processedArguments = parseSerializedToolArguments(tc.function.arguments);
 
         // Use AI to enhance arguments for MCP tools
@@ -1550,7 +1556,7 @@ Please analyze this data and provide a specific, detailed response that directly
         return {
           id: tc.id,
           name: toolName,
-          description: this.getToolDescription(toolName, isMCPTool),
+          description: this.getToolDescription(toolName, isMCPTool, mcpToolEntry?.description),
           arguments: processedArguments,
           type: isMCPTool ? 'mcp' : 'regular',
         };
@@ -1673,7 +1679,8 @@ Please analyze this data and provide a specific, detailed response that directly
       enabledToolCalls.map(async tc => {
         const toolName = tc.function.name;
         const mcpTools = this.toolManager.getMCPTools();
-        const isMCPTool = mcpTools.some(tool => tool.name === toolName);
+        const mcpToolEntry = mcpTools.find(tool => tool.name === toolName);
+        const isMCPTool = Boolean(mcpToolEntry);
         let processedArguments = parseSerializedToolArguments(tc.function.arguments);
 
         // Use AI to enhance arguments for MCP tools
@@ -1705,7 +1712,7 @@ Please analyze this data and provide a specific, detailed response that directly
         return {
           id: tc.id,
           name: toolName,
-          description: this.getToolDescription(toolName, isMCPTool),
+          description: this.getToolDescription(toolName, isMCPTool, mcpToolEntry?.description),
           arguments: processedArguments,
           type: isMCPTool ? 'mcp' : 'regular',
         };

--- a/ai-assistant/packages/ai-common/src/tools/catalog/getToolDescription.test.ts
+++ b/ai-assistant/packages/ai-common/src/tools/catalog/getToolDescription.test.ts
@@ -47,10 +47,28 @@ describe('getToolDescription', () => {
       expect(desc).toContain('containers');
     });
 
-    it('returns generic Inspektor Gadget fallback for unknown MCP tools', () => {
+    it('returns a generic MCP fallback for unknown MCP tools (no catalog description)', () => {
       const desc = getToolDescription('gadget__some_unknown_tool', true);
-      expect(desc).toContain('Inspektor Gadget');
+      expect(desc).toContain('MCP tool');
       expect(desc).toContain('gadget__some_unknown_tool');
+      expect(desc).not.toContain('Inspektor Gadget');
+    });
+
+    it('prefers the catalog description over keyword heuristics when provided', () => {
+      // A Flux tool whose name contains 'run' would normally match the exec/run heuristic,
+      // but a catalog description provided by the MCP server should win.
+      const desc = getToolDescription(
+        'flux__run_reconcile',
+        true,
+        'Reconcile a Flux Kustomization object'
+      );
+      expect(desc).toBe('Reconcile a Flux Kustomization object');
+    });
+
+    it('falls through to keyword heuristics when catalogDescription is an empty string', () => {
+      // An empty string is falsy, so the keyword heuristics should still apply.
+      const desc = getToolDescription('gadget__trace_open', true, '');
+      expect(desc).toContain('Traces');
     });
   });
 

--- a/ai-assistant/packages/ai-common/src/tools/catalog/getToolDescription.ts
+++ b/ai-assistant/packages/ai-common/src/tools/catalog/getToolDescription.ts
@@ -24,17 +24,32 @@
 /**
  * Returns a short, human-readable description for a tool.
  *
- * For MCP tools the description is inferred from keyword patterns in the tool
- * name (e.g. "trace" → tracing description). For built-in Kubernetes tools a
- * generic description is returned.
+ * When a `catalogDescription` is provided (sourced from the MCP server's own
+ * tool manifest) it is returned immediately for MCP tools. This ensures that
+ * non-Gadget MCP servers such as Flux or Prometheus display accurate text in
+ * the approval dialog rather than Inspektor-Gadget-specific heuristic text.
  *
- * @param toolName  - The full tool identifier (e.g. `"gadget__trace_open"`).
- * @param isMCPTool - Whether the tool comes from an MCP server.
- * @returns A keyword-specific description or a generic description containing the tool name.
+ * When no catalog description is available the function falls back to keyword
+ * heuristics that work well for Inspektor Gadget tool names.
+ *
+ * @param toolName          - The full tool identifier (e.g. `"gadget__trace_open"`).
+ * @param isMCPTool         - Whether the tool comes from an MCP server.
+ * @param catalogDescription - Optional description from the MCP server manifest.
+ * @returns The catalog description, a keyword-specific description, or a generic fallback.
  */
-export function getToolDescription(toolName: string, isMCPTool: boolean): string {
+export function getToolDescription(
+  toolName: string,
+  isMCPTool: boolean,
+  catalogDescription?: string
+): string {
   if (isMCPTool) {
-    // Check exec/run before trace so 'exec_tracer' gets the exec description
+    // Prefer the description provided by the MCP server's own manifest.
+    if (catalogDescription) {
+      return catalogDescription;
+    }
+
+    // Keyword heuristics — useful when the catalog description is absent.
+    // Check exec/run before trace so 'exec_tracer' gets the exec description.
     if (toolName.includes('exec') || toolName.includes('run')) {
       return 'Executes commands in containers';
     }
@@ -47,7 +62,7 @@ export function getToolDescription(toolName: string, isMCPTool: boolean): string
     if (toolName.includes('top') || toolName.includes('process')) {
       return 'Shows running processes and resource usage';
     }
-    return `Inspektor Gadget debugging tool: ${toolName}`;
+    return `MCP tool: ${toolName}`;
   }
 
   if (toolName.includes('kubernetes')) {


### PR DESCRIPTION
## What does this PR do?

Fixes the MCP tool approval dialog showing `"Inspektor Gadget debugging tool: <name>"` for every non-Gadget MCP server (Flux, Prometheus, Vault, custom tools, etc.).

Closes #1096

---

## Problem

`getToolDescription()` in `packages/ai-common/src/tools/catalog/getToolDescription.ts` used keyword heuristics tuned to Inspektor Gadget naming conventions, with a catch-all fallback that hardcoded the "Inspektor Gadget" brand name:

```ts
// Before
return `Inspektor Gadget debugging tool: ${toolName}`;
```

The MCP server's own tool description was already stored in `RuntimeToolInfo.description` at the `getMCPTools()` call sites — but it was never threaded through to `getToolDescription`. Every non-Gadget MCP tool therefore showed completely wrong text in the human approval dialog.

---

## Solution

1. **`getToolDescription.ts`** — added an optional `catalogDescription?: string` third parameter. When present for an MCP tool it is returned immediately, before any keyword heuristic runs. The `"Inspektor Gadget"` catch-all is replaced with the generic `"MCP tool: <name>"`:

```ts
// After
export function getToolDescription(
  toolName: string,
  isMCPTool: boolean,
  catalogDescription?: string   // ← new optional param
): string {
  if (isMCPTool) {
    if (catalogDescription) return catalogDescription;  // server's own description wins
    // keyword heuristics as fallback …
    return `MCP tool: ${toolName}`;                    // generic, not Gadget-specific
  }
  …
}
```

2. **`LangChainAssistantSession.ts`** — both `toolCallsForApproval` construction sites changed from `.some()` → `.find()` to capture the full `RuntimeToolInfo` object, then pass `mcpToolEntry?.description` as the third argument. The private `getToolDescription` wrapper is updated to forward the new parameter.

3. **`getToolDescription.test.ts`** — updated the stale `'Inspektor Gadget'` fallback assertion; added two new tests:
   - Catalog description wins over keyword heuristics (simulates a Flux tool containing `run` in its name)
   - Empty-string catalog description falls through to keyword heuristics

---

## Before / After

| Scenario | Before | After |
|---|---|---|
| `flux__reconcile_kustomization` (manifest desc: *"Reconcile a Flux Kustomization object"*) | `"Inspektor Gadget debugging tool: flux__reconcile_kustomization"` | `"Reconcile a Flux Kustomization object"`  |
| Unknown tool, no manifest description | `"Inspektor Gadget debugging tool: some__tool"` | `"MCP tool: some__tool"`  |
| Gadget `gadget__trace_open`, no manifest description | `"Traces system calls and processes for debugging"` | unchanged  |

---

## Checklist

- [x] Bug fix (non-breaking — new parameter is optional; all existing callers remain valid)
- [x] Tests updated / added (`getToolDescription.test.ts` — 11/11 )
- [x] No changes to public API surface
- [x] `LangChainAssistantSession.ts` — both approval construction sites updated consistently

---

## Files changed

| File | Change |
|---|---|
| `packages/ai-common/src/tools/catalog/getToolDescription.ts` | Added `catalogDescription` param; replaced Gadget fallback |
| `packages/ai-common/src/assistant/LangChainAssistantSession.ts` | Pass `mcpToolEntry?.description` at both call sites |
| `packages/ai-common/src/tools/catalog/getToolDescription.test.ts` | Updated stale test + 2 new tests |
