### PR TITLE
knative: fix unbounded re-render loop in TrafficSplittingSection

### DIFF
--- a/knative/src/components/kservices/detail/sections/traffic/TrafficSplittingSection.test.tsx
+++ b/knative/src/components/kservices/detail/sections/traffic/TrafficSplittingSection.test.tsx
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from '@testing-library/react';
+import React from 'react';
+import { vi } from 'vitest';
+
+/**
+ * Render counter, incremented by the SimpleTable mock below.
+ *
+ * The guard throw is load-bearing: without it a regression makes React loop
+ * indefinitely and the test run hangs rather than failing. Throwing converts
+ * the hang into a readable failure.
+ */
+let renderCount = 0;
+const RENDER_LIMIT = 300;
+
+vi.mock('@kinvolk/headlamp-plugin/lib/CommonComponents', () => ({
+  Link: ({ children }: { children?: React.ReactNode }) => <span>{children}</span>,
+  SectionBox: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  SimpleTable: ({ data }: { data: { nameLabel: string }[] }) => {
+    renderCount++;
+    if (renderCount > RENDER_LIMIT) {
+      throw new Error(`Render loop detected: SimpleTable rendered ${renderCount} times`);
+    }
+    return <div data-testid="traffic-table">{data.map(row => row.nameLabel).join(',')}</div>;
+  },
+}));
+
+vi.mock('../../../../common/notifications/useNotify', () => ({
+  useNotify: () => ({ notifySuccess: vi.fn(), notifyError: vi.fn() }),
+}));
+
+// The real hooks throw outside their providers. isEditMode: false is the default
+// state and the only one in which the reset effect runs.
+vi.mock('../../hooks/useKServiceEditMode', () => ({
+  useKServiceEditMode: () => ({ isEditMode: false, setIsEditMode: vi.fn() }),
+}));
+
+// canPatchKService: true makes isReadOnly depend solely on isEditMode, which is the
+// exact configuration that regressed.
+vi.mock('../../permissions/KServicePermissionsProvider', () => ({
+  useKServicePermissions: () => ({ canPatchKService: true, isLoading: false }),
+}));
+
+import TrafficSplittingSection from './TrafficSplittingSection';
+
+function makeKService() {
+  return {
+    metadata: { name: 'hello', namespace: 'default' },
+    cluster: 'c1',
+    spec: { traffic: [{ latestRevision: true, percent: 100 }] },
+    status: { latestReadyRevisionName: 'hello-00001', traffic: [] },
+    patch: vi.fn(),
+  };
+}
+
+function makeRevisions() {
+  return [
+    {
+      metadata: {
+        name: 'hello-00001',
+        namespace: 'default',
+        creationTimestamp: '2025-01-01T00:00:00Z',
+      },
+      status: { conditions: [{ type: 'Ready', status: 'True' }] },
+    },
+  ];
+}
+
+describe('TrafficSplittingSection', () => {
+  beforeEach(() => {
+    renderCount = 0;
+  });
+
+  /**
+   * Regression: the reset effect used to list `resetSection` in its dependency array.
+   * That function is redeclared every render, so the effect re-ran after every render,
+   * and the state it writes (notably setPendingTagInputs({})) always had a fresh
+   * identity, so React never bailed out. Every user opening a KService detail page —
+   * isEditMode defaults to false — hit an unbounded re-render loop.
+   */
+  it('settles after mount in view mode instead of re-rendering forever', () => {
+    render(
+      <TrafficSplittingSection
+        cluster="c1"
+        kservice={makeKService() as never}
+        revisions={makeRevisions() as never}
+      />
+    );
+
+    // Settles at 2: initial render plus the one legitimate state write from the
+    // mount-time reset. Asserting a small bound rather than an exact count leaves
+    // headroom without hiding a regression.
+    expect(renderCount).toBeLessThan(5);
+  });
+
+  /**
+   * Guards against "fixing" the loop by deleting the effect: without it the section
+   * never seeds its state from the KService and the total renders as 0%.
+   */
+  it('seeds traffic state from the KService on mount', () => {
+    const { getByTestId, getByText } = render(
+      <TrafficSplittingSection
+        cluster="c1"
+        kservice={makeKService() as never}
+        revisions={makeRevisions() as never}
+      />
+    );
+
+    expect(getByTestId('traffic-table').textContent).toBe('Latest Ready Revision,hello-00001');
+    expect(getByText('Total: 100% (must equal 100%)')).toBeTruthy();
+  });
+});

--- a/knative/src/components/kservices/detail/sections/traffic/TrafficSplittingSection.tsx
+++ b/knative/src/components/kservices/detail/sections/traffic/TrafficSplittingSection.tsx
@@ -371,11 +371,17 @@ export default function TrafficSplittingSection({ cluster, kservice, revisions }
     }
   }
 
+  // Reset whenever we leave edit mode. resetSection is intentionally not a dependency:
+  // it is redeclared on every render, so including it would re-run this effect after every
+  // render, and the state it writes (setPendingTagInputs({}) in particular) always has a
+  // fresh identity, so React never bails out and the component re-renders forever.
+  // Matches ScaleBoundsSection and AutoscalingSettings, which key this effect on isEditMode.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   React.useEffect(() => {
     if (!isEditMode) {
       resetSection();
     }
-  }, [isEditMode, resetSection]);
+  }, [isEditMode]);
 
   const getTagUrl = (tagName: string) => {
     const trafficEntry = kservice.status?.traffic?.find(t => t.tag === tagName);


### PR DESCRIPTION
## The bug

`TrafficSplittingSection` resets its local state whenever the user leaves edit mode:

```ts
React.useEffect(() => {
  if (!isEditMode) {
    resetSection();
  }
}, [isEditMode, resetSection]);
```

`resetSection` is a plain function declaration inside the component body, so it gets a new identity on every render. Listing it as a dependency means the effect re-runs after *every* render. It calls `setPendingTagInputs({})` (and, via `initializeFromKService()`, `setRevPercents` / `setRevTags` / `setLatestTags`) — all fresh object identities, so React never bails out of the update. Render → new `resetSection` → effect fires → state written → render, without end.

`isEditMode` defaults to `false` (`useKServiceEditMode` → `useState(false)`), so the guard is satisfied immediately and **every user opening a KService detail page hits this**, not just those who enter and leave edit mode.

Because the updates originate in a passive effect, React never raises "Maximum update depth exceeded". There is no error in the console — the tab just pegs a core and the page becomes sluggish to interact with.

The two sibling sections in this same feature already key this effect on `isEditMode` alone — `ScaleBoundsSection.tsx` and `AutoscalingSettings.tsx` — which is what makes this look like an accidental addition rather than an intentional difference.

## The fix

Drop `resetSection` from the dependency array so the effect runs on edit-mode transitions only, matching the sibling sections. Added a comment explaining why the dependency is deliberately omitted, plus a scoped `eslint-disable-next-line react-hooks/exhaustive-deps` so the intent is explicit rather than looking like an oversight to the next reader.

Memoising `resetSection` with `useCallback` would also work, but it would need `initializeFromKService` memoised too, and it would leave this component structured differently from its two siblings for no benefit.

## Tests

Added `TrafficSplittingSection.test.tsx` with two cases:

1. **The loop guard** — renders in view mode and asserts the table renders fewer than 5 times. The mock throws past 300 renders; that throw is deliberate, because without it a regression makes the suite hang instead of fail.
2. **A content assertion** — that the section still seeds its state from the KService (`Total: 100%` and both expected rows). This exists so the loop can't be "fixed" by deleting the effect: remove it and the total renders as `0%` and this test fails.

Verified both tests fail against `main` and pass with the fix. On `main` the first fails with `Render loop detected: SimpleTable rendered 303 times`, reproducibly. With the fix, renders settle at exactly 2 — the initial render plus the one legitimate state write from the mount-time reset.

## Checks

`npm test` 24 passed (5 files) · `npm run lint` clean at `--max-warnings 0` · `npm run tsc` clean · `npm run format` applied.

## Note

Found by reading the code rather than from a bug report, so there's no existing issue for it — happy to open one first if maintainers prefer that order.
