### PR TITLE
keda: guard optional scalingModifiers in ScaledObject details

### DIFF
--- a/keda/src/components/scaledobjects/Detail.tsx
+++ b/keda/src/components/scaledobjects/Detail.tsx
@@ -344,7 +344,7 @@ export function ScaledObjectDetail(props: { namespace?: string; name?: string })
                           />
                         ),
                       },
-                      ...(Object.keys(item.spec.advanced.scalingModifiers).length > 0
+                      ...(Object.keys(item.spec.advanced.scalingModifiers ?? {}).length > 0
                         ? [
                             {
                               name: t('Scaling Modifiers'),


### PR DESCRIPTION
Opening the details view of a ScaledObject whose `spec.advanced` does not set `scalingModifiers` crashes the page:

```
TypeError: Cannot convert undefined or null to object
  at Object.keys (<anonymous>)
  at extraSections (plugins/keda/dist/main.js:5:14279)
```

`scalingModifiers` is optional - in KEDA itself and in this plugin's own type (`scalingModifiers?: ScalingModifiers` in `resources/scaledobject.ts`) - but the details section computes `Object.keys(item.spec.advanced.scalingModifiers).length` unguarded. The enclosing section is gated on `spec.advanced`, which in practice always exists because KEDA's admission webhook defaults `advanced.horizontalPodAutoscalerConfig` - so any ScaledObject that does not use scaling modifiers hits the crash.

Fix: `?? {}` on the optional field, mirroring the guards its inner fields already use a few lines below (`?? 0`, `||`).

Reproduced with plugin 0.1.2 on Headlamp v0.44.0 in-cluster (ScaledObject with a `temporal` trigger, no scaling modifiers). `headlamp-plugin lint` and `headlamp-plugin tsc` pass locally on the change.
