### PR TITLE
prometheus: snap time range to step boundary to fix chart flicker (#217)

### DIFF
--- a/prometheus/src/util.test.ts
+++ b/prometheus/src/util.test.ts
@@ -102,6 +102,19 @@ describe('getTimeRangeAndStepSize', () => {
       step: 14,
     });
   });
+
+  test('should quantize timestamps to step boundary to prevent auto-refresh flicker', () => {
+    const unalignedTime = 1700000007; // 7 seconds after step boundary
+    vitest.spyOn(Date, 'now').mockImplementation(() => unalignedTime * 1000);
+
+    const result = getTimeRangeAndStepSize('1h', '30s');
+    // Expected step is 30s; 1700000007 % 30 = 7, so to should be 1700000000
+    expect(result).toEqual({
+      from: 1700000000 - 3600,
+      to: 1700000000,
+      step: 30,
+    });
+  });
 });
 
 describe('supportsPrometheusMetrics', () => {

--- a/prometheus/src/util.ts
+++ b/prometheus/src/util.ts
@@ -424,6 +424,15 @@ export function getTimeRangeAndStepSize(
     step = Math.max(Math.floor(rangeMs / factor / 1000), 1);
   }
 
+  // Snap timestamps to step boundary to prevent X-axis flicker on refresh
+  if (to === now && step > 1) {
+    const remainder = now % step;
+    if (remainder > 0) {
+      to = now - remainder;
+      from = from - remainder;
+    }
+  }
+
   return { from, to, step };
 }
 


### PR DESCRIPTION
Fixes #217

## Problem
When viewing Prometheus charts (CPU, Memory, Disk, Knative, Karpenter, Volcano, Strimzi), the graph flickers and shifts X-axis tick labels every 10 seconds during auto-refresh (as reported in #217 and Discussion #3055).

### Root Cause
In `getTimeRangeAndStepSize`, `from` and `to` timestamps were derived directly from `Date.now() / 1000`. On every 10-second auto-refresh, `from` and `to` shifted by unaligned seconds, causing Prometheus to return data with shifted X-axis timestamps. Recharts destroyed and re-rendered X-axis tick labels on every cycle.

## Solution
Quantized `from` and `to` timestamps to the calculated `step` boundary (`to = now - (now % step)`). For auto-refreshes occurring within the same step window (e.g., a 15s or 30s step), `from` and `to` remain constant and deterministic. Recharts updates chart data inside fixed grid lines without flickering X-axis ticks.

### Changes
- Updated `getTimeRangeAndStepSize` in `prometheus/src/util.ts` to snap timestamps to step boundaries.
- Added unit test coverage in `prometheus/src/util.test.ts` verifying timestamp quantization.

## How to Test
1. Open any page rendering Prometheus metric charts (e.g. Deployment, Node, or Pod detail view).
2. Ensure auto-refresh is active and observe graph behavior over >10 seconds.
3. Verify that metric data updates smoothly within fixed X-axis grid lines without graph flickering or jumping labels.

## Verification
- Added unit test in `util.test.ts` verifying that auto-refreshes within step windows return quantized timestamps.
- Executed standalone mathematical step-quantization verification script simulating auto-refreshes at 10s intervals across step boundaries.
