### PR TITLE
knative: Check Serving and Eventing separately

### DIFF
--- a/knative/src/components/certificates/List.tsx
+++ b/knative/src/components/certificates/List.tsx
@@ -35,7 +35,7 @@ import {
 
 export function CertificatesList() {
   const clusters = useClusters();
-  const { isKnativeInstalled, isKnativeCheckLoading } = useKnativeInstalled(clusters);
+  const { isKnativeInstalled, isKnativeCheckLoading } = useKnativeInstalled('serving', clusters);
   const showClusterColumn = clusters.length > 1;
   const columns = React.useMemo<
     (ResourceTableColumn<KnativeCertificate> | 'name' | 'namespace' | 'cluster' | 'age')[]

--- a/knative/src/components/configurations/List.tsx
+++ b/knative/src/components/configurations/List.tsx
@@ -27,7 +27,7 @@ import { getReadinessColumns, NamespacedResourceLink } from '../common/ResourceL
 
 export function ConfigurationsList() {
   const clusters = useClusters();
-  const { isKnativeInstalled, isKnativeCheckLoading } = useKnativeInstalled(clusters);
+  const { isKnativeInstalled, isKnativeCheckLoading } = useKnativeInstalled('serving', clusters);
   const showClusterColumn = clusters.length > 1;
   const columns = React.useMemo<
     (ResourceTableColumn<KnativeConfiguration> | 'name' | 'namespace' | 'cluster' | 'age')[]

--- a/knative/src/components/images/List.tsx
+++ b/knative/src/components/images/List.tsx
@@ -31,7 +31,7 @@ import {
 
 export function ImagesList() {
   const clusters = useClusters();
-  const { isKnativeInstalled, isKnativeCheckLoading } = useKnativeInstalled(clusters);
+  const { isKnativeInstalled, isKnativeCheckLoading } = useKnativeInstalled('serving', clusters);
   const showClusterColumn = clusters.length > 1;
   const columns = React.useMemo<
     (ResourceTableColumn<KnativeImage> | 'name' | 'namespace' | 'cluster' | 'age')[]

--- a/knative/src/components/ingresses/List.tsx
+++ b/knative/src/components/ingresses/List.tsx
@@ -29,7 +29,7 @@ import { getReadinessColumns, TextValue } from '../common/ResourceListCells';
 
 export function IngressesList() {
   const clusters = useClusters();
-  const { isKnativeInstalled, isKnativeCheckLoading } = useKnativeInstalled(clusters);
+  const { isKnativeInstalled, isKnativeCheckLoading } = useKnativeInstalled('serving', clusters);
   const showClusterColumn = clusters.length > 1;
   const columns = React.useMemo<
     (ResourceTableColumn<KnativeIngress> | 'name' | 'namespace' | 'cluster' | 'age')[]

--- a/knative/src/components/kservices/Detail.tsx
+++ b/knative/src/components/kservices/Detail.tsx
@@ -43,7 +43,7 @@ import { TrafficSection } from './detail/sections/traffic/TrafficSection';
 export function KServiceDetail() {
   const { name, namespace } = useParams<{ namespace: string; name: string }>();
   const clusters = useClusters();
-  const { isKnativeInstalled, isKnativeCheckLoading } = useKnativeInstalled(clusters);
+  const { isKnativeInstalled, isKnativeCheckLoading } = useKnativeInstalled('serving', clusters);
   return (
     <KServiceEditContextProvider>
       {isKnativeInstalled ? (

--- a/knative/src/components/kservices/List.tsx
+++ b/knative/src/components/kservices/List.tsx
@@ -613,7 +613,7 @@ function KServicesListContents({ clusters }: KServicesListContentsProps) {
 
 export function KServicesList() {
   const clusters = useClusters();
-  const { isKnativeInstalled, isKnativeCheckLoading } = useKnativeInstalled(clusters);
+  const { isKnativeInstalled, isKnativeCheckLoading } = useKnativeInstalled('serving', clusters);
 
   return isKnativeInstalled ? (
     <KServicesListContents clusters={clusters} />

--- a/knative/src/components/metrics/List.tsx
+++ b/knative/src/components/metrics/List.tsx
@@ -32,7 +32,7 @@ import {
 
 export function MetricsList() {
   const clusters = useClusters();
-  const { isKnativeInstalled, isKnativeCheckLoading } = useKnativeInstalled(clusters);
+  const { isKnativeInstalled, isKnativeCheckLoading } = useKnativeInstalled('serving', clusters);
   const showClusterColumn = clusters.length > 1;
   const columns = React.useMemo<
     (ResourceTableColumn<KnativeMetric> | 'name' | 'namespace' | 'cluster' | 'age')[]

--- a/knative/src/components/networking/Configuration.tsx
+++ b/knative/src/components/networking/Configuration.tsx
@@ -298,7 +298,7 @@ export function ClusterNetworkingCard({
 export function NetworkingConfiguration() {
   const clusters = useClusters();
   const hasCluster = clusters.length > 0;
-  const { isKnativeInstalled, isKnativeCheckLoading } = useKnativeInstalled(clusters);
+  const { isKnativeInstalled, isKnativeCheckLoading } = useKnativeInstalled('serving', clusters);
 
   if (!hasCluster) {
     return (

--- a/knative/src/components/podautoscalers/List.tsx
+++ b/knative/src/components/podautoscalers/List.tsx
@@ -31,7 +31,7 @@ import {
 
 export function PodAutoscalersList() {
   const clusters = useClusters();
-  const { isKnativeInstalled, isKnativeCheckLoading } = useKnativeInstalled(clusters);
+  const { isKnativeInstalled, isKnativeCheckLoading } = useKnativeInstalled('serving', clusters);
   const showClusterColumn = clusters.length > 1;
   const columns = React.useMemo<
     (ResourceTableColumn<KnativePodAutoscaler> | 'name' | 'namespace' | 'cluster' | 'age')[]

--- a/knative/src/components/revisions/Detail.tsx
+++ b/knative/src/components/revisions/Detail.tsx
@@ -114,7 +114,7 @@ function TrafficDisplayWithService({ revision }: { revision: KRevision }) {
 export function RevisionDetail() {
   const { name, namespace } = useParams<{ namespace: string; name: string }>();
   const clusters = useClusters();
-  const { isKnativeInstalled, isKnativeCheckLoading } = useKnativeInstalled(clusters);
+  const { isKnativeInstalled, isKnativeCheckLoading } = useKnativeInstalled('serving', clusters);
 
   if (!isKnativeInstalled) {
     return <NotInstalledBanner isLoading={isKnativeCheckLoading} />;

--- a/knative/src/components/revisions/List.tsx
+++ b/knative/src/components/revisions/List.tsx
@@ -149,7 +149,7 @@ function RevisionTagDisplay({
 
 export function RevisionsList() {
   const clusters = useClusters();
-  const { isKnativeInstalled, isKnativeCheckLoading } = useKnativeInstalled(clusters);
+  const { isKnativeInstalled, isKnativeCheckLoading } = useKnativeInstalled('serving', clusters);
   const showClusterColumn = clusters.length > 1;
 
   const kserviceResult = KService.useList({ clusters });

--- a/knative/src/components/routes/List.tsx
+++ b/knative/src/components/routes/List.tsx
@@ -34,7 +34,7 @@ import {
 
 export function RoutesList() {
   const clusters = useClusters();
-  const { isKnativeInstalled, isKnativeCheckLoading } = useKnativeInstalled(clusters);
+  const { isKnativeInstalled, isKnativeCheckLoading } = useKnativeInstalled('serving', clusters);
   const showClusterColumn = clusters.length > 1;
   const columns = React.useMemo<
     (ResourceTableColumn<KnativeRoute> | 'name' | 'namespace' | 'cluster' | 'age')[]

--- a/knative/src/components/serverlessservices/List.tsx
+++ b/knative/src/components/serverlessservices/List.tsx
@@ -31,7 +31,7 @@ import {
 
 export function ServerlessServicesList() {
   const clusters = useClusters();
-  const { isKnativeInstalled, isKnativeCheckLoading } = useKnativeInstalled(clusters);
+  const { isKnativeInstalled, isKnativeCheckLoading } = useKnativeInstalled('serving', clusters);
   const showClusterColumn = clusters.length > 1;
   const columns = React.useMemo<
     (ResourceTableColumn<KnativeServerlessService> | 'name' | 'namespace' | 'cluster' | 'age')[]

--- a/knative/src/hooks/useKnativeInstalled.ts
+++ b/knative/src/hooks/useKnativeInstalled.ts
@@ -15,9 +15,19 @@
  */
 
 import { useEffect, useState } from 'react';
-import { isKnativeInstalled } from '../isKnativeInstalled';
+import { isKnativeComponentInstalled, type KnativeComponent } from '../isKnativeInstalled';
 
-export function useKnativeInstalled(clusters: string[]) {
+/**
+ * Tracks whether the Knative component a view needs is installed.
+ *
+ * Serving and Eventing install independently, so a view has to say which one it
+ * needs rather than ask whether Knative in general is present.
+ *
+ * @param component The Knative component the view depends on.
+ * @param clusters The clusters the view is showing.
+ * @returns The result of the check, and whether it is still running.
+ */
+export function useKnativeInstalled(component: KnativeComponent, clusters: string[]) {
   const clustersKey = clusters.join(',');
 
   const [isKnativeInstalledState, setIsKnativeInstalledState] = useState<boolean | null>(null);
@@ -27,7 +37,7 @@ export function useKnativeInstalled(clusters: string[]) {
 
     async function checkKnativeInstalled() {
       setIsKnativeInstalledState(null);
-      const installed = await isKnativeInstalled(clusters);
+      const installed = await isKnativeComponentInstalled(component, clusters);
       if (cancelled) {
         return;
       }
@@ -39,7 +49,7 @@ export function useKnativeInstalled(clusters: string[]) {
     return () => {
       cancelled = true;
     };
-  }, [clustersKey]);
+  }, [component, clustersKey]);
 
   return {
     isKnativeInstalled: isKnativeInstalledState,

--- a/knative/src/index.tsx
+++ b/knative/src/index.tsx
@@ -29,12 +29,13 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 import { KServiceDetail } from './components/kservices/Detail';
 import { RevisionDetail } from './components/revisions/Detail';
-import { isKnativeInstalled } from './isKnativeInstalled';
+import { isKnativeComponentInstalled } from './isKnativeInstalled';
 import { registerKnativeIcon } from './knativeIcon';
 import { getKnativeListRouteComponent } from './listRoutes';
 import { KnativeInternalResourceGlance, knativePluginSource } from './mapView';
 import { knativeNavigationItems, knativeNavigationSections } from './navigation';
 import { filterReadOnlyKnativeHeaderActions } from './readOnlyResources';
+import { createSidebarGate } from './sidebarGating';
 
 registerKnativeIcon();
 registerDetailsViewHeaderActionsProcessor((resource, actions) =>
@@ -42,11 +43,6 @@ registerDetailsViewHeaderActionsProcessor((resource, actions) =>
 );
 
 const queryClient = new QueryClient();
-
-const knativeSidebarParents = new Set([
-  'knative',
-  ...knativeNavigationSections.map(section => section.name),
-]);
 
 function withQueryClient(Component: React.ComponentType) {
   return React.memo(function WithQueryClient() {
@@ -58,43 +54,13 @@ function withQueryClient(Component: React.ComponentType) {
   });
 }
 
-// Track whether Knative CRDs exist per cluster to hide sidebar.
-const knativeInstalledByCluster: Record<string, boolean> = {};
-const lastCheckedAt: Record<string, number> = {};
-const inFlight: Record<string, boolean> = {};
-const CHECK_TTL_MS = 30 * 1000;
-
-/**
- * Checks if Knative is installed on the given cluster using the shared
- * installed check.
- *
- * @param cluster The name of the cluster to check.
- */
-async function checkKnativeInstalled(cluster: string) {
-  const now = Date.now();
-  const fresh = now - (lastCheckedAt[cluster] ?? 0) < CHECK_TTL_MS;
-  if (inFlight[cluster] || fresh) {
-    return;
-  }
-  inFlight[cluster] = true;
-  knativeInstalledByCluster[cluster] = await isKnativeInstalled([cluster]);
-  lastCheckedAt[cluster] = Date.now();
-  inFlight[cluster] = false;
-}
-
-registerSidebarEntryFilter(entry => {
-  if (entry.name !== 'knative' && !knativeSidebarParents.has(entry.parent ?? '')) {
-    return entry;
-  }
-
-  const cluster = Utils.getCluster() ?? '';
-  void checkKnativeInstalled(cluster);
-
-  if (knativeInstalledByCluster[cluster] === false) {
-    return null;
-  }
-  return entry;
-});
+// Hide Knative sidebar entries whose component is not installed on the cluster.
+registerSidebarEntryFilter(
+  createSidebarGate({
+    getCluster: () => Utils.getCluster() ?? '',
+    isInstalled: isKnativeComponentInstalled,
+  })
+);
 
 registerSidebarEntry({
   parent: null,

--- a/knative/src/isKnativeInstalled.test.ts
+++ b/knative/src/isKnativeInstalled.test.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { vi } from 'vitest';
+import { isKnativeComponentInstalled } from './isKnativeInstalled';
+import { CustomResourceDefinition } from './resources/k8s/customResourceDefinition';
+
+vi.mock('./resources/k8s/customResourceDefinition', () => ({
+  CustomResourceDefinition: { apiGet: vi.fn() },
+}));
+
+const apiGet = CustomResourceDefinition.apiGet as unknown as ReturnType<typeof vi.fn>;
+
+const SERVING_CRD = 'services.serving.knative.dev';
+const EVENTING_CRD = 'brokers.eventing.knative.dev';
+
+const cancel = vi.fn();
+
+/**
+ * Makes apiGet behave like a cluster that only has the given CRDs.
+ *
+ * @param crdsByCluster The CRD names present in each cluster.
+ */
+function clusterHas(crdsByCluster: Record<string, string[]>) {
+  apiGet.mockImplementation(
+    (
+      onGet: (item: unknown) => void,
+      crdName: string,
+      _namespace: undefined,
+      onError: (err: unknown) => void,
+      opts: { cluster: string }
+    ) => {
+      return () => {
+        // The real request answers after it has handed back its cancel
+        // function, so the callbacks are deferred here the same way.
+        setTimeout(() => {
+          if ((crdsByCluster[opts.cluster] ?? []).includes(crdName)) {
+            onGet({ metadata: { name: crdName } });
+          } else {
+            onError(new Error('not found'));
+          }
+        }, 0);
+        return Promise.resolve(cancel);
+      };
+    }
+  );
+}
+
+describe('isKnativeComponentInstalled', () => {
+  beforeEach(() => {
+    apiGet.mockReset();
+    cancel.mockReset();
+  });
+
+  it('returns false when no clusters are given', async () => {
+    await expect(isKnativeComponentInstalled('serving', [])).resolves.toBe(false);
+    expect(apiGet).not.toHaveBeenCalled();
+  });
+
+  it('detects Serving through its own CRD', async () => {
+    clusterHas({ a: [SERVING_CRD] });
+    await expect(isKnativeComponentInstalled('serving', ['a'])).resolves.toBe(true);
+  });
+
+  it('detects Eventing through its own CRD', async () => {
+    clusterHas({ a: [EVENTING_CRD] });
+    await expect(isKnativeComponentInstalled('eventing', ['a'])).resolves.toBe(true);
+  });
+
+  it('does not report Eventing when only Serving is installed', async () => {
+    clusterHas({ a: [SERVING_CRD] });
+    await expect(isKnativeComponentInstalled('eventing', ['a'])).resolves.toBe(false);
+  });
+
+  it('does not report Serving when only Eventing is installed', async () => {
+    clusterHas({ a: [EVENTING_CRD] });
+    await expect(isKnativeComponentInstalled('serving', ['a'])).resolves.toBe(false);
+  });
+
+  it('reports both when both are installed', async () => {
+    clusterHas({ a: [SERVING_CRD, EVENTING_CRD] });
+    await expect(isKnativeComponentInstalled('serving', ['a'])).resolves.toBe(true);
+    await expect(isKnativeComponentInstalled('eventing', ['a'])).resolves.toBe(true);
+  });
+
+  it('requires the component in every cluster', async () => {
+    clusterHas({ a: [SERVING_CRD], b: [SERVING_CRD] });
+    await expect(isKnativeComponentInstalled('serving', ['a', 'b'])).resolves.toBe(true);
+
+    clusterHas({ a: [SERVING_CRD], b: [] });
+    await expect(isKnativeComponentInstalled('serving', ['a', 'b'])).resolves.toBe(false);
+  });
+
+  it('returns false when the request itself fails', async () => {
+    apiGet.mockImplementation(() => () => Promise.reject(new Error('network down')));
+    await expect(isKnativeComponentInstalled('serving', ['a'])).resolves.toBe(false);
+  });
+
+  it('cancels the watch once a result is known', async () => {
+    clusterHas({ a: [SERVING_CRD] });
+    await isKnativeComponentInstalled('serving', ['a']);
+    expect(cancel).toHaveBeenCalled();
+  });
+});

--- a/knative/src/isKnativeInstalled.ts
+++ b/knative/src/isKnativeInstalled.ts
@@ -16,7 +16,24 @@
 
 import { CustomResourceDefinition } from './resources/k8s/customResourceDefinition';
 
-const KNATIVE_SERVING_KSERVICE_CRD_NAME = 'services.serving.knative.dev';
+/**
+ * Knative components install independently of each other, so a cluster may
+ * serve Serving, Eventing, both, or neither. Anything that depends on Knative
+ * being present has to say which component it needs.
+ */
+export type KnativeComponent = 'serving' | 'eventing';
+
+/**
+ * A CRD that is present whenever the component is installed, used to detect it.
+ *
+ * Serving is detected through Service because it is the resource the plugin is
+ * built around. Eventing is detected through Broker for the same reason: it is
+ * part of the core Eventing install rather than an optional add-on.
+ */
+const COMPONENT_CRD_NAME: Record<KnativeComponent, string> = {
+  serving: 'services.serving.knative.dev',
+  eventing: 'brokers.eventing.knative.dev',
+};
 
 function hasCrdInCluster(cluster: string, crdName: string): Promise<boolean> {
   return new Promise(resolve => {
@@ -52,15 +69,25 @@ function hasCrdInCluster(cluster: string, crdName: string): Promise<boolean> {
   });
 }
 
-export async function isKnativeInstalled(clusters: string[]): Promise<boolean> {
+/**
+ * Checks whether a single Knative component is installed.
+ *
+ * @param component The Knative component to look for.
+ * @param clusters The clusters to check.
+ * @returns True when the component is present in every given cluster.
+ */
+export async function isKnativeComponentInstalled(
+  component: KnativeComponent,
+  clusters: string[]
+): Promise<boolean> {
   if (!clusters || clusters.length === 0) {
     return false;
   }
 
-  const results = await Promise.all(
-    clusters.map(cluster => hasCrdInCluster(cluster, KNATIVE_SERVING_KSERVICE_CRD_NAME))
-  );
+  const crdName = COMPONENT_CRD_NAME[component];
 
-  // Consider Knative "installed" only if it exists in all selected clusters.
+  const results = await Promise.all(clusters.map(cluster => hasCrdInCluster(cluster, crdName)));
+
+  // Consider the component "installed" only if it exists in all selected clusters.
   return results.every(Boolean);
 }

--- a/knative/src/sidebarGating.test.ts
+++ b/knative/src/sidebarGating.test.ts
@@ -1,0 +1,268 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { vi } from 'vitest';
+import type { KnativeComponent } from './isKnativeInstalled';
+import { knativeNavigationSections } from './navigation';
+import { componentsForEntry, createSidebarGate, SECTION_COMPONENT } from './sidebarGating';
+
+const root = { name: 'knative', parent: null };
+const section = { name: 'knative-serving', parent: 'knative' };
+const kservices = { name: 'knative-services', parent: 'knative-serving' };
+const foreign = { name: 'workloads', parent: null };
+
+/** Lets the queued install checks settle before the next assertion. */
+async function settle() {
+  await new Promise(resolve => setTimeout(resolve, 0));
+}
+
+describe('componentsForEntry', () => {
+  it('leaves entries from other plugins alone', () => {
+    expect(componentsForEntry(foreign)).toBeNull();
+    expect(componentsForEntry({ name: 'workloads', parent: 'something-else' })).toBeNull();
+  });
+
+  it('gates each section on the component it needs', () => {
+    expect(componentsForEntry(section)).toEqual(['serving']);
+    expect(componentsForEntry({ name: 'knative-configuration', parent: 'knative' })).toEqual([
+      'serving',
+    ]);
+  });
+
+  it('gives an item the component of the section it sits in', () => {
+    expect(componentsForEntry(kservices)).toEqual(['serving']);
+    expect(
+      componentsForEntry({ name: 'knative-certificates', parent: 'knative-serving-internals' })
+    ).toEqual(['serving']);
+  });
+
+  it('falls back to Serving for an entry navigation does not describe', () => {
+    expect(componentsForEntry({ name: 'not-mapped-yet', parent: 'knative' })).toEqual(['serving']);
+    expect(componentsForEntry({ name: 'new-item', parent: 'knative-serving' })).toEqual([
+      'serving',
+    ]);
+  });
+
+  it('does not read anything off the prototype chain', () => {
+    // An entry named after an Object member must still resolve to a component
+    // rather than to whatever that member happens to be.
+    ['constructor', 'toString', 'valueOf', 'hasOwnProperty', '__proto__'].forEach(name => {
+      expect(componentsForEntry({ name, parent: 'knative' })).toEqual(['serving']);
+    });
+  });
+
+  it('gates the top level entry on every component its sections need', () => {
+    const rootComponents = componentsForEntry(root);
+    expect(rootComponents).not.toBeNull();
+
+    // The top level entry has to cover each section, otherwise it can be shown
+    // with every section under it filtered out.
+    SECTION_COMPONENT.forEach(component => {
+      expect(rootComponents).toContain(component);
+    });
+  });
+
+  it('lists each component once', () => {
+    const rootComponents = componentsForEntry(root)!;
+    expect(rootComponents).toEqual(Array.from(new Set(rootComponents)));
+  });
+});
+
+describe('every registered Knative sidebar entry', () => {
+  // The entries the plugin actually registers in index.tsx, in the same shape
+  // the sidebar filter sees them.
+  const registered = [
+    { name: 'knative', parent: null },
+    ...knativeNavigationSections.flatMap(navSection => [
+      { name: navSection.name, parent: 'knative' },
+      ...navSection.items.map(item => ({ name: item.name, parent: navSection.name })),
+    ]),
+  ];
+
+  it.each(registered)('$name is gated on a known component', entry => {
+    const components = componentsForEntry(entry);
+    expect(components).not.toBeNull();
+    expect(components!.length).toBeGreaterThan(0);
+    components!.forEach(component => expect(['serving', 'eventing']).toContain(component));
+  });
+
+  it('shows all of them when the components they need are installed', async () => {
+    const isInstalled = vi.fn(async () => true);
+    const gate = createSidebarGate({ getCluster: () => 'a', isInstalled });
+
+    registered.forEach(entry => gate(entry));
+    await settle();
+
+    registered.forEach(entry => expect(gate(entry)).toBe(entry));
+  });
+
+  it('hides all of them when Knative is absent', async () => {
+    const isInstalled = vi.fn(async () => false);
+    const gate = createSidebarGate({ getCluster: () => 'a', isInstalled });
+
+    registered.forEach(entry => gate(entry));
+    await settle();
+
+    registered.forEach(entry => expect(gate(entry)).toBeNull());
+  });
+});
+
+describe('createSidebarGate', () => {
+  /**
+   * Builds a gate over a cluster with a fixed set of installed components.
+   *
+   * @param installedComponents The components the cluster is running.
+   * @param cluster The cluster name reported to the gate.
+   */
+  function gateFor(installedComponents: KnativeComponent[], cluster = 'a') {
+    const isInstalled = vi.fn(async (component: KnativeComponent) =>
+      installedComponents.includes(component)
+    );
+    const gate = createSidebarGate({ getCluster: () => cluster, isInstalled });
+    return { gate, isInstalled };
+  }
+
+  it('never touches entries from other plugins', async () => {
+    const { gate, isInstalled } = gateFor([]);
+    expect(gate(foreign)).toBe(foreign);
+    await settle();
+    expect(isInstalled).not.toHaveBeenCalled();
+  });
+
+  it('keeps entries visible while the first check is in flight', () => {
+    const { gate } = gateFor([]);
+    expect(gate(root)).toBe(root);
+    expect(gate(kservices)).toBe(kservices);
+  });
+
+  it('shows Serving sections when Serving is installed', async () => {
+    const { gate } = gateFor(['serving']);
+    gate(kservices);
+    await settle();
+    expect(gate(kservices)).toBe(kservices);
+    expect(gate(root)).toBe(root);
+  });
+
+  it('hides Serving sections when Serving is missing', async () => {
+    const { gate } = gateFor([]);
+    gate(kservices);
+    await settle();
+    expect(gate(kservices)).toBeNull();
+  });
+
+  it('hides the top level entry only when every section is hidden', async () => {
+    const { gate } = gateFor([]);
+    gate(root);
+    await settle();
+    expect(gate(root)).toBeNull();
+  });
+
+  it('checks exactly the components the sections need, and no others', async () => {
+    const { gate, isInstalled } = gateFor(['serving']);
+    gate(root);
+    gate(kservices);
+    await settle();
+
+    const checked = isInstalled.mock.calls.map(([component]) => component);
+    expect(checked).toContain('serving');
+
+    // Gating per component must not cost extra lookups. Nothing needs Eventing
+    // yet, so nothing should be asking about it.
+    expect(new Set(checked)).toEqual(new Set(SECTION_COMPONENT.values()));
+  });
+
+  it('reuses a result until the cache expires', async () => {
+    let clock = 0;
+    const isInstalled = vi.fn(async () => true);
+    const gate = createSidebarGate({
+      getCluster: () => 'a',
+      isInstalled,
+      now: () => clock,
+      ttlMs: 1000,
+    });
+
+    gate(kservices);
+    await settle();
+    const afterFirst = isInstalled.mock.calls.length;
+
+    clock = 500;
+    gate(kservices);
+    await settle();
+    expect(isInstalled.mock.calls).toHaveLength(afterFirst);
+
+    clock = 2000;
+    gate(kservices);
+    await settle();
+    expect(isInstalled.mock.calls.length).toBeGreaterThan(afterFirst);
+  });
+
+  it('caches per cluster as well as per component', async () => {
+    let cluster = 'a';
+    const isInstalled = vi.fn(async () => cluster === 'a');
+    const gate = createSidebarGate({ getCluster: () => cluster, isInstalled });
+
+    gate(kservices);
+    await settle();
+    expect(gate(kservices)).toBe(kservices);
+
+    cluster = 'b';
+    gate(kservices);
+    await settle();
+    expect(gate(kservices)).toBeNull();
+
+    // Switching back uses the earlier result rather than checking again.
+    cluster = 'a';
+    expect(gate(kservices)).toBe(kservices);
+  });
+
+  it('runs one check at a time for the same key', async () => {
+    let resolveCheck: (value: boolean) => void = () => {};
+    const isInstalled = vi.fn(
+      () =>
+        new Promise<boolean>(resolve => {
+          resolveCheck = resolve;
+        })
+    );
+    const gate = createSidebarGate({ getCluster: () => 'a', isInstalled });
+
+    gate(kservices);
+    gate(kservices);
+    gate(kservices);
+    expect(isInstalled).toHaveBeenCalledTimes(1);
+
+    resolveCheck(true);
+    await settle();
+  });
+
+  it('stops blocking further checks when one rejects', async () => {
+    const isInstalled = vi.fn().mockRejectedValueOnce(new Error('boom')).mockResolvedValue(true);
+    let clock = 0;
+    const gate = createSidebarGate({
+      getCluster: () => 'a',
+      isInstalled,
+      now: () => clock,
+      ttlMs: 1000,
+    });
+
+    gate(kservices);
+    await settle();
+
+    clock = 2000;
+    gate(kservices);
+    await settle();
+    expect(isInstalled).toHaveBeenCalledTimes(2);
+  });
+});

--- a/knative/src/sidebarGating.ts
+++ b/knative/src/sidebarGating.ts
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { KnativeComponent } from './isKnativeInstalled';
+import { knativeNavigationSections } from './navigation';
+
+/** The name of the top level Knative sidebar entry. */
+const KNATIVE_ROOT_ENTRY = 'knative';
+
+/**
+ * The Knative component each navigation section needs.
+ *
+ * A section is only useful when the component that serves its resources is
+ * installed, so this is what its entries are gated on. Adding an Eventing
+ * section to navigation.ts means adding one line here.
+ *
+ * A Map rather than an object so that a lookup can only ever return something
+ * that was put here, whatever an entry happens to be called.
+ */
+export const SECTION_COMPONENT = new Map<string, KnativeComponent>([
+  ['knative-serving', 'serving'],
+  ['knative-serving-internals', 'serving'],
+  ['knative-configuration', 'serving'],
+]);
+
+const DEFAULT_SECTION_COMPONENT: KnativeComponent = 'serving';
+
+/**
+ * Every named entry the plugin registers, mapped to the component it needs.
+ *
+ * Items inherit the component of the section they sit in, so the sections stay
+ * the only place a component is decided.
+ */
+const ENTRY_COMPONENT = new Map<string, KnativeComponent>([
+  ...SECTION_COMPONENT,
+  ...knativeNavigationSections.flatMap(section => {
+    const component = SECTION_COMPONENT.get(section.name) ?? DEFAULT_SECTION_COMPONENT;
+    return section.items.map(item => [item.name, component] as [string, KnativeComponent]);
+  }),
+]);
+
+/** The components at least one entry needs, without duplicates. */
+const NEEDED_COMPONENTS = Array.from(new Set(ENTRY_COMPONENT.values()));
+
+/** How long an install check is reused before it is made again. */
+const CHECK_TTL_MS = 30 * 1000;
+
+/** The shape of a sidebar entry this module needs to make a decision. */
+interface SidebarEntryLike {
+  name: string;
+  parent?: string | null;
+}
+
+/**
+ * Builds the key a check result is cached under.
+ *
+ * @param cluster The cluster the check was made against.
+ * @param component The component that was looked for.
+ * @returns The cache key.
+ */
+function cacheKey(cluster: string, component: KnativeComponent) {
+  return `${cluster}/${component}`;
+}
+
+export interface SidebarGateOptions {
+  /** Returns the cluster the sidebar is being rendered for. */
+  getCluster: () => string;
+  /** Checks whether a component is installed in the given clusters. */
+  isInstalled: (component: KnativeComponent, clusters: string[]) => Promise<boolean>;
+  /** Reads the current time. Injectable for tests. */
+  now?: () => number;
+  /** How long a result is reused before it is checked again. */
+  ttlMs?: number;
+}
+
+/**
+ * Returns the components an entry depends on, or null when the entry does not
+ * belong to this plugin.
+ *
+ * The top level entry depends on every component the sections need, so that it
+ * is hidden exactly when all of them would be hidden. Headlamp keeps a parent
+ * whose children have all been filtered out, and a parent with no children
+ * links nowhere, so the top level entry must not outlive its sections.
+ *
+ * @param entry The sidebar entry being filtered.
+ * @returns The components to check, or null to leave the entry alone.
+ */
+export function componentsForEntry(entry: SidebarEntryLike): KnativeComponent[] | null {
+  if (entry.name === KNATIVE_ROOT_ENTRY) {
+    return NEEDED_COMPONENTS;
+  }
+
+  const component = ENTRY_COMPONENT.get(entry.name);
+  if (component !== undefined) {
+    return [component];
+  }
+
+  // An entry registered under Knative that navigation.ts does not describe.
+  const parent = entry.parent ?? '';
+  if (parent === KNATIVE_ROOT_ENTRY || SECTION_COMPONENT.has(parent)) {
+    return [DEFAULT_SECTION_COMPONENT];
+  }
+
+  return null;
+}
+
+/**
+ * Builds a sidebar entry filter that hides Knative entries whose component is
+ * not installed.
+ *
+ * Results are cached per cluster and component for a short time, and only one
+ * check per key is in flight at once. An entry stays visible until a check has
+ * come back negative, so nothing flickers out and back while the first lookup
+ * is running.
+ *
+ * @param options Cluster lookup and the injectable pieces used by tests.
+ * @returns A filter for registerSidebarEntryFilter.
+ */
+export function createSidebarGate(options: SidebarGateOptions) {
+  const { getCluster, isInstalled, now = Date.now, ttlMs = CHECK_TTL_MS } = options;
+
+  const installed: Record<string, boolean> = {};
+  const lastCheckedAt: Record<string, number> = {};
+  const inFlight: Record<string, boolean> = {};
+
+  async function check(cluster: string, component: KnativeComponent) {
+    const key = cacheKey(cluster, component);
+    const lastChecked = lastCheckedAt[key];
+    // A key that has never been checked is not fresh, whatever the clock reads.
+    const fresh = lastChecked !== undefined && now() - lastChecked < ttlMs;
+    if (inFlight[key] || fresh) {
+      return;
+    }
+
+    inFlight[key] = true;
+    try {
+      installed[key] = await isInstalled(component, [cluster]);
+    } catch {
+      // A failed check is not evidence either way. The entry stays visible and
+      // the check is made again once the cached result expires.
+    } finally {
+      lastCheckedAt[key] = now();
+      inFlight[key] = false;
+    }
+  }
+
+  return function gate<T extends SidebarEntryLike>(entry: T): T | null {
+    const components = componentsForEntry(entry);
+    if (components === null) {
+      return entry;
+    }
+
+    const cluster = getCluster();
+    components.forEach(component => void check(cluster, component));
+
+    const allKnownMissing = components.every(
+      component => installed[cacheKey(cluster, component)] === false
+    );
+
+    return allKnownMissing ? null : entry;
+  };
+}


### PR DESCRIPTION
Follow up to https://github.com/cncf/mentoring/issues/2001#issuecomment-5224692202, where @kahirokunn confirmed the install check is Serving only and said a standalone PR for it was welcome.

Scope is the detection split and the gating that uses it. No Eventing views, routes or sidebar entries, so #922 is untouched.

## The problem

Serving and Eventing install independently. A cluster can run either one, both, or neither. `isKnativeInstalled` looked for `services.serving.knative.dev` and returned that one answer as "Knative is installed", and every caller acted on it:

- the sidebar filter showed or hid all Knative entries on it
- `useKnativeInstalled` gated every view on it

That answer is correct for the Serving views we have today, and it is not something a caller can act on once anything reads Eventing resources.

## What this changes

`isKnativeComponentInstalled(component, clusters)` replaces `isKnativeInstalled`. Serving is detected through `services.serving.knative.dev` and Eventing through `brokers.eventing.knative.dev`, both part of their core install rather than an optional add-on. `hasCrdInCluster` is unchanged, and so is the rule that a component counts as installed only when it is present in every selected cluster.

`SECTION_COMPONENT` in `sidebarGating.ts` maps each of the three navigation sections to the component it needs. Items inherit the component of the section they sit in, derived from `knativeNavigationSections`, so `navigation.ts` stays
the source of truth for what exists and `SECTION_COMPONENT` is the only place a component is decided. Adding an Eventing section is one line in each.

The top level entry is gated on every component its sections need, so it is hidden exactly when all of them would be hidden. That is the reason it is not simply gated on "any component installed": `filterSublist` in `useSidebarItems.tsx` removes children but keeps the parent, and `SidebarItem` falls back to `routeName = ''` when `subList` is empty. A top level entry that outlived its sections would leave a dead item in the sidebar, which is what an Eventing only cluster would have got.

The gating logic moved to `sidebarGating.ts` with the install check passed in, so it can be tested without loading the plugin runtime. The cache is keyed by cluster and component instead of cluster alone, and keeps the 30 second TTL and the single in flight check per key.

**This costs no extra API calls.** Only components that some section asks for are ever looked up. All three sections map to Serving today, so the sidebar makes exactly the same one check per cluster that it made before. A test asserts this.

Two smaller things are tightened on the way. Neither is reachable in a running Headlamp and I am not claiming them as user facing fixes:

- a key that had never been checked compared against a default of `0`, which reads as a fresh result rather than a missing one. With `Date.now()` this never fires, but it made the cache impossible to test with an injected clock.
- a rejected check left its in flight flag set, which would freeze that cluster's result for good. `hasCrdInCluster` settles rather than rejects, so this needs `apiGet` to throw synchronously to happen at all.

## On YAGNI

You raised YAGNI on #2001, and it is the fair objection here, so I would rather answer it than hope it does not come up.

`eventing` is not speculation about a future view. It is the thing that makes this a split rather than a rename: without a second component there is no way to express "this section needs Serving" as distinct from "Knative is present", and the bug you confirmed stays exactly where it is. It costs one line in a lookup table, and the tests cover Serving only, Eventing only, both and neither, so the behavior is pinned before anything depends on it.

What I deliberately did not do is guess at what the Eventing views will need. There are no Eventing sections, routes or resource classes here. If the shape turns out wrong when those land, changing a map entry is cheap.

## Behavior today

None of this changes what a user sees, and I would rather say that plainly than dress it up. All three sections map to Serving, so the sidebar and the views resolve to the same answer they did before. This is the seam, so the Eventing work does not have to carry a detection rewrite as well.

## Tests and verification

`isKnativeInstalled.test.ts` covers Serving only, Eventing only, both, neither, the multi cluster rule, a failed request, and that the watch is cancelled once a result is known.

`sidebarGating.test.ts` covers the per section mapping, item inheritance, the top level rule, the per cluster and per component cache, TTL expiry, single in flight check, recovery after a rejection, and that no component is looked up unless a section needs it. It also walks every entry `index.tsx` registers, the top level one, the three sections and all thirteen items, and asserts each resolves to a known component and is shown or hidden with the rest, so a section added to `navigation.ts` without a component mapping fails the suite.

140 tests pass. `tsc`, `lint`, `format --check` and `build` are clean.

Verified on a real cluster as well: Kubernetes 1.34.3, Knative Serving 1.19.0, Headlamp 0.44.0. All thirteen menus open and match `kubectl`, and removing `services.serving.knative.dev` hides the whole tree and shows the not detected banner rather than an error. Videos are in the comments below.

I did not add manifests under `test-files/`. There is no Eventing view to look at yet, so a Broker fixture would only be there to make this look bigger than it is.

## Overlap with other open PRs

- Rebased onto `main` at 5bac06b6, which includes #986. That PR restructured the sidebar into three sections with items underneath, so the gate now walks sections and items rather than a flat list.
- #1077 rewrites the error handling inside `hasCrdInCluster`, which this PR leaves alone. The two apply cleanly in either order.
- #1075 adds tests for `isKnativeInstalled`, which this PR renames. If that lands first I am happy to rebase and fold its cases into `isKnativeInstalled.test.ts`.

## One thing I noticed and left alone

In `hasCrdInCluster`, `cancelFn` is assigned in the `.then` of `request()`. If a callback fires before that microtask runs, the result settles while `cancelFn` is still null and the watch is never cancelled. It needs a genuinely synchronous callback, which I have not seen happen, and it sits in the function #1077 is already rewriting, so it seemed better raised than patched here.
