### PR TITLE
kueue: extract ResourceFlavor display logic into formatters

### DIFF
--- a/kueue/src/resources/resourceFlavor.test.ts
+++ b/kueue/src/resources/resourceFlavor.test.ts
@@ -1,0 +1,75 @@
+import { renderNodeLabels, renderTaint, renderTaints, renderToleration, renderTolerations, renderTopologyName } from './resourceFlavorFormatters';
+
+describe('renderNodeLabels', () => {
+  it('returns a dash when there are no labels', () => {
+    expect(renderNodeLabels()).toBe('-');
+    expect(renderNodeLabels({})).toBe('-');
+  });
+
+  it('renders labels as key=value pairs', () => {
+    expect(renderNodeLabels({ zone: 'us-east-1', gpu: 'true' })).toBe('zone=us-east-1, gpu=true');
+  });
+});
+
+describe('renderTaint', () => {
+  it('renders a taint without a value', () => {
+    expect(renderTaint({ key: 'spot', effect: 'NoSchedule' })).toBe('spot:NoSchedule');
+  });
+
+  it('renders a taint with a value', () => {
+    expect(renderTaint({ key: 'spot', value: 'true', effect: 'NoSchedule' })).toBe(
+      'spot=true:NoSchedule'
+    );
+  });
+});
+
+describe('renderTaints', () => {
+  it('returns a dash when there are no taints', () => {
+    expect(renderTaints()).toBe('-');
+    expect(renderTaints([])).toBe('-');
+  });
+
+  it('renders multiple taints joined by commas', () => {
+    expect(
+      renderTaints([
+        { key: 'spot', effect: 'NoSchedule' },
+        { key: 'gpu', value: 'true', effect: 'NoExecute' },
+      ])
+    ).toBe('spot:NoSchedule, gpu=true:NoExecute');
+  });
+});
+
+describe('renderToleration', () => {
+  it('renders a toleration with defaults when fields are missing', () => {
+    expect(renderToleration({})).toBe('*');
+  });
+
+  it('renders a toleration with an Exists operator', () => {
+    expect(renderToleration({ key: 'spot', operator: 'Exists', effect: 'NoSchedule' })).toBe(
+      'spot:NoSchedule'
+    );
+  });
+
+  it('renders a toleration with a value and tolerationSeconds', () => {
+    expect(
+      renderToleration({ key: 'spot', value: 'true', effect: 'NoExecute', tolerationSeconds: 30 })
+    ).toBe('spot=true:NoExecute (30s)');
+  });
+});
+
+describe('renderTolerations', () => {
+  it('returns a dash when there are no tolerations', () => {
+    expect(renderTolerations()).toBe('-');
+    expect(renderTolerations([])).toBe('-');
+  });
+});
+
+describe('renderTopologyName', () => {
+  it('returns a dash when topologyName is missing', () => {
+    expect(renderTopologyName()).toBe('-');
+  });
+
+  it('returns the topology name when present', () => {
+    expect(renderTopologyName('rack')).toBe('rack');
+  });
+});

--- a/kueue/src/resources/resourceFlavor.ts
+++ b/kueue/src/resources/resourceFlavor.ts
@@ -1,6 +1,12 @@
 import { KubeObject, KubeObjectInterface } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
 import { kueueApiVersions } from '../utils/kueueApi';
 import { kueueRoutePaths } from '../utils/kueueRoutes';
+import {
+  renderNodeLabels,
+  renderTaints,
+  renderTolerations,
+  renderTopologyName,
+} from './resourceFlavorFormatters';
 
 /**
  * Node label selector values associated with a Kueue ResourceFlavor.
@@ -153,13 +159,7 @@ export class ResourceFlavor extends KubeObject<KubeResourceFlavor> {
   }
 
   get nodeLabelsDisplay() {
-    const labels = Object.entries(this.nodeLabels);
-
-    if (labels.length === 0) {
-      return '-';
-    }
-
-    return labels.map(([key, value]) => `${key}=${value}`).join(', ');
+    return renderNodeLabels(this.nodeLabels);
   }
 
   get nodeTaints() {
@@ -179,41 +179,6 @@ export class ResourceFlavor extends KubeObject<KubeResourceFlavor> {
   }
 
   get topologyName() {
-    return this.spec.topologyName || '-';
+    return renderTopologyName(this.spec.topologyName);
   }
-}
-
-function renderTaints(taints: ResourceFlavorTaint[]) {
-  if (taints.length === 0) {
-    return '-';
-  }
-
-  return taints.map(renderTaint).join(', ');
-}
-
-function renderTaint(taint: ResourceFlavorTaint) {
-  const value = taint.value ? `=${taint.value}` : '';
-
-  return `${taint.key}${value}:${taint.effect}`;
-}
-
-function renderTolerations(tolerations: ResourceFlavorToleration[]) {
-  if (tolerations.length === 0) {
-    return '-';
-  }
-
-  return tolerations.map(renderToleration).join(', ');
-}
-
-function renderToleration(toleration: ResourceFlavorToleration) {
-  const key = toleration.key || '*';
-  const value =
-    toleration.operator === 'Exists' || toleration.value === undefined
-      ? ''
-      : `=${toleration.value}`;
-  const effect = toleration.effect ? `:${toleration.effect}` : '';
-  const seconds =
-    toleration.tolerationSeconds === undefined ? '' : ` (${toleration.tolerationSeconds}s)`;
-
-  return `${key}${value}${effect}${seconds}`;
 }

--- a/kueue/src/resources/resourceFlavorFormatters.ts
+++ b/kueue/src/resources/resourceFlavorFormatters.ts
@@ -1,0 +1,56 @@
+import type { ResourceFlavorTaint, ResourceFlavorToleration, NodeLabels } from './resourceFlavor';
+
+/** Render a ResourceFlavor's node label selector as a comma-separated key=value list. */
+export function renderNodeLabels(nodeLabels?: NodeLabels) {
+  const labels = Object.entries(nodeLabels || {});
+
+  if (labels.length === 0) {
+    return '-';
+  }
+
+  return labels.map(([key, value]) => `${key}=${value}`).join(', ');
+}
+
+/** Render a single ResourceFlavor node taint as `key=value:effect`. */
+export function renderTaint(taint: ResourceFlavorTaint) {
+  const value = taint.value ? `=${taint.value}` : '';
+
+  return `${taint.key}${value}:${taint.effect}`;
+}
+
+/** Render a ResourceFlavor's node taints as a comma-separated list. */
+export function renderTaints(taints?: ResourceFlavorTaint[]) {
+  if (!taints || taints.length === 0) {
+    return '-';
+  }
+
+  return taints.map(renderTaint).join(', ');
+}
+
+/** Render a single ResourceFlavor toleration as `key=value:effect (Ns)`. */
+export function renderToleration(toleration: ResourceFlavorToleration) {
+  const key = toleration.key || '*';
+  const value =
+    toleration.operator === 'Exists' || toleration.value === undefined
+      ? ''
+      : `=${toleration.value}`;
+  const effect = toleration.effect ? `:${toleration.effect}` : '';
+  const seconds =
+    toleration.tolerationSeconds === undefined ? '' : ` (${toleration.tolerationSeconds}s)`;
+
+  return `${key}${value}${effect}${seconds}`;
+}
+
+/** Render a ResourceFlavor's tolerations as a comma-separated list. */
+export function renderTolerations(tolerations?: ResourceFlavorToleration[]) {
+  if (!tolerations || tolerations.length === 0) {
+    return '-';
+  }
+
+  return tolerations.map(renderToleration).join(', ');
+}
+
+/** Render a ResourceFlavor's topology name, falling back when the API omits the field. */
+export function renderTopologyName(topologyName?: string) {
+  return topologyName || '-';
+}


### PR DESCRIPTION
## What this PR does

`ResourceFlavor` was the only Kueue resource type in this plugin that formatted its display
values with inline, unexported helper functions inside `resourceFlavor.ts`, instead of a
dedicated `*Formatters.ts` file like `ClusterQueue`, `LocalQueue`, and `Workload` already use.

This PR brings `ResourceFlavor` in line with that existing pattern:

- Adds `src/resources/resourceFlavorFormatters.ts` with exported, documented, pure functions:
  `renderNodeLabels`, `renderTaint`, `renderTaints`, `renderToleration`, `renderTolerations`,
  `renderTopologyName`.
- Updates `resourceFlavor.ts` getters to delegate to these formatters instead of using
  private inline functions.
- Adds `src/resources/resourceFlavor.test.ts` with unit tests covering each formatter,
  including empty/undefined edge cases.

## Testing

- `npm run test` — all 34 tests pass (12 new).
- `npm run build` — builds cleanly.
- Verified locally in a running Headlamp instance against a kind cluster with real
  ResourceFlavor, ClusterQueue, LocalQueue, and Workload resources — the ResourceFlavors
  list and detail views render correctly with no behavior change.

## Why

This is a small, low-risk refactor with no behavior change, aimed at improving consistency
and testability ahead of building out more ResourceFlavor functionality.