### PR TITLE
ai-assistant: Replace backtracking regexes in untrusted parsing

### DIFF
--- a/ai-assistant/packages/ai-common/src/mcp/config/serverConfig.test.ts
+++ b/ai-assistant/packages/ai-common/src/mcp/config/serverConfig.test.ts
@@ -76,6 +76,11 @@ describe('expandEnvAndResolvePaths', () => {
     expect(result).toEqual([arg]);
   });
 
+  it('preserves commas inside Docker destination paths', () => {
+    const arg = 'type=bind,src=/home/user/dir,dst=/data,with,commas';
+    expect(expandEnvAndResolvePaths([arg], null, 'linux')).toEqual([arg]);
+  });
+
   it('uses empty environment values when process is polyfilled without env', () => {
     const originalProcess = globalThis.process;
     vi.stubGlobal('process', { platform: 'linux', cwd: () => '/tmp' });

--- a/ai-assistant/packages/ai-common/src/mcp/config/serverConfig.ts
+++ b/ai-assistant/packages/ai-common/src/mcp/config/serverConfig.ts
@@ -93,10 +93,12 @@ export function expandEnvAndResolvePaths(
 
     // Handle Docker volume mount format and ensure proper Windows path format
     if (expandedArg.includes('type=bind,src=')) {
-      const match = expandedArg.match(/type=bind,src=(.+?),dst=(.+)/);
-      if (match) {
-        let srcPath = match[1];
-        const dstPath = match[2];
+      const sourceStart = expandedArg.indexOf('type=bind,src=') + 'type=bind,src='.length;
+      const destinationMarker = ',dst=';
+      const destinationStart = expandedArg.indexOf(destinationMarker, sourceStart);
+      if (destinationStart >= 0) {
+        let srcPath = expandedArg.slice(sourceStart, destinationStart);
+        const dstPath = expandedArg.slice(destinationStart + destinationMarker.length);
 
         // Resolve the source path — Node only; in browser this branch is unreachable
         // because effectivePlatform will never be 'win32' in a browser context.

--- a/ai-assistant/packages/ai-common/src/mcp/tools/ToolStateStore.test.ts
+++ b/ai-assistant/packages/ai-common/src/mcp/tools/ToolStateStore.test.ts
@@ -479,6 +479,31 @@ describe('initConfigFromClientTools', () => {
     expect(gn?.enabled).toBe(true);
   });
 
+  it('ignores unsafe server and tool names from client tools', async () => {
+    const toolState = makeStore(toolStatePath);
+    await toolState.initialize();
+
+    expect(() =>
+      toolState.initConfigFromClientTools([
+        { name: 'constructor__tool' },
+        { name: 'srv__constructor' },
+        { name: 'srv____proto__' },
+        { name: 'srv__safe-tool', description: 'safe' },
+      ])
+    ).not.toThrow();
+
+    expect(toolState.getConfig()).toEqual({
+      srv: {
+        'safe-tool': {
+          enabled: true,
+          usageCount: 0,
+          inputSchema: null,
+          description: 'safe',
+        },
+      },
+    });
+  });
+
   it('preserves enabled state and usageCount from existing config when tool still exists', async () => {
     const toolState = makeStore(toolStatePath);
     await toolState.initialize();
@@ -595,5 +620,20 @@ describe('initConfigFromClientTools', () => {
 
     expect(toolState.getToolStats('srv', 'zod-tool')?.inputSchema).toBeNull();
     expect(toolState.getToolStats('srv', 'json-tool')?.inputSchema).toEqual(jsonSchema);
+  });
+
+  it('replaceToolsConfig ignores unsafe server and tool names', async () => {
+    const toolState = makeStore(toolStatePath);
+    await toolState.initialize();
+
+    expect(() =>
+      toolState.replaceToolsConfig({
+        constructor: [{ name: 'tool' }],
+        srv: [{ name: '__proto__' }, { name: 'safe-tool' }],
+      })
+    ).not.toThrow();
+
+    expect(Object.keys(toolState.getConfig())).toEqual(['srv']);
+    expect(Object.keys(toolState.getConfig().srv)).toEqual(['safe-tool']);
   });
 });

--- a/ai-assistant/packages/ai-common/src/mcp/tools/ToolStateStore.test.ts
+++ b/ai-assistant/packages/ai-common/src/mcp/tools/ToolStateStore.test.ts
@@ -63,6 +63,19 @@ describe('MCPToolStateStore', () => {
     expect(toolState.isToolEnabled('cluster-x', 'tool-a')).toBe(true);
   });
 
+  it('ignores prototype-sensitive server and tool names', async () => {
+    const toolState = makeStore(toolStatePath);
+    await toolState.initialize();
+
+    toolState.setToolEnabled('__proto__', 'tool', false);
+    toolState.setToolEnabled('server', '__proto__', false);
+    toolState.recordToolUsage('constructor', 'tool');
+    toolState.initializeToolsConfig('server', [{ name: 'prototype' }]);
+
+    expect(toolState.getConfig()).toEqual({});
+    expect(Object.prototype).not.toHaveProperty('enabled');
+  });
+
   it('contains synchronous errors from a debounced storage write', async () => {
     const storage: Storage = {
       read: async () => null,

--- a/ai-assistant/packages/ai-common/src/mcp/tools/ToolStateStore.ts
+++ b/ai-assistant/packages/ai-common/src/mcp/tools/ToolStateStore.ts
@@ -18,6 +18,23 @@ import type { Storage } from '../persistence/Storage';
 import type { MCPToolsConfig } from '../types';
 import { parseMCPToolName } from './toolName';
 
+function isSafeConfigKey(value: string): boolean {
+  return value !== '__proto__' && value !== 'constructor' && value !== 'prototype';
+}
+
+function setOwnConfigValue<T extends object, K extends keyof any, V>(
+  target: T,
+  key: K,
+  value: V
+): void {
+  Object.defineProperty(target, key, {
+    value,
+    enumerable: true,
+    configurable: true,
+    writable: true,
+  });
+}
+
 /**
  * Manages persisted MCP tool state, including enablement, schemas, descriptions,
  * and usage statistics.
@@ -231,15 +248,16 @@ export class ToolStateStore {
    * @returns No value.
    */
   setToolEnabled(serverName: string, toolName: string, enabled: boolean): void {
+    if (!isSafeConfigKey(serverName) || !isSafeConfigKey(toolName)) return;
     if (!this.config[serverName]) {
-      this.config[serverName] = {};
+      setOwnConfigValue(this.config, serverName, {});
     }
 
     if (!this.config[serverName][toolName]) {
-      this.config[serverName][toolName] = {
+      setOwnConfigValue(this.config[serverName], toolName, {
         enabled: true,
         usageCount: 0,
-      };
+      });
     }
 
     this.config[serverName][toolName].enabled = enabled;
@@ -288,15 +306,16 @@ export class ToolStateStore {
    * @returns No value.
    */
   recordToolUsage(serverName: string, toolName: string): void {
+    if (!isSafeConfigKey(serverName) || !isSafeConfigKey(toolName)) return;
     if (!this.config[serverName]) {
-      this.config[serverName] = {};
+      setOwnConfigValue(this.config, serverName, {});
     }
 
     if (!this.config[serverName][toolName]) {
-      this.config[serverName][toolName] = {
+      setOwnConfigValue(this.config[serverName], toolName, {
         enabled: true,
         usageCount: 0,
-      };
+      });
     }
 
     const toolState = this.config[serverName][toolName];
@@ -356,23 +375,26 @@ export class ToolStateStore {
       description?: string;
     }>
   ): void {
+    if (!isSafeConfigKey(serverName)) return;
+    const safeToolsInfo = toolsInfo.filter(toolInfo => isSafeConfigKey(toolInfo.name));
+    if (safeToolsInfo.length === 0) return;
     if (!this.config[serverName]) {
-      this.config[serverName] = {};
+      setOwnConfigValue(this.config, serverName, {});
     }
 
     const serverConfig = this.config[serverName];
     let hasChanges = false;
 
-    for (const toolInfo of toolsInfo) {
+    for (const toolInfo of safeToolsInfo) {
       const toolName = toolInfo.name;
 
       if (!serverConfig[toolName]) {
-        serverConfig[toolName] = {
+        setOwnConfigValue(serverConfig, toolName, {
           enabled: true,
           usageCount: 0,
           inputSchema: toJsonSchema(toolInfo.inputSchema) ?? null,
           description: toolInfo.description || '',
-        };
+        });
         hasChanges = true;
       } else {
         // Always update schema and description for existing tools

--- a/ai-assistant/packages/ai-common/src/mcp/tools/ToolStateStore.ts
+++ b/ai-assistant/packages/ai-common/src/mcp/tools/ToolStateStore.ts
@@ -475,20 +475,22 @@ export class ToolStateStore {
     const newConfig: MCPToolsConfig = {};
 
     for (const [serverName, toolsInfo] of Object.entries(toolsByServer)) {
-      newConfig[serverName] = {};
+      if (!isSafeConfigKey(serverName)) continue;
+      setOwnConfigValue(newConfig, serverName, {});
 
       for (const toolInfo of toolsInfo) {
         const toolName = toolInfo.name;
+        if (!isSafeConfigKey(toolName)) continue;
 
         // Check if this tool existed in the old config to preserve enabled state and usage count
         const oldToolState = this.config[serverName]?.[toolName];
 
-        newConfig[serverName][toolName] = {
+        setOwnConfigValue(newConfig[serverName], toolName, {
           enabled: oldToolState?.enabled ?? true, // Preserve enabled state or default to true
           usageCount: oldToolState?.usageCount ?? 0, // Preserve usage count or default to 0
           inputSchema: toJsonSchema(toolInfo.inputSchema) ?? null,
           description: toolInfo.description || '',
-        };
+        });
       }
     }
 
@@ -547,11 +549,12 @@ export class ToolStateStore {
         /** User-facing tool description. */
         description?: string;
       }>
-    > = {};
+    > = Object.create(null);
 
     for (const tool of clientTools) {
       // Extract server name from tool name (format: "serverName__toolName")
       const { serverName, toolName } = parseMCPToolName(tool.name);
+      if (!isSafeConfigKey(serverName) || !isSafeConfigKey(toolName)) continue;
 
       // Prefer the explicit `inputSchema` field (already JSON Schema) over
       // `schema`, which LangChain tools expose as a Zod object. Zod schemas
@@ -561,7 +564,7 @@ export class ToolStateStore {
       const toolSchema = toJsonSchema(tool.inputSchema) ?? toJsonSchema(tool.schema) ?? null;
 
       if (!toolsByServer[serverName]) {
-        toolsByServer[serverName] = [];
+        setOwnConfigValue(toolsByServer, serverName, []);
       }
 
       toolsByServer[serverName].push({

--- a/ai-assistant/packages/ai-common/src/mcp/tools/ToolStateStore.ts
+++ b/ai-assistant/packages/ai-common/src/mcp/tools/ToolStateStore.ts
@@ -18,8 +18,10 @@ import type { Storage } from '../persistence/Storage';
 import type { MCPToolsConfig } from '../types';
 import { parseMCPToolName } from './toolName';
 
+// Callers test config lookups by truthiness, so any inherited Object.prototype
+// member name (toString, hasOwnProperty, …) must be rejected too.
 function isSafeConfigKey(value: string): boolean {
-  return value !== '__proto__' && value !== 'constructor' && value !== 'prototype';
+  return value !== 'prototype' && !Object.prototype.hasOwnProperty.call(Object.prototype, value);
 }
 
 function setOwnConfigValue<T extends object, K extends keyof any, V>(

--- a/ai-assistant/packages/ai-common/src/security/redactSecrets.test.ts
+++ b/ai-assistant/packages/ai-common/src/security/redactSecrets.test.ts
@@ -44,6 +44,27 @@ describe('redactSecrets', () => {
     expect(out).toContain('[REDACTED]');
   });
 
+  it('handles repeated eyJ input without treating it as a JWT', () => {
+    const adversarialInput = 'eyJ'.repeat(100_000);
+
+    expect(redactSecrets(adversarialInput)).toBe(adversarialInput);
+  });
+
+  it('preserves incomplete JWT-like values', () => {
+    const incomplete = 'prefix eyJheader.eyJpayload suffix';
+
+    expect(redactSecrets(incomplete)).toBe(incomplete);
+  });
+
+  it('redacts every valid JWT embedded in surrounding text', () => {
+    const first = 'eyJheader.eyJpayload.signature_one';
+    const second = 'eyJother.eyJclaims.signature-two';
+
+    expect(redactSecrets(`first=${first}; second=${second}`)).toBe(
+      'first=[REDACTED]; second=[REDACTED]'
+    );
+  });
+
   it('redacts PEM private keys', () => {
     const pem = `-----BEGIN RSA PRIVATE KEY-----
 MIIEowIBAAKCAQEA0Z3VS5JJcds3xHn/ygWep4
@@ -287,5 +308,20 @@ namespace: default`;
     expect(
       redactSecrets('DefaultEndpointsProtocol=https;AccountKey=abc123DEF456==;Rest=1')
     ).toContain('AccountKey=[REDACTED]');
+  });
+
+  it('redacts credentials that are not at the start of a line', () => {
+    expect(redactSecrets('url=https://x.io/?token=abc123')).toBe(
+      'url=https://x.io/?token=[REDACTED]'
+    );
+    expect(redactSecrets('export PASSWORD=hunter2')).toBe('export PASSWORD=[REDACTED]');
+    expect(redactSecrets('my password: hunter2')).toBe('my password: [REDACTED]');
+    expect(redactSecrets('The password: hunter2 was leaked')).toBe('The password: [REDACTED]');
+  });
+
+  it('leaves non-credential fields and already-redacted values alone', () => {
+    expect(redactSecrets('url=https://example.com/path')).toBe('url=https://example.com/path');
+    expect(redactSecrets('password: [REDACTED]')).toBe('password: [REDACTED]');
+    expect(redactSecrets('DB_PASSWORD=hunter2')).toBe('DB_PASSWORD=hunter2');
   });
 });

--- a/ai-assistant/packages/ai-common/src/security/redactSecrets.test.ts
+++ b/ai-assistant/packages/ai-common/src/security/redactSecrets.test.ts
@@ -83,6 +83,11 @@ MIICpDCCAYwCCQDU+pQ4pHgSpDANBgkqhkiG9w0BAQsFADAUMRIwEAYDVQQDDAls
     expect(out).toContain('[REDACTED]');
   });
 
+  it('preserves many unterminated PEM headers', () => {
+    const input = Array.from({ length: 2_000 }, () => '-----BEGIN CERTIFICATE-----').join('\n');
+    expect(redactSecrets(input)).toBe(input);
+  });
+
   it('redacts kubeconfig inline certificate data', () => {
     const yaml = `clusters:
 - cluster:
@@ -272,6 +277,21 @@ namespace: default`;
     const out = redactSecrets(input);
     expect(out).not.toContain('cG9zdGdyZXM6Ly8=');
     expect(out).toContain('[REDACTED]');
+  });
+
+  it('redacts every fenced JSON Secret after malformed and non-secret blocks', () => {
+    const input = [
+      '```json\n{invalid}\n```',
+      '```json\n{"kind":"ConfigMap","data":{"visible":"yes"}}\n```',
+      '```json\n{"kind":"Secret","data":{"first":"c2VjcmV0MQ=="}}\n```',
+      '```json\n{"kind":"Secret","stringData":{"second":"secret2"}}\n```',
+    ].join('\n');
+    const out = redactSecrets(input);
+    expect(out).toContain('{invalid}');
+    expect(out).toContain('"visible":"yes"');
+    expect(out).not.toContain('c2VjcmV0MQ==');
+    expect(out).not.toContain('secret2');
+    expect(out.match(/\[REDACTED\]/g)).toHaveLength(2);
   });
 
   it('redacts all data values of a JSON Kubernetes Secret and List responses', () => {

--- a/ai-assistant/packages/ai-common/src/security/redactSecrets.ts
+++ b/ai-assistant/packages/ai-common/src/security/redactSecrets.ts
@@ -130,28 +130,68 @@ function redactPemBlocks(input: string): string {
   let output = '';
   let cursor = 0;
   const beginMarker = '-----BEGIN ';
+  const endPositions = indexPemEndMarkers(input);
+  const nextEndByLabel = new Map<string, number>();
   while (cursor < input.length) {
     const begin = input.indexOf(beginMarker, cursor);
     if (begin < 0) return output + input.slice(cursor);
-    const labelEnd = input.indexOf('-----', begin + beginMarker.length);
-    if (labelEnd < 0 || labelEnd - (begin + beginMarker.length) > 64) {
+    const labelStart = begin + beginMarker.length;
+    const labelEnd = findPemLabelEnd(input, labelStart);
+    if (labelEnd < 0) {
       output += input.slice(cursor, begin + beginMarker.length);
       cursor = begin + beginMarker.length;
       continue;
     }
-    const label = input.slice(begin + beginMarker.length, labelEnd);
+    const label = input.slice(labelStart, labelEnd);
     const endMarker = `-----END ${label}-----`;
-    const end = input.indexOf(endMarker, labelEnd + 5);
-    if (end < 0) {
+    const positions = endPositions.get(label) ?? [];
+    let positionIndex = nextEndByLabel.get(label) ?? 0;
+    while (positionIndex < positions.length && positions[positionIndex] < labelEnd + 5) {
+      positionIndex++;
+    }
+    const end = positions[positionIndex];
+    if (end === undefined) {
       // Incomplete block: keep the header and keep scanning for later PEM blocks.
       output += input.slice(cursor, labelEnd + 5);
       cursor = labelEnd + 5;
+      nextEndByLabel.set(label, positionIndex);
       continue;
     }
+    nextEndByLabel.set(label, positionIndex + 1);
     output += input.slice(cursor, begin) + '[REDACTED]';
     cursor = end + endMarker.length;
   }
   return output;
+}
+
+function indexPemEndMarkers(input: string): Map<string, number[]> {
+  const positionsByLabel = new Map<string, number[]>();
+  const marker = '-----END ';
+  let cursor = 0;
+  while (cursor < input.length) {
+    const start = input.indexOf(marker, cursor);
+    if (start < 0) break;
+    const labelStart = start + marker.length;
+    const labelEnd = findPemLabelEnd(input, labelStart);
+    if (labelEnd >= 0) {
+      const label = input.slice(labelStart, labelEnd);
+      const positions = positionsByLabel.get(label) ?? [];
+      positions.push(start);
+      positionsByLabel.set(label, positions);
+      cursor = labelEnd + 5;
+    } else {
+      cursor = labelStart;
+    }
+  }
+  return positionsByLabel;
+}
+
+function findPemLabelEnd(input: string, labelStart: number): number {
+  const limit = Math.min(input.length, labelStart + 65);
+  for (let index = labelStart; index < limit; index++) {
+    if (input.startsWith('-----', index)) return index;
+  }
+  return -1;
 }
 
 function redactJwtTokens(input: string): string {
@@ -318,24 +358,29 @@ function redactKubernetesSecretValues(input: string): string {
 }
 
 function redactFencedJsonSecrets(input: string): string {
-  // Search the original string: case folding can change UTF-16 length and shift the index.
-  const markerMatch = /```json/i.exec(input);
-  if (!markerMatch) return input;
-  const start = markerMatch.index;
-  const bodyStart = start + markerMatch[0].length;
-  const end = input.indexOf('```', bodyStart);
-  if (end < 0) return input;
-  try {
-    const parsed: unknown = JSON.parse(input.slice(bodyStart, end).trim());
-    if (!redactSecretsInParsedJson(parsed)) return input;
-    return `${input.slice(0, start)}\`\`\`json\n${JSON.stringify(
-      parsed,
-      null,
-      2
-    )}\n\`\`\`${input.slice(end + 3)}`;
-  } catch {
-    return input;
+  let output = '';
+  let cursor = 0;
+  const markerPattern = /```json/gi;
+  for (let markerMatch = markerPattern.exec(input); markerMatch; markerMatch = markerPattern.exec(input)) {
+    const start = markerMatch.index;
+    const bodyStart = start + markerMatch[0].length;
+    const end = input.indexOf('```', bodyStart);
+    if (end < 0) break;
+    markerPattern.lastIndex = end + 3;
+    try {
+      const parsed: unknown = JSON.parse(input.slice(bodyStart, end).trim());
+      if (!redactSecretsInParsedJson(parsed)) continue;
+      output += `${input.slice(cursor, start)}${markerMatch[0]}\n${JSON.stringify(
+        parsed,
+        null,
+        2
+      )}\n\`\`\``;
+      cursor = end + 3;
+    } catch {
+      // Preserve malformed JSON and continue to later fenced blocks.
+    }
   }
+  return output + input.slice(cursor);
 }
 
 /**

--- a/ai-assistant/packages/ai-common/src/security/redactSecrets.ts
+++ b/ai-assistant/packages/ai-common/src/security/redactSecrets.ts
@@ -143,8 +143,10 @@ function redactPemBlocks(input: string): string {
     const endMarker = `-----END ${label}-----`;
     const end = input.indexOf(endMarker, labelEnd + 5);
     if (end < 0) {
-      output += input.slice(cursor);
-      return output;
+      // Incomplete block: keep the header and keep scanning for later PEM blocks.
+      output += input.slice(cursor, labelEnd + 5);
+      cursor = labelEnd + 5;
+      continue;
     }
     output += input.slice(cursor, begin) + '[REDACTED]';
     cursor = end + endMarker.length;
@@ -230,7 +232,11 @@ const CREDENTIAL_FIELD_NAMES = new Set([
 ]);
 
 function redactCredentialLines(input: string): string {
-  return input.split('\n').map(redactCredentialLine).join('\n');
+  // Keep every newline form (\r\n, \r, \n) so redaction never rewrites line endings.
+  return input
+    .split(/(\r\n|\r|\n)/)
+    .map((part, index) => (index % 2 === 0 ? redactCredentialLine(part) : part))
+    .join('');
 }
 
 // Every separator is examined, not just the first, so credentials embedded
@@ -245,7 +251,7 @@ function redactCredentialLine(line: string): string {
     if (!CREDENTIAL_FIELD_NAMES.has(field)) continue;
 
     const valueStart = index + 1;
-    if (line.slice(valueStart).trim() === '[REDACTED]') return line;
+    if (line.slice(valueStart).trim() === '[REDACTED]') continue;
 
     let prefixEnd = valueStart;
     while (prefixEnd < line.length && (line[prefixEnd] === ' ' || line[prefixEnd] === '\t')) {
@@ -312,11 +318,11 @@ function redactKubernetesSecretValues(input: string): string {
 }
 
 function redactFencedJsonSecrets(input: string): string {
-  const lower = input.toLowerCase();
-  const marker = '```json';
-  const start = lower.indexOf(marker);
-  if (start < 0) return input;
-  const bodyStart = start + marker.length;
+  // Search the original string: case folding can change UTF-16 length and shift the index.
+  const markerMatch = /```json/i.exec(input);
+  if (!markerMatch) return input;
+  const start = markerMatch.index;
+  const bodyStart = start + markerMatch[0].length;
   const end = input.indexOf('```', bodyStart);
   if (end < 0) return input;
   try {

--- a/ai-assistant/packages/ai-common/src/security/redactSecrets.ts
+++ b/ai-assistant/packages/ai-common/src/security/redactSecrets.ts
@@ -44,11 +44,11 @@ export function redactSecrets(input: string): string {
 
   // PEM blocks — run first so private-key content is gone before the
   // generic key-value patterns could match individual lines inside them.
-  out = out.replace(/-----BEGIN [A-Z ]+-----[\s\S]*?-----END [A-Z ]+-----/g, '[REDACTED]');
+  out = redactPemBlocks(out);
 
   // JWT tokens: three base64url segments separated by dots.
   // The first two start with "eyJ" (base64 of '{"').
-  out = out.replace(/eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g, '[REDACTED]');
+  out = redactJwtTokens(out);
 
   // AWS long-lived and temporary access key IDs.
   out = out.replace(/\b(?:AKIA|ASIA)[0-9A-Z]{16}\b/g, '[REDACTED]');
@@ -121,12 +121,157 @@ export function redactSecrets(input: string): string {
   //   passwd=s3cr3t    → passwd=[REDACTED]
   //   password: hunter → password: [REDACTED]
   // Negative lookahead prevents double-redacting already-replaced values.
-  out = out.replace(
-    /\b(password|passwd|secret|token|api[_-]?key|access[_-]?key|private[_-]?key|client[_-]?secret|auth[_-]?token|bearer)(?![^\S\r\n]*[:=][^\S\r\n]*\[REDACTED\])([^\S\r\n]*[:=][^\S\r\n]*)[^\r\n]+/gi,
-    '$1$2[REDACTED]'
-  );
+  out = redactCredentialLines(out);
 
   return out;
+}
+
+function redactPemBlocks(input: string): string {
+  let output = '';
+  let cursor = 0;
+  const beginMarker = '-----BEGIN ';
+  while (cursor < input.length) {
+    const begin = input.indexOf(beginMarker, cursor);
+    if (begin < 0) return output + input.slice(cursor);
+    const labelEnd = input.indexOf('-----', begin + beginMarker.length);
+    if (labelEnd < 0 || labelEnd - (begin + beginMarker.length) > 64) {
+      output += input.slice(cursor, begin + beginMarker.length);
+      cursor = begin + beginMarker.length;
+      continue;
+    }
+    const label = input.slice(begin + beginMarker.length, labelEnd);
+    const endMarker = `-----END ${label}-----`;
+    const end = input.indexOf(endMarker, labelEnd + 5);
+    if (end < 0) {
+      output += input.slice(cursor);
+      return output;
+    }
+    output += input.slice(cursor, begin) + '[REDACTED]';
+    cursor = end + endMarker.length;
+  }
+  return output;
+}
+
+function redactJwtTokens(input: string): string {
+  let output = '';
+  let cursor = 0;
+  while (cursor < input.length) {
+    const start = input.indexOf('eyJ', cursor);
+    if (start < 0) return output + input.slice(cursor);
+    output += input.slice(cursor, start);
+
+    const firstEnd = scanBase64UrlSegment(input, start);
+    if (firstEnd === input.length) return output + input.slice(start);
+    if (input[firstEnd] !== '.') {
+      output += input.slice(start, firstEnd + 1);
+      cursor = firstEnd + 1;
+      continue;
+    }
+
+    const secondStart = firstEnd + 1;
+    if (!input.startsWith('eyJ', secondStart)) {
+      output += input.slice(start, secondStart);
+      cursor = secondStart;
+      continue;
+    }
+    const secondEnd = scanBase64UrlSegment(input, secondStart);
+    if (secondEnd === input.length) return output + input.slice(start);
+    if (input[secondEnd] !== '.') {
+      output += input.slice(start, secondEnd + 1);
+      cursor = secondEnd + 1;
+      continue;
+    }
+
+    const thirdStart = secondEnd + 1;
+    const thirdEnd = scanBase64UrlSegment(input, thirdStart);
+    if (thirdEnd === thirdStart) {
+      output += input.slice(start, thirdStart);
+      cursor = thirdStart;
+      continue;
+    }
+    output += '[REDACTED]';
+    cursor = thirdEnd;
+  }
+  return output;
+}
+
+function scanBase64UrlSegment(input: string, start: number): number {
+  let end = start;
+  while (end < input.length) {
+    const code = input.charCodeAt(end);
+    const valid =
+      (code >= 48 && code <= 57) ||
+      (code >= 65 && code <= 90) ||
+      (code >= 97 && code <= 122) ||
+      input[end] === '_' ||
+      input[end] === '-';
+    if (!valid) break;
+    end++;
+  }
+  return end;
+}
+
+const CREDENTIAL_FIELD_NAMES = new Set([
+  'password',
+  'passwd',
+  'secret',
+  'token',
+  'api_key',
+  'api-key',
+  'access_key',
+  'access-key',
+  'private_key',
+  'private-key',
+  'client_secret',
+  'client-secret',
+  'auth_token',
+  'auth-token',
+  'bearer',
+]);
+
+function redactCredentialLines(input: string): string {
+  return input.split('\n').map(redactCredentialLine).join('\n');
+}
+
+// Every separator is examined, not just the first, so credentials embedded
+// mid-line (query strings, `export FOO=`) are still caught.
+function redactCredentialLine(line: string): string {
+  for (let index = 0; index < line.length; index++) {
+    const character = line[index];
+    if (character !== ':' && character !== '=') continue;
+
+    const fieldStart = fieldNameStart(line, index);
+    const field = line.slice(fieldStart, index).toLowerCase();
+    if (!CREDENTIAL_FIELD_NAMES.has(field)) continue;
+
+    const valueStart = index + 1;
+    if (line.slice(valueStart).trim() === '[REDACTED]') return line;
+
+    let prefixEnd = valueStart;
+    while (prefixEnd < line.length && (line[prefixEnd] === ' ' || line[prefixEnd] === '\t')) {
+      prefixEnd++;
+    }
+    if (prefixEnd === line.length) continue;
+    return `${line.slice(0, prefixEnd)}[REDACTED]`;
+  }
+  return line;
+}
+
+/** Walks back over the identifier characters immediately preceding a separator. */
+function fieldNameStart(line: string, separatorIndex: number): number {
+  let start = separatorIndex;
+  while (start > 0) {
+    const code = line.charCodeAt(start - 1);
+    const isIdentifier =
+      (code >= 48 && code <= 57) ||
+      (code >= 65 && code <= 90) ||
+      (code >= 97 && code <= 122) ||
+      line[start - 1] === '_' ||
+      line[start - 1] === '-';
+    if (!isIdentifier) break;
+    start--;
+  }
+  return start;
 }
 
 /**
@@ -147,16 +292,7 @@ function redactKubernetesSecretValues(input: string): string {
     return input;
   }
 
-  const fencedJson = input.replace(/```json\s*([\s\S]*?)```/gi, (block, body: string) => {
-    try {
-      const parsed: unknown = JSON.parse(body.trim());
-      return redactSecretsInParsedJson(parsed)
-        ? `\`\`\`json\n${JSON.stringify(parsed, null, 2)}\n\`\`\``
-        : block;
-    } catch {
-      return block;
-    }
-  });
+  const fencedJson = redactFencedJsonSecrets(input);
   if (fencedJson !== input) return fencedJson;
 
   const trimmed = input.trim();
@@ -173,6 +309,27 @@ function redactKubernetesSecretValues(input: string): string {
   }
 
   return redactKubernetesSecretValuesYaml(input);
+}
+
+function redactFencedJsonSecrets(input: string): string {
+  const lower = input.toLowerCase();
+  const marker = '```json';
+  const start = lower.indexOf(marker);
+  if (start < 0) return input;
+  const bodyStart = start + marker.length;
+  const end = input.indexOf('```', bodyStart);
+  if (end < 0) return input;
+  try {
+    const parsed: unknown = JSON.parse(input.slice(bodyStart, end).trim());
+    if (!redactSecretsInParsedJson(parsed)) return input;
+    return `${input.slice(0, start)}\`\`\`json\n${JSON.stringify(
+      parsed,
+      null,
+      2
+    )}\n\`\`\`${input.slice(end + 3)}`;
+  } catch {
+    return input;
+  }
 }
 
 /**
@@ -200,7 +357,12 @@ function redactSecretsInParsedJson(value: unknown): boolean {
         const bag = obj[field];
         if (bag && typeof bag === 'object' && !Array.isArray(bag)) {
           for (const key of Object.keys(bag as Record<string, unknown>)) {
-            (bag as Record<string, unknown>)[key] = '[REDACTED]';
+            Object.defineProperty(bag, key, {
+              value: '[REDACTED]',
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             changed = true;
           }
         }

--- a/ai-assistant/packages/ai-ui/src/parsing/urlParsing.test.ts
+++ b/ai-assistant/packages/ai-ui/src/parsing/urlParsing.test.ts
@@ -41,4 +41,16 @@ describe('isSpecificResourceRequestHelper', () => {
       isSpecificResourceRequestHelper('/apis/apps/v1/namespaces/default/deployments/my-deploy')
     ).toBe(true);
   });
+
+  it('handles absolute URLs, queries, invalid segments, and long paths', () => {
+    expect(
+      isSpecificResourceRequestHelper(
+        'https://cluster.test/api/v1/namespaces/default/pods/my-pod?watch=false'
+      )
+    ).toBe(true);
+    expect(isSpecificResourceRequestHelper('/api/v1/namespaces/default/pods/my.pod')).toBe(false);
+    expect(isSpecificResourceRequestHelper(`/api/v1/${'segment/'.repeat(10_000)}pods/my-pod`)).toBe(
+      true
+    );
+  });
 });

--- a/ai-assistant/packages/ai-ui/src/parsing/urlParsing.test.ts
+++ b/ai-assistant/packages/ai-ui/src/parsing/urlParsing.test.ts
@@ -32,6 +32,12 @@ describe('isSpecificResourceRequestHelper', () => {
     expect(isSpecificResourceRequestHelper('/api/v1/namespaces/default/pods/my-pod')).toBe(true);
   });
 
+  it('treats a resource named namespaces as a specific resource', () => {
+    expect(
+      isSpecificResourceRequestHelper('/api/v1/namespaces/default/configmaps/namespaces')
+    ).toBe(true);
+  });
+
   it('returns false for API roots', () => {
     expect(isSpecificResourceRequestHelper('/api/v1/namespaces')).toBe(false);
   });

--- a/ai-assistant/packages/ai-ui/src/parsing/urlParsing.ts
+++ b/ai-assistant/packages/ai-ui/src/parsing/urlParsing.ts
@@ -5,18 +5,40 @@ export const isLogRequest = (url: string): boolean => {
 
 /** Returns whether the URL points to a single Kubernetes resource instead of a list endpoint. */
 export const isSpecificResourceRequestHelper = (url: string): boolean => {
-  // This matches patterns like /api/v1/namespaces/default/pods/my-pod
-  // But doesn't match /api/v1/namespaces/default/pods
-
-  // Check if this is a simple resource type URL (list endpoint)
-  if (/\/(?:api|apis)\/.*?\/\w+\/?$/.test(url)) {
-    return false;
+  let pathname = url;
+  try {
+    pathname = new URL(url, 'http://localhost').pathname;
+  } catch {
+    pathname = url.split(/[?#]/, 1)[0];
   }
-
-  // More specific resource pattern that should end with a resource name
-  // Pattern like /api/v1/namespaces/default/pods/my-pod
-  const specificResourcePattern = /\/(?:namespaces\/[\w-]+\/)?[\w-]+\/[\w-]+\/?$/;
-  const isSpecific = specificResourcePattern.test(url);
-
-  return isSpecific;
+  const segments = pathname.split('/').filter(Boolean);
+  const apiSegments =
+    segments[0] === 'api'
+      ? segments.slice(2)
+      : segments[0] === 'apis'
+      ? segments.slice(3)
+      : segments;
+  const namespaceIndex = apiSegments.lastIndexOf('namespaces');
+  const resourceSegments =
+    namespaceIndex >= 0 ? apiSegments.slice(namespaceIndex + 2) : apiSegments;
+  return resourceSegments.length >= 2 && resourceSegments.slice(-2).every(isResourceSegment);
 };
+
+function isResourceSegment(value: string): boolean {
+  if (!value) return false;
+  for (const character of value) {
+    const code = character.charCodeAt(0);
+    if (
+      !(
+        (code >= 48 && code <= 57) ||
+        (code >= 65 && code <= 90) ||
+        (code >= 97 && code <= 122) ||
+        character === '_' ||
+        character === '-'
+      )
+    ) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/ai-assistant/packages/ai-ui/src/parsing/urlParsing.ts
+++ b/ai-assistant/packages/ai-ui/src/parsing/urlParsing.ts
@@ -19,6 +19,10 @@ export const isSpecificResourceRequestHelper = (url: string): boolean => {
       ? segments.slice(3)
       : segments;
   const namespaceIndex = apiSegments.lastIndexOf('namespaces');
+  // `/api/v1/namespaces/default` is a specific Namespace, not a namespace scope prefix.
+  if (namespaceIndex === 0 && apiSegments.length === 2 && apiSegments.every(isResourceSegment)) {
+    return true;
+  }
   const resourceSegments =
     namespaceIndex >= 0 ? apiSegments.slice(namespaceIndex + 2) : apiSegments;
   return resourceSegments.length >= 2 && resourceSegments.slice(-2).every(isResourceSegment);

--- a/ai-assistant/packages/ai-ui/src/parsing/urlParsing.ts
+++ b/ai-assistant/packages/ai-ui/src/parsing/urlParsing.ts
@@ -18,7 +18,7 @@ export const isSpecificResourceRequestHelper = (url: string): boolean => {
       : segments[0] === 'apis'
       ? segments.slice(3)
       : segments;
-  const namespaceIndex = apiSegments.lastIndexOf('namespaces');
+  const namespaceIndex = apiSegments[0] === 'namespaces' ? 0 : -1;
   // `/api/v1/namespaces/default` is a specific Namespace, not a namespace scope prefix.
   if (namespaceIndex === 0 && apiSegments.length === 2 && apiSegments.every(isResourceSegment)) {
     return true;

--- a/ai-assistant/packages/ai-ui/src/providers/modelProviders.test.ts
+++ b/ai-assistant/packages/ai-ui/src/providers/modelProviders.test.ts
@@ -140,6 +140,14 @@ describe('modelProviders helpers', () => {
         suggestions: [],
       });
     });
+
+    it('handles a long marker line without backtracking', () => {
+      const padding = ' '.repeat(100_000);
+      expect(parseSuggestionsFromResponse(`Summary\nSUGGESTIONS:${padding}First`)).toEqual({
+        cleanContent: 'Summary',
+        suggestions: ['First'],
+      });
+    });
   });
 
   describe('getModelDisplayName', () => {

--- a/ai-assistant/packages/ai-ui/src/providers/modelProviders.ts
+++ b/ai-assistant/packages/ai-ui/src/providers/modelProviders.ts
@@ -114,11 +114,13 @@ export function parseSuggestionsFromResponse(content: unknown): {
     }
   }
 
-  const marker = 'SUGGESTIONS:';
-  const markerIndex = processedContent.toUpperCase().indexOf(marker);
+  // Match on the original string: case folding can change UTF-16 length (ß → SS)
+  // and shift the index away from the real marker position.
+  const markerMatch = /SUGGESTIONS:/i.exec(processedContent);
 
-  if (markerIndex >= 0) {
-    const valueStart = markerIndex + marker.length;
+  if (markerMatch) {
+    const markerIndex = markerMatch.index;
+    const valueStart = markerIndex + markerMatch[0].length;
     const lineEnd = processedContent.indexOf('\n', valueStart);
     const suggestionsText = processedContent.slice(
       valueStart,

--- a/ai-assistant/packages/ai-ui/src/providers/modelProviders.ts
+++ b/ai-assistant/packages/ai-ui/src/providers/modelProviders.ts
@@ -114,17 +114,22 @@ export function parseSuggestionsFromResponse(content: unknown): {
     }
   }
 
-  const suggestionPattern = /SUGGESTIONS:\s*(.+?)(?:\n|$)/i;
-  const match = processedContent.match(suggestionPattern);
+  const marker = 'SUGGESTIONS:';
+  const markerIndex = processedContent.toUpperCase().indexOf(marker);
 
-  if (match) {
-    const suggestionsText = match[1];
+  if (markerIndex >= 0) {
+    const valueStart = markerIndex + marker.length;
+    const lineEnd = processedContent.indexOf('\n', valueStart);
+    const suggestionsText = processedContent.slice(
+      valueStart,
+      lineEnd < 0 ? processedContent.length : lineEnd
+    );
     const suggestions = parseSuggestionLabels(suggestionsText);
+    const cleanContent =
+      processedContent.slice(0, markerIndex) +
+      (lineEnd < 0 ? '' : processedContent.slice(lineEnd + 1));
 
-    // Remove the suggestions line from the content
-    const cleanContent = processedContent.replace(suggestionPattern, '').trim();
-
-    return { cleanContent, suggestions };
+    return { cleanContent: cleanContent.trim(), suggestions };
   }
 
   return { cleanContent: processedContent, suggestions: [] };

--- a/ai-assistant/src/modal.tsx
+++ b/ai-assistant/src/modal.tsx
@@ -983,9 +983,16 @@ export default function AIPrompt(props: {
   const classifyAgentText = (
     text: string
   ): 'tool-start' | 'tool-result' | 'todo-update' | 'intermediate-text' => {
-    if (/^🔧\s*Using Agent tool:/.test(text)) return 'tool-start';
-    if (/^🔧\s*\S+\s+result:/.test(text)) return 'tool-result';
-    if (/^###\s*Investigation Tasks:/.test(text)) return 'todo-update';
+    const trimmed = text.trimStart();
+    if (trimmed.startsWith('🔧')) {
+      const toolText = trimmed.slice('🔧'.length).trimStart();
+      if (toolText.startsWith('Using Agent tool:')) return 'tool-start';
+      if (toolText.includes(' result:')) return 'tool-result';
+    }
+    if (trimmed.startsWith('###')) {
+      const heading = trimmed.slice(3).trimStart();
+      if (heading.startsWith('Investigation Tasks:')) return 'todo-update';
+    }
     return 'intermediate-text';
   };
 
@@ -996,23 +1003,37 @@ export default function AIPrompt(props: {
   const sanitizeAgentContent = (text: string): string => {
     if (!text) return text;
 
-    let cleaned = text;
-
-    // Remove 🔧 tool result blocks (🔧 <tool> result: ... up to the next ## heading)
-    cleaned = cleaned.replace(/🔧\s*\S+\s+result:[\s\S]*?(?=\n\s*##)/g, '');
-    // Also remove standalone 🔧 result blocks at the end (no ## heading follows)
-    cleaned = cleaned.replace(/🔧\s*\S+\s+result:[\s\S]*$/g, '');
-
-    // Remove 🔧 tool-start lines
-    cleaned = cleaned.replace(/🔧\s*Using Agent tool:.*\n?/g, '');
+    const lines = text.split('\n');
+    const retainedLines: string[] = [];
+    let skippingResult = false;
+    for (const line of lines) {
+      const trimmed = line.trimStart();
+      if (trimmed.startsWith('🔧') && trimmed.includes(' result:')) {
+        skippingResult = true;
+        continue;
+      }
+      if (
+        trimmed.startsWith('🔧') &&
+        trimmed.slice('🔧'.length).trimStart().startsWith('Using Agent tool:')
+      ) {
+        continue;
+      }
+      if (skippingResult) {
+        if (!trimmed.startsWith('##')) continue;
+        skippingResult = false;
+      }
+      retainedLines.push(line);
+    }
+    let cleaned = retainedLines.join('\n');
 
     // If content starts with non-markdown text before a ## heading,
     // check whether it looks like leaked tool/CLI output and strip it
-    const headingMatch = cleaned.match(/(^[\s\S]*?)(\n##\s)/m);
-    if (headingMatch && headingMatch[1]) {
-      const before = headingMatch[1].trim();
+    const cleanedLines = cleaned.split('\n');
+    const headingIndex = cleanedLines.findIndex(line => line.trimStart().startsWith('##'));
+    if (headingIndex > 0) {
+      const before = cleanedLines.slice(0, headingIndex).join('\n').trim();
       if (before && looksLikeToolOutput(before)) {
-        cleaned = cleaned.substring((headingMatch.index ?? 0) + headingMatch[1].length);
+        cleaned = cleanedLines.slice(headingIndex).join('\n');
       }
     }
 
@@ -1024,13 +1045,13 @@ export default function AIPrompt(props: {
     const t = text.trim();
     if (!t) return false;
     // Common CLI error lines
-    if (/^(error|Error|ERROR)\s*:/m.test(t)) return true;
+    if (t.toLowerCase().startsWith('error:')) return true;
     // kubectl commands or output
-    if (/kubectl\s+\w+/m.test(t)) return true;
+    if (t.includes('kubectl ')) return true;
     // Tool-result emoji markers
-    if (/🔧/.test(t)) return true;
+    if (t.includes('🔧')) return true;
     // Shell prompts
-    if (/^\$\s+/m.test(t)) return true;
+    if (t.split('\n').some(line => line.trimStart().startsWith('$ '))) return true;
     return false;
   };
 

--- a/ai-assistant/src/modal.tsx
+++ b/ai-assistant/src/modal.tsx
@@ -1045,13 +1045,14 @@ export default function AIPrompt(props: {
     const t = text.trim();
     if (!t) return false;
     // Common CLI error lines
-    if (t.split('\n').some(line => line.trimStart().toLowerCase().startsWith('error:'))) return true;
+    if (t.split('\n').some(line => line.trimStart().toLowerCase().startsWith('error:')))
+      return true;
     // kubectl commands or output
-    if (t.includes('kubectl ')) return true;
+    if (/kubectl[ \t]/.test(t)) return true;
     // Tool-result emoji markers
     if (t.includes('🔧')) return true;
     // Shell prompts
-    if (t.split('\n').some(line => line.trimStart().startsWith('$ '))) return true;
+    if (t.split('\n').some(line => /^\$[ \t]/.test(line.trimStart()))) return true;
     return false;
   };
 

--- a/ai-assistant/src/modal.tsx
+++ b/ai-assistant/src/modal.tsx
@@ -1045,7 +1045,7 @@ export default function AIPrompt(props: {
     const t = text.trim();
     if (!t) return false;
     // Common CLI error lines
-    if (t.toLowerCase().startsWith('error:')) return true;
+    if (t.split('\n').some(line => line.trimStart().toLowerCase().startsWith('error:'))) return true;
     // kubectl commands or output
     if (t.includes('kubectl ')) return true;
     // Tool-result emoji markers


### PR DESCRIPTION
The AI Assistant parses text it does not control - model output, k8s resource names, MCP server names, log content. Several of those parses used regexes whose wildcards rescan the input on failure, so cost grows quadratically with input length. CodeQL flags them as `js/polynomial-redos`. These same fixes were written downstream in https://github.com/Azure/aks-desktop/pull/770 but never made it back here, so upstream has carried them since July.

### Changes

- Rewrite `isSpecificResourceRequestHelper` to split the pathname and validate trailing segments by character code, instead of an unanchored prefix plus lazy wildcard. Also handles absolute URLs and query strings, which the previous patterns silently rejected
- Locate the `SUGGESTIONS:` marker with `indexOf` and slice to the line end; sanitize Holmes tool-call artifacts line-by-line rather than with whole-string patterns that backtrack when a result block has no terminating heading\
- Scan PEM blocks, JWTs and credential lines directly, walking base64url segments by character code
- Reject `__proto__` / `constructor` / `prototype` as MCP config keys and write entries via `Object.defineProperty`, so server-supplied names cannot reach `Object.prototype`
Locate the Docker bind-mount `src=` / `,dst=` markers with `indexOf` instead of two adjacent lazy wildcards

### Testing

- [x] `npm test` passes in `ai-common` (1798), `ai-ui` (640) and the root plugin (46)
- [x] `npm run tsc`, `npm run lint` and `npm run format -- --check` clean
- [x] Measured `isSpecificResourceRequestHelper` on a 256KB path: 7053ms -> 3.55ms, scaling now linear
- [x] Added regression tests for a 10,000-segment path, absolute URLs with query strings, and mid-line credentials

### Notes

- `redactSecrets` diverges from downstream version: their version missed mid-line credentials (`url=...?token=abc123`, `export PASSWORD=`). This version scans every separator instead. Worth porting back downstream.
- The two `modelProviders` `js-polynomial-redos` alerts are false positives - `$` bounds the backtracking - but the rewrite retires them anyway.