### PR TITLE
Kueue: add relational navigation for queues and workloads

### DIFF
--- a/kueue/src/components/clusterqueues/Detail.tsx
+++ b/kueue/src/components/clusterqueues/Detail.tsx
@@ -14,6 +14,10 @@ import {
 } from '../../resources/clusterQueue';
 import { kueueRouteNames } from '../../utils/kueueRoutes';
 import KueueAdminResourceAccess from '../common/KueueAdminResourceAccess';
+import {
+  RelatedLocalQueuesSection,
+  RelatedWorkloadsSection,
+} from '../common/RelatedResources';
 
 /** Flattened row rendered in the ClusterQueue resource groups table. */
 interface ResourceGroupRow {
@@ -369,6 +373,16 @@ export default function ClusterQueueDetail() {
                   'flavor-usage',
                   clusterQueue.status.flavorsUsage
                 ),
+                {
+                  id: 'related-local-queues',
+                  section: (
+                    <RelatedLocalQueuesSection clusterQueueName={clusterQueue.metadata.name} />
+                  ),
+                },
+                {
+                  id: 'related-workloads',
+                  section: <RelatedWorkloadsSection clusterQueueName={clusterQueue.metadata.name} />,
+                },
               ].filter(Boolean)
             : []
         }

--- a/kueue/src/components/common/RelatedResources.tsx
+++ b/kueue/src/components/common/RelatedResources.tsx
@@ -1,0 +1,162 @@
+import {
+  Link,
+  Loader,
+  SectionBox,
+  SimpleTable,
+} from '@kinvolk/headlamp-plugin/lib/components/common';
+import { useMemo } from 'react';
+import { LocalQueue } from '../../resources/localQueue';
+import { Workload } from '../../resources/workload';
+import { kueueRouteNames } from '../../utils/kueueRoutes';
+
+interface RelatedLocalQueuesSectionProps {
+  clusterQueueName: string;
+}
+
+interface RelatedWorkloadsSectionProps {
+  clusterQueueName?: string;
+  localQueueName?: string;
+  namespace?: string;
+}
+
+/** List the LocalQueues backed by a ClusterQueue. */
+export function RelatedLocalQueuesSection({
+  clusterQueueName,
+}: RelatedLocalQueuesSectionProps) {
+  const [localQueues, error] = LocalQueue.useList();
+
+  const relatedLocalQueues = useMemo(
+    () =>
+      (localQueues || []).filter(localQueue => localQueue.clusterQueueName === clusterQueueName),
+    [clusterQueueName, localQueues]
+  );
+
+  if (error) {
+    return null;
+  }
+
+  if (!localQueues) {
+    return <Loader title="Loading related LocalQueues..." />;
+  }
+
+  return (
+    <SectionBox title="Related LocalQueues">
+      <SimpleTable
+        data={relatedLocalQueues}
+        columns={[
+          {
+            label: 'Name',
+            getter: (localQueue: LocalQueue) => (
+              <Link kubeObject={localQueue}>{localQueue.metadata.name}</Link>
+            ),
+          },
+          {
+            label: 'Namespace',
+            getter: (localQueue: LocalQueue) => localQueue.metadata.namespace || '-',
+          },
+          {
+            label: 'Pending Workloads',
+            getter: (localQueue: LocalQueue) => localQueue.pendingWorkloads,
+          },
+          {
+            label: 'Admitted Workloads',
+            getter: (localQueue: LocalQueue) => localQueue.admittedWorkloads,
+          },
+          {
+            label: 'Status',
+            getter: (localQueue: LocalQueue) => localQueue.statusDisplay,
+          },
+        ]}
+      />
+    </SectionBox>
+  );
+}
+
+/** List Workloads related to either a ClusterQueue or a LocalQueue. */
+export function RelatedWorkloadsSection({
+  clusterQueueName,
+  localQueueName,
+  namespace,
+}: RelatedWorkloadsSectionProps) {
+  const [localQueues, localQueuesError] = LocalQueue.useList(
+    clusterQueueName ? undefined : { namespace }
+  );
+  const [workloads, workloadsError] = Workload.useList(namespace ? { namespace } : undefined);
+
+  const relatedWorkloads = useMemo(() => {
+    if (!workloads) {
+      return [];
+    }
+
+    if (localQueueName) {
+      return workloads.filter(workload => workload.queueName === localQueueName);
+    }
+
+    const relatedLocalQueueKeys = new Set(
+      (localQueues || [])
+        .filter(localQueue => localQueue.clusterQueueName === clusterQueueName)
+        .map(localQueue => `${localQueue.metadata.namespace}/${localQueue.metadata.name}`)
+    );
+
+    return workloads.filter(
+      workload =>
+        workload.admissionClusterQueue === clusterQueueName ||
+        relatedLocalQueueKeys.has(`${workload.metadata.namespace}/${workload.queueName}`)
+    );
+  }, [clusterQueueName, localQueueName, localQueues, workloads]);
+
+  if ((clusterQueueName && localQueuesError) || workloadsError) {
+    return null;
+  }
+
+  if ((clusterQueueName && !localQueues) || !workloads) {
+    return <Loader title="Loading related Workloads..." />;
+  }
+
+  return (
+    <SectionBox title="Related Workloads">
+      <SimpleTable
+        data={relatedWorkloads}
+        columns={[
+          {
+            label: 'Name',
+            getter: (workload: Workload) => (
+              <Link kubeObject={workload}>{workload.metadata.name}</Link>
+            ),
+          },
+          {
+            label: 'Namespace',
+            getter: (workload: Workload) => workload.metadata.namespace || '-',
+          },
+          {
+            label: 'LocalQueue',
+            getter: (workload: Workload) => {
+              const workloadNamespace = workload.metadata.namespace;
+
+              if (!workload.queueName || !workloadNamespace) {
+                return '-';
+              }
+
+              return (
+                <Link
+                  routeName={kueueRouteNames.localQueueDetail}
+                  params={{ namespace: workloadNamespace, name: workload.queueName }}
+                >
+                  {workload.queueName}
+                </Link>
+              );
+            },
+          },
+          {
+            label: 'Priority',
+            getter: (workload: Workload) => workload.priorityDisplay,
+          },
+          {
+            label: 'Status',
+            getter: (workload: Workload) => workload.statusDisplay,
+          },
+        ]}
+      />
+    </SectionBox>
+  );
+}

--- a/kueue/src/components/localqueues/Detail.tsx
+++ b/kueue/src/components/localqueues/Detail.tsx
@@ -7,6 +7,7 @@ import { useParams } from 'react-router-dom';
 import { LocalQueue } from '../../resources/localQueue';
 import { kueueRouteNames } from '../../utils/kueueRoutes';
 import KueueAdminResourceAccess from '../common/KueueAdminResourceAccess';
+import { RelatedWorkloadsSection } from '../common/RelatedResources';
 
 /** Render a ClusterQueue reference as a detail-page link. */
 function renderClusterQueueLink(localQueue: LocalQueue) {
@@ -81,7 +82,20 @@ export default function LocalQueueDetail() {
             : []
         }
         extraSections={localQueue =>
-          localQueue ? [getConditionsSection(localQueue)].filter(Boolean) : []
+          localQueue
+            ? [
+                getConditionsSection(localQueue),
+                {
+                  id: 'related-workloads',
+                  section: (
+                    <RelatedWorkloadsSection
+                      namespace={localQueue.metadata.namespace}
+                      localQueueName={localQueue.metadata.name}
+                    />
+                  ),
+                },
+              ].filter(Boolean)
+            : []
         }
       />
     </KueueAdminResourceAccess>


### PR DESCRIPTION
## Description

This PR adds relational navigation between Kueue resources, completing the core navigation flow:

**ClusterQueue → LocalQueues → Workloads**

Operators can now inspect the resources associated with a queue directly from its detail page instead of manually searching for them across separate views.

## Changes

* Added a **Related LocalQueues** table to the ClusterQueue detail page.
* Added a **Related Workloads** table to the ClusterQueue detail page.
* Added a **Related Workloads** table to the LocalQueue detail page.
* Made LocalQueue and Workload names clickable for direct navigation to their detail pages.
* Added namespace-aware filtering for namespaced resources.
* Included both:

  * Pending workloads associated through a LocalQueue.
  * Admitted workloads assigned directly to a ClusterQueue.
* Reused the existing Headlamp table and navigation patterns for consistent UX.

## Relationship flow

```text
ClusterQueue
├── LocalQueues
│   └── Workloads
└── Admitted Workloads
```

A ClusterQueue’s related workload list is determined using either:

* The workload’s admitted ClusterQueue assignment.
* The LocalQueue referenced by the workload when that LocalQueue targets the current ClusterQueue.

This ensures that pending workloads are not omitted simply because they have not yet been admitted.

## Why is this needed?

The Kueue plugin already exposes ClusterQueues, LocalQueues, and Workloads, but users previously had to locate related resources manually.

This change makes queue relationships directly inspectable and implements the relational-navigation requirement defined in the project scope.

## Validation

* TypeScript checks pass.
* ESLint passes.
* All existing tests pass (`22/22`).
