### PR TITLE
karpenter: renderDisruptionBudgets: Fix duplicate React keys

### DIFF
--- a/karpenter/src/helpers/renderBudgets.test.tsx
+++ b/karpenter/src/helpers/renderBudgets.test.tsx
@@ -1,0 +1,61 @@
+import { render } from '@testing-library/react';
+import { renderDisruptionBudgets } from './renderBudgets';
+
+/** The disruption budgets from the default NodePool in the Karpenter docs. */
+const docsBudgets = [{ nodes: '10%' }, { schedule: '0 9 * * mon-fri', duration: '8h', nodes: '0' }];
+
+function renderBudgets(budgets: any[]) {
+  const duplicateKeyWarnings: string[] = [];
+  const spy = vitest.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+    const message = args.map(String).join(' ');
+    if (message.includes('same key')) {
+      duplicateKeyWarnings.push(message);
+    }
+  });
+
+  const { container } = render(<div>{renderDisruptionBudgets(budgets)}</div>);
+  spy.mockRestore();
+
+  return { container, duplicateKeyWarnings };
+}
+
+function chipLabels(container: HTMLElement) {
+  return Array.from(container.querySelectorAll('.MuiChip-label')).map(chip => chip.textContent);
+}
+
+describe('renderDisruptionBudgets', () => {
+  it('reports when no budgets are set', () => {
+    expect(renderDisruptionBudgets([])).toBe('No budgets set');
+    expect(renderDisruptionBudgets(undefined as unknown as any[])).toBe('No budgets set');
+  });
+
+  it('renders every field of every budget', () => {
+    const { container } = renderBudgets(docsBudgets);
+
+    expect(chipLabels(container)).toEqual([
+      'nodes: 10%',
+      'schedule: 0 9 * * mon-fri',
+      'duration: 8h',
+      'nodes: 0',
+    ]);
+  });
+
+  it('does not emit duplicate React keys for multi-field budgets', () => {
+    const { duplicateKeyWarnings } = renderBudgets(docsBudgets);
+
+    expect(duplicateKeyWarnings).toEqual([]);
+  });
+
+  it('groups each budget separately so fields are not flattened together', () => {
+    const { container } = renderBudgets(docsBudgets);
+
+    // <div>(test wrapper) > <Box>(all budgets) > <Box>(one per budget) > <Chip>(one per field)
+    const budgetRows = Array.from(container.firstElementChild!.firstElementChild!.children);
+
+    expect(budgetRows).toHaveLength(docsBudgets.length);
+    expect(budgetRows.map(row => chipLabels(row as HTMLElement))).toEqual([
+      ['nodes: 10%'],
+      ['schedule: 0 9 * * mon-fri', 'duration: 8h', 'nodes: 0'],
+    ]);
+  });
+});

--- a/karpenter/src/helpers/renderBudgets.tsx
+++ b/karpenter/src/helpers/renderBudgets.tsx
@@ -1,14 +1,26 @@
 import { Box, Chip } from '@mui/material';
 
+/**
+ * Renders a NodePool's disruption budgets, one row per budget.
+ *
+ * Each budget is a separate object whose fields (`nodes`, `schedule`, `duration`,
+ * `reasons`) only make sense together, so budgets are grouped rather than
+ * flattened into a single row of chips.
+ *
+ * @param budgets - The `spec.disruption.budgets` entries of a NodePool.
+ * @see https://karpenter.sh/docs/concepts/disruption/#disruption-budgets
+ */
 export function renderDisruptionBudgets(budgets: any[] = []) {
   if (!budgets || budgets.length === 0) return 'No budgets set';
   return (
-    <Box sx={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
-      {budgets.map((budget, index) =>
-        Object.entries(budget).map(([k, v]) => (
-          <Chip key={index} label={`${k}: ${v}`} variant="outlined" size="small" />
-        ))
-      )}
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+      {budgets.map((budget, index) => (
+        <Box key={index} sx={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+          {Object.entries(budget).map(([k, v]) => (
+            <Chip key={k} label={`${k}: ${v}`} variant="outlined" size="small" />
+          ))}
+        </Box>
+      ))}
     </Box>
   );
 }


### PR DESCRIPTION
## Description

`spec.disruption.budgets` is a list of independent budget objects whose fields
(`nodes`, `schedule`, `duration`, `reasons`) only mean anything together. The
NodePool detail page flattened every field of every budget into one row of chips,
so the grouping was lost, and because the inner map returned several elements per
budget while keying each on the outer budget index, sibling chips shared a key.
React warns that such children may be duplicated or omitted.

This renders one row per budget and keys each chip by its field name, which is
unique within a single budget object.

The grouping and the keys are the same defect: flattening the two loops into one
list of siblings is what made the outer index collide. Fixing the keys alone would
silence the warning but leave the page ambiguous, so both are addressed together.

Fixes #1101 

## Steps to Test

1. Apply a NodePool with the disruption budgets from the Karpenter docs:

       disruption:
         budgets:
         - nodes: 10%
         - schedule: "0 9 * * mon-fri"
           duration: 8h
           nodes: "0"

2. Open Karpenter > NodePools and select it.
3. Disruption Budgets now shows two rows, `nodes: 10%` on one and
   `schedule` / `duration` / `nodes: 0` on the other.
4. No duplicate key warnings in the browser console.

## Tests

Adds `renderBudgets.test.tsx`. Against the previous implementation two of the four
tests fail:

    × does not emit duplicate React keys   → expected [ …(2) ] to deeply equal []
    × groups each budget separately        → expected length 2 but got 4

The other two cover the empty case and the rendered field list, so they pass
before and after and guard against a behaviour change.

Verified locally in `karpenter/`: `npm run build`, `npm run tsc`, `npm run lint`
and `npm run test` all pass.
