### PR TITLE
Kueue: Add relational navigation 

### DIFF
--- a/kueue/src/components/clusterqueues/Detail.tsx
+++ b/kueue/src/components/clusterqueues/Detail.tsx
@@ -9,6 +9,7 @@ import { ClusterQueue, FlavorUsage } from '../../resources/clusterQueue';
 import { getResourceGroupRows, ResourceGroupRow } from '../../resources/clusterQueueFormatters';
 import KueueAdminResourceAccess from '../common/KueueAdminResourceAccess';
 import { renderCohortLink, renderResourceFlavorLink } from '../common/KueueResourceLinks';
+import { RelatedLocalQueuesSection, RelatedWorkloadsSection } from '../common/RelatedResources';
 
 /** Flattened row rendered for status flavor reservations or flavor usage. */
 interface FlavorUsageRow {
@@ -293,6 +294,18 @@ export default function ClusterQueueDetail() {
                   'flavor-usage',
                   clusterQueue.status.flavorsUsage
                 ),
+                {
+                  id: 'related-local-queues',
+                  section: (
+                    <RelatedLocalQueuesSection clusterQueueName={clusterQueue.metadata.name} />
+                  ),
+                },
+                {
+                  id: 'related-workloads',
+                  section: (
+                    <RelatedWorkloadsSection clusterQueueName={clusterQueue.metadata.name} />
+                  ),
+                },
               ].filter(Boolean)
             : []
         }

--- a/kueue/src/components/common/RelatedResources.tsx
+++ b/kueue/src/components/common/RelatedResources.tsx
@@ -1,0 +1,242 @@
+import {
+  EmptyContent,
+  Link,
+  Loader,
+  SectionBox,
+  SimpleTable,
+} from '@kinvolk/headlamp-plugin/lib/components/common';
+import { useMemo } from 'react';
+import { LocalQueue } from '../../resources/localQueue';
+import { Workload } from '../../resources/workload';
+import { kueueRouteNames } from '../../utils/kueueRoutes';
+
+interface RelatedLocalQueuesSectionProps {
+  clusterQueueName: string;
+}
+
+interface RelatedWorkloadsSectionProps {
+  clusterQueueName?: string;
+  localQueueName?: string;
+  namespace?: string;
+}
+
+function getRelatedClusterQueueWorkloads(
+  clusterQueueName: string | undefined,
+  workloads: Workload[],
+  localQueues?: LocalQueue[] | null
+) {
+  if (!clusterQueueName) {
+    return [];
+  }
+
+  const relatedLocalQueueKeys = new Set(
+    (localQueues || [])
+      .filter(localQueue => localQueue.clusterQueueName === clusterQueueName)
+      .map(localQueue => `${localQueue.metadata.namespace}/${localQueue.metadata.name}`)
+  );
+
+  return workloads.filter(
+    workload =>
+      workload.admissionClusterQueue === clusterQueueName ||
+      relatedLocalQueueKeys.has(`${workload.metadata.namespace}/${workload.queueName}`)
+  );
+}
+
+function renderLoadError(title: string, resourceLabel: string) {
+  return (
+    <SectionBox title={title}>
+      <EmptyContent color="text.secondary">
+        Unable to load related {resourceLabel}. Check that you have access to list them.
+      </EmptyContent>
+    </SectionBox>
+  );
+}
+
+/** List the LocalQueues backed by a ClusterQueue. */
+export function RelatedLocalQueuesSection({ clusterQueueName }: RelatedLocalQueuesSectionProps) {
+  const [localQueues, error] = LocalQueue.useList();
+
+  const relatedLocalQueues = useMemo(
+    () =>
+      (localQueues || []).filter(localQueue => localQueue.clusterQueueName === clusterQueueName),
+    [clusterQueueName, localQueues]
+  );
+
+  if (error) {
+    return renderLoadError('Related LocalQueues', 'LocalQueues');
+  }
+
+  if (!localQueues) {
+    return <Loader title="Loading related LocalQueues..." />;
+  }
+
+  return (
+    <SectionBox title="Related LocalQueues">
+      <SimpleTable
+        data={relatedLocalQueues}
+        columns={[
+          {
+            label: 'Name',
+            getter: (localQueue: LocalQueue) => (
+              <Link kubeObject={localQueue}>{localQueue.metadata.name}</Link>
+            ),
+          },
+          {
+            label: 'Namespace',
+            getter: (localQueue: LocalQueue) => localQueue.metadata.namespace || '-',
+          },
+          {
+            label: 'Pending Workloads',
+            getter: (localQueue: LocalQueue) => localQueue.pendingWorkloads,
+          },
+          {
+            label: 'Admitted Workloads',
+            getter: (localQueue: LocalQueue) => localQueue.admittedWorkloads,
+          },
+          {
+            label: 'Status',
+            getter: (localQueue: LocalQueue) => localQueue.statusDisplay,
+          },
+        ]}
+      />
+    </SectionBox>
+  );
+}
+
+/** List Workloads related to either a ClusterQueue or a LocalQueue. */
+export function RelatedWorkloadsSection({
+  clusterQueueName,
+  localQueueName,
+  namespace,
+}: RelatedWorkloadsSectionProps) {
+  if (localQueueName) {
+    return (
+      <RelatedLocalQueueWorkloadsSection localQueueName={localQueueName} namespace={namespace} />
+    );
+  }
+
+  return <RelatedClusterQueueWorkloadsSection clusterQueueName={clusterQueueName} />;
+}
+
+function RelatedClusterQueueWorkloadsSection({
+  clusterQueueName,
+}: Pick<RelatedWorkloadsSectionProps, 'clusterQueueName'>) {
+  const [localQueues, localQueuesError] = LocalQueue.useList();
+  const [workloads, workloadsError] = Workload.useList();
+
+  const relatedWorkloads = useMemo(() => {
+    if (!workloads) {
+      return [];
+    }
+
+    return getRelatedClusterQueueWorkloads(
+      clusterQueueName,
+      workloads,
+      localQueuesError ? null : localQueues
+    );
+  }, [clusterQueueName, localQueues, localQueuesError, workloads]);
+
+  if (workloadsError) {
+    return renderLoadError('Related Workloads', 'Workloads');
+  }
+
+  if ((!localQueues && !localQueuesError) || !workloads) {
+    return <Loader title="Loading related Workloads..." />;
+  }
+
+  return (
+    <RelatedWorkloadsTable
+      workloads={relatedWorkloads}
+      loadWarning={
+        localQueuesError
+          ? 'Unable to load related LocalQueues. Workloads found through LocalQueues may be incomplete.'
+          : undefined
+      }
+    />
+  );
+}
+
+function RelatedLocalQueueWorkloadsSection({
+  localQueueName,
+  namespace,
+}: Pick<RelatedWorkloadsSectionProps, 'localQueueName' | 'namespace'>) {
+  const [workloads, workloadsError] = Workload.useList(namespace ? { namespace } : undefined);
+
+  const relatedWorkloads = useMemo(() => {
+    if (!workloads) {
+      return [];
+    }
+
+    if (localQueueName) {
+      return workloads.filter(workload => workload.queueName === localQueueName);
+    }
+
+    return [];
+  }, [localQueueName, workloads]);
+
+  if (workloadsError) {
+    return renderLoadError('Related Workloads', 'Workloads');
+  }
+
+  if (!workloads) {
+    return <Loader title="Loading related Workloads..." />;
+  }
+
+  return <RelatedWorkloadsTable workloads={relatedWorkloads} />;
+}
+
+function RelatedWorkloadsTable({
+  workloads,
+  loadWarning,
+}: {
+  workloads: Workload[];
+  loadWarning?: string;
+}) {
+  return (
+    <SectionBox title="Related Workloads">
+      {loadWarning && <EmptyContent color="text.secondary">{loadWarning}</EmptyContent>}
+      <SimpleTable
+        data={workloads}
+        columns={[
+          {
+            label: 'Name',
+            getter: (workload: Workload) => (
+              <Link kubeObject={workload}>{workload.metadata.name}</Link>
+            ),
+          },
+          {
+            label: 'Namespace',
+            getter: (workload: Workload) => workload.metadata.namespace || '-',
+          },
+          {
+            label: 'LocalQueue',
+            getter: (workload: Workload) => {
+              const workloadNamespace = workload.metadata.namespace;
+
+              if (!workload.queueName || !workloadNamespace) {
+                return '-';
+              }
+
+              return (
+                <Link
+                  routeName={kueueRouteNames.localQueueDetail}
+                  params={{ namespace: workloadNamespace, name: workload.queueName }}
+                >
+                  {workload.queueName}
+                </Link>
+              );
+            },
+          },
+          {
+            label: 'Priority',
+            getter: (workload: Workload) => workload.priorityDisplay,
+          },
+          {
+            label: 'Status',
+            getter: (workload: Workload) => workload.statusDisplay,
+          },
+        ]}
+      />
+    </SectionBox>
+  );
+}

--- a/kueue/src/components/localqueues/Detail.tsx
+++ b/kueue/src/components/localqueues/Detail.tsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom';
 import { LocalQueue } from '../../resources/localQueue';
 import KueueAdminResourceAccess from '../common/KueueAdminResourceAccess';
 import { renderClusterQueueLink } from '../common/KueueResourceLinks';
+import { RelatedWorkloadsSection } from '../common/RelatedResources';
 
 /** Build the standard Headlamp conditions section for LocalQueue status. */
 function getConditionsSection(localQueue: LocalQueue) {
@@ -62,7 +63,20 @@ export default function LocalQueueDetail() {
             : []
         }
         extraSections={localQueue =>
-          localQueue ? [getConditionsSection(localQueue)].filter(Boolean) : []
+          localQueue
+            ? [
+                getConditionsSection(localQueue),
+                {
+                  id: 'related-workloads',
+                  section: (
+                    <RelatedWorkloadsSection
+                      namespace={localQueue.metadata.namespace}
+                      localQueueName={localQueue.metadata.name}
+                    />
+                  ),
+                },
+              ].filter(Boolean)
+            : []
         }
       />
     </KueueAdminResourceAccess>


### PR DESCRIPTION
## Description

This PR adds relational navigation between Kueue resources, completing the core navigation flow:

**ClusterQueue → LocalQueues → Workloads**

Operators can now inspect the resources associated with a queue directly from its detail page instead of manually searching for them across separate views.

## Changes

* Added a **Related LocalQueues** table to the ClusterQueue detail page.
* Added a **Related Workloads** table to the ClusterQueue detail page.
* Added a **Related Workloads** table to the LocalQueue detail page.
* Made LocalQueue and Workload names clickable for direct navigation to their detail pages.
* Added namespace-aware filtering for namespaced resources.
* Included both:

  * Pending workloads associated through a LocalQueue.
  * Admitted workloads assigned directly to a ClusterQueue.
* Reused the existing Headlamp table and navigation patterns for consistent UX.

## Relationship flow

```text
ClusterQueue
├── LocalQueues
│   └── Workloads
└── Admitted Workloads
```

A ClusterQueue’s related workload list is determined using either:

* The workload’s admitted ClusterQueue assignment.
* The LocalQueue referenced by the workload when that LocalQueue targets the current ClusterQueue.

This ensures that pending workloads are not omitted simply because they have not yet been admitted.

## Why is this needed?

The Kueue plugin already exposes ClusterQueues, LocalQueues, and Workloads, but users previously had to locate related resources manually.

This change makes queue relationships directly inspectable and implements the relational-navigation requirement defined in the project scope.

## Validation

* TypeScript checks pass.
* ESLint passes.
* All existing tests pass (`22/22`).

## Screenshot

<img width="1440" height="779" alt="Screenshot 2026-08-11 at 9 45 55 PM" src="https://github.com/user-attachments/assets/0cf4f6bb-45dd-4e06-bcbd-2d4fa595be06" />

<img width="1440" height="778" alt="Screenshot 2026-08-11 at 9 46 14 PM" src="https://github.com/user-attachments/assets/dad70cf9-fbb6-4a93-800d-356d9521bddc" />

<img width="1438" height="774" alt="Screenshot 2026-08-11 at 9 46 32 PM" src="https://github.com/user-attachments/assets/c3609b7a-9bbe-4a9d-be41-2a7d63e52d2c" />

