### PR TITLE
Kueue 0.1.0 alpha artifacthub

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This is a repository of official plugins that Headlamp uses or recommends.
 | [flux](./flux) | Visualize Flux in Headlamp. | |[@ashu8912](https://github.com/ashu8912) |
 | [karpenter](./karpenter) | Adds Karpenter-specific custom resources to the Headlamp UI. | | [@SinghaAnirban005](https://github.com/SinghaAnirban005) |
 | [keda](./keda) | A UI for viewing and managing KEDA resources. | | [@adwait-godbole](https://github.com/adwait-godbole), [@yolossn](https://github.com/yolossn) |
-| [kueue](./kueue) | A UI for viewing and managing Kueue batch queueing resources. | Initial skeleton. | |
+| [kueue](./kueue) | A UI for viewing Kueue Cohorts, ClusterQueues, LocalQueues, ResourceFlavors, and Workloads. | 0.1.0-alpha. | |
 | [knative](./knative) | A UI for viewing and managing Knative. | | [@kahirokunn](https://github.com/kahirokunn), [@mudit06mah](https://github.com/mudit06mah) |
 | [kompose](./kompose) | Translates docker-compose manifests to Kubernetes's. | Runs kompose in a job in the cluster for now. | [@joaquimrocha](https://github.com/joaquimrocha) |
 | [kro](./kro) | A UI for viewing kro (Kube Resource Orchestrator) ResourceGraphDefinitions and their instances. | Alpha. | [@danbruno101](https://github.com/danbruno101) |

--- a/kueue/0.1.0-alpha/README.md
+++ b/kueue/0.1.0-alpha/README.md
@@ -1,0 +1,128 @@
+# Kueue Headlamp Plugin
+
+The Kueue plugin brings Kubernetes batch workload queueing and admission visibility into Headlamp.
+
+[Kueue](https://kueue.sigs.k8s.io/) is a Kubernetes-native job queueing system for managing batch workloads and resource sharing. The plugin adds dedicated Headlamp views for the Kueue resources operators use most often, making it easier to inspect queue configuration, workload admission, resource usage, and relationships between resources without moving between multiple `kubectl` commands and raw CRDs.
+
+## Features
+
+### Cohorts
+
+Cohort views show how ClusterQueues share unused resources. List and detail views expose:
+
+- parent and child Cohorts
+- member ClusterQueues
+- resource groups and referenced ResourceFlavors
+- nominal quotas, borrowing limits, and lending limits
+- fair-sharing weight and current weighted share
+
+Related Cohorts, ClusterQueues, and ResourceFlavors are linked directly to their Headlamp detail pages.
+
+### ClusterQueues
+
+The ClusterQueue views provide both an overview of queue state and the details behind admission capacity. The plugin shows:
+
+- cohort and queueing strategy
+- namespace selection and stop policy
+- pending, admitted, and reserving workload counts
+- resource groups and referenced ResourceFlavors
+- nominal quotas, borrowing limits, and lending limits
+- flavor reservations and current flavor usage
+- preemption, flavor fungibility, fair sharing, and admission configuration
+- Kueue conditions and Kubernetes events
+- related LocalQueues and pending or admitted Workloads
+
+Cohort, ResourceFlavor, LocalQueue, and Workload references are linked directly to their Headlamp detail pages.
+
+### LocalQueues
+
+LocalQueues are displayed as namespace-scoped entry points into Kueue. List and detail views expose:
+
+- the associated ClusterQueue
+- stop policy and queue status
+- pending, admitted, and reserving workload counts
+- Kueue conditions and Kubernetes events
+- related Workloads in the same namespace
+
+ClusterQueue and Workload references are navigable, so users can move between a namespace queue, the cluster-level capacity backing it, and its workloads.
+
+### ResourceFlavors
+
+ResourceFlavor views expose the scheduling characteristics Kueue can use when assigning resources to admitted workloads, including:
+
+- node labels
+- node taints
+- tolerations
+- topology configuration
+
+### Workloads
+
+The Workloads view provides a namespace-aware overview of Kueue-managed workloads with:
+
+- LocalQueue
+- priority and priority class
+- active state
+- admission state
+- completion state
+- human-readable workload status
+
+Workload details go further by exposing PodSets, resource requests, admission assignments, assigned ClusterQueue and ResourceFlavors, admission checks, reclaimable pods, requeue information, scheduling statistics, Kueue conditions, and Kubernetes events.
+
+Statuses such as **Admitted**, **Finished**, and **Inadmissible** make it easier to identify where a workload is in the admission lifecycle and investigate why it is not progressing.
+
+## Resource Navigation
+
+The plugin links related Kueue resources where possible:
+
+- Cohort → parent and child Cohorts
+- Cohort → member ClusterQueues
+- Cohort → ResourceFlavors
+- ClusterQueue → Cohort
+- ClusterQueue → related LocalQueues
+- ClusterQueue → related pending and admitted Workloads
+- Workload → LocalQueue
+- Workload → assigned ClusterQueue
+- LocalQueue → ClusterQueue
+- LocalQueue → related Workloads in its namespace
+- ClusterQueue → ResourceFlavor
+
+This keeps the queueing path connected while troubleshooting admission, resource sharing, and scheduling state.
+
+Workload owner references are displayed as plain `Kind/name` text and are not currently navigable.
+
+## Kubernetes Permissions
+
+Kueue views respect the Kubernetes credentials currently used by Headlamp. Before rendering a resource page, the plugin checks whether the user can perform the required `list` or `get` operation and displays an access message when permission is unavailable.
+
+## Prerequisites
+
+Kueue CRDs must be installed in the cluster before the plugin can display Kueue resources.
+
+See the [Kueue installation guide](https://kueue.sigs.k8s.io/docs/getting-started/installation/) for installation instructions.
+
+This release provides views for the Kueue `kueue.x-k8s.io/v1beta2` `Cohort`, `ClusterQueue`, `LocalQueue`, `ResourceFlavor`, and `Workload` resources.
+
+## Development
+
+From the `kueue` plugin directory:
+
+```bash
+npm install
+npm run format
+npm run build
+npm run tsc
+npm run lint
+npm run test
+```
+
+To create the distributable plugin archive:
+
+```bash
+npm run package
+```
+
+## Release
+
+This is the initial alpha release of the Kueue plugin for Headlamp: **0.1.0-alpha**.
+
+For the full release notes and demo, see [#1251](https://github.com/headlamp-k8s/plugins/issues/1251).

--- a/kueue/0.1.0-alpha/artifacthub-pkg.yml
+++ b/kueue/0.1.0-alpha/artifacthub-pkg.yml
@@ -1,0 +1,52 @@
+version: 0.1.0-alpha
+name: headlamp_kueue
+displayName: Kueue
+createdAt: "2026-08-10T00:00:00Z"
+description: A Headlamp plugin for viewing Kueue batch workload queueing, admission, and resource usage.
+license: Apache-2.0
+homeURL: https://github.com/headlamp-k8s/plugins/tree/main/kueue
+keywords:
+  - headlamp
+  - headlamp-plugin
+  - kubernetes
+  - kueue
+  - batch
+  - scheduling
+  - queueing
+  - workloads
+screenshots:
+  - title: Kueue Workloads
+    url: https://github.com/user-attachments/assets/2410ca41-5f66-4ed1-937a-3f6ecb47f9e8
+  - title: ClusterQueue details
+    url: https://github.com/user-attachments/assets/670db93b-12e6-4e1b-afc5-81f728d46a3e
+  - title: Cohort details
+    url: https://github.com/user-attachments/assets/96e71bb0-b277-4c2f-be2b-7d5558f96c01
+changes:
+  - kind: added
+    description: "Add Kueue sidebar navigation and list/detail routes for supported resources"
+  - kind: added
+    description: "Add Cohort views with parent and child Cohorts, member ClusterQueues, ResourceFlavor references, quotas, and fair sharing"
+  - kind: added
+    description: "Add ClusterQueue views with queue status, workload counts, resource groups, and ResourceFlavor links"
+  - kind: added
+    description: "Add ClusterQueue quota, borrowing and lending limits, flavor reservations, and resource usage"
+  - kind: added
+    description: "Add ClusterQueue preemption, flavor fungibility, fair sharing, admission settings, and conditions"
+  - kind: added
+    description: "Add LocalQueue views with workload counts, status, conditions, and ClusterQueue navigation"
+  - kind: added
+    description: "Add ResourceFlavor views for node labels, taints, tolerations, and topology configuration"
+  - kind: added
+    description: "Add Workload list and detail views with priority, admission, completion, and scheduling status"
+  - kind: added
+    description: "Add Workload PodSet, resource request, admission assignment, admission check, and requeue details"
+  - kind: added
+    description: "Add navigation and related-resource tables between Cohorts, ClusterQueues, LocalQueues, Workloads, and ResourceFlavors"
+  - kind: added
+    description: "Add Kubernetes RBAC-aware access handling for Kueue resource pages"
+annotations:
+  headlamp/plugin/archive-url: >-
+    https://github.com/headlamp-k8s/plugins/releases/download/kueue-0.1.0-alpha/headlamp-k8s-kueue-0.1.0-alpha.tar.gz
+  headlamp/plugin/archive-checksum: SHA256:2f8a896dd297a01d03be56bd0d61016194e37b9a8e6c91c583e240b7b7b8a120
+  headlamp/plugin/version-compat: ">=0.22"
+  headlamp/plugin/distro-compat: in-cluster,web,docker-desktop,desktop

--- a/kueue/README.md
+++ b/kueue/README.md
@@ -10,7 +10,7 @@ This plugin currently reads Kueue `Cohort`, `ClusterQueue`, `LocalQueue`, `Resou
 
 The views are read-only. Cohort pages show parent and child Cohort relationships, member ClusterQueues, ResourceFlavor references, resource groups, and fair-sharing values.
 
-Additional queueing views will be added in later PRs.
+Related Cohorts, ClusterQueues, LocalQueues, ResourceFlavors, and Workloads are linked so users can follow the queueing path between resources. The plugin checks Kubernetes permissions before loading resource pages and shows an access message when the current user cannot view a resource.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary

This prepares the first Artifact Hub release of the Kueue Headlamp plugin as `0.1.0-alpha`.

- add the versioned `0.1.0-alpha` README for Artifact Hub
- add Artifact Hub package metadata for the initial Kueue release
- point Artifact Hub at the `kueue-0.1.0-alpha` release archive and include the generated SHA-256 checksum
- document the supported ClusterQueue, LocalQueue, ResourceFlavor, and Workload views, including cross-resource navigation and RBAC-aware access behavior

## Release highlights

- **ClusterQueues** — queueing strategy, workload counts, resource groups, quotas, borrowing/lending limits, flavor reservations and usage, preemption, flavor fungibility, fair sharing, admission settings, and conditions
- **LocalQueues** — namespace-scoped queue status, pending/admitted/reserving workload counts, conditions, and navigation to the backing ClusterQueue
- **ResourceFlavors** — node labels, taints, tolerations, and topology configuration
- **Workloads** — priority, admission/completion state, PodSets, resource requests, admission assignments, assigned ClusterQueue/ResourceFlavors, admission checks, requeue information, scheduling statistics, conditions, and events
- **Resource relationships** — navigation between Workloads, LocalQueues, ClusterQueues, ResourceFlavors, and owning Kubernetes resources
- **Headlamp integration** — dedicated Kueue navigation and Kubernetes RBAC-aware access handling

## Artifact Hub metadata

- Version: `0.1.0-alpha`
- Release tag: `kueue-0.1.0-alpha`
- Archive: `headlamp-k8s-kueue-0.1.0-alpha.tar.gz`
- SHA-256: `0c0b6e93844362aa262e602a0b6fd9feedecb6e7709dae443be48a3cab0cdca4`
- Headlamp compatibility: `>=0.22`
- Distributions: `in-cluster`, `web`, `docker-desktop`, `desktop`

## Validation

The release archive was generated from the current Kueue plugin using Node.js 22 with:

```bash
npm ci
npm run build
npm run package