### PR TITLE
fix(kyverno): guard CRD spec getters with optional chaining

### DIFF
--- a/kyverno/src/resources/celPolicies.ts
+++ b/kyverno/src/resources/celPolicies.ts
@@ -92,19 +92,19 @@ export class ValidatingPolicy extends KubeObject<ValidatingPolicyInterface> {
   }
 
   get validationActions(): string[] {
-    return this.spec.validationActions || ['Audit'];
+    return this.spec?.validationActions || ['Audit'];
   }
 
   get validationCount(): number {
-    return this.spec.validations?.length || 0;
+    return this.spec?.validations?.length || 0;
   }
 
   get isAdmissionEnabled(): boolean {
-    return this.spec.evaluation?.admission?.enabled ?? true;
+    return this.spec?.evaluation?.admission?.enabled ?? true;
   }
 
   get isBackgroundEnabled(): boolean {
-    return this.spec.evaluation?.background?.enabled ?? true;
+    return this.spec?.evaluation?.background?.enabled ?? true;
   }
 
   get ready(): boolean {
@@ -148,15 +148,15 @@ export class MutatingPolicy extends KubeObject<MutatingPolicyInterface> {
   }
 
   get mutationCount(): number {
-    return this.spec.mutations?.length || 0;
+    return this.spec?.mutations?.length || 0;
   }
 
   get isAdmissionEnabled(): boolean {
-    return this.spec.evaluation?.admission?.enabled ?? true;
+    return this.spec?.evaluation?.admission?.enabled ?? true;
   }
 
   get isBackgroundEnabled(): boolean {
-    return this.spec.evaluation?.background?.enabled ?? true;
+    return this.spec?.evaluation?.background?.enabled ?? true;
   }
 
   get ready(): boolean {
@@ -199,7 +199,7 @@ export class GeneratingPolicy extends KubeObject<GeneratingPolicyInterface> {
   }
 
   get generateCount(): number {
-    return this.spec.generate?.length || 0;
+    return this.spec?.generate?.length || 0;
   }
 
   get ready(): boolean {
@@ -238,7 +238,7 @@ export class DeletingPolicy extends KubeObject<DeletingPolicyInterface> {
   }
 
   get schedule(): string {
-    return this.spec.schedule || '-';
+    return this.spec?.schedule || '-';
   }
 
   get ready(): boolean {
@@ -300,11 +300,11 @@ export class ImageValidatingPolicy extends KubeObject<ImageValidatingPolicyInter
   }
 
   get imagePatterns(): string[] {
-    return (this.spec.matchImageReferences || []).map(r => r.glob || r.expression || '');
+    return (this.spec?.matchImageReferences || []).map(r => r.glob || r.expression || '');
   }
 
   get attestorCount(): number {
-    return this.spec.attestors?.length || 0;
+    return this.spec?.attestors?.length || 0;
   }
 
   get ready(): boolean {

--- a/kyverno/src/resources/kyvernoPolicy.test.ts
+++ b/kyverno/src/resources/kyvernoPolicy.test.ts
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@kinvolk/headlamp-plugin/lib/k8s/cluster', () => {
+  class KubeObject {
+    jsonData: any;
+    constructor(jsonData: any) {
+      this.jsonData = jsonData;
+    }
+    static getBaseObject() {
+      return {};
+    }
+  }
+  return { KubeObject };
+});
+
+import { KyvernoClusterPolicy, KyvernoPolicy } from './kyvernoPolicy';
+import {
+  DeletingPolicy,
+  GeneratingPolicy,
+  ImageValidatingPolicy,
+  MutatingPolicy,
+  ValidatingPolicy,
+} from './celPolicies';
+
+describe('Kyverno Policy Resources - Spec Safety', () => {
+  describe('KyvernoPolicy & KyvernoClusterPolicy', () => {
+    it('should safely handle missing spec in KyvernoPolicy', () => {
+      const policy = new KyvernoPolicy({
+        kind: 'Policy',
+        apiVersion: 'kyverno.io/v1',
+        metadata: { name: 'disallow-latest-tag', namespace: 'default' },
+      });
+
+      expect(policy.rules).toEqual([]);
+      expect(policy.ruleTypes).toEqual([]);
+      expect(policy.validationFailureAction).toBe('Audit');
+      expect(policy.background).toBe(true);
+    });
+
+    it('should safely handle missing spec in KyvernoClusterPolicy', () => {
+      const clusterPolicy = new KyvernoClusterPolicy({
+        kind: 'ClusterPolicy',
+        apiVersion: 'kyverno.io/v1',
+        metadata: { name: 'require-labels' },
+      });
+
+      expect(clusterPolicy.rules).toEqual([]);
+      expect(clusterPolicy.ruleTypes).toEqual([]);
+      expect(clusterPolicy.validationFailureAction).toBe('Audit');
+      expect(clusterPolicy.background).toBe(true);
+    });
+
+    it('should evaluate rules and properties correctly when spec is defined', () => {
+      const policy = new KyvernoPolicy({
+        kind: 'Policy',
+        apiVersion: 'kyverno.io/v1',
+        metadata: { name: 'check-labels', namespace: 'prod' },
+        spec: {
+          validationFailureAction: 'Enforce',
+          background: false,
+          rules: [
+            {
+              name: 'check-team-label',
+              validate: { message: 'Label required' },
+            },
+          ],
+        },
+      });
+
+      expect(policy.rules).toHaveLength(1);
+      expect(policy.ruleTypes).toEqual(['Validate']);
+      expect(policy.validationFailureAction).toBe('Enforce');
+      expect(policy.background).toBe(false);
+    });
+  });
+
+  describe('CEL Policy Resources', () => {
+    it('should safely handle missing spec in ValidatingPolicy', () => {
+      const vp = new ValidatingPolicy({
+        kind: 'ValidatingPolicy',
+        apiVersion: 'policies.kyverno.io/v1',
+        metadata: { name: 'cel-validating' },
+      });
+
+      expect(vp.validationActions).toEqual(['Audit']);
+      expect(vp.validationCount).toBe(0);
+      expect(vp.isAdmissionEnabled).toBe(true);
+      expect(vp.isBackgroundEnabled).toBe(true);
+    });
+
+    it('should safely handle missing spec in MutatingPolicy', () => {
+      const mp = new MutatingPolicy({
+        kind: 'MutatingPolicy',
+        apiVersion: 'policies.kyverno.io/v1',
+        metadata: { name: 'cel-mutating' },
+      });
+
+      expect(mp.mutationCount).toBe(0);
+      expect(mp.isAdmissionEnabled).toBe(true);
+      expect(mp.isBackgroundEnabled).toBe(true);
+    });
+
+    it('should safely handle missing spec in GeneratingPolicy', () => {
+      const gp = new GeneratingPolicy({
+        kind: 'GeneratingPolicy',
+        apiVersion: 'policies.kyverno.io/v1',
+        metadata: { name: 'cel-generating' },
+      });
+
+      expect(gp.generateCount).toBe(0);
+    });
+
+    it('should safely handle missing spec in DeletingPolicy', () => {
+      const dp = new DeletingPolicy({
+        kind: 'DeletingPolicy',
+        apiVersion: 'policies.kyverno.io/v1',
+        metadata: { name: 'cel-deleting' },
+      });
+
+      expect(dp.schedule).toBe('-');
+    });
+
+    it('should safely handle missing spec in ImageValidatingPolicy', () => {
+      const ivp = new ImageValidatingPolicy({
+        kind: 'ImageValidatingPolicy',
+        apiVersion: 'policies.kyverno.io/v1',
+        metadata: { name: 'cel-image-validating' },
+      });
+
+      expect(ivp.imagePatterns).toEqual([]);
+      expect(ivp.attestorCount).toBe(0);
+    });
+  });
+});

--- a/kyverno/src/resources/kyvernoPolicy.ts
+++ b/kyverno/src/resources/kyvernoPolicy.ts
@@ -134,7 +134,7 @@ abstract class KyvernoPolicyBase extends KubeObject<KyvernoPolicyInterface> {
   }
 
   get rules(): PolicyRule[] {
-    return this.spec.rules || [];
+    return this.spec?.rules || [];
   }
 
   get ruleTypes(): string[] {
@@ -142,11 +142,11 @@ abstract class KyvernoPolicyBase extends KubeObject<KyvernoPolicyInterface> {
   }
 
   get validationFailureAction(): string {
-    return this.spec.validationFailureAction || 'Audit';
+    return this.spec?.validationFailureAction || 'Audit';
   }
 
   get background(): boolean {
-    return this.spec.background ?? true;
+    return this.spec?.background ?? true;
   }
 }
 


### PR DESCRIPTION
## Summary
Fixes potential runtime crashes (`TypeError: Cannot read properties of undefined (reading 'rules')`) when rendering Kyverno policies (`Policy`, `ClusterPolicy`, `ValidatingPolicy`, `MutatingPolicy`, `GeneratingPolicy`, `DeletingPolicy`, `ImageValidatingPolicy`) whose Kubernetes resource payloads omit or partially initialize the `.spec` object field.


## Root Cause
`KyvernoPolicyBase` in `src/resources/kyvernoPolicy.ts` and CEL policy wrappers (`ValidatingPolicy`, `MutatingPolicy`, `GeneratingPolicy`, `DeletingPolicy`, `ImageValidatingPolicy`) in `src/resources/celPolicies.ts` dereferenced `this.spec` directly without optional chaining. When a resource's `.spec` field is undefined during streaming or mock loading, calling getters like `.rules`, `.validationFailureAction`, `.background`, or `.validationCount` threw an unhandled `TypeError`.

## Changes Made
- **`plugins/kyverno/src/resources/kyvernoPolicy.ts`**:
  - Updated `rules`, `validationFailureAction`, and `background` getters to evaluate `this.spec?....`.
- **`plugins/kyverno/src/resources/celPolicies.ts`**:
  - Updated `validationActions`, `validationCount`, `isAdmissionEnabled`, `isBackgroundEnabled`, `mutationCount`, `generateCount`, `schedule`, `imagePatterns`, and `attestorCount` getters to evaluate `this.spec?....`.
- **`plugins/kyverno/src/resources/kyvernoPolicy.test.ts`**:
  - Added unit regression test suite verifying that all policy classes gracefully return default fallbacks when `.spec` is `undefined`.

## How to Test
1. Run `npm test` inside `plugins/kyverno` to execute the new unit test suite in `src/resources/kyvernoPolicy.test.ts`.
2. Verify that mock objects constructed with `{ kind: 'Policy', metadata: { name: 'test' } }` evaluate `.rules`, `.validationFailureAction`, and `.background` without throwing runtime errors.

