### PR TITLE
kyverno: add aria-pressed to violation status filter chips

### DIFF
--- a/kyverno/src/components/ViolationsView.tsx
+++ b/kyverno/src/components/ViolationsView.tsx
@@ -120,6 +120,8 @@ function StatusFilterChips({
   onChange: (statuses: PolicyResultStatus[]) => void;
   counts: Record<PolicyResultStatus, number>;
 }) {
+  const { t } = useTranslation();
+
   function toggle(status: PolicyResultStatus) {
     if (selected.includes(status)) {
       if (selected.length > 1) {
@@ -131,23 +133,33 @@ function StatusFilterChips({
   }
 
   return (
-    <Box sx={{ display: 'flex', gap: 1 }}>
-      {VIOLATION_STATUSES.map(status => (
-        <Chip
-          key={status}
-          label={`${status} (${counts[status] || 0})`}
-          color={
-            selected.includes(status)
-              ? status === 'fail' || status === 'error'
-                ? 'error'
-                : 'warning'
-              : 'default'
-          }
-          variant={selected.includes(status) ? 'filled' : 'outlined'}
-          onClick={() => toggle(status)}
-          sx={{ cursor: 'pointer' }}
-        />
-      ))}
+    <Box sx={{ display: 'flex', gap: 1 }} role="group" aria-label={t('Filter by status')}>
+      {VIOLATION_STATUSES.map(status => {
+        const isSelected = selected.includes(status);
+        // The last remaining filter cannot be turned off, otherwise the table
+        // would show nothing. Expose that to assistive tech rather than
+        // letting the click silently do nothing.
+        const isLocked = isSelected && selected.length === 1;
+
+        return (
+          <Chip
+            key={status}
+            label={`${status} (${counts[status] || 0})`}
+            color={
+              isSelected
+                ? status === 'fail' || status === 'error'
+                  ? 'error'
+                  : 'warning'
+                : 'default'
+            }
+            variant={isSelected ? 'filled' : 'outlined'}
+            onClick={() => toggle(status)}
+            aria-pressed={isSelected}
+            aria-disabled={isLocked || undefined}
+            sx={{ cursor: 'pointer' }}
+          />
+        );
+      })}
     </Box>
   );
 }


### PR DESCRIPTION
## What

The status filter chips in `ViolationsView` are toggle controls, but they expose no pressed state. Sighted users can tell selection apart from the `filled` vs `outlined` variant — screen reader users get no indication of which filters are currently active.

- `aria-pressed` on each chip, reflecting selection state
- `role="group"` with a translated label, so the chips are announced as one filter set rather than three unrelated buttons
- `aria-disabled` on the last remaining selected chip. `toggle()` already refuses to deselect it so the table is never empty, but that refusal was silent to everyone.

Follows the `aria-pressed` pattern already used by `AIAssistantToggle`.

## Why

The Kyverno plugin currently has no `aria-label` anywhere across its 21 components. This is a small first step; related to the accessibility work described in #938.

## Testing

- `npx tsc --noEmit -p tsconfig.json` — passes
- `npx eslint src/components/ViolationsView.tsx` — passes
- Prettier formatting verified

I could not run `headlamp-plugin tsc`/`lint` locally — the toolchain hits a `yargs` ESM error on Node 26, unrelated to this change.

## Question for maintainers

For the locked last chip, `aria-disabled` seemed the most honest signal, but an alternative would be keeping it fully enabled and showing a tooltip explaining why at least one filter must stay on. Happy to switch if you'd prefer that.