### PR TITLE
fix(karpenter): safely handle undefined conditions in NodeClaim views

### DIFF
--- a/karpenter/src/Scaling/Details.tsx
+++ b/karpenter/src/Scaling/Details.tsx
@@ -24,8 +24,14 @@ export function ScalingDetailView(props: { name?: string }) {
       name={name}
       withEvents
       extraInfo={item => {
-        const conditionsLength = item.jsonData.status?.conditions?.length || 0;
-        const nodepool = item.jsonData.metadata?.ownerReferences?.find(x => x.kind === 'NodePool');
+        const conditions = item?.jsonData?.status?.conditions;
+        const lastCondition =
+          Array.isArray(conditions) && conditions.length > 0
+            ? conditions[conditions.length - 1]
+            : null;
+        const nodepool = item?.jsonData?.metadata?.ownerReferences?.find(
+          (x: any) => x.kind === 'NodePool'
+        );
 
         return (
           item && [
@@ -48,11 +54,7 @@ export function ScalingDetailView(props: { name?: string }) {
             },
             {
               name: t('Status'),
-              value: (
-                <StatusLabel>
-                  {item.jsonData.status?.conditions[conditionsLength - 1]?.reason || '-'}
-                </StatusLabel>
-              ),
+              value: <StatusLabel>{lastCondition?.reason || '-'}</StatusLabel>,
             },
             {
               name: t('Instance Type'),

--- a/karpenter/src/Scaling/Details.tsx
+++ b/karpenter/src/Scaling/Details.tsx
@@ -58,11 +58,11 @@ export function ScalingDetailView(props: { name?: string }) {
             },
             {
               name: t('Instance Type'),
-              value: item.jsonData.metadata?.labels['node.kubernetes.io/instance-type'] || '-',
+              value: item.jsonData.metadata?.labels?.['node.kubernetes.io/instance-type'] || '-',
             },
             {
               name: t('Capacity Type'),
-              value: item.jsonData.metadata?.labels['karpenter.sh/capacity-type'] || '-',
+              value: item.jsonData.metadata?.labels?.['karpenter.sh/capacity-type'] || '-',
             },
           ]
         );

--- a/karpenter/src/Scaling/List.tsx
+++ b/karpenter/src/Scaling/List.tsx
@@ -75,9 +75,9 @@ export function NodeClaimList() {
         {
           id: 'instance-type',
           label: t('Instance Type'),
-          getValue: item => item.jsonData?.metadata?.labels['node.kubernetes.io/instance-type'],
+          getValue: item => item.jsonData?.metadata?.labels?.['node.kubernetes.io/instance-type'],
           render: item => {
-            return item.jsonData?.metadata?.labels['node.kubernetes.io/instance-type'] || '-';
+            return item.jsonData?.metadata?.labels?.['node.kubernetes.io/instance-type'] || '-';
           },
         },
         {
@@ -91,9 +91,9 @@ export function NodeClaimList() {
         {
           id: 'zone',
           label: t('Zone'),
-          getValue: item => item.jsonData.metadata?.labels['topology.kubernetes.io/zone'],
+          getValue: item => item.jsonData.metadata?.labels?.['topology.kubernetes.io/zone'],
           render: item => {
-            return item.jsonData.metadata?.labels['topology.kubernetes.io/zone'] || '-';
+            return item.jsonData.metadata?.labels?.['topology.kubernetes.io/zone'] || '-';
           },
         },
         'age',

--- a/karpenter/src/Scaling/List.tsx
+++ b/karpenter/src/Scaling/List.tsx
@@ -64,12 +64,12 @@ export function NodeClaimList() {
           label: t('Status'),
           getValue: item => item.jsonData?.status?.conditions,
           render: item => {
-            const finalCondition = item.jsonData?.status?.conditions?.length;
-            return (
-              <StatusLabel>
-                {item.jsonData?.status?.conditions[finalCondition - 1]?.reason || '-'}
-              </StatusLabel>
-            );
+            const conditions = item.jsonData?.status?.conditions;
+            const lastCondition =
+              Array.isArray(conditions) && conditions.length > 0
+                ? conditions[conditions.length - 1]
+                : null;
+            return <StatusLabel>{lastCondition?.reason || '-'}</StatusLabel>;
           },
         },
         {

--- a/karpenter/src/Scaling/Scaling.test.ts
+++ b/karpenter/src/Scaling/Scaling.test.ts
@@ -37,3 +37,48 @@ describe('NodeClaim status condition extraction', () => {
     expect(getLastConditionReason(item.jsonData)).toBe('NodeReady');
   });
 });
+
+describe('NodeClaim metadata labels extraction', () => {
+  const getInstanceType = (jsonData: any) => {
+    return jsonData?.metadata?.labels?.['node.kubernetes.io/instance-type'] || '-';
+  };
+
+  const getCapacityType = (jsonData: any) => {
+    return jsonData?.metadata?.labels?.['karpenter.sh/capacity-type'] || '-';
+  };
+
+  const getZone = (jsonData: any) => {
+    return jsonData?.metadata?.labels?.['topology.kubernetes.io/zone'] || '-';
+  };
+
+  it('should return "-" when metadata is undefined', () => {
+    const item = { jsonData: {} };
+    expect(getInstanceType(item.jsonData)).toBe('-');
+    expect(getCapacityType(item.jsonData)).toBe('-');
+    expect(getZone(item.jsonData)).toBe('-');
+  });
+
+  it('should return "-" when labels is undefined', () => {
+    const item = { jsonData: { metadata: {} } };
+    expect(getInstanceType(item.jsonData)).toBe('-');
+    expect(getCapacityType(item.jsonData)).toBe('-');
+    expect(getZone(item.jsonData)).toBe('-');
+  });
+
+  it('should return label values when labels is populated', () => {
+    const item = {
+      jsonData: {
+        metadata: {
+          labels: {
+            'node.kubernetes.io/instance-type': 'm5.large',
+            'karpenter.sh/capacity-type': 'on-demand',
+            'topology.kubernetes.io/zone': 'us-east-1a',
+          },
+        },
+      },
+    };
+    expect(getInstanceType(item.jsonData)).toBe('m5.large');
+    expect(getCapacityType(item.jsonData)).toBe('on-demand');
+    expect(getZone(item.jsonData)).toBe('us-east-1a');
+  });
+});

--- a/karpenter/src/Scaling/Scaling.test.ts
+++ b/karpenter/src/Scaling/Scaling.test.ts
@@ -1,0 +1,39 @@
+describe('NodeClaim status condition extraction', () => {
+  const getLastConditionReason = (jsonData: any) => {
+    const conditions = jsonData?.status?.conditions;
+    const lastCondition =
+      Array.isArray(conditions) && conditions.length > 0
+        ? conditions[conditions.length - 1]
+        : null;
+    return lastCondition?.reason || '-';
+  };
+
+  it('should return "-" when status is undefined', () => {
+    const item = { jsonData: {} };
+    expect(getLastConditionReason(item.jsonData)).toBe('-');
+  });
+
+  it('should return "-" when status.conditions is undefined', () => {
+    const item = { jsonData: { status: {} } };
+    expect(getLastConditionReason(item.jsonData)).toBe('-');
+  });
+
+  it('should return "-" when status.conditions is empty array', () => {
+    const item = { jsonData: { status: { conditions: [] } } };
+    expect(getLastConditionReason(item.jsonData)).toBe('-');
+  });
+
+  it('should return condition reason when status.conditions is populated', () => {
+    const item = {
+      jsonData: {
+        status: {
+          conditions: [
+            { type: 'Building', reason: 'NodeBuilding' },
+            { type: 'Ready', reason: 'NodeReady' },
+          ],
+        },
+      },
+    };
+    expect(getLastConditionReason(item.jsonData)).toBe('NodeReady');
+  });
+});


### PR DESCRIPTION
### Description
The NodeClaim list and detail views crash with `TypeError: Cannot read properties of undefined` when certain fields are missing from the resource object.

Two categories of crashes were identified:

1. **`status.conditions` is undefined** — When a NodeClaim has just been created and the controller hasn't populated conditions yet, accessing the last element of an undefined array throws.
2. **`metadata.labels` is undefined** — When a NodeClaim has no labels, the bracket-notation access (`labels['key']`) on `undefined` throws. This affects both rendering and sorting — clicking a column header like "Instance Type" or "Zone" will crash the page.

### Changes
- **`Scaling/Details.tsx`**: Safe-guard `status.conditions` with `Array.isArray()` check, and add optional chaining before all bracket-notation label accesses (`labels?.['...']`).
- **`Scaling/List.tsx`**: Same safe-guards for conditions and all label accesses in both `render` and `getValue`.
- **`Scaling/Scaling.test.ts`** *(new)*: Unit tests covering undefined status, empty conditions, undefined metadata, undefined labels, and fully populated objects.

Closes #1120

### Checklist
- [x] Signed commits with Developer Certificate of Origin (DCO `-s`)
- [x] Code follows repository style guidelines
- [x] TypeScript compilation passes (`tsc --noEmit`)
- [x] Unit tests added and passing
