### PR TITLE
fix: update plugin-catalog search pagination and fix karpenter CPU millicores parsing

### DIFF
--- a/karpenter/src/NodePool/Details.tsx
+++ b/karpenter/src/NodePool/Details.tsx
@@ -16,6 +16,7 @@ import { DiffEditorDialog } from '../common/resourceEditor';
 import { handleShowDiff } from '../helpers/handleDiff';
 import { getHandleSaveHelper } from '../helpers/handleSave';
 import { renderInstanceRequirements } from '../helpers/instanceRequirements';
+import { parseCpu } from '../helpers/parseCpu';
 import { parseRam } from '../helpers/parseRam';
 import { renderDisruptionBudgets } from '../helpers/renderBudgets';
 import { nodePoolClass } from './List';
@@ -91,8 +92,8 @@ export function NodePoolDetailView(props: { name?: string }) {
         withEvents
         actions={actions()}
         extraInfo={item => {
-          const usedCPU = parseInt(item.jsonData.status?.resources?.cpu || '0');
-          const CPUlimit = parseInt(item.jsonData.spec?.limits?.cpu || '0');
+          const usedCPU = parseCpu(item.jsonData.status?.resources?.cpu || '0');
+          const CPUlimit = parseCpu(item.jsonData.spec?.limits?.cpu || '0');
 
           const usedMemory = parseRam(item.jsonData.status?.resources?.memory || '0');
           const memoryLimit = parseRam(item.jsonData.spec?.limits?.memory || '0');

--- a/karpenter/src/NodePool/List.tsx
+++ b/karpenter/src/NodePool/List.tsx
@@ -3,6 +3,7 @@ import { Link, ResourceListView } from '@kinvolk/headlamp-plugin/lib/CommonCompo
 import { PercentageBar } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 import { makeCustomResourceClass } from '@kinvolk/headlamp-plugin/lib/lib/k8s/crd';
 import { getResourceStr } from '@kinvolk/headlamp-plugin/lib/Utils';
+import { parseCpu } from '../helpers/parseCpu';
 import { parseRam } from '../helpers/parseRam';
 import { CPUtooltip, Memorytooltip } from '../helpers/tooltip';
 
@@ -73,14 +74,14 @@ function NodePoolsList() {
           id: 'nodepool-cpu',
           label: t('CPU'),
           getValue: nodePool => {
-            const used = parseInt(nodePool.jsonData.status?.resources?.cpu || '0');
-            const limit = parseInt(nodePool.jsonData.spec?.limits?.cpu || '0');
+            const used = parseCpu(nodePool.jsonData.status?.resources?.cpu || '0');
+            const limit = parseCpu(nodePool.jsonData.spec?.limits?.cpu || '0');
 
             return limit > 0 ? `${used}/${limit}` : t('{{used}} (No limit)', { used });
           },
           render: nodePool => {
-            const used = parseInt(nodePool.jsonData.status?.resources?.cpu || 0);
-            const limit = parseInt(nodePool.jsonData.spec?.limits?.cpu || 0);
+            const used = parseCpu(nodePool.jsonData.status?.resources?.cpu || 0);
+            const limit = parseCpu(nodePool.jsonData.spec?.limits?.cpu || 0);
             const data: ChartDataPoint[] = [
               {
                 name: 'CPU',

--- a/karpenter/src/helpers/parseCpu.test.ts
+++ b/karpenter/src/helpers/parseCpu.test.ts
@@ -1,0 +1,24 @@
+import { parseCpu } from './parseCpu';
+
+describe('parseCpu', () => {
+  it('should parse millicores correctly', () => {
+    expect(parseCpu('500m')).toBe(0.5);
+    expect(parseCpu('1000m')).toBe(1);
+    expect(parseCpu('250m')).toBe(0.25);
+    expect(parseCpu('1500m')).toBe(1.5);
+  });
+
+  it('should parse whole cores correctly', () => {
+    expect(parseCpu('1')).toBe(1);
+    expect(parseCpu('4')).toBe(4);
+    expect(parseCpu('0.5')).toBe(0.5);
+    expect(parseCpu(2)).toBe(2);
+  });
+
+  it('should handle falsy and invalid values', () => {
+    expect(parseCpu('')).toBe(0);
+    expect(parseCpu(undefined)).toBe(0);
+    expect(parseCpu(null)).toBe(0);
+    expect(parseCpu('invalid')).toBe(0);
+  });
+});

--- a/karpenter/src/helpers/parseCpu.ts
+++ b/karpenter/src/helpers/parseCpu.ts
@@ -1,0 +1,11 @@
+export function parseCpu(cpuStr: string | number | undefined | null): number {
+  if (typeof cpuStr === 'number') return cpuStr;
+  if (!cpuStr) return 0;
+  const str = cpuStr.toString().trim();
+  if (str.endsWith('m')) {
+    const val = parseFloat(str.slice(0, -1));
+    return isNaN(val) ? 0 : val / 1000;
+  }
+  const val = parseFloat(str);
+  return isNaN(val) ? 0 : val;
+}

--- a/plugin-catalog/src/components/plugins/List.tsx
+++ b/plugin-catalog/src/components/plugins/List.tsx
@@ -292,7 +292,6 @@ export function PluginList() {
   const [search, setSearch] = useState('');
   const [allPlugins, setAllPlugins] = useState<PluginPackage[] | null>(null);
   const [page, setPage] = useState(1);
-  const [totalPages, setTotalPages] = useState(0);
   const conf = configStore.useConfig()();
   const [fetchSettings, setFetchSettings] = useState<conf | null>({
     displayOnlyOfficialPlugins: true,
@@ -301,10 +300,8 @@ export function PluginList() {
 
   useEffect(() => {
     const fetchAndProcessPlugins = async () => {
-      const { plugins, totalPages } = await processPlugins();
+      const { plugins } = await processPlugins();
       setAllPlugins(plugins);
-      setTotalPages(totalPages);
-      console.log(plugins, totalPages);
     };
     fetchAndProcessPlugins();
   }, [fetchSettings]);
@@ -330,12 +327,25 @@ export function PluginList() {
 
   const filteredPlugins = useMemo(() => {
     if (!allPlugins) return null;
+    const query = search.toLowerCase();
     return allPlugins.filter(
       plugin =>
-        plugin.name.toLowerCase().includes(search.toLowerCase()) ||
-        plugin.description.toLowerCase().includes(search.toLowerCase())
+        plugin.name.toLowerCase().includes(query) ||
+        plugin.description.toLowerCase().includes(query) ||
+        (plugin.display_name && plugin.display_name.toLowerCase().includes(query))
     );
   }, [allPlugins, search]);
+
+  const totalPages = useMemo(() => {
+    if (!filteredPlugins) return 0;
+    return Math.ceil(filteredPlugins.length / PAGE_SIZE);
+  }, [filteredPlugins]);
+
+  useEffect(() => {
+    if (totalPages > 0 && page > totalPages) {
+      setPage(1);
+    }
+  }, [totalPages, page]);
 
   const paginatedPlugins = useMemo(() => {
     if (!filteredPlugins) return null;


### PR DESCRIPTION
### Description
This PR resolves two bug fixes across `plugin-catalog` and `karpenter`:
#1114 

1. **`plugin-catalog` Pagination Fix**: When searching for plugins, the plugin list filtered correctly, but the total page count stayed stuck on the unfiltered count (e.g. displaying "Page 1 of 2" for 1 matching search result). This PR calculates `totalPages` dynamically based on `filteredPlugins.length` and clamps out-of-bounds page indexes.
2. **`karpenter` CPU Unit Parsing Fix**: CPU quantities specified in millicores (such as `"500m"`) were misparsed as `500` cores by `parseInt()`. This PR introduces a `parseCpu` helper to properly convert millicores (`"m"` suffix) into fractional core values (e.g. `0.5` cores).

---

### What Changes Were Made?

#### `plugin-catalog`
- Derived `totalPages` dynamically from `filteredPlugins.length`.
- Added auto-clamping so `page` resets to `1` whenever `page > totalPages`.
- Expanded search matching to check against `plugin.display_name` in addition to `name` and `description`.

#### `karpenter`
- Added `parseCpu` helper in `karpenter/src/helpers/parseCpu.ts` and unit tests in `karpenter/src/helpers/parseCpu.test.ts`.
- Replaced `parseInt` with `parseCpu` in `NodePool/List.tsx` and `NodePool/Details.tsx`.

---

### How Has This Been Tested?
1. Ran `npm run tsc` in both `plugin-catalog/` and `karpenter/` to ensure clean TypeScript compilation.
2. Added unit tests for `parseCpu` helper verifying `parseCpu("500m") === 0.5` and `parseCpu("1000m") === 1`.
3. Verified dynamic pagination behavior when entering search terms in `PurePluginList`.

---

### Checklist
- [x] Signed commit with Developer Certificate of Origin (DCO `-s`)
- [x] Code follows repository style guidelines
- [x] Unit tests added and passing
