### PR TITLE
knative: i18n split — clusterdomainclaims + domain.ts fix

### DIFF
--- a/knative/locales/en/translation.json
+++ b/knative/locales/en/translation.json
@@ -1,0 +1,17 @@
+{
+  "Cluster": "Cluster",
+  "Cluster Domain Claims": "Cluster Domain Claims",
+  "Domain name is missing": "Domain name is missing",
+  "DomainMapping": "DomainMapping",
+  "Failed to annotate DomainMapping": "Failed to annotate DomainMapping",
+  "Failed to annotate DomainMapping: {{ detail }}": "Failed to annotate DomainMapping: {{ detail }}",
+  "Failed to create ClusterDomainClaim": "Failed to create ClusterDomainClaim",
+  "Failed to create ClusterDomainClaim: {{ detail }}": "Failed to create ClusterDomainClaim: {{ detail }}",
+  "Invalid domain name format": "Invalid domain name format",
+  "Missing": "Missing",
+  "Namespace": "Namespace",
+  "No cluster available": "No cluster available",
+  "Owner: {{ namespace }}": "Owner: {{ namespace }}",
+  "Please enter a domain name": "Please enter a domain name",
+  "Present": "Present"
+}

--- a/knative/src/components/clusterdomainclaims/Glance.tsx
+++ b/knative/src/components/clusterdomainclaims/Glance.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
 import { StatusLabel } from '@kinvolk/headlamp-plugin/lib/components/common';
 import { Box } from '@mui/system';
 import { ClusterDomainClaim } from '../../resources/knative';
@@ -35,6 +36,7 @@ interface GlanceProps {
  * @param props.node - The map node containing the resource.
  */
 export function ClusterDomainClaimGlance({ node }: GlanceProps) {
+  const { t } = useTranslation();
   const kubeObject = node.kubeObject;
   const isKnativeClusterDomainClaim =
     kubeObject instanceof ClusterDomainClaim ||
@@ -47,7 +49,9 @@ export function ClusterDomainClaimGlance({ node }: GlanceProps) {
 
     return (
       <Box display="flex" gap={1} alignItems="center" mt={2} flexWrap="wrap" key="cdc-glance">
-        <StatusLabel status="">Owner: {cdc.targetNamespace || '-'}</StatusLabel>
+        <StatusLabel status="">
+          {t('Owner: {{ namespace }}', { namespace: cdc.targetNamespace || '-' })}
+        </StatusLabel>
       </Box>
     );
   }

--- a/knative/src/components/clusterdomainclaims/List.tsx
+++ b/knative/src/components/clusterdomainclaims/List.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
 import {
   CreateResourceButton,
   Link,
@@ -30,6 +31,7 @@ export function useClusterDomainClaimColumns(
   clusters: string[],
   domainMappings: KnativeDomainMapping[] | null
 ) {
+  const { t } = useTranslation();
   const showClusterColumn = clusters.length > 1;
 
   return useMemo<(ResourceTableColumn<KubeObject> | 'age' | 'name')[]>(() => {
@@ -37,7 +39,7 @@ export function useClusterDomainClaimColumns(
       'name',
       {
         id: 'namespace',
-        label: 'Namespace',
+        label: t('Namespace'),
         gridTemplate: 'auto',
         getValue: item => {
           const cdc = item as ClusterDomainClaim;
@@ -67,7 +69,7 @@ export function useClusterDomainClaimColumns(
         ? ([
             {
               id: 'cluster',
-              label: 'Cluster',
+              label: t('Cluster'),
               gridTemplate: 'auto',
               getValue: item => item.cluster ?? '',
             },
@@ -75,7 +77,7 @@ export function useClusterDomainClaimColumns(
         : []),
       {
         id: 'domainmapping',
-        label: 'DomainMapping',
+        label: t('DomainMapping'),
         gridTemplate: 'auto',
         disableFiltering: true,
         getValue: item => {
@@ -138,11 +140,11 @@ export function useClusterDomainClaimColumns(
                   crName: found.metadata.name,
                 }}
               >
-                <Chip label="Present" color="success" size="small" clickable />
+                <Chip label={t('Present')} color="success" size="small" clickable />
               </Link>
             );
           } else {
-            return <Chip label="Missing" color="warning" size="small" />;
+            return <Chip label={t('Missing')} color="warning" size="small" />;
           }
         },
       },
@@ -154,6 +156,7 @@ export function useClusterDomainClaimColumns(
 }
 
 function ClusterDomainClaimsListContent({ clusters }: { clusters: string[] }) {
+  const { t } = useTranslation();
   const domainMappingsResult = KnativeDomainMapping.useList({ clusters });
   const domainMappings = domainMappingsResult.items;
 
@@ -178,7 +181,7 @@ function ClusterDomainClaimsListContent({ clusters }: { clusters: string[] }) {
 
   return (
     <ResourceListView
-      title="Cluster Domain Claims"
+      title={t('Cluster Domain Claims')}
       headerProps={headerProps}
       resourceClass={ClusterDomainClaim}
       columns={columns}

--- a/knative/src/components/domainmappings/List.tsx
+++ b/knative/src/components/domainmappings/List.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
 import {
   CreateResourceButton,
   Link,
@@ -153,6 +154,7 @@ export function useDomainMappingColumns(
 }
 
 function DomainMappingsListContents({ clusters }: { clusters: string[] }) {
+  const { t } = useTranslation();
   const { notifyError, notifyInfo } = useNotify();
 
   // We need to fetch ClusterDomainClaims to cross-reference their status
@@ -194,7 +196,7 @@ function DomainMappingsListContents({ clusters }: { clusters: string[] }) {
                 dm={dm}
                 onAction={async () => {
                   try {
-                    await createClusterDomainClaim(dm, namespace);
+                    await createClusterDomainClaim(dm, namespace, t);
                     notifyInfo('ClusterDomainClaim created');
                   } catch (err: unknown) {
                     const error = err as { message?: string } | undefined;

--- a/knative/src/components/kservices/detail/sections/networking/DomainMappingSection.tsx
+++ b/knative/src/components/kservices/detail/sections/networking/DomainMappingSection.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
 import {
   ResourceTable,
   type ResourceTableColumn,
@@ -59,6 +60,7 @@ function getReadyCondition(dm: KnativeDomainMapping): {
 }
 
 export default function DomainMappingSection({ namespace, serviceName, cluster }: Props) {
+  const { t } = useTranslation();
   const clusters = [cluster];
   const { notifyError, notifyInfo } = useNotify();
   const [creating, setCreating] = React.useState<boolean>(false);
@@ -83,7 +85,7 @@ export default function DomainMappingSection({ namespace, serviceName, cluster }
   async function handleCreate() {
     setCreating(true);
     try {
-      await createDomainMapping(domainInput, cluster, namespace, serviceName);
+      await createDomainMapping(domainInput, cluster, namespace, serviceName, t);
       notifyInfo('DomainMapping Created');
       setDomainInput('');
     } catch (err: unknown) {
@@ -100,7 +102,7 @@ export default function DomainMappingSection({ namespace, serviceName, cluster }
   //   navigates to item.getListLink(). We override getListLink per item to keep users on this page.
   async function handleCreateClusterDomainClaim(dm: KnativeDomainMapping) {
     try {
-      await createClusterDomainClaim(dm, namespace);
+      await createClusterDomainClaim(dm, namespace, t);
       notifyInfo('ClusterDomainClaim created');
     } catch (err: unknown) {
       const error = err as { message?: string } | undefined;

--- a/knative/src/utils/domain.ts
+++ b/knative/src/utils/domain.ts
@@ -16,6 +16,8 @@
 
 import { ClusterDomainClaim, KnativeDomainMapping } from '../resources/knative';
 
+type TFunc = (key: string, options?: Record<string, string>) => string;
+
 export function getClusterDomainClaim(
   dm: KnativeDomainMapping,
   clusterDomainClaims: ClusterDomainClaim[] | null,
@@ -95,17 +97,18 @@ export async function createDomainMapping(
   domainInput: string,
   cluster: string,
   namespace: string,
-  serviceName: string
+  serviceName: string,
+  t: TFunc
 ) {
   const host = domainInput.trim();
   if (!host) {
-    throw new Error('Please enter a domain name');
+    throw new Error(t('Please enter a domain name'));
   }
   if (!isValidDomain(host)) {
-    throw new Error('Invalid domain name format');
+    throw new Error(t('Invalid domain name format'));
   }
   if (!cluster) {
-    throw new Error('No cluster available');
+    throw new Error(t('No cluster available'));
   }
 
   // Create Cluster Domain Claim
@@ -138,10 +141,14 @@ export async function createDomainMapping(
  * Creates a ClusterDomainClaim.
  * Throws an error if validation or API calls fail.
  */
-export async function createClusterDomainClaim(dm: KnativeDomainMapping, namespace: string) {
+export async function createClusterDomainClaim(
+  dm: KnativeDomainMapping,
+  namespace: string,
+  t: TFunc
+) {
   const host = dm.host?.trim();
   if (!host) {
-    throw new Error('Domain name is missing');
+    throw new Error(t('Domain name is missing'));
   }
 
   try {
@@ -161,8 +168,8 @@ export async function createClusterDomainClaim(dm: KnativeDomainMapping, namespa
       const detail2 = error2?.message?.trim();
       throw new Error(
         detail2
-          ? `Failed to annotate DomainMapping: ${detail2}`
-          : 'Failed to annotate DomainMapping'
+          ? t('Failed to annotate DomainMapping: {{ detail }}', { detail: detail2 })
+          : t('Failed to annotate DomainMapping')
       );
     }
   } catch (e: unknown) {
@@ -170,8 +177,8 @@ export async function createClusterDomainClaim(dm: KnativeDomainMapping, namespa
     const detail = error?.message?.trim();
     throw new Error(
       detail
-        ? `Failed to create ClusterDomainClaim: ${detail}`
-        : 'Failed to create ClusterDomainClaim'
+        ? t('Failed to create ClusterDomainClaim: {{ detail }}', { detail })
+        : t('Failed to create ClusterDomainClaim')
     );
   }
 }


### PR DESCRIPTION
<!-- Title: knative: i18n split — clusterdomainclaims + domain.ts fix -->

## Summary

Split from #1066, offered proactively in that PR's description, to give reviewers a smaller, self-contained reviewable unit.

**In scope:**

- `clusterdomainclaims/` directory (`Glance.tsx`, `List.tsx`) — verified self-contained; no cross-imports with other directories modified in #1066.
- `utils/domain.ts` — 6 user-facing error strings wrapped in `t()`, with a `TFunc` parameter threaded from both call sites (`domainmappings/List.tsx` and `kservices/.../DomainMappingSection.tsx`). This was a gap in #1066 identified by tracing the call sites: those components are translated, but the error strings they surface through `domain.ts` were not.
- 15 locale keys added to `knative/locales/en/translation.json` (only keys used by files in this PR).

**Not in scope:**

- The remaining ~245 keys stay in #1066 for a follow-up.

**Notes:**

- `getAge()` duration suffixes (e.g. "5d", "3h") are deliberately left untranslated, consistent with Kubernetes CLI convention (`kubectl get`), so Headlamp stays aligned with tooling users read alongside it.
- This PR has no file-level conflicts with #986. Either can merge first; the other rebases cleanly.

**AI disclosure:** Locale key generation and initial string extraction were AI-assisted, reviewed and corrected manually. Convention check (against `flux`, `#941`, `#940`, `#963`, `#964`) and the `domain.ts` call-site trace were manual.

Part of the i18n work tracked in #922.
