### PR TITLE
argocd: Prepare 0.1.0-alpha release

### DIFF
--- a/argocd/0.1.0-alpha/README.md
+++ b/argocd/0.1.0-alpha/README.md
@@ -1,0 +1,107 @@
+# Headlamp Argo CD Plugin
+
+This is a Headlamp plugin created for the LFX Mentorship project to integrate Argo CD concepts directly into Headlamp Kubernetes workflows.
+
+To learn more about Argo CD, see the [Argo CD Getting Started Guide](https://argo-cd.readthedocs.io/en/stable/getting_started/).
+
+## Features
+
+- **Application List View** — Lists all Argo CD `Application` resources in the cluster with columns for project, source repo, target revision, sync status, and health status (rendered as color-coded badges).
+- **Application Detail View** — Displays detailed metadata for a single Application: project, source, destination, sync status, health status, and Kubernetes events.
+- **Sync Action** — Triggers a sync by patching the Application's `.operation` field via the Kubernetes API. The Argo CD application-controller picks this up exactly as it would from the Argo CD UI.
+- **Refresh Action** — Requests a refresh by setting the `argocd.argoproj.io/refresh` annotation (supports `normal` and `hard` refresh types).
+- **Argo CD Sidebar Icon** — Registers the official Argo CD octopus logo as an offline Iconify icon (CSP-safe, no external fetch).
+
+### Why the Kubernetes API instead of the Argo CD REST API?
+
+Headlamp routes all plugin API calls through the Kubernetes apiserver service proxy. The apiserver consumes the `Authorization: Bearer` header for its own auth, so the Argo CD session token can never reach `argocd-server`. The browser also strips the `Cookie` header (a forbidden header in fetch). This makes the Argo CD REST API unreachable from a Headlamp plugin.
+
+Instead, this plugin drives Argo CD the **Kubernetes-native way** — by writing directly to the `Application` custom resource. No Argo CD API token is needed; only standard Kubernetes RBAC permissions apply.
+
+### Behavioral differences from the Argo CD UI
+
+| Behavior | Argo CD UI | This plugin |
+|---|---|---|
+| **Auth** | Argo CD session token (JWT or cookie) | Kubernetes RBAC (same kubeconfig as Headlamp) |
+| **Sync** | REST API `POST /api/v1/applications/{name}/sync` | K8s PATCH on `.operation.sync` field |
+| **Refresh** | REST API `GET` with `?refresh=normal` | K8s PATCH setting `argocd.argoproj.io/refresh` annotation |
+| **Refresh annotation cleanup** | Controller removes the annotation after reconciliation | Same — the controller handles cleanup |
+| **`.operation` field cleanup** | Controller clears `.operation` and writes `.status.operationState` | Same — this is controller-managed |
+
+## Prerequisites
+
+- Node.js (v20.11.1 or later)
+- npm
+- Headlamp running locally (desktop or in-cluster)
+- A local Kubernetes cluster with Argo CD installed
+
+## Required RBAC Permissions
+
+The user's Kubernetes role must allow `patch` on `applications.argoproj.io` in the namespace where Argo CD Applications live (usually `argocd`). Example ClusterRole:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: argocd-headlamp-plugin
+rules:
+  - apiGroups: ["argoproj.io"]
+    resources: ["applications"]
+    verbs: ["get", "list", "watch", "patch"]
+```
+
+If the user lacks `patch` permission, the plugin shows a clear error message explaining which RBAC permission is missing.
+
+## Development
+
+Run `npm install` and then `npm run start` to begin development.
+
+## Local Testing with Mock Data
+
+If you don't have a full Argo CD installation, you can use the provided test manifests to create mock data in your cluster. This is useful for developing and testing the plugin UI without a full Argo CD deployment.
+
+### Steps
+
+1. **Create the Argo CD Application CRD** (this teaches Kubernetes about the Application resource type):
+
+   ```bash
+   kubectl apply -f test-files/deploy/crd.yaml
+   ```
+
+2. **Create the `argocd` namespace** (required for the sample Application):
+
+   ```bash
+   kubectl create namespace argocd
+   ```
+
+3. **Deploy the sample Application resource**:
+
+   ```bash
+   kubectl apply -f test-files/deploy/application.yaml
+   ```
+
+4. **Build and install the plugin**:
+
+   ```bash
+   npm install
+   npm run build
+   ```
+
+5. Copy the contents of the `dist/` folder to your Headlamp plugins directory:
+   - **Linux/macOS**: `~/.config/Headlamp/plugins/argocd/`
+   - **Windows**: `%APPDATA%\Headlamp\Config\plugins\argocd\`
+
+6. **Launch Headlamp** and navigate to the **Argo CD > Applications** sidebar entry to see the mock `guestbook` application.
+
+### Verifying the mock data
+
+```bash
+kubectl get applications -n argocd
+```
+
+You should see:
+
+```
+NAME        AGE
+guestbook   Xs
+```

--- a/argocd/0.1.0-alpha/artifacthub-pkg.yml
+++ b/argocd/0.1.0-alpha/artifacthub-pkg.yml
@@ -1,0 +1,61 @@
+version: 0.1.0-alpha
+name: headlamp_argocd
+displayName: Argo CD
+createdAt: "2025-08-11T00:00:00Z"
+description: A Headlamp plugin for Argo CD GitOps Application Management
+logoURL: https://raw.githubusercontent.com/argoproj/argo-cd/master/docs/assets/argo.png
+license: Apache-2.0
+homeURL: https://github.com/headlamp-k8s/plugins/tree/main/argocd
+keywords:
+  - headlamp
+  - headlamp-plugin
+  - kubernetes
+  - argocd
+  - gitops
+screenshots:
+  - title: Application List
+    url: https://github.com/user-attachments/assets/e9606b89-3976-4669-a41d-fdef2b8bed10
+  - title: Application Detail
+    url: https://github.com/user-attachments/assets/383a2c97-df18-49a8-a584-2746e75a47e7
+  - title: Managed Resources
+    url: https://github.com/user-attachments/assets/e3a4e9bc-008f-4688-8c0d-3d5248184811
+  - title: Sync History
+    url: https://github.com/user-attachments/assets/cf40ac44-4765-4e5e-b019-05894c817b4c
+  - title: AppProjects
+    url: https://github.com/user-attachments/assets/c7927dd2-215a-4ca6-99b0-0eae0d832768
+maintainers:
+  - name: Joshna Waikar
+    email: joshnawaikar@gmail.com
+changes:
+  - kind: added
+    description: "Application list view with project, source repo, revision, sync status, and health status columns"
+  - kind: added
+    description: "Application detail view with GitOps Summary (source, revision, path, destination, project, sync, health)"
+  - kind: added
+    description: "Managed Resources table with sync and health information"
+  - kind: added
+    description: "Sync Policy section (automated sync, self-heal, prune, retry settings, sync options)"
+  - kind: added
+    description: "Sync History section from Application status history"
+  - kind: added
+    description: "AppProject list and detail views with source repos, destinations, cluster resource whitelist, and roles"
+  - kind: added
+    description: "Namespace GitOps Insights section extending Headlamp Namespace detail page"
+  - kind: added
+    description: "Kubernetes-native Sync action via PATCH on .operation.sync"
+  - kind: added
+    description: "Kubernetes-native Refresh action via argocd.argoproj.io/refresh annotation"
+  - kind: added
+    description: "RBAC-aware action visibility using AuthVisible"
+  - kind: added
+    description: "Argo CD CRD detection to hide sidebar when Argo CD is not installed"
+  - kind: added
+    description: "Official Argo CD octopus icon registered as offline Iconify icon (CSP-safe)"
+  - kind: added
+    description: "Argo CD status icons (heart-pulse for Healthy, check-circle for Synced)"
+annotations:
+  headlamp/plugin/archive-url: >-
+    https://github.com/headlamp-k8s/plugins/releases/download/argocd-0.1.0-alpha/headlamp-k8s-argocd-0.1.0-alpha.tar.gz
+  headlamp/plugin/archive-checksum: SHA256:52eec016c40e1abe2c9a797391de0119c94f10c22005f9638389027604e8c39b
+  headlamp/plugin/version-compat: ">=0.22"
+  headlamp/plugin/distro-compat: in-cluster,web,docker-desktop,desktop

--- a/argocd/package-lock.json
+++ b/argocd/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@headlamp-k8s/argocd",
-  "version": "0.2.0",
+  "version": "0.1.0-alpha",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@headlamp-k8s/argocd",
-      "version": "0.2.0",
+      "version": "0.1.0-alpha",
       "devDependencies": {
         "@kinvolk/headlamp-plugin": "^0.14.0"
       }
@@ -2652,9 +2652,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2669,9 +2666,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2686,9 +2680,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2703,9 +2694,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2720,9 +2708,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2737,9 +2722,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2754,9 +2736,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2771,9 +2750,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2788,9 +2764,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2805,9 +2778,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2822,9 +2792,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2839,9 +2806,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2856,9 +2820,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3676,9 +3637,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3696,9 +3654,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3716,9 +3671,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3736,9 +3688,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3756,9 +3705,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3776,9 +3722,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [

--- a/argocd/package.json
+++ b/argocd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@headlamp-k8s/argocd",
-  "version": "0.2.0",
+  "version": "0.1.0-alpha",
   "description": "Headlamp plugin for Argo CD GitOps Application Management",
   "author": "Joshna Waikar",
   "scripts": {


### PR DESCRIPTION
## Summary

- bump the Argo CD plugin and lockfile to 0.1.0-alpha
- add the versioned README and Artifact Hub metadata
- include the changes from the draft release notes in Argo CD: Release notes for 0.1.0-alpha #1048
- point Artifact Hub at the 0.1.0-alpha archive with its generated SHA-256 checksum

## Highlights

- add Application and AppProject list and detail views
- add Kubernetes-native Sync and Refresh actions
- add Managed Resources, Sync Policy, and Sync History sections
- add Namespace GitOps Insights
- add RBAC-aware action visibility and CRD detection

Release notes:

- Argo CD: Release notes for 0.1.0-alpha #1048