### PR TITLE
repo: Add .gitattributes to normalise line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
## Summary

The repository has no `.gitattributes`, so on Windows every tracked file is checked out
with CRLF while Prettier expects LF. `npm run lint` and `npm run format -- --check` fail on
a clean checkout, in files the contributor has not touched. 1,676 of 1,678 tracked text
files are affected, across all 27 plugin directories.

Fixes #1105

## Changes

- Add a root `.gitattributes` containing `* text=auto eol=lf`

## Testing

On Windows 11 with `core.autocrlf=true`, in the `kueue` plugin:

- Before: Prettier reports all 24 source files as incorrectly formatted
- After adding `.gitattributes` and re-checking out `kueue/src`: `All matched files use
  Prettier code style!`

I also re-checked out files under `knative`, `kyverno`, `prometheus`, `.github` and the
repository root to confirm git applies the attribute recursively - all arrive with LF.

`git status` reports no content change to any file, only the new `.gitattributes`, because
the files are already stored with LF in the repository. This changes how they are checked
out and nothing else.

## Notes for the Reviewer

No screenshots - repository configuration only, no UI impact.

I used `* text=auto eol=lf` because it covers all 27 plugin directories without needing
maintenance as new file types are added. If you'd prefer the narrower per-extension form
used in kubernetes-sigs/headlamp, that's a one-line change - happy to switch.

This PR was written in part with the assistance of generative AI.