### PR TITLE
ai-assistant: AKS mcp configured by default for aks-desktop

### DIFF
--- a/ai-assistant/packages/ai-common/package.json
+++ b/ai-assistant/packages/ai-common/package.json
@@ -53,6 +53,7 @@
     "./skills/SkillLoader": "./src/skills/SkillLoader.ts",
     "./skills/SkillManager": "./src/skills/SkillManager.ts",
     "./skills/adapters/browser": "./src/skills/adapters/browser.ts",
+    "./skills/builtinSources": "./src/skills/builtinSources.ts",
     "./skills/config": "./src/skills/config.ts",
     "./skills/routing/EmbeddingSkillRouter": "./src/skills/routing/EmbeddingSkillRouter.ts",
     "./skills/routing/KeywordSkillRouter": "./src/skills/routing/KeywordSkillRouter.ts",

--- a/ai-assistant/packages/ai-common/package.json
+++ b/ai-assistant/packages/ai-common/package.json
@@ -28,6 +28,7 @@
     "./mcp/routing/EmbeddingToolRouter": "./src/mcp/routing/EmbeddingToolRouter.ts",
     "./mcp/routing/ToolRouter": "./src/mcp/routing/ToolRouter.ts",
     "./mcp/types": "./src/mcp/types.ts",
+    "./mcp/config/builtinServers": "./src/mcp/config/builtinServers.ts",
     "./mcp/config/serverConfig": "./src/mcp/config/serverConfig.ts",
     "./mcp/persistence/FileStorage": "./src/mcp/persistence/FileStorage.ts",
     "./mcp/persistence/Storage": "./src/mcp/persistence/Storage.ts",

--- a/ai-assistant/packages/ai-common/src/assistant/LangChainAssistantSession.test.ts
+++ b/ai-assistant/packages/ai-common/src/assistant/LangChainAssistantSession.test.ts
@@ -28,6 +28,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { sanitizeToolAlignment } from '../conversation/history';
 import { convertPromptsToMessages } from '../conversation/langchain/messages';
 import type { ConversationMessage as Prompt } from '../conversation/types';
+import type { ToolClient } from '../mcp/client/ToolClient';
 import type { UserContext } from '../mcp/tools/types';
 import { DEFAULT_SKILLS_CONFIG } from '../skills/config';
 import type { SkillManager } from '../skills/SkillManager';
@@ -1119,6 +1120,63 @@ describe('userSend — with MockKubernetesToolManager', () => {
     const response = await manager.userSend('list pods');
     expect(response.content).toContain('pods');
     expect(response.error).toBeFalsy();
+  });
+});
+
+// =============================================================================
+// Injected MCP client
+// =============================================================================
+
+describe('mcpClient option', () => {
+  /**
+   * Build a minimal MCP bridge that reports itself as available.
+   *
+   * @returns A ToolClient usable as an injected MCP bridge.
+   */
+  function makeToolClient(): ToolClient {
+    return {
+      isAvailable: () => true,
+      getConfig: async () => ({ success: true, config: { enabled: true, servers: [] } }),
+      getToolsConfig: async () => ({ success: true, config: {} }),
+      executeTool: async () => null,
+      isToolEnabled: async () => true,
+      setToolEnabled: async () => true,
+      getToolStats: async () => null,
+      updateToolsConfig: async () => true,
+      parseToolName: name => ({ serverName: 'default', toolName: name }),
+    };
+  }
+
+  /**
+   * Read the MCP bridge held by a session's tool manager.
+   *
+   * @param manager - Session whose tool manager should be inspected.
+   * @returns The MCP bridge in use.
+   */
+  function mcpClientOf(manager: LangChainAssistantSession): ToolClient {
+    return (
+      privateManager(manager).toolManager as unknown as { getMCPClient(): ToolClient }
+    ).getMCPClient();
+  }
+
+  it('falls back to an unavailable bridge when no client is injected', () => {
+    const manager = new LangChainAssistantSession('mock-testing-model', {});
+    expect(mcpClientOf(manager).isAvailable()).toBe(false);
+  });
+
+  it('forwards the injected client to the tool manager', () => {
+    const mcpClient = makeToolClient();
+    const manager = new LangChainAssistantSession('mock-testing-model', {}, [], { mcpClient });
+    expect(mcpClientOf(manager)).toBe(mcpClient);
+  });
+
+  it('prefers an explicit tool manager over the injected client', () => {
+    const toolManager = createMockToolManager({ enabledToolNames: [] });
+    const manager = new LangChainAssistantSession('mock-testing-model', {}, [], {
+      toolManager,
+      mcpClient: makeToolClient(),
+    });
+    expect(privateManager(manager).toolManager).toBe(toolManager);
   });
 });
 

--- a/ai-assistant/packages/ai-common/src/assistant/LangChainAssistantSession.ts
+++ b/ai-assistant/packages/ai-common/src/assistant/LangChainAssistantSession.ts
@@ -30,6 +30,7 @@ import {
 } from '../conversation/history';
 import { convertPromptsToMessages } from '../conversation/langchain/messages';
 import type { ConversationMessage } from '../conversation/types';
+import type { ToolClient } from '../mcp/client/ToolClient';
 import { MCPArgumentProcessor } from '../mcp/tools/ArgumentProcessor';
 import type { MCPToolSchema, UserContext } from '../mcp/tools/types';
 import { buildSystemPrompt, buildToolResponseSystemPrompt } from '../prompts/buildSystemPrompt';
@@ -216,6 +217,9 @@ export default class LangChainAssistantSession extends AssistantSession {
    *     }),
    *   });
    *   ```
+   * @param options.mcpClient - Inject the host MCP bridge so discovered MCP
+   *   tools are bound to the model. Without it the manager falls back to a
+   *   no-op client and only built-in tools are available.
    */
   constructor(
     providerId: string,
@@ -224,6 +228,8 @@ export default class LangChainAssistantSession extends AssistantSession {
     options?: {
       /** Optional replacement tool runtime for tests, CLI, or demos. */
       toolManager?: LangChainToolRuntime;
+      /** Host MCP bridge used to discover and execute MCP tools. */
+      mcpClient?: ToolClient;
     }
   ) {
     super();
@@ -233,7 +239,9 @@ export default class LangChainAssistantSession extends AssistantSession {
       'AI Assistant: Initializing with enabled tools:',
       enabledToolIds || 'all tools enabled'
     );
-    this.toolManager = options?.toolManager ?? new LangChainToolManager({ enabledToolIds });
+    this.toolManager =
+      options?.toolManager ??
+      new LangChainToolManager({ enabledToolIds, mcpClient: options?.mcpClient });
     this.model = this.createModel(providerId, config);
 
     // Initialize prompt template and output parser

--- a/ai-assistant/packages/ai-common/src/kubernetes/context/buildContextDescription.test.ts
+++ b/ai-assistant/packages/ai-common/src/kubernetes/context/buildContextDescription.test.ts
@@ -231,6 +231,66 @@ describe('contextGenerator', () => {
         '- kind: Deployment, name: web, namespace: default, cluster: remote'
       );
     });
+
+    it('describes the project shown in the project details view', () => {
+      const result = generateContextDescription({
+        type: 'headlamp.project-details-view',
+        title: 'Project: my-project',
+        project: { id: 'my-project', namespaces: ['dev', 'staging'], clusters: ['minikube'] },
+      });
+
+      expect(result).toContain('Current view: Project: my-project');
+      expect(result).toContain('Viewing project: my-project');
+      expect(result).toContain('Project namespaces: dev, staging');
+      expect(result).toContain('Project clusters: minikube');
+    });
+
+    it('describes the selected project tab', () => {
+      const result = generateContextDescription({
+        type: 'headlamp.project-details-tab-change',
+        project: { id: 'my-project' },
+        projectTab: 'Workloads',
+      });
+
+      expect(result).toContain('Selected project tab: Workloads');
+    });
+
+    it('omits project details that are empty', () => {
+      const result = generateContextDescription({ project: { id: 'my-project' } });
+
+      expect(result).toContain('Viewing project: my-project');
+      expect(result).not.toContain('Project namespaces:');
+      expect(result).not.toContain('Project clusters:');
+      expect(result).not.toContain('Selected project tab:');
+    });
+
+    it('lists the projects shown in the project list view', () => {
+      const result = generateContextDescription({
+        type: 'headlamp.project-list-view',
+        projects: [{ id: 'alpha' }, { id: 'beta' }],
+      });
+
+      expect(result).toContain('Showing 2 projects');
+      expect(result).toContain('Projects: alpha, beta');
+    });
+
+    it('uses the singular form for a single project', () => {
+      const result = generateContextDescription({ projects: [{ id: 'alpha' }] });
+
+      expect(result).toContain('Showing 1 project');
+    });
+
+    it('includes project resources in the structured resource list', () => {
+      const result = generateContextDescription(
+        {
+          project: { id: 'my-project' },
+          resources: [{ kind: 'Pod', metadata: { name: 'api', namespace: 'dev' } }],
+        },
+        'minikube'
+      );
+
+      expect(result).toContain('- kind: Pod, name: api, namespace: dev, cluster: minikube');
+    });
   });
 
   describe('generateResourceSummary', () => {

--- a/ai-assistant/packages/ai-common/src/kubernetes/context/buildContextDescription.ts
+++ b/ai-assistant/packages/ai-common/src/kubernetes/context/buildContextDescription.ts
@@ -58,6 +58,16 @@ type MinimizedResource = Pick<
   'kind' | 'metadata' | 'status' | '_clusterName'
 >;
 
+/** Headlamp project shape used for context generation. */
+export interface ProjectContext {
+  /** Project identifier, also used as its display name. */
+  id?: string;
+  /** Namespaces that belong to the project. */
+  namespaces?: string[];
+  /** Clusters the project spans. */
+  clusters?: string[];
+}
+
 /** Event payload structure for context generation (platform-agnostic). */
 export interface ContextEventPayload {
   /** Event type or view identifier. */
@@ -72,6 +82,12 @@ export interface ContextEventPayload {
   resources?: KubernetesContextResource[];
   /** Resource kind shared by the resources collection. */
   resourceKind?: string;
+  /** Project currently open in the project details view. */
+  project?: ProjectContext;
+  /** Projects shown in the project list view. */
+  projects?: ProjectContext[];
+  /** Tab selected in the project details view. */
+  projectTab?: string;
 }
 
 /**
@@ -143,6 +159,36 @@ export function generateContextDescription(
   if (event?.title || event?.type) {
     const viewName = event.title || event.type;
     contextParts.push(`Current view: ${viewName}`);
+  }
+
+  // Add project context
+  if (event?.project?.id) {
+    contextParts.push(`Viewing project: ${event.project.id}`);
+
+    if (event.project.namespaces && event.project.namespaces.length > 0) {
+      contextParts.push(`Project namespaces: ${event.project.namespaces.join(', ')}`);
+    }
+    if (event.project.clusters && event.project.clusters.length > 0) {
+      contextParts.push(`Project clusters: ${event.project.clusters.join(', ')}`);
+    }
+    if (event.projectTab) {
+      contextParts.push(`Selected project tab: ${event.projectTab}`);
+    }
+  }
+
+  // Add project list context
+  if (event?.projects && Array.isArray(event.projects)) {
+    const projectCount = event.projects.length;
+    if (projectCount > 0) {
+      contextParts.push(`Showing ${projectCount} project${projectCount !== 1 ? 's' : ''}`);
+
+      const projectNames = event.projects
+        .map(project => project?.id)
+        .filter((id): id is string => !!id);
+      if (projectNames.length > 0) {
+        contextParts.push(`Projects: ${projectNames.join(', ')}`);
+      }
+    }
   }
 
   // Add resource details context

--- a/ai-assistant/packages/ai-common/src/mcp/config/builtinServers.test.ts
+++ b/ai-assistant/packages/ai-common/src/mcp/config/builtinServers.test.ts
@@ -152,6 +152,27 @@ describe('reconcileBuiltinServers', () => {
     expect(result.config.servers[0].args).toEqual(createAksMcpServer().args);
   });
 
+  it('reports a state change when only the legacy state needs upgrading', () => {
+    const upToDate = configWithArgs(createAksMcpServer().args);
+
+    const result = reconcileBuiltinServers(upToDate, [createAksMcpServer()], [AKS_MCP_SERVER_NAME]);
+
+    expect(result.changed).toBe(false);
+    expect(result.stateChanged).toBe(true);
+    expect(result.state[AKS_MCP_SERVER_NAME]).toEqual({
+      command: 'aks-mcp',
+      args: createAksMcpServer().args,
+    });
+  });
+
+  it('reports no state change when the built-in is already up to date', () => {
+    const seeded = reconcileBuiltinServers(EMPTY, [createAksMcpServer()]);
+
+    const again = reconcileBuiltinServers(seeded.config, [createAksMcpServer()], seeded.state);
+
+    expect(again.stateChanged).toBe(false);
+  });
+
   it('preserves unrelated servers', () => {
     const existing: MCPSettings = {
       enabled: true,

--- a/ai-assistant/packages/ai-common/src/mcp/config/builtinServers.test.ts
+++ b/ai-assistant/packages/ai-common/src/mcp/config/builtinServers.test.ts
@@ -99,6 +99,32 @@ describe('reconcileBuiltinServers', () => {
     ]);
   });
 
+  it('treats an environment written in a different key order as unchanged', () => {
+    const builtin = { ...createAksMcpServer(), env: { A: '1', B: '2' } };
+    const stored = configWithArgs(builtin.args, { env: { B: '2', A: '1' } });
+    const state = {
+      [AKS_MCP_SERVER_NAME]: { command: 'aks-mcp', args: builtin.args, env: builtin.env },
+    };
+
+    const result = reconcileBuiltinServers(stored, [builtin], state);
+
+    expect(result.changed).toBe(false);
+  });
+
+  it('clears an environment the built-in no longer sets', () => {
+    const builtin = createAksMcpServer();
+    const stored = configWithArgs(builtin.args, { env: { LEGACY: '1' } });
+    const state = {
+      [AKS_MCP_SERVER_NAME]: { command: 'aks-mcp', args: builtin.args, env: { LEGACY: '1' } },
+    };
+
+    const result = reconcileBuiltinServers(stored, [builtin], state);
+
+    expect(result.changed).toBe(true);
+    expect(result.config.servers[0]).not.toHaveProperty('env');
+    expect(result.state[AKS_MCP_SERVER_NAME]).not.toHaveProperty('env');
+  });
+
   it('does not reseed a server the user removed', () => {
     const state = { [AKS_MCP_SERVER_NAME]: { command: 'aks-mcp', args: [] } };
 

--- a/ai-assistant/packages/ai-common/src/mcp/config/builtinServers.test.ts
+++ b/ai-assistant/packages/ai-common/src/mcp/config/builtinServers.test.ts
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { MCPSettings } from '../types';
+import { AKS_MCP_SERVER_NAME, createAksMcpServer, reconcileBuiltinServers } from './builtinServers';
+
+const EMPTY: MCPSettings = { enabled: false, servers: [] };
+
+/** @returns Config holding one aks-mcp server with the supplied arguments. */
+function configWithArgs(args: string[], overrides = {}): MCPSettings {
+  return {
+    enabled: true,
+    servers: [{ name: AKS_MCP_SERVER_NAME, command: 'aks-mcp', args, enabled: true, ...overrides }],
+  };
+}
+
+describe('createAksMcpServer', () => {
+  it('enables only components that need no extra CLI binary', () => {
+    const args = createAksMcpServer().args;
+    const components = args[args.indexOf('--enabled-components') + 1].split(',');
+
+    expect(components).toContain('az_cli');
+    expect(components).toContain('inspektorgadget');
+    expect(components).not.toContain('cilium');
+    expect(components).not.toContain('hubble');
+    expect(components).not.toContain('kubectl');
+    expect(components).not.toContain('helm');
+  });
+});
+
+describe('reconcileBuiltinServers', () => {
+  it('adds a built-in server and enables MCP', () => {
+    const result = reconcileBuiltinServers(EMPTY, [createAksMcpServer()]);
+
+    expect(result.changed).toBe(true);
+    expect(result.config.enabled).toBe(true);
+    expect(result.config.servers).toHaveLength(1);
+    expect(result.state[AKS_MCP_SERVER_NAME]).toEqual({
+      command: 'aks-mcp',
+      args: createAksMcpServer().args,
+    });
+  });
+
+  it('makes no changes when the built-in is already up to date', () => {
+    const seeded = reconcileBuiltinServers(EMPTY, [createAksMcpServer()]);
+
+    const again = reconcileBuiltinServers(seeded.config, [createAksMcpServer()], seeded.state);
+
+    expect(again.changed).toBe(false);
+    expect(again.config).toBe(seeded.config);
+  });
+
+  it('refreshes arguments when the built-in definition changes', () => {
+    const stale = configWithArgs(['--transport', 'stdio']);
+    const state = { [AKS_MCP_SERVER_NAME]: { command: 'aks-mcp', args: ['--transport', 'stdio'] } };
+
+    const result = reconcileBuiltinServers(stale, [createAksMcpServer()], state);
+
+    expect(result.changed).toBe(true);
+    expect(result.config.servers[0].args).toEqual(createAksMcpServer().args);
+  });
+
+  it('preserves the user enabled and autoApprove toggles when refreshing', () => {
+    const stale = configWithArgs(['--transport', 'stdio'], { enabled: false, autoApprove: true });
+    const state = { [AKS_MCP_SERVER_NAME]: { command: 'aks-mcp', args: ['--transport', 'stdio'] } };
+
+    const result = reconcileBuiltinServers(stale, [createAksMcpServer()], state);
+
+    expect(result.config.servers[0].enabled).toBe(false);
+    expect(result.config.servers[0].autoApprove).toBe(true);
+  });
+
+  it('does not overwrite arguments the user edited', () => {
+    const customized = configWithArgs(['--transport', 'stdio', '--access-level', 'admin']);
+    const state = { [AKS_MCP_SERVER_NAME]: { command: 'aks-mcp', args: ['--transport', 'stdio'] } };
+
+    const result = reconcileBuiltinServers(customized, [createAksMcpServer()], state);
+
+    expect(result.changed).toBe(false);
+    expect(result.config.servers[0].args).toEqual([
+      '--transport',
+      'stdio',
+      '--access-level',
+      'admin',
+    ]);
+  });
+
+  it('does not reseed a server the user removed', () => {
+    const state = { [AKS_MCP_SERVER_NAME]: { command: 'aks-mcp', args: [] } };
+
+    const result = reconcileBuiltinServers(EMPTY, [createAksMcpServer()], state);
+
+    expect(result.changed).toBe(false);
+    expect(result.config.servers).toEqual([]);
+  });
+
+  it('does not adopt a same-named server the user created', () => {
+    const custom = configWithArgs([], { command: '/custom/aks-mcp' });
+
+    const result = reconcileBuiltinServers(custom, [createAksMcpServer()]);
+
+    expect(result.changed).toBe(false);
+    expect(result.config.servers[0].command).toBe('/custom/aks-mcp');
+  });
+
+  it('upgrades servers seeded before definitions were recorded', () => {
+    const stale = configWithArgs(['--transport', 'stdio']);
+
+    const result = reconcileBuiltinServers(stale, [createAksMcpServer()], [AKS_MCP_SERVER_NAME]);
+
+    expect(result.changed).toBe(true);
+    expect(result.config.servers[0].args).toEqual(createAksMcpServer().args);
+  });
+
+  it('preserves unrelated servers', () => {
+    const existing: MCPSettings = {
+      enabled: true,
+      servers: [{ name: 'flux-mcp', command: 'flux-operator-mcp', args: ['serve'], enabled: true }],
+    };
+
+    const result = reconcileBuiltinServers(existing, [createAksMcpServer()]);
+
+    expect(result.config.servers.map(server => server.name)).toEqual([
+      'flux-mcp',
+      AKS_MCP_SERVER_NAME,
+    ]);
+  });
+});

--- a/ai-assistant/packages/ai-common/src/mcp/config/builtinServers.ts
+++ b/ai-assistant/packages/ai-common/src/mcp/config/builtinServers.ts
@@ -96,8 +96,10 @@ export interface ReconcileBuiltinServersResult {
   config: MCPSettings;
   /** Definitions to persist for the next reconciliation. */
   state: BuiltinServerState;
-  /** Whether anything changed and the result needs persisting. */
+  /** Whether the configuration changed and needs writing back to the host. */
   changed: boolean;
+  /** Whether the recorded definitions changed, which can happen without a config change. */
+  stateChanged: boolean;
 }
 
 /** @returns The comparison key for a server name. */
@@ -171,6 +173,7 @@ export function reconcileBuiltinServers(
   const servers = [...config.servers];
   let enabled = config.enabled;
   let changed = false;
+  let stateChanged = false;
 
   for (const builtin of builtinServers) {
     const key = toKey(builtin.name);
@@ -184,6 +187,7 @@ export function reconcileBuiltinServers(
       nextState[key] = toDefinition(builtin);
       enabled = true;
       changed = true;
+      stateChanged = true;
       continue;
     }
 
@@ -197,7 +201,10 @@ export function reconcileBuiltinServers(
     }
 
     const definition = toDefinition(builtin);
-    nextState[key] = definition;
+    if (lastWritten === null || !isSameDefinition(lastWritten, definition)) {
+      nextState[key] = definition;
+      stateChanged = true;
+    }
     if (isSameDefinition(toDefinition(existing), definition)) continue;
 
     servers[index] = applyDefinition(existing, definition);
@@ -205,6 +212,6 @@ export function reconcileBuiltinServers(
   }
 
   return changed
-    ? { config: { enabled, servers }, state: nextState, changed }
-    : { config, state: nextState, changed };
+    ? { config: { enabled, servers }, state: nextState, changed, stateChanged }
+    : { config, state: nextState, changed, stateChanged };
 }

--- a/ai-assistant/packages/ai-common/src/mcp/config/builtinServers.ts
+++ b/ai-assistant/packages/ai-common/src/mcp/config/builtinServers.ts
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { MCPServer, MCPSettings } from '../types';
+
+/** Server name used for the Azure Kubernetes Service MCP server. */
+export const AKS_MCP_SERVER_NAME = 'aks-mcp';
+
+/**
+ * Components enabled for the preconfigured `aks-mcp` server.
+ *
+ * `aks-mcp` enables every component by default and refuses to start when any
+ * enabled component's CLI is missing from `PATH`. These components need only
+ * the bundled Azure CLI. The `kubectl`, `helm`, `cilium`, and `hubble`
+ * components each require their own binary, so they are opt-in: add them to the
+ * server arguments in MCP settings once the CLI is installed.
+ */
+const AKS_MCP_COMPONENTS = [
+  'az_cli',
+  'monitor',
+  'fleet',
+  'network',
+  'compute',
+  'detectors',
+  'advisor',
+  'inspektorgadget',
+].join(',');
+
+/**
+ * Builds the preconfigured `aks-mcp` server definition.
+ *
+ * The command is left unqualified so it resolves from `PATH`; hosts that ship
+ * the binary (AKS Desktop) prepend their bundled tools directory to `PATH`.
+ *
+ * @returns The default `aks-mcp` stdio server definition.
+ */
+export function createAksMcpServer(): MCPServer {
+  return {
+    name: AKS_MCP_SERVER_NAME,
+    command: 'aks-mcp',
+    args: [
+      '--transport',
+      'stdio',
+      '--access-level',
+      'readonly',
+      '--enabled-components',
+      AKS_MCP_COMPONENTS,
+    ],
+    enabled: true,
+  };
+}
+
+/** The parts of a built-in server the plugin owns, as last written by it. */
+export interface BuiltinServerDefinition {
+  /** Executable used to start the server. */
+  command: string;
+  /** Arguments passed to the server command. */
+  args: string[];
+  /** Environment variables added to the server process. */
+  env?: Record<string, string>;
+}
+
+/**
+ * Records the definition last written for each built-in server name.
+ *
+ * A `null` value means the server was seeded by an older version that did not
+ * record its definition, so customization cannot be detected.
+ */
+export type BuiltinServerState = Record<string, BuiltinServerDefinition | null>;
+
+/** Outcome of reconciling built-in server definitions with stored config. */
+export interface ReconcileBuiltinServersResult {
+  /** Configuration including any added or refreshed built-in servers. */
+  config: MCPSettings;
+  /** Definitions to persist for the next reconciliation. */
+  state: BuiltinServerState;
+  /** Whether anything changed and the result needs persisting. */
+  changed: boolean;
+}
+
+/** @returns The comparison key for a server name. */
+function toKey(name: string): string {
+  return name.trim().toLowerCase();
+}
+
+/** @returns Whether two definitions describe the same server process. */
+function isSameDefinition(a: BuiltinServerDefinition, b: BuiltinServerDefinition): boolean {
+  return (
+    a.command === b.command &&
+    JSON.stringify(a.args) === JSON.stringify(b.args) &&
+    JSON.stringify(a.env ?? {}) === JSON.stringify(b.env ?? {})
+  );
+}
+
+/** @returns The plugin-owned parts of a server definition. */
+function toDefinition({ command, args, env }: MCPServer): BuiltinServerDefinition {
+  return env === undefined ? { command, args } : { command, args, env };
+}
+
+/** @returns Previously seeded state, upgrading the legacy name-list format. */
+function normalizeState(previous: readonly string[] | BuiltinServerState): BuiltinServerState {
+  const entries = Array.isArray(previous)
+    ? previous.map(name => [toKey(name), null] as const)
+    : Object.entries(previous).map(([name, definition]) => [toKey(name), definition] as const);
+  return Object.fromEntries(entries);
+}
+
+/**
+ * Applies host-provided built-in MCP servers to a stored configuration.
+ *
+ * A built-in is added once. On later runs its command and arguments are
+ * refreshed so improvements reach existing installs, but only while the user
+ * has not edited them; a customized or deleted server is left untouched. The
+ * `enabled` and `autoApprove` toggles always belong to the user.
+ *
+ * @param config - Currently persisted MCP configuration.
+ * @param builtinServers - Server definitions the host wants preconfigured.
+ * @param previousState - Definitions written by the previous reconciliation.
+ * @returns The reconciled config, the state to persist, and whether it changed.
+ */
+export function reconcileBuiltinServers(
+  config: MCPSettings,
+  builtinServers: MCPServer[],
+  previousState: readonly string[] | BuiltinServerState = {}
+): ReconcileBuiltinServersResult {
+  const state = normalizeState(previousState);
+  const nextState: BuiltinServerState = { ...state };
+  const servers = [...config.servers];
+  let enabled = config.enabled;
+  let changed = false;
+
+  for (const builtin of builtinServers) {
+    const key = toKey(builtin.name);
+    const index = servers.findIndex(server => toKey(server.name) === key);
+    const wasSeeded = key in state;
+
+    if (!wasSeeded) {
+      // A server the user created under this name is theirs, not ours to adopt.
+      if (index !== -1) continue;
+      servers.push(builtin);
+      nextState[key] = toDefinition(builtin);
+      enabled = true;
+      changed = true;
+      continue;
+    }
+
+    // Seeded before but no longer present: the user deleted it, so keep it gone.
+    if (index === -1) continue;
+
+    const existing = servers[index];
+    const lastWritten = state[key];
+    if (lastWritten !== null && !isSameDefinition(toDefinition(existing), lastWritten)) {
+      continue;
+    }
+
+    const refreshed: MCPServer = { ...existing, ...toDefinition(builtin) };
+    nextState[key] = toDefinition(refreshed);
+    if (isSameDefinition(toDefinition(existing), toDefinition(refreshed))) continue;
+
+    servers[index] = refreshed;
+    changed = true;
+  }
+
+  return changed
+    ? { config: { enabled, servers }, state: nextState, changed }
+    : { config, state: nextState, changed };
+}

--- a/ai-assistant/packages/ai-common/src/mcp/config/builtinServers.ts
+++ b/ai-assistant/packages/ai-common/src/mcp/config/builtinServers.ts
@@ -74,12 +74,21 @@ export interface BuiltinServerDefinition {
 }
 
 /**
- * Records the definition last written for each built-in server name.
+ * Records the definition last written for each built-in server, keyed by its
+ * name trimmed and lowercased.
  *
  * A `null` value means the server was seeded by an older version that did not
  * record its definition, so customization cannot be detected.
  */
 export type BuiltinServerState = Record<string, BuiltinServerDefinition | null>;
+
+/**
+ * Reconciliation state as it may exist on disk.
+ *
+ * Installs seeded before definitions were recorded persisted a plain list of
+ * server names; {@link reconcileBuiltinServers} upgrades those on the next run.
+ */
+export type PersistedBuiltinServerState = BuiltinServerState | readonly string[];
 
 /** Outcome of reconciling built-in server definitions with stored config. */
 export interface ReconcileBuiltinServersResult {
@@ -96,12 +105,22 @@ function toKey(name: string): string {
   return name.trim().toLowerCase();
 }
 
+/** @returns Whether two environments hold the same variables, whatever their key order. */
+function isSameEnv(a: Record<string, string> = {}, b: Record<string, string> = {}): boolean {
+  const aKeys = Object.keys(a).sort();
+  const bKeys = Object.keys(b).sort();
+  return (
+    aKeys.length === bKeys.length && aKeys.every((key, i) => key === bKeys[i] && a[key] === b[key])
+  );
+}
+
 /** @returns Whether two definitions describe the same server process. */
 function isSameDefinition(a: BuiltinServerDefinition, b: BuiltinServerDefinition): boolean {
   return (
     a.command === b.command &&
-    JSON.stringify(a.args) === JSON.stringify(b.args) &&
-    JSON.stringify(a.env ?? {}) === JSON.stringify(b.env ?? {})
+    a.args.length === b.args.length &&
+    a.args.every((arg, i) => arg === b.args[i]) &&
+    isSameEnv(a.env, b.env)
   );
 }
 
@@ -110,8 +129,19 @@ function toDefinition({ command, args, env }: MCPServer): BuiltinServerDefinitio
   return env === undefined ? { command, args } : { command, args, env };
 }
 
+/** @returns The server with plugin-owned fields replaced, dropping an env the built-in no longer sets. */
+function applyDefinition(existing: MCPServer, definition: BuiltinServerDefinition): MCPServer {
+  const refreshed: MCPServer = { ...existing, command: definition.command, args: definition.args };
+  if (definition.env === undefined) {
+    delete refreshed.env;
+  } else {
+    refreshed.env = definition.env;
+  }
+  return refreshed;
+}
+
 /** @returns Previously seeded state, upgrading the legacy name-list format. */
-function normalizeState(previous: readonly string[] | BuiltinServerState): BuiltinServerState {
+function normalizeState(previous: PersistedBuiltinServerState): BuiltinServerState {
   const entries = Array.isArray(previous)
     ? previous.map(name => [toKey(name), null] as const)
     : Object.entries(previous).map(([name, definition]) => [toKey(name), definition] as const);
@@ -134,7 +164,7 @@ function normalizeState(previous: readonly string[] | BuiltinServerState): Built
 export function reconcileBuiltinServers(
   config: MCPSettings,
   builtinServers: MCPServer[],
-  previousState: readonly string[] | BuiltinServerState = {}
+  previousState: PersistedBuiltinServerState = {}
 ): ReconcileBuiltinServersResult {
   const state = normalizeState(previousState);
   const nextState: BuiltinServerState = { ...state };
@@ -166,11 +196,11 @@ export function reconcileBuiltinServers(
       continue;
     }
 
-    const refreshed: MCPServer = { ...existing, ...toDefinition(builtin) };
-    nextState[key] = toDefinition(refreshed);
-    if (isSameDefinition(toDefinition(existing), toDefinition(refreshed))) continue;
+    const definition = toDefinition(builtin);
+    nextState[key] = definition;
+    if (isSameDefinition(toDefinition(existing), definition)) continue;
 
-    servers[index] = refreshed;
+    servers[index] = applyDefinition(existing, definition);
     changed = true;
   }
 

--- a/ai-assistant/packages/ai-common/src/skills/builtinSources.test.ts
+++ b/ai-assistant/packages/ai-common/src/skills/builtinSources.test.ts
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  AKS_SKILLS_PATH,
+  AKS_SKILLS_REF,
+  AKS_SKILLS_REPO_URL,
+  AKS_SKILLS_SHA256,
+  createAksSkillsSource,
+  reconcileBuiltinSkillSources,
+} from './builtinSources';
+import { DEFAULT_SKILLS_CONFIG, getSkillSourceIdentity, SkillsConfig } from './config';
+import { isPinnedRef, isValidGitUrl } from './SkillLoader';
+
+const IDENTITY = getSkillSourceIdentity({
+  type: 'git',
+  url: AKS_SKILLS_REPO_URL,
+  path: AKS_SKILLS_PATH,
+});
+
+function emptyConfig(): SkillsConfig {
+  return { ...DEFAULT_SKILLS_CONFIG, sources: [] };
+}
+
+describe('createAksSkillsSource', () => {
+  it('targets only the AKS subdirectory of the Azure skill collection', () => {
+    const source = createAksSkillsSource();
+    expect(isValidGitUrl(source.url)).toBe(true);
+    expect(source.path).toBe('skills/azure-kubernetes');
+    expect(source.enabled).toBe(true);
+  });
+
+  it('pins an immutable ref with an integrity hash', () => {
+    const source = createAksSkillsSource();
+    expect(isPinnedRef(source.ref!)).toBe(true);
+    expect(source.sha256).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe('reconcileBuiltinSkillSources', () => {
+  it('adds the built-in source on a fresh configuration', () => {
+    const result = reconcileBuiltinSkillSources(emptyConfig(), [createAksSkillsSource()]);
+
+    expect(result.changed).toBe(true);
+    expect(result.config.sources).toEqual([createAksSkillsSource()]);
+    expect(result.state[IDENTITY]).toEqual({ ref: AKS_SKILLS_REF, sha256: AKS_SKILLS_SHA256 });
+  });
+
+  it('reports no change when the source is already current', () => {
+    const config: SkillsConfig = { ...emptyConfig(), sources: [createAksSkillsSource()] };
+    const result = reconcileBuiltinSkillSources(config, [createAksSkillsSource()], {
+      [IDENTITY]: { ref: AKS_SKILLS_REF, sha256: AKS_SKILLS_SHA256 },
+    });
+
+    expect(result.changed).toBe(false);
+    expect(result.config).toBe(config);
+  });
+
+  it('bumps a seeded source to a newer pinned ref', () => {
+    const config: SkillsConfig = {
+      ...emptyConfig(),
+      sources: [{ ...createAksSkillsSource(), ref: 'old-ref', sha256: 'old-hash', enabled: false }],
+    };
+
+    const result = reconcileBuiltinSkillSources(config, [createAksSkillsSource()], {
+      [IDENTITY]: { ref: 'old-ref', sha256: 'old-hash' },
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.config.sources[0]).toMatchObject({
+      ref: AKS_SKILLS_REF,
+      sha256: AKS_SKILLS_SHA256,
+      enabled: false,
+    });
+  });
+
+  it('leaves a seeded source alone once the user repinned it', () => {
+    const config: SkillsConfig = {
+      ...emptyConfig(),
+      sources: [{ ...createAksSkillsSource(), ref: 'user-ref', sha256: 'user-hash' }],
+    };
+
+    const result = reconcileBuiltinSkillSources(config, [createAksSkillsSource()], {
+      [IDENTITY]: { ref: 'old-ref', sha256: 'old-hash' },
+    });
+
+    expect(result.changed).toBe(false);
+    expect(result.config.sources[0].ref).toBe('user-ref');
+  });
+
+  it('does not restore a source the user removed', () => {
+    const result = reconcileBuiltinSkillSources(emptyConfig(), [createAksSkillsSource()], {
+      [IDENTITY]: { ref: AKS_SKILLS_REF, sha256: AKS_SKILLS_SHA256 },
+    });
+
+    expect(result.changed).toBe(false);
+    expect(result.config.sources).toEqual([]);
+  });
+
+  it('does not adopt a same-location source the user configured', () => {
+    const config: SkillsConfig = {
+      ...emptyConfig(),
+      sources: [{ type: 'git', url: AKS_SKILLS_REPO_URL, path: AKS_SKILLS_PATH, enabled: true }],
+    };
+
+    const result = reconcileBuiltinSkillSources(config, [createAksSkillsSource()]);
+
+    expect(result.changed).toBe(false);
+    expect(result.config.sources[0].ref).toBeUndefined();
+  });
+
+  it('preserves unrelated sources', () => {
+    const other = { type: 'local' as const, url: '/home/user/skills', enabled: true };
+    const config: SkillsConfig = { ...emptyConfig(), sources: [other] };
+
+    const result = reconcileBuiltinSkillSources(config, [createAksSkillsSource()]);
+
+    expect(result.config.sources).toHaveLength(2);
+    expect(result.config.sources[0]).toEqual(other);
+  });
+});

--- a/ai-assistant/packages/ai-common/src/skills/builtinSources.ts
+++ b/ai-assistant/packages/ai-common/src/skills/builtinSources.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getSkillSourceIdentity, SkillsConfig } from './config';
+import type { SkillSource } from './SkillLoader';
+
+/** Repository publishing the Microsoft-authored Azure skill collection. */
+export const AKS_SKILLS_REPO_URL = 'https://github.com/microsoft/azure-skills';
+
+/** Subdirectory holding the AKS skills, so the other Azure skills stay out. */
+export const AKS_SKILLS_PATH = 'skills/azure-kubernetes';
+
+/** Pinned commit of {@link AKS_SKILLS_REPO_URL}, matching {@link AKS_SKILLS_SHA256}. */
+export const AKS_SKILLS_REF = '66cd9273ed146a311699898596bc916711494481';
+
+/**
+ * Content hash of the markdown under {@link AKS_SKILLS_PATH} at {@link AKS_SKILLS_REF}.
+ *
+ * Recompute with `computeContentHash()` over the fetched files whenever the ref
+ * is bumped; the loader rejects the source when it fails to match.
+ */
+export const AKS_SKILLS_SHA256 = '227f6be516801a63e6ab5dbe9f65457d1c7c80ab59b71cbab89eb634b3a91520';
+
+/** @returns The AKS skill source preconfigured on AKS Desktop. */
+export function createAksSkillsSource(): SkillSource {
+  return {
+    type: 'git',
+    url: AKS_SKILLS_REPO_URL,
+    path: AKS_SKILLS_PATH,
+    ref: AKS_SKILLS_REF,
+    sha256: AKS_SKILLS_SHA256,
+    enabled: true,
+  };
+}
+
+/** Definition last written for one built-in skill source. */
+export interface BuiltinSkillSourceDefinition {
+  /** Pinned Git ref fetched for the source. */
+  ref?: string;
+  /** Expected content hash of the fetched skill files. */
+  sha256?: string;
+}
+
+/** Built-in skill source definitions last written, keyed by source identity. */
+export type BuiltinSkillSourceState = Record<string, BuiltinSkillSourceDefinition>;
+
+/** Outcome of reconciling built-in skill sources against persisted settings. */
+export interface ReconcileBuiltinSkillSourcesResult {
+  /** Settings to persist, unchanged by identity when nothing needed updating. */
+  config: SkillsConfig;
+  /** Definitions written for built-in sources, to persist alongside the settings. */
+  state: BuiltinSkillSourceState;
+  /** Whether the settings differ from the supplied ones. */
+  changed: boolean;
+}
+
+/** @returns Whether two built-in source definitions describe the same content. */
+function isSameDefinition(
+  a: BuiltinSkillSourceDefinition,
+  b: BuiltinSkillSourceDefinition
+): boolean {
+  return a.ref === b.ref && a.sha256 === b.sha256;
+}
+
+/** @returns The reconcilable fields of a skill source. */
+function toDefinition(source: SkillSource): BuiltinSkillSourceDefinition {
+  return { ref: source.ref, sha256: source.sha256 };
+}
+
+/**
+ * Adds built-in skill sources and keeps their pinned refs current.
+ *
+ * Sources the user removed are not restored, and sources the user retargeted or
+ * configured themselves are left alone, so seeding never fights manual edits.
+ *
+ * @param config - Persisted skills settings.
+ * @param builtinSources - Sources the host preconfigures.
+ * @param previousState - Definitions written on an earlier run.
+ * @returns Settings to persist, the definitions written, and whether anything changed.
+ */
+export function reconcileBuiltinSkillSources(
+  config: SkillsConfig,
+  builtinSources: readonly SkillSource[],
+  previousState: BuiltinSkillSourceState = {}
+): ReconcileBuiltinSkillSourcesResult {
+  const sources = [...config.sources];
+  const state: BuiltinSkillSourceState = { ...previousState };
+  let changed = false;
+
+  for (const builtin of builtinSources) {
+    const identity = getSkillSourceIdentity(builtin);
+    const definition = toDefinition(builtin);
+    const index = sources.findIndex(source => getSkillSourceIdentity(source) === identity);
+    const lastWritten = previousState[identity];
+    const seeded = identity in previousState;
+
+    if (index === -1) {
+      // A source that is gone after being seeded was removed by the user.
+      if (seeded) continue;
+      sources.push({ ...builtin });
+      state[identity] = definition;
+      changed = true;
+      continue;
+    }
+
+    // The user configured this repository themselves, so leave it untouched.
+    if (!seeded) continue;
+
+    const existing = toDefinition(sources[index]);
+    if (!isSameDefinition(existing, lastWritten)) continue;
+    if (isSameDefinition(existing, definition)) continue;
+
+    sources[index] = { ...sources[index], ...definition };
+    state[identity] = definition;
+    changed = true;
+  }
+
+  if (!changed) {
+    return { config, state, changed };
+  }
+
+  return { config: { ...config, sources }, state, changed };
+}

--- a/ai-assistant/packages/ai-common/src/skills/config.ts
+++ b/ai-assistant/packages/ai-common/src/skills/config.ts
@@ -59,6 +59,23 @@ function positiveNumberOr(value: unknown, fallback: number): number {
   return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : fallback;
 }
 
+const isForwardSlash = (char: string): boolean => char === '/';
+const isPathSeparator = (char: string): boolean => char === '/' || char === '\\';
+
+/** Character scan avoids the backtracking cost of anchored `+` separator regexes. */
+function trimTrailing(value: string, isSeparator: (char: string) => boolean): string {
+  let end = value.length;
+  while (end > 0 && isSeparator(value[end - 1])) end -= 1;
+  return value.slice(0, end);
+}
+
+/** Character scan avoids the backtracking cost of anchored `+` separator regexes. */
+function trimLeading(value: string, isSeparator: (char: string) => boolean): string {
+  let start = 0;
+  while (start < value.length && isSeparator(value[start])) start += 1;
+  return value.slice(start);
+}
+
 /**
  * Normalizes a filesystem path or Git URL used as a skill source location.
  *
@@ -71,20 +88,24 @@ export function normalizeSkillSourceUrl(value: string, type: SkillSource['type']
   if (type === 'git') {
     try {
       const parsed = new URL(trimmed);
-      const pathname = parsed.pathname.replace(/\/+$/, '').replace(/\.git$/i, '');
+      const pathname = trimTrailing(parsed.pathname, isForwardSlash).replace(/\.git$/i, '');
       return `${parsed.origin}${pathname}`;
     } catch {
-      return trimmed.replace(/\/+$/, '').replace(/\.git$/i, '');
+      return trimTrailing(trimmed, isForwardSlash).replace(/\.git$/i, '');
     }
   }
   return trimmed === '/' || /^[A-Za-z]:[\\/]?$/.test(trimmed)
     ? trimmed
-    : trimmed.replace(/[\\/]+$/, '');
+    : trimTrailing(trimmed, isPathSeparator);
 }
 
 /** @returns Canonical optional Git subdirectory without surrounding separators. */
 export function normalizeSkillSourcePath(value: string | undefined): string | undefined {
-  const normalized = value?.trim().replace(/^[\\/]+|[\\/]+$/g, '');
+  const trimmed = value?.trim();
+  const normalized =
+    trimmed === undefined
+      ? undefined
+      : trimLeading(trimTrailing(trimmed, isPathSeparator), isPathSeparator);
   return normalized || undefined;
 }
 

--- a/ai-assistant/packages/ai-common/src/tools/langchain/LangChainToolManager.test.ts
+++ b/ai-assistant/packages/ai-common/src/tools/langchain/LangChainToolManager.test.ts
@@ -617,6 +617,22 @@ describe('ToolManager — initializeMCPTools via constructor', () => {
     expect(mgr.getMCPTools()).toHaveLength(0);
   });
 
+  it('loads no tools when MCP is globally disabled', async () => {
+    const adapter = makeMCPAdapter({
+      getConfig: async () => ({
+        success: true,
+        config: {
+          enabled: false,
+          servers: [{ name: 'test-server', command: 'test', args: [], enabled: true }],
+        },
+      }),
+    });
+    const mgr = new LangChainToolManager({ mcpClient: adapter });
+    await mgr.waitForMCPToolsInitialization();
+    expect(mgr.areMCPToolsInitialized()).toBe(true);
+    expect(mgr.getMCPTools()).toHaveLength(0);
+  });
+
   it('filters out disabled tools (enabled:false)', async () => {
     const adapter = makeMCPAdapter({
       getToolsConfig: async () => ({

--- a/ai-assistant/packages/ai-common/src/tools/langchain/LangChainToolManager.ts
+++ b/ai-assistant/packages/ai-common/src/tools/langchain/LangChainToolManager.ts
@@ -153,6 +153,14 @@ export class LangChainToolManager {
       const serverConfigResponse = await this.mcpClient.getConfig();
       const configuredServerNames = new Set<string>();
 
+      // The global toggle wins: hosts keep per-tool metadata while MCP is off,
+      // so binding those tools would offer the model calls that always fail.
+      if (serverConfigResponse.success && serverConfigResponse.config?.enabled === false) {
+        this.mcpTools = [];
+        this.mcpToolsInitialized = true;
+        return;
+      }
+
       if (serverConfigResponse.success && serverConfigResponse.config?.servers) {
         for (const server of serverConfigResponse.config.servers) {
           if (server.enabled !== false && server.name) {

--- a/ai-assistant/packages/ai-ui/package.json
+++ b/ai-assistant/packages/ai-ui/package.json
@@ -53,6 +53,7 @@
     "./parsing/urlParsing": "./src/parsing/urlParsing.ts",
     "./parsing/yamlParser": "./src/parsing/yamlParser.ts",
     "./mcp/electron-client": "./src/mcp/electron-client.ts",
+    "./mcp/host": "./src/mcp/host.ts",
     "./types/electron": "./src/types/electron.d.ts",
     "./testing/i18nTestSetup": "./src/testing/i18nTestSetup.ts",
     "./i18n": "./src/i18n.ts"

--- a/ai-assistant/packages/ai-ui/src/mcp/electron-client.ts
+++ b/ai-assistant/packages/ai-ui/src/mcp/electron-client.ts
@@ -357,17 +357,24 @@ class ElectronMCPClient implements ToolClient {
   }
 }
 
+/**
+ * Shared Electron MCP client.
+ *
+ * The client resolves the bridge per call and holds no per-instance state, so
+ * every caller can share one instance instead of duplicating IPC wiring.
+ */
+const electronMCPClient = new ElectronMCPClient();
+
 // Export a function that returns enabled tools (compatible with existing interface)
 /**
- * Returns enabled Electron MCP tools using a new client instance.
+ * Returns enabled Electron MCP tools.
  *
  * @returns Enabled tools available through the Electron bridge.
  */
 const tools = async function (): Promise<ElectronMCPTool[]> {
-  const client = new ElectronMCPClient();
-  return client.getEnabledTools();
+  return electronMCPClient.getEnabledTools();
 };
 
 // Export both the client class and the tools function for flexibility
-export { ElectronMCPClient };
+export { ElectronMCPClient, electronMCPClient };
 export default tools;

--- a/ai-assistant/packages/ai-ui/src/mcp/host.ts
+++ b/ai-assistant/packages/ai-ui/src/mcp/host.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Identifies which desktop distribution the plugin is running inside.
+ *
+ * Detection is feature based rather than name based: AKS Desktop is the only
+ * host whose preload bridge exposes `registerAKSCluster`, and it also puts its
+ * bundled Azure tooling (`az`, `aks-mcp`) on the process `PATH`.
+ *
+ * @returns Whether the plugin is running inside AKS Desktop.
+ */
+export function isAksDesktopHost(): boolean {
+  if (typeof window === 'undefined') return false;
+  const desktopApi = window.desktopApi as { registerAKSCluster?: unknown } | undefined;
+  return typeof desktopApi?.registerAKSCluster === 'function';
+}

--- a/ai-assistant/src/components/appbar/HeadlampEventHandler.test.tsx
+++ b/ai-assistant/src/components/appbar/HeadlampEventHandler.test.tsx
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const registerHeadlampEventCallback = vi.fn();
+const setEvent = vi.fn();
+
+vi.mock('@kinvolk/headlamp-plugin/lib', () => ({
+  registerHeadlampEventCallback: (callback: unknown) => registerHeadlampEventCallback(callback),
+}));
+
+vi.mock('../../pluginState', () => ({
+  useGlobalState: () => ({ event: null, setEvent }),
+}));
+
+/** Renders the handler and returns the callback it registered. */
+async function getEventCallback() {
+  const { default: HeadlampEventHandler } = await import('./HeadlampEventHandler');
+  HeadlampEventHandler();
+  return registerHeadlampEventCallback.mock.calls.at(-1)![0] as (event: {
+    type: string;
+    data?: unknown;
+  }) => null;
+}
+
+const project = { id: 'my-project', namespaces: ['dev'], clusters: ['minikube'] };
+
+describe('HeadlampEventHandler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('stores the project list from the project list view event', async () => {
+    const callback = await getEventCallback();
+
+    callback({ type: 'headlamp.project-list-view', data: { projects: [project] } });
+
+    expect(setEvent).toHaveBeenCalledWith({
+      type: 'headlamp.project-list-view',
+      title: 'Projects',
+      projects: [project],
+    });
+  });
+
+  it('defaults to an empty project list when none are provided', async () => {
+    const callback = await getEventCallback();
+
+    callback({ type: 'headlamp.project-list-view', data: {} });
+
+    expect(setEvent).toHaveBeenCalledWith(expect.objectContaining({ projects: [] }));
+  });
+
+  it('stores the project and its resources from the project details view event', async () => {
+    const callback = await getEventCallback();
+    const resources = [{ kind: 'Pod', metadata: { name: 'api' } }];
+
+    callback({ type: 'headlamp.project-details-view', data: { project, resources } });
+
+    expect(setEvent).toHaveBeenCalledWith({
+      type: 'headlamp.project-details-view',
+      title: 'Project: my-project',
+      project,
+      resources,
+    });
+  });
+
+  it('tracks the selected and previous tab on tab change', async () => {
+    const callback = await getEventCallback();
+
+    callback({
+      type: 'headlamp.project-details-tab-change',
+      data: {
+        project,
+        tab: { id: 'workloads', label: 'Workloads' },
+        previousTab: { id: 'overview', label: 'Overview' },
+        resources: [],
+      },
+    });
+
+    expect(setEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'headlamp.project-details-tab-change',
+        projectTab: 'Workloads',
+        previousProjectTab: 'Overview',
+      })
+    );
+  });
+
+  it('falls back to the tab id when the label is not a string', async () => {
+    const callback = await getEventCallback();
+
+    callback({
+      type: 'headlamp.project-details-tab-change',
+      data: {
+        project,
+        tab: { id: 'workloads', label: React.createElement('span', null, 'Workloads') },
+        previousTab: { id: 'overview' },
+        resources: [],
+      },
+    });
+
+    expect(setEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ projectTab: 'workloads', previousProjectTab: 'overview' })
+    );
+  });
+
+  it('records project creation and deletion', async () => {
+    const callback = await getEventCallback();
+
+    callback({ type: 'headlamp.create-project', data: { project, status: 'CONFIRMED' } });
+    expect(setEvent).toHaveBeenCalledWith({
+      type: 'headlamp.create-project',
+      title: 'Project: my-project',
+      project,
+    });
+
+    callback({
+      type: 'headlamp.delete-project',
+      data: { project, deleteNamespaces: true, status: 'CONFIRMED' },
+    });
+    expect(setEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'headlamp.delete-project', deleteNamespaces: true })
+    );
+  });
+
+  it('ignores unrelated events', async () => {
+    const callback = await getEventCallback();
+
+    callback({ type: 'headlamp.plugins-loaded', data: {} });
+
+    expect(setEvent).not.toHaveBeenCalled();
+  });
+});

--- a/ai-assistant/src/components/appbar/HeadlampEventHandler.tsx
+++ b/ai-assistant/src/components/appbar/HeadlampEventHandler.tsx
@@ -1,8 +1,12 @@
 import { registerHeadlampEventCallback } from '@kinvolk/headlamp-plugin/lib';
-// @todo: this HeadlampEventType import is weird. Maybe fix in headlamp to be better.
-import { DefaultHeadlampEvents as HeadlampEventType } from '@kinvolk/headlamp-plugin/lib/plugin/registry';
 import type { HeadlampEventPayload } from '../../pluginState';
 import { useGlobalState } from '../../pluginState';
+
+const HEADLAMP_EVENT_TYPE = {
+  DETAILS_VIEW: 'headlamp.details-view',
+  LIST_VIEW: 'headlamp.list-view',
+  OBJECT_EVENTS: 'headlamp.object-events',
+} as const;
 
 /**
  * Headless component that registers Headlamp event callbacks.
@@ -31,18 +35,18 @@ export default function HeadlampEventHandler() {
         errors: data.errors,
       } as HeadlampEventPayload);
     }
-    if (event.type === HeadlampEventType.OBJECT_EVENTS) {
+    if (event.type === HEADLAMP_EVENT_TYPE.OBJECT_EVENTS) {
       _pluginState.setEvent({
         ..._pluginState.event,
-        type: HeadlampEventType.OBJECT_EVENTS,
+        type: HEADLAMP_EVENT_TYPE.OBJECT_EVENTS,
         objectEvent: prev.objectEvent,
         resources: data.resources,
         resourceKind: data.resourceKind,
       } as HeadlampEventPayload);
     }
-    if (event.type === HeadlampEventType.DETAILS_VIEW) {
+    if (event.type === HEADLAMP_EVENT_TYPE.DETAILS_VIEW) {
       _pluginState.setEvent({
-        type: HeadlampEventType.DETAILS_VIEW,
+        type: HEADLAMP_EVENT_TYPE.DETAILS_VIEW,
         title: data.title,
         resource: data.resource,
         objectEvent: prev.objectEvent,
@@ -50,9 +54,9 @@ export default function HeadlampEventHandler() {
         resourceKind: data.resourceKind,
       } as HeadlampEventPayload);
     }
-    if (event.type === HeadlampEventType.LIST_VIEW) {
+    if (event.type === HEADLAMP_EVENT_TYPE.LIST_VIEW) {
       _pluginState.setEvent({
-        type: HeadlampEventType.LIST_VIEW,
+        type: HEADLAMP_EVENT_TYPE.LIST_VIEW,
         title: data.title,
         resources: data.resources,
         resourceKind: data.resourceKind,

--- a/ai-assistant/src/components/appbar/HeadlampEventHandler.tsx
+++ b/ai-assistant/src/components/appbar/HeadlampEventHandler.tsx
@@ -1,19 +1,35 @@
 import { registerHeadlampEventCallback } from '@kinvolk/headlamp-plugin/lib';
-import type { HeadlampEventPayload } from '../../pluginState';
+import type { HeadlampEventPayload, ProjectSummary } from '../../pluginState';
 import { useGlobalState } from '../../pluginState';
 
 const HEADLAMP_EVENT_TYPE = {
   DETAILS_VIEW: 'headlamp.details-view',
   LIST_VIEW: 'headlamp.list-view',
   OBJECT_EVENTS: 'headlamp.object-events',
+  PROJECT_LIST_VIEW: 'headlamp.project-list-view',
+  PROJECT_DETAILS_VIEW: 'headlamp.project-details-view',
+  PROJECT_DETAILS_TAB_CHANGE: 'headlamp.project-details-tab-change',
+  CREATE_PROJECT: 'headlamp.create-project',
+  DELETE_PROJECT: 'headlamp.delete-project',
 } as const;
+
+/** Tab labels can be React nodes, so fall back to the serializable tab id. */
+function projectTabName(tab: unknown): string | undefined {
+  const { id, label } = (tab ?? {}) as { id?: string; label?: unknown };
+  return typeof label === 'string' ? label : id;
+}
+
+function projectTitle(project: ProjectSummary | undefined): string {
+  return project?.id ? `Project: ${project.id}` : 'Project';
+}
 
 /**
  * Headless component that registers Headlamp event callbacks.
  *
  * Listens for page-level navigation events (home page loaded, object events,
- * details view, list view) and mirrors them into the plugin's global state so
- * the AI Assistant can generate context-aware prompts.
+ * details view, list view, and the project list/details/tab-change and
+ * create/delete events) and mirrors them into the plugin's global state so the
+ * AI Assistant can generate context-aware prompts.
  *
  * This component renders nothing (`null`); it exists solely for its side
  * effects.
@@ -62,6 +78,50 @@ export default function HeadlampEventHandler() {
         resourceKind: data.resourceKind,
         resource: data.resource,
         objectEvent: prev.objectEvent,
+      } as HeadlampEventPayload);
+    }
+    if (event.type === HEADLAMP_EVENT_TYPE.PROJECT_LIST_VIEW) {
+      _pluginState.setEvent({
+        type: HEADLAMP_EVENT_TYPE.PROJECT_LIST_VIEW,
+        title: 'Projects',
+        projects: (data.projects ?? []) as ProjectSummary[],
+      } as HeadlampEventPayload);
+    }
+    if (event.type === HEADLAMP_EVENT_TYPE.PROJECT_DETAILS_VIEW) {
+      const project = data.project as ProjectSummary | undefined;
+      _pluginState.setEvent({
+        type: HEADLAMP_EVENT_TYPE.PROJECT_DETAILS_VIEW,
+        title: projectTitle(project),
+        project,
+        resources: data.resources,
+      } as HeadlampEventPayload);
+    }
+    if (event.type === HEADLAMP_EVENT_TYPE.PROJECT_DETAILS_TAB_CHANGE) {
+      const project = data.project as ProjectSummary | undefined;
+      _pluginState.setEvent({
+        type: HEADLAMP_EVENT_TYPE.PROJECT_DETAILS_TAB_CHANGE,
+        title: projectTitle(project),
+        project,
+        projectTab: projectTabName(data.tab),
+        previousProjectTab: projectTabName(data.previousTab),
+        resources: data.resources,
+      } as HeadlampEventPayload);
+    }
+    if (event.type === HEADLAMP_EVENT_TYPE.CREATE_PROJECT) {
+      const project = data.project as ProjectSummary | undefined;
+      _pluginState.setEvent({
+        type: HEADLAMP_EVENT_TYPE.CREATE_PROJECT,
+        title: projectTitle(project),
+        project,
+      } as HeadlampEventPayload);
+    }
+    if (event.type === HEADLAMP_EVENT_TYPE.DELETE_PROJECT) {
+      const project = data.project as ProjectSummary | undefined;
+      _pluginState.setEvent({
+        type: HEADLAMP_EVENT_TYPE.DELETE_PROJECT,
+        title: projectTitle(project),
+        project,
+        deleteNamespaces: data.deleteNamespaces as boolean | undefined,
       } as HeadlampEventPayload);
     }
     return null;

--- a/ai-assistant/src/index.tsx
+++ b/ai-assistant/src/index.tsx
@@ -41,8 +41,10 @@ import Settings from './components/settings/Settings';
 import type { RawK8sEvent } from './kubernetes/EventFetcher';
 import { seedBuiltinMCPServers } from './mcp/seedBuiltinServers';
 import { PLUGIN_NAME, useGlobalState, usePluginConfig } from './pluginState';
+import { seedBuiltinSkillSources } from './skills/seedBuiltinSources';
 
 void seedBuiltinMCPServers();
+seedBuiltinSkillSources();
 
 // Register UI Panel component that uses the shared state to show/hide
 registerUIPanel({

--- a/ai-assistant/src/index.tsx
+++ b/ai-assistant/src/index.tsx
@@ -39,7 +39,10 @@ import HeadlampEventHandler from './components/appbar/HeadlampEventHandler';
 import AIPanelComponent from './components/panel/AIPanelComponent';
 import Settings from './components/settings/Settings';
 import type { RawK8sEvent } from './kubernetes/EventFetcher';
+import { seedBuiltinMCPServers } from './mcp/seedBuiltinServers';
 import { PLUGIN_NAME, useGlobalState, usePluginConfig } from './pluginState';
+
+void seedBuiltinMCPServers();
 
 // Register UI Panel component that uses the shared state to show/hide
 registerUIPanel({

--- a/ai-assistant/src/mcp/seedBuiltinServers.ts
+++ b/ai-assistant/src/mcp/seedBuiltinServers.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  createAksMcpServer,
+  reconcileBuiltinServers,
+} from '@headlamp-k8s/ai-common/mcp/config/builtinServers';
+import type { MCPServer, MCPSettings } from '@headlamp-k8s/ai-common/mcp/types';
+import { isAksDesktopHost } from '@headlamp-k8s/ai-ui/mcp/host';
+import { pluginStore } from '../pluginState';
+
+const EMPTY_MCP_CONFIG: MCPSettings = { enabled: false, servers: [] };
+
+/** @returns Built-in MCP servers the current desktop host preconfigures. */
+function getBuiltinServersForHost(): MCPServer[] {
+  return isAksDesktopHost() ? [createAksMcpServer()] : [];
+}
+
+/**
+ * Preconfigures host-provided MCP servers and keeps their definitions current.
+ *
+ * @returns Resolves once reconciliation has been attempted.
+ */
+export async function seedBuiltinMCPServers(): Promise<void> {
+  const builtinServers = getBuiltinServersForHost();
+  if (builtinServers.length === 0) return;
+
+  const mcpApi = typeof window === 'undefined' ? undefined : window.desktopApi?.mcp;
+  if (!mcpApi) return;
+
+  try {
+    const response = await mcpApi.getConfig();
+    const currentConfig =
+      response?.success && Array.isArray(response.config?.servers)
+        ? (response.config as MCPSettings)
+        : EMPTY_MCP_CONFIG;
+
+    const previousState = pluginStore.get()?.seededBuiltinMCPServers;
+    const result = reconcileBuiltinServers(currentConfig, builtinServers, previousState);
+    if (!result.changed) return;
+
+    const updateResponse = await mcpApi.updateConfig(result.config);
+    if (!updateResponse?.success) {
+      console.error('Failed to preconfigure built-in MCP servers:', updateResponse?.error);
+      return;
+    }
+
+    pluginStore.update({
+      mcpConfig: result.config,
+      seededBuiltinMCPServers: result.state,
+    });
+  } catch (error) {
+    console.error('Error preconfiguring built-in MCP servers:', error);
+  }
+}

--- a/ai-assistant/src/mcp/seedBuiltinServers.ts
+++ b/ai-assistant/src/mcp/seedBuiltinServers.ts
@@ -43,14 +43,21 @@ export async function seedBuiltinMCPServers(): Promise<void> {
 
   try {
     const response = await mcpApi.getConfig();
-    const currentConfig =
-      response?.success && Array.isArray(response.config?.servers)
-        ? (response.config as MCPSettings)
-        : EMPTY_MCP_CONFIG;
+    // Seeding against a fallback config would drop servers the read failed to return.
+    if (!response?.success || !Array.isArray(response.config?.servers)) {
+      console.error('Failed to read MCP configuration before seeding:', response?.error);
+      return;
+    }
+    const currentConfig = { ...EMPTY_MCP_CONFIG, ...response.config } as MCPSettings;
 
     const previousState = pluginStore.get()?.seededBuiltinMCPServers;
     const result = reconcileBuiltinServers(currentConfig, builtinServers, previousState);
-    if (!result.changed) return;
+    if (!result.changed) {
+      if (result.stateChanged) {
+        pluginStore.update({ seededBuiltinMCPServers: result.state });
+      }
+      return;
+    }
 
     const updateResponse = await mcpApi.updateConfig(result.config);
     if (!updateResponse?.success) {

--- a/ai-assistant/src/modal.tsx
+++ b/ai-assistant/src/modal.tsx
@@ -34,7 +34,7 @@ import type { ChatMode } from '@headlamp-k8s/ai-ui/components/assistant/AllInput
 import HolmesSetupGuide from '@headlamp-k8s/ai-ui/components/assistant/HolmesSetupGuide';
 import { PromptSuggestions } from '@headlamp-k8s/ai-ui/components/assistant/PromptSuggestions';
 import ApiConfirmationDialog from '@headlamp-k8s/ai-ui/components/common/ApiConfirmationDialog';
-import { ElectronMCPClient } from '@headlamp-k8s/ai-ui/mcp/electron-client';
+import { electronMCPClient } from '@headlamp-k8s/ai-ui/mcp/electron-client';
 import {
   getProviderModels,
   parseSuggestionsFromResponse,
@@ -601,7 +601,7 @@ export default function AIPrompt(props: {
           enabledTools,
           pluginSettings?.devOptions?.enableMockTools
             ? { toolManager: createMockKubernetesToolManager() }
-            : { mcpClient: new ElectronMCPClient() }
+            : { mcpClient: electronMCPClient }
         );
         setAiManager(newManager);
       } catch (error: unknown) {
@@ -684,7 +684,7 @@ export default function AIPrompt(props: {
             enabledTools,
             pluginSettings?.devOptions?.enableMockTools
               ? { toolManager: createMockKubernetesToolManager() }
-              : { mcpClient: new ElectronMCPClient() }
+              : { mcpClient: electronMCPClient }
           );
           // LangChain doesn't stream intermediate events, so just report start/end
           onStep?.({

--- a/ai-assistant/src/modal.tsx
+++ b/ai-assistant/src/modal.tsx
@@ -34,6 +34,7 @@ import type { ChatMode } from '@headlamp-k8s/ai-ui/components/assistant/AllInput
 import HolmesSetupGuide from '@headlamp-k8s/ai-ui/components/assistant/HolmesSetupGuide';
 import { PromptSuggestions } from '@headlamp-k8s/ai-ui/components/assistant/PromptSuggestions';
 import ApiConfirmationDialog from '@headlamp-k8s/ai-ui/components/common/ApiConfirmationDialog';
+import { ElectronMCPClient } from '@headlamp-k8s/ai-ui/mcp/electron-client';
 import {
   getProviderModels,
   parseSuggestionsFromResponse,
@@ -600,7 +601,7 @@ export default function AIPrompt(props: {
           enabledTools,
           pluginSettings?.devOptions?.enableMockTools
             ? { toolManager: createMockKubernetesToolManager() }
-            : undefined
+            : { mcpClient: new ElectronMCPClient() }
         );
         setAiManager(newManager);
       } catch (error: unknown) {
@@ -683,7 +684,7 @@ export default function AIPrompt(props: {
             enabledTools,
             pluginSettings?.devOptions?.enableMockTools
               ? { toolManager: createMockKubernetesToolManager() }
-              : undefined
+              : { mcpClient: new ElectronMCPClient() }
           );
           // LangChain doesn't stream intermediate events, so just report start/end
           onStep?.({

--- a/ai-assistant/src/pluginState.tsx
+++ b/ai-assistant/src/pluginState.tsx
@@ -133,6 +133,19 @@ export function initializeToolsState(pluginSettings: unknown) {
 //   };
 // }
 
+/**
+ * Headlamp project shape, mirrored locally because @kinvolk/headlamp-plugin
+ * does not export the project event types.
+ */
+export interface ProjectSummary {
+  /** Project identifier, also used as its display name. */
+  id: string;
+  /** Namespaces that belong to the project. */
+  namespaces: string[];
+  /** Clusters the project spans. */
+  clusters: string[];
+}
+
 export type HeadlampEventPayload =
   | {
       type: 'headlamp.home-page-loaded';
@@ -141,6 +154,36 @@ export type HeadlampEventPayload =
       clusters: any;
       errors: any;
       resource?: EventListEvent['data']['resource'];
+      resources?: any;
+      resourceKind?: string;
+      objectEvent?: any;
+    }
+  | {
+      type: 'headlamp.project-list-view';
+      title?: string;
+      items?: any[];
+      projects: ProjectSummary[];
+      resource?: any;
+      resources?: any;
+      resourceKind?: string;
+      objectEvent?: any;
+    }
+  | {
+      type:
+        | 'headlamp.project-details-view'
+        | 'headlamp.project-details-tab-change'
+        | 'headlamp.create-project'
+        | 'headlamp.delete-project';
+      title?: string;
+      items?: any[];
+      project: ProjectSummary;
+      /** Selected tab in the project details view. */
+      projectTab?: string;
+      /** Tab that was selected before the current one. */
+      previousProjectTab?: string;
+      /** Whether project namespaces were deleted along with the project. */
+      deleteNamespaces?: boolean;
+      resource?: any;
       resources?: any;
       resourceKind?: string;
       objectEvent?: any;

--- a/ai-assistant/src/pluginState.tsx
+++ b/ai-assistant/src/pluginState.tsx
@@ -19,6 +19,8 @@ import {
   SavedConfigurations,
   StoredProviderConfig,
 } from '@headlamp-k8s/ai-common/providers/savedConfigs';
+import type { BuiltinSkillSourceState } from '@headlamp-k8s/ai-common/skills/builtinSources';
+import type { SkillsConfig } from '@headlamp-k8s/ai-common/skills/config';
 import {
   getAllAvailableToolsIncludingMCP as discoverAllAvailableToolsIncludingMCP,
   getEnabledToolIdsIncludingMCP as discoverEnabledToolIdsIncludingMCP,
@@ -194,6 +196,10 @@ export interface PluginConfig extends SavedConfigurations {
   mcpConfig?: MCPConfig;
   /** Definitions last written for host-provided built-in MCP servers, keyed by name. */
   seededBuiltinMCPServers?: BuiltinServerState;
+  /** Skills configuration */
+  skills?: SkillsConfig;
+  /** Definitions last written for host-provided built-in skill sources, keyed by identity. */
+  seededBuiltinSkillSources?: BuiltinSkillSourceState;
   /** Is the AI Assistant preview enabled? Disabled by default. */
   previewEnabled?: boolean;
   /** Is scheduled proactive diagnosis enabled? Disabled by default. */

--- a/ai-assistant/src/pluginState.tsx
+++ b/ai-assistant/src/pluginState.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { BuiltinServerState } from '@headlamp-k8s/ai-common/mcp/config/builtinServers';
+import type { PersistedBuiltinServerState } from '@headlamp-k8s/ai-common/mcp/config/builtinServers';
 import {
   SavedConfigurations,
   StoredProviderConfig,
@@ -194,8 +194,11 @@ export interface PluginConfig extends SavedConfigurations {
   enabledTools?: string[] | Record<string, boolean>;
   /** MCP configuration */
   mcpConfig?: MCPConfig;
-  /** Definitions last written for host-provided built-in MCP servers, keyed by name. */
-  seededBuiltinMCPServers?: BuiltinServerState;
+  /**
+   * Definitions last written for host-provided built-in MCP servers, keyed by
+   * trimmed lowercase server name. Older installs persisted a plain name list.
+   */
+  seededBuiltinMCPServers?: PersistedBuiltinServerState;
   /** Skills configuration */
   skills?: SkillsConfig;
   /** Definitions last written for host-provided built-in skill sources, keyed by identity. */

--- a/ai-assistant/src/pluginState.tsx
+++ b/ai-assistant/src/pluginState.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { BuiltinServerState } from '@headlamp-k8s/ai-common/mcp/config/builtinServers';
 import {
   SavedConfigurations,
   StoredProviderConfig,
@@ -191,6 +192,8 @@ export interface PluginConfig extends SavedConfigurations {
   enabledTools?: string[] | Record<string, boolean>;
   /** MCP configuration */
   mcpConfig?: MCPConfig;
+  /** Definitions last written for host-provided built-in MCP servers, keyed by name. */
+  seededBuiltinMCPServers?: BuiltinServerState;
   /** Is the AI Assistant preview enabled? Disabled by default. */
   previewEnabled?: boolean;
   /** Is scheduled proactive diagnosis enabled? Disabled by default. */

--- a/ai-assistant/src/prompts/promptGenerator.test.ts
+++ b/ai-assistant/src/prompts/promptGenerator.test.ts
@@ -120,6 +120,38 @@ describe('generatePrompts', () => {
     expect(result[2]).toBe('What pods need my attention?');
   });
 
+  it('returns project prompts when a project is in context', async () => {
+    const { generatePrompts } = await loadGeneratePrompts();
+    const result = generatePrompts({ project: { id: 'my-project' } });
+    expect(result).toHaveLength(3);
+    expect(result[0]).toBe('Is everything healthy in this project?');
+    expect(result[1]).toBe('Summarize the resources in this project');
+    expect(result[2]).toBe('What pods need my attention?');
+  });
+
+  it('returns a tab-specific prompt when a project tab is selected', async () => {
+    const { generatePrompts } = await loadGeneratePrompts();
+    const result = generatePrompts({ project: { id: 'my-project' }, projectTab: 'Workloads' });
+    expect(result[2]).toBe('What should I check in the Workloads tab?');
+  });
+
+  it('returns project list prompts when projects are in context', async () => {
+    const { generatePrompts } = await loadGeneratePrompts();
+    const result = generatePrompts({ projects: [{ id: 'alpha' }] });
+    expect(result).toHaveLength(3);
+    expect(result[0]).toBe('Which projects need my attention?');
+    expect(result[1]).toBe('Summarize the status of these projects');
+  });
+
+  it('prioritizes project prompts over resource list prompts', async () => {
+    const { generatePrompts } = await loadGeneratePrompts();
+    const result = generatePrompts({
+      project: { id: 'my-project' },
+      resources: [{ kind: 'Pod' }],
+    });
+    expect(result[0]).toBe('Is everything healthy in this project?');
+  });
+
   it('prioritizes context prompts over base prompts', async () => {
     const { generatePrompts } = await loadGeneratePrompts();
     const result = generatePrompts({

--- a/ai-assistant/src/prompts/promptGenerator.ts
+++ b/ai-assistant/src/prompts/promptGenerator.ts
@@ -7,6 +7,9 @@ export interface PromptEvent {
   resource?: { kind?: string; [key: string]: unknown };
   resources?: Array<{ kind?: string; [key: string]: unknown }>;
   objectEvent?: { events?: unknown[] };
+  project?: { id?: string; [key: string]: unknown };
+  projects?: unknown[];
+  projectTab?: string;
 }
 
 /**
@@ -28,6 +31,20 @@ export function generatePrompts(event: PromptEvent | null | undefined): string[]
 
   // Context-specific prompts
   const contextPrompts: string[] = [];
+
+  if (event?.project) {
+    contextPrompts.push('Is everything healthy in this project?');
+    contextPrompts.push('Summarize the resources in this project');
+
+    if (event.projectTab) {
+      contextPrompts.push(`What should I check in the ${event.projectTab} tab?`);
+    }
+  }
+
+  if (event?.projects && Array.isArray(event.projects)) {
+    contextPrompts.push('Which projects need my attention?');
+    contextPrompts.push('Summarize the status of these projects');
+  }
 
   if (event?.resource) {
     const resource = event.resource;

--- a/ai-assistant/src/skills/seedBuiltinSources.ts
+++ b/ai-assistant/src/skills/seedBuiltinSources.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  createAksSkillsSource,
+  reconcileBuiltinSkillSources,
+} from '@headlamp-k8s/ai-common/skills/builtinSources';
+import { getSkillsConfig } from '@headlamp-k8s/ai-common/skills/config';
+import type { SkillSource } from '@headlamp-k8s/ai-common/skills/SkillLoader';
+import { isAksDesktopHost } from '@headlamp-k8s/ai-ui/mcp/host';
+import { pluginStore } from '../pluginState';
+
+/** @returns Skill sources the current desktop host preconfigures. */
+function getBuiltinSourcesForHost(): SkillSource[] {
+  return isAksDesktopHost() ? [createAksSkillsSource()] : [];
+}
+
+/** Preconfigures host-provided skill sources and keeps their pinned refs current. */
+export function seedBuiltinSkillSources(): void {
+  const builtinSources = getBuiltinSourcesForHost();
+  if (builtinSources.length === 0) return;
+
+  try {
+    const stored = pluginStore.get();
+    const result = reconcileBuiltinSkillSources(
+      getSkillsConfig(stored),
+      builtinSources,
+      stored?.seededBuiltinSkillSources
+    );
+    if (!result.changed) return;
+
+    pluginStore.update({
+      skills: result.config,
+      seededBuiltinSkillSources: result.state,
+    });
+  } catch (error) {
+    console.error('Error preconfiguring built-in skill sources:', error);
+  }
+}


### PR DESCRIPTION
## What this does

Makes the AI assistant useful out of the box on AKS Desktop by preconfiguring the
`aks-mcp` MCP server and the AKS skills, and by actually binding discovered MCP
tools to the chat model.

The AKS Desktop distribution ships the `aks-mcp` binary on `PATH`, so the plugin
can offer it without asking the user to configure anything. The host is detected
by feature-testing `desktopApi.registerAKSCluster`, which vanilla Headlamp does
not expose, so nothing changes for other hosts.

## Changes

**Preconfigure the `aks-mcp` server** (`packages/ai-common/src/mcp/config/builtinServers.ts`,
`src/mcp/seedBuiltinServers.ts`)

- Registers the server on startup when running in AKS Desktop.
- Only components that need no extra CLI binary are enabled. `aks-mcp` validates
  every enabled component at startup and exits when its CLI is missing, so the
  default set of all components fails on a machine without `cilium`/`hubble`.
  `kubectl`, `helm`, `cilium` and `hubble` stay opt-in via MCP settings.
- Runs with `--access-level readonly`.

**Preconfigure the AKS skills** (`packages/ai-common/src/skills/builtinSources.ts`,
`src/skills/seedBuiltinSources.ts`)

- Seeds the skills from `microsoft/azure-skills`, filtered to the
  `skills/azure-kubernetes` subtree so the rest of the Azure collection stays
  out. The source is pinned to a commit with the content hash the loader
  verifies.

**Reconciliation, shared by both**

- The plugin records the definition it last wrote, not just the name, so later
  changes to a built-in reach installs that were already seeded.
- Anything the user edited, deleted, repinned, or created themselves under the
  same name is left untouched, and the `enabled`/`autoApprove` toggles always
  belong to the user.
- Seeding is skipped entirely when the stored configuration cannot be read, so a
  transient read failure cannot reconcile against an empty config and drop the
  user's servers.

**Bind discovered MCP tools to the chat model**
(`packages/ai-common/src/assistant/LangChainAssistantSession.ts`)

- The assistant session always constructed its tool manager without an MCP
  bridge, so the manager fell back to `NullToolClient`, discovery was skipped,
  and the model only ever saw the built-in `kubernetes_api_request` tool. The
  settings dialog worked because it builds its own client.
- Adds an `mcpClient` option forwarded to `LangChainToolManager`, and passes a
  shared `ElectronMCPClient` from the plugin. The client reports itself
  unavailable outside Electron, so non-desktop hosts keep the previous
  behaviour.
- Tool discovery now returns early when the global MCP toggle is off, since the
  host keeps per-tool metadata around and those tools would always fail to run.

**Project events in the assistant context**
(`src/components/appbar/HeadlampEventHandler.tsx`, `src/prompts/promptGenerator.ts`)

- Mirrors Headlamp's project events (list view, details view, details tab
  change, project create/delete) into plugin state so the assistant knows which
  project, namespaces, clusters and tab the user is looking at, and suggests
  project-aware prompts.

## Testing

Unit tests cover reconciliation (first seed, refresh, user customization,
deletion, legacy state migration, env comparison), MCP tool discovery including
the globally-disabled path, host detection, the project event handler, and the
prompt suggestions.
