### PR TITLE
knative: label DomainMapping annotation failures correctly

### DIFF
--- a/knative/src/utils/domain.test.ts
+++ b/knative/src/utils/domain.test.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { vi } from 'vitest';
+
+const post = vi.fn();
+
+vi.mock('../resources/knative', () => ({
+  ClusterDomainClaim: {
+    kind: 'ClusterDomainClaim',
+    apiVersion: 'networking.internal.knative.dev/v1alpha1',
+    apiEndpoint: { post: (...args: unknown[]) => post(...args) },
+  },
+  KnativeDomainMapping: {
+    kind: 'DomainMapping',
+    apiVersion: 'serving.knative.dev/v1beta1',
+    apiEndpoint: { post: (...args: unknown[]) => post(...args) },
+  },
+}));
+
+import { createClusterDomainClaim } from './domain';
+
+/** Minimal DomainMapping stand-in with the fields createClusterDomainClaim touches. */
+function makeDomainMapping(overrides: Partial<{ host: string; cluster: string }> = {}) {
+  return {
+    host: 'example.com',
+    cluster: 'my-cluster',
+    patch: vi.fn().mockResolvedValue({}),
+    ...overrides,
+  };
+}
+
+describe('createClusterDomainClaim', () => {
+  beforeEach(() => {
+    post.mockReset();
+    post.mockResolvedValue({});
+  });
+
+  it('rejects a DomainMapping with no host', async () => {
+    const dm = makeDomainMapping({ host: '' });
+    await expect(createClusterDomainClaim(dm as never, 'default')).rejects.toThrow(
+      'Domain name is missing'
+    );
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it('creates the claim and annotates the DomainMapping on the happy path', async () => {
+    const dm = makeDomainMapping();
+    await expect(createClusterDomainClaim(dm as never, 'default')).resolves.toBeUndefined();
+
+    expect(post).toHaveBeenCalledTimes(1);
+    expect(dm.patch).toHaveBeenCalledTimes(1);
+    const patchArg = dm.patch.mock.calls[0][0] as {
+      metadata: { annotations: Record<string, string> };
+    };
+    expect(patchArg.metadata.annotations).toHaveProperty('knative.headlamp.dev/reconciledAt');
+  });
+
+  it('reports a claim-creation failure as a ClusterDomainClaim error', async () => {
+    post.mockRejectedValue(new Error('forbidden'));
+    const dm = makeDomainMapping();
+
+    await expect(createClusterDomainClaim(dm as never, 'default')).rejects.toThrow(
+      'Failed to create ClusterDomainClaim: forbidden'
+    );
+  });
+
+  // Regression: the claim POST succeeds and only the follow-up annotation patch fails.
+  // The surfaced message must describe the annotation step, not claim creation, because
+  // the ClusterDomainClaim does exist by this point and telling the user it failed to be
+  // created sends them to debug the wrong resource.
+  it('reports an annotation failure without blaming ClusterDomainClaim creation', async () => {
+    const dm = makeDomainMapping();
+    dm.patch = vi.fn().mockRejectedValue(new Error('patch conflict'));
+
+    await expect(createClusterDomainClaim(dm as never, 'default')).rejects.toThrow(
+      'Failed to annotate DomainMapping: patch conflict'
+    );
+
+    // The claim itself was created, so the error must not claim otherwise.
+    expect(post).toHaveBeenCalledTimes(1);
+    await expect(createClusterDomainClaim(dm as never, 'default')).rejects.not.toThrow(
+      /Failed to create ClusterDomainClaim/
+    );
+  });
+
+  it('treats an already-existing claim as success and still annotates', async () => {
+    post.mockRejectedValue(new Error('clusterdomainclaims "example.com" already exists'));
+    const dm = makeDomainMapping();
+
+    await expect(createClusterDomainClaim(dm as never, 'default')).resolves.toBeUndefined();
+    expect(dm.patch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/knative/src/utils/domain.ts
+++ b/knative/src/utils/domain.ts
@@ -146,25 +146,6 @@ export async function createClusterDomainClaim(dm: KnativeDomainMapping, namespa
 
   try {
     await ensureClusterDomainClaim({ host, cluster: dm.cluster, namespace });
-
-    // Add dummy annotation to trigger DomainMapping reconciliation
-    try {
-      await dm.patch({
-        metadata: {
-          annotations: {
-            'knative.headlamp.dev/reconciledAt': new Date().toISOString(),
-          },
-        },
-      });
-    } catch (e2: unknown) {
-      const error2 = e2 as { message?: string } | undefined;
-      const detail2 = error2?.message?.trim();
-      throw new Error(
-        detail2
-          ? `Failed to annotate DomainMapping: ${detail2}`
-          : 'Failed to annotate DomainMapping'
-      );
-    }
   } catch (e: unknown) {
     const error = e as { message?: string } | undefined;
     const detail = error?.message?.trim();
@@ -172,6 +153,26 @@ export async function createClusterDomainClaim(dm: KnativeDomainMapping, namespa
       detail
         ? `Failed to create ClusterDomainClaim: ${detail}`
         : 'Failed to create ClusterDomainClaim'
+    );
+  }
+
+  // Add dummy annotation to trigger DomainMapping reconciliation.
+  // Kept outside the block above so that a patch failure is not reported as a
+  // claim-creation failure: the ClusterDomainClaim already exists by this point, and
+  // mislabelling the error sends users to debug the wrong resource.
+  try {
+    await dm.patch({
+      metadata: {
+        annotations: {
+          'knative.headlamp.dev/reconciledAt': new Date().toISOString(),
+        },
+      },
+    });
+  } catch (e: unknown) {
+    const error = e as { message?: string } | undefined;
+    const detail = error?.message?.trim();
+    throw new Error(
+      detail ? `Failed to annotate DomainMapping: ${detail}` : 'Failed to annotate DomainMapping'
     );
   }
 }


### PR DESCRIPTION
## What this fixes

`createClusterDomainClaim()` in `knative/src/utils/domain.ts` does two things in sequence: it creates the `ClusterDomainClaim`, then patches the `DomainMapping` with a `knative.headlamp.dev/reconciledAt` annotation to trigger reconciliation.

The annotation patch sat inside the same `try` block that guards claim creation, and its `catch` re-threw. That re-thrown error was then caught by the *outer* `catch`, which wrapped everything as a claim-creation failure.

So when only the annotation patch failed, the user saw:

```
Failed to create ClusterDomainClaim: Failed to annotate DomainMapping: <detail>
```

The `ClusterDomainClaim` was in fact created successfully. The message points at the wrong resource, and both call sites surface `error.message` directly in an error toast — `DomainMappingSection.tsx` and `domainmappings/List.tsx` — so this is what the operator actually reads. Someone debugging this goes looking at RBAC and admission for `clusterdomainclaims` when the real failure was patching the `DomainMapping`.

## The change

Split the sequential steps into their own `try`/`catch` blocks so each error is labelled by the operation that actually failed. Behaviour on every other path is unchanged:

- host missing → `Domain name is missing` (unchanged)
- claim POST fails → `Failed to create ClusterDomainClaim: <detail>` (unchanged)
- claim already exists → still swallowed by `ensureClusterDomainClaim`, still annotates (unchanged)
- **annotation patch fails → now `Failed to annotate DomainMapping: <detail>`** (was double-wrapped)

## Tests

Added `knative/src/utils/domain.test.ts` (no test file existed for this module). Five cases covering the branches above, including a regression test for the mislabelled error that asserts the message does *not* match `/Failed to create ClusterDomainClaim/` when only the patch fails.

Verified the regression test fails against `main` with exactly:

```
AssertionError: expected [Function] to throw error not matching /Failed to create ClusterDomainClaim/
+ Received: "Failed to create ClusterDomainClaim: Failed to annotate DomainMapping: patch conflict"
```

and passes with the fix.

## Checks

`npm test` 27 passed (5 files) · `npm run lint` clean at `--max-warnings 0` · `npm run tsc` clean · `npm run format` applied.
