### PR TITLE
flux: fix crashes in ImageAutomationSingle when spec or imageRepositoryRef are missing

### DIFF
--- a/flux/src/image-automation/ImageAutomationSingle.tsx
+++ b/flux/src/image-automation/ImageAutomationSingle.tsx
@@ -95,14 +95,14 @@ function CustomResourceDetails(props) {
           <HeadlampLink
             routeName="image"
             params={{
-              name: resource.jsonData.spec?.imageRepositoryRef.name,
+              name: resource.jsonData.spec?.imageRepositoryRef?.name,
               namespace:
-                resource.jsonData.spec.imageRepositoryRef.namespace ??
-                resource.jsonData.metadata.namespace,
+                resource.jsonData.spec?.imageRepositoryRef?.namespace ??
+                resource.jsonData.metadata?.namespace,
               pluralName: 'imagerepositories',
             }}
           >
-            {resource.jsonData.spec?.imageRepositoryRef.name}
+            {resource.jsonData.spec?.imageRepositoryRef?.name}
           </HeadlampLink>
         ),
       });
@@ -149,7 +149,7 @@ function CustomResourceDetails(props) {
       if (resource.jsonData?.spec?.interval) {
         extraInfo.push({
           name: 'Interval',
-          value: resource.jsonData.spec.interval,
+          value: resource.jsonData.spec?.interval,
         });
       }
 
@@ -228,7 +228,7 @@ function Policies(props: { resource }) {
                 routeName="image"
                 params={{
                   name: cell.getValue(),
-                  namespace: resource.metadata.namespace,
+                  namespace: resource?.metadata?.namespace,
                   pluralName: 'imagepolicies',
                 }}
               >
@@ -238,11 +238,11 @@ function Policies(props: { resource }) {
           },
           {
             header: 'Image',
-            accessorFn: item => item[1].name,
+            accessorFn: item => item[1]?.name,
           },
           {
             header: 'Tag',
-            accessorFn: item => item[1].tag,
+            accessorFn: item => item[1]?.tag,
           },
         ]}
       />


### PR DESCRIPTION
Follow-up to #1056 (as suggested by @Ralthos in #1056 review comment).

## Problem
In `ImageAutomationSingle.tsx`, the `ImagePolicy` branch previously used optional chaining on the first line (`resource.jsonData.spec?.imageRepositoryRef.name`) but used unguarded access three lines later (`resource.jsonData.spec.imageRepositoryRef.namespace`), making the initial guard ineffective if `spec` or `imageRepositoryRef` is omitted on an `ImagePolicy` manifest.

## Solution
Added safe optional chaining (`?.`) across all `spec`, `imageRepositoryRef`, `metadata`, and table item accessors in `ImageAutomationSingle.tsx`.

### Changes
- Added optional chaining (`?.`) to `spec?.imageRepositoryRef?.name` and `spec?.imageRepositoryRef?.namespace` in `CustomResourceDetails`.
- Added optional chaining (`?.`) to `spec?.interval` in `CustomResourceDetails`.
- Added optional chaining (`?.`) to `resource?.metadata?.namespace`, `item[1]?.name`, and `item[1]?.tag` in `Policies`.

## How to Test
1. Open an `ImagePolicy` detail view for a resource without `spec.imageRepositoryRef` or `metadata`.
2. Verify the detail view renders cleanly without throwing a white-screen `TypeError` crash.

## Verification
- Code diff inspected and verified against TypeScript optional chaining semantics.
- Linting checks passed cleanly.
