### PR TITLE
volcano: Add tests for the phase to status colour helpers

### DIFF
--- a/volcano/src/utils/status.test.ts
+++ b/volcano/src/utils/status.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import type { JobPhase } from '../resources/job';
+import type { PodGroupPhase } from '../resources/podgroup';
+import type { QueueState } from '../resources/queue';
+import {
+  getJobFlowStatusColor,
+  getJobStatusColor,
+  getPodGroupStatusColor,
+  getQueueStatusColor,
+} from './status';
+
+/**
+ * Phase values are taken from the upstream Volcano API types rather than from
+ * the local unions, so that a phase added upstream shows up here as a gap.
+ *
+ * @see https://github.com/volcano-sh/apis/blob/master/pkg/apis/batch/v1alpha1/job.go
+ * @see https://github.com/volcano-sh/apis/blob/master/pkg/apis/scheduling/v1beta1/types.go
+ * @see https://github.com/volcano-sh/apis/blob/master/pkg/apis/flow/v1alpha1/jobflow_types.go
+ */
+
+describe('getJobStatusColor', () => {
+  const cases: Array<[JobPhase, string]> = [
+    ['Running', 'success'],
+    ['Completing', 'success'],
+    ['Completed', 'success'],
+    ['Pending', 'warning'],
+    ['Restarting', 'warning'],
+    ['Aborting', 'warning'],
+    ['Terminating', 'warning'],
+    ['Failed', 'error'],
+    ['Aborted', 'error'],
+    ['Terminated', 'error'],
+  ];
+
+  it.each(cases)('maps %s to %s', (phase, expected) => {
+    expect(getJobStatusColor(phase)).toBe(expected);
+  });
+
+  it('covers every phase the upstream API can emit', () => {
+    // JobPhase in job.go declares exactly these ten.
+    expect(cases).toHaveLength(10);
+  });
+
+  it('returns undefined for a phase it does not know', () => {
+    // The signature says this cannot happen, but the value arrives from the
+    // API as a string, so an upstream addition would land here.
+    expect(getJobStatusColor('SomethingNew' as JobPhase)).toBeUndefined();
+  });
+});
+
+describe('getQueueStatusColor', () => {
+  const cases: Array<[QueueState, string]> = [
+    ['Open', 'success'],
+    ['Closing', 'warning'],
+    ['Unknown', 'warning'],
+    ['Closed', 'error'],
+  ];
+
+  it.each(cases)('maps %s to %s', (state, expected) => {
+    expect(getQueueStatusColor(state)).toBe(expected);
+  });
+
+  it('returns undefined for a state it does not know', () => {
+    expect(getQueueStatusColor('Draining' as QueueState)).toBeUndefined();
+  });
+});
+
+describe('getPodGroupStatusColor', () => {
+  const cases: Array<[PodGroupPhase, string]> = [
+    ['Running', 'success'],
+    ['Completed', 'success'],
+    ['Pending', 'warning'],
+    ['Inqueue', 'warning'],
+    ['Unknown', 'warning'],
+  ];
+
+  it.each(cases)('maps %s to %s', (phase, expected) => {
+    expect(getPodGroupStatusColor(phase)).toBe(expected);
+  });
+
+  it('returns undefined for a phase it does not know', () => {
+    expect(getPodGroupStatusColor('Scheduling' as PodGroupPhase)).toBeUndefined();
+  });
+});
+
+describe('getJobFlowStatusColor', () => {
+  // jobflow_types.go validates the enum as Succeed;Terminating;Failed;Running;Pending.
+  const cases: Array<[string, string]> = [
+    ['Running', 'success'],
+    ['Succeed', 'success'],
+    ['Pending', 'warning'],
+    ['Terminating', 'warning'],
+    ['Failed', 'error'],
+  ];
+
+  it.each(cases)('maps %s to %s', (phase, expected) => {
+    expect(getJobFlowStatusColor(phase)).toBe(expected);
+  });
+
+  it('falls back to warning for a phase it does not know', () => {
+    expect(getJobFlowStatusColor('SomethingNew')).toBe('warning');
+  });
+
+  it('is the only one of the four that falls back rather than returning undefined', () => {
+    expect(getJobFlowStatusColor('SomethingNew')).toBe('warning');
+    expect(getJobStatusColor('SomethingNew' as JobPhase)).toBeUndefined();
+    expect(getQueueStatusColor('SomethingNew' as QueueState)).toBeUndefined();
+    expect(getPodGroupStatusColor('SomethingNew' as PodGroupPhase)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What Changed

`src/utils/status.ts` maps four Volcano phase enums onto the status colours `StatusLabel` renders. It had no test coverage.

This adds `src/utils/status.test.ts` with 30 cases across `getJobStatusColor`, `getQueueStatusColor`, `getPodGroupStatusColor` and `getJobFlowStatusColor`. No source changes.

## Where the cases come from

The expected phases come from the upstream Volcano API types, not the local unions. A phase added upstream then shows up here as a gap, where today it would fall through the map silently:

- `JobPhase`, ten values, from [`batch/v1alpha1/job.go`](https://github.com/volcano-sh/apis/blob/master/pkg/apis/batch/v1alpha1/job.go)
- `QueueState` and `PodGroupPhase`, from [`scheduling/v1beta1/types.go`](https://github.com/volcano-sh/apis/blob/master/pkg/apis/scheduling/v1beta1/types.go)
- JobFlow phases, from [`flow/v1alpha1/jobflow_types.go`](https://github.com/volcano-sh/apis/blob/master/pkg/apis/flow/v1alpha1/jobflow_types.go), where the kubebuilder marker validates the enum as `Succeed;Terminating;Failed;Running;Pending`

## Two things the tests record rather than change

Both are behaviour decisions, so I have left the source alone and raised them here.

**The four helpers disagree about unknown phases.** `getJobFlowStatusColor` ends in `?? 'warning'`. The other three return `undefined`, which reaches `StatusLabel` as an absent status:

```ts
getJobFlowStatusColor('SomethingNew')   // 'warning'
getJobStatusColor('SomethingNew')       // undefined
getQueueStatusColor('SomethingNew')     // undefined
getPodGroupStatusColor('SomethingNew')  // undefined
```

Their signatures say this cannot happen, and for well-typed input it cannot. The value arrives from the API as a string though, so a phase added in a future Volcano release would land in exactly that path. Should the other three fall back the same way?

**`JobFlowPhase` cannot be exhaustiveness-checked.** It is declared as:

```ts
export type JobFlowPhase = 'Pending' | 'Running' | 'Failed' | 'Terminating' | 'Succeed' | string;
```

The trailing `| string` collapses the union, so the named literals are documentation and `JOBFLOW_STATUS_COLORS` has to be `Record<string, StatusColor>` where the others are keyed on their real unions. That is also why it carries a `Succeeded` key, which the upstream enum cannot emit.

Dropping `| string` would restore that checking, at the cost of a compile error whenever Volcano adds a phase, which is arguably the point. Happy to send that separately if it is wanted.

## Verification

Run in `volcano/`:

```
npx tsc --noEmit
npx eslint --cache -c package.json --max-warnings 0 --ext .js,.ts,.tsx src/
npx prettier --check "src/**/*.{js,ts,tsx}"
npx vitest run -c node_modules/@kinvolk/headlamp-plugin/config/vite.config.mjs
npx vite build -c node_modules/@kinvolk/headlamp-plugin/config/vite.config.mjs
```

Type check, lint, format and build pass. 46 tests pass across the plugin, 30 of them new.