### PR TITLE
test(flux): add unit tests for PluralName and parseDuration

### DIFF
--- a/flux/src/helpers/index.tsx
+++ b/flux/src/helpers/index.tsx
@@ -153,30 +153,7 @@ export function ObjectEventsRenderer(props: { events?: Event[] }) {
   );
 }
 
-export function parseDuration(duration) {
-  const regex = /(\d+)([hms])/g; // Match numbers followed by h, m, or s
-  let totalMilliseconds = 0;
-  let match;
-
-  while ((match = regex.exec(duration)) !== null) {
-    const value = parseInt(match[1], 10);
-    const unit = match[2];
-
-    switch (unit) {
-      case 'h':
-        totalMilliseconds += value * 60 * 60 * 1000; // Convert hours to milliseconds
-        break;
-      case 'm':
-        totalMilliseconds += value * 60 * 1000; // Convert minutes to milliseconds
-        break;
-      case 's':
-        totalMilliseconds += value * 1000; // Convert seconds to milliseconds
-        break;
-    }
-  }
-
-  return totalMilliseconds;
-}
+export { parseDuration } from './parseDuration';
 
 export function NameLink(resourceClass: KubeObjectClass) {
   const apiVersion = new String(resourceClass.apiVersion); // explicit String cast is needed for string methods

--- a/flux/src/helpers/parseDuration.test.ts
+++ b/flux/src/helpers/parseDuration.test.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { parseDuration } from './parseDuration';
+
+describe('parseDuration', () => {
+  // ── Single units ──────────────────────────────────────────────────────────
+  describe('single time unit', () => {
+    it('converts 1h to 3 600 000 ms', () => {
+      expect(parseDuration('1h')).toBe(3_600_000);
+    });
+
+    it('converts 2h to 7 200 000 ms', () => {
+      expect(parseDuration('2h')).toBe(7_200_000);
+    });
+
+    it('converts 30m to 1 800 000 ms', () => {
+      expect(parseDuration('30m')).toBe(1_800_000);
+    });
+
+    it('converts 1m to 60 000 ms', () => {
+      expect(parseDuration('1m')).toBe(60_000);
+    });
+
+    it('converts 45s to 45 000 ms', () => {
+      expect(parseDuration('45s')).toBe(45_000);
+    });
+
+    it('converts 1s to 1 000 ms', () => {
+      expect(parseDuration('1s')).toBe(1_000);
+    });
+
+    it('converts 0s to 0 ms', () => {
+      expect(parseDuration('0s')).toBe(0);
+    });
+  });
+
+  // ── Combined units ────────────────────────────────────────────────────────
+  describe('combined time units', () => {
+    it('converts 1h30m to 5 400 000 ms', () => {
+      expect(parseDuration('1h30m')).toBe(5_400_000);
+    });
+
+    it('converts 5m30s to 330 000 ms', () => {
+      expect(parseDuration('5m30s')).toBe(330_000);
+    });
+
+    it('converts 1h30m45s to 5 445 000 ms', () => {
+      expect(parseDuration('1h30m45s')).toBe(5_445_000);
+    });
+
+    it('converts 2h5m to 7 500 000 ms', () => {
+      expect(parseDuration('2h5m')).toBe(7_500_000);
+    });
+  });
+
+  // ── Typical Flux reconciliation intervals ─────────────────────────────────
+  describe('typical Flux reconciliation intervals', () => {
+    it('parses 10m (common default interval)', () => {
+      expect(parseDuration('10m')).toBe(600_000);
+    });
+
+    it('parses 1h (common sync interval)', () => {
+      expect(parseDuration('1h')).toBe(3_600_000);
+    });
+
+    it('parses 5m (common retry interval)', () => {
+      expect(parseDuration('5m')).toBe(300_000);
+    });
+  });
+
+  // ── Edge cases ────────────────────────────────────────────────────────────
+  describe('edge cases', () => {
+    it('returns 0 for an empty string', () => {
+      expect(parseDuration('')).toBe(0);
+    });
+
+    it('returns 0 for a string with no recognisable units', () => {
+      expect(parseDuration('invalid')).toBe(0);
+    });
+  });
+});

--- a/flux/src/helpers/parseDuration.ts
+++ b/flux/src/helpers/parseDuration.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Parses a Flux duration string (e.g. "1h30m", "5m30s") into total milliseconds.
+ *
+ * Recognised units:
+ *   h – hours
+ *   m – minutes
+ *   s – seconds
+ *
+ * Returns 0 for an empty string or a string that contains no recognised units.
+ */
+export function parseDuration(duration: string): number {
+  const regex = /(\d+)([hms])/g; // Match numbers followed by h, m, or s
+  let totalMilliseconds = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = regex.exec(duration)) !== null) {
+    const value = parseInt(match[1], 10);
+    const unit = match[2];
+
+    switch (unit) {
+      case 'h':
+        totalMilliseconds += value * 60 * 60 * 1000; // Convert hours to milliseconds
+        break;
+      case 'm':
+        totalMilliseconds += value * 60 * 1000; // Convert minutes to milliseconds
+        break;
+      case 's':
+        totalMilliseconds += value * 1000; // Convert seconds to milliseconds
+        break;
+    }
+  }
+
+  return totalMilliseconds;
+}

--- a/flux/src/helpers/pluralName.test.ts
+++ b/flux/src/helpers/pluralName.test.ts
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { PluralName } from './pluralName';
+
+describe('PluralName', () => {
+  // ── Real Flux CRD kinds ──────────────────────────────────────────────────
+  describe('real Flux CRD kinds', () => {
+    it('pluralises GitRepository', () => {
+      expect(PluralName('GitRepository')).toBe('gitrepositories');
+    });
+
+    it('pluralises HelmRepository', () => {
+      expect(PluralName('HelmRepository')).toBe('helmrepositories');
+    });
+
+    it('pluralises OCIRepository', () => {
+      expect(PluralName('OCIRepository')).toBe('ocirepositories');
+    });
+
+    it('pluralises HelmChart', () => {
+      expect(PluralName('HelmChart')).toBe('helmcharts');
+    });
+
+    it('pluralises HelmRelease', () => {
+      expect(PluralName('HelmRelease')).toBe('helmreleases');
+    });
+
+    it('pluralises Kustomization', () => {
+      expect(PluralName('Kustomization')).toBe('kustomizations');
+    });
+
+    it('pluralises Bucket', () => {
+      expect(PluralName('Bucket')).toBe('buckets');
+    });
+
+    it('pluralises ImagePolicy', () => {
+      expect(PluralName('ImagePolicy')).toBe('imagepolicies');
+    });
+
+    it('pluralises ImageRepository', () => {
+      expect(PluralName('ImageRepository')).toBe('imagerepositories');
+    });
+  });
+
+  // ── Ends in s / x / z → +es ─────────────────────────────────────────────
+  describe('words ending in s, x or z (→ +es)', () => {
+    it('appends es to a word ending in s', () => {
+      expect(PluralName('Class')).toBe('classes');
+    });
+
+    it('appends es to a word ending in x', () => {
+      expect(PluralName('Box')).toBe('boxes');
+    });
+
+    it('appends es to a word ending in z', () => {
+      expect(PluralName('Fuzz')).toBe('fuzzes');
+    });
+  });
+
+  // ── Ends in y ────────────────────────────────────────────────────────────
+  describe('words ending in y', () => {
+    it('replaces consonant+y with ies', () => {
+      expect(PluralName('Policy')).toBe('policies');
+    });
+
+    it('replaces consonant+y with ies (category)', () => {
+      expect(PluralName('Category')).toBe('categories');
+    });
+
+    it('keeps vowel+y and appends s', () => {
+      expect(PluralName('Day')).toBe('days');
+    });
+
+    it('keeps vowel+y and appends s (key)', () => {
+      expect(PluralName('Key')).toBe('keys');
+    });
+  });
+
+  // ── Ends in h ────────────────────────────────────────────────────────────
+  describe('words ending in h', () => {
+    it('appends es after ch', () => {
+      expect(PluralName('Watch')).toBe('watches');
+    });
+
+    it('appends es after sh', () => {
+      expect(PluralName('Mesh')).toBe('meshes');
+    });
+
+    it('appends s after other consonant+h', () => {
+      expect(PluralName('Auth')).toBe('auths');
+    });
+
+    it('appends s after vowel+h (graph)', () => {
+      expect(PluralName('Graph')).toBe('graphs');
+    });
+  });
+
+  // ── Ends in e ────────────────────────────────────────────────────────────
+  describe('words ending in e', () => {
+    it('converts fe ending to ves (knife)', () => {
+      expect(PluralName('Knife')).toBe('knives');
+    });
+
+    it('appends s for non-fe ending (HelmRelease)', () => {
+      expect(PluralName('HelmRelease')).toBe('helmreleases');
+    });
+
+    it('appends s for non-fe ending (Node)', () => {
+      expect(PluralName('Node')).toBe('nodes');
+    });
+  });
+
+  // ── Ends in f → ves ──────────────────────────────────────────────────────
+  describe('words ending in f (→ ves)', () => {
+    it('converts leaf to leaves', () => {
+      expect(PluralName('Leaf')).toBe('leaves');
+    });
+
+    it('converts Wolf to wolves', () => {
+      expect(PluralName('Wolf')).toBe('wolves');
+    });
+  });
+
+  // ── Default (→ +s) ───────────────────────────────────────────────────────
+  describe('default case (→ +s)', () => {
+    it('appends s to a plain noun (Pod)', () => {
+      expect(PluralName('Pod')).toBe('pods');
+    });
+
+    it('appends s to a CamelCase kind (ConfigMap)', () => {
+      expect(PluralName('ConfigMap')).toBe('configmaps');
+    });
+
+    it('appends s to a kind ending in t (Bucket)', () => {
+      expect(PluralName('Bucket')).toBe('buckets');
+    });
+  });
+
+  // ── Case handling ─────────────────────────────────────────────────────────
+  describe('input casing', () => {
+    it('is case-insensitive (all uppercase)', () => {
+      expect(PluralName('GITREPOSITORY')).toBe('gitrepositories');
+    });
+
+    it('is case-insensitive (all lowercase)', () => {
+      expect(PluralName('gitrepository')).toBe('gitrepositories');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Two pure-logic utility functions in the `flux` plugin had zero test coverage:

- **`PluralName`** (`flux/src/helpers/pluralName.tsx`) - derives the plural REST-API name of a Kubernetes CRD kind. Ported from Go's `kubernetes/gengo` pluralizer and used by the kustomization inventory to resolve API URLs.
- - **`parseDuration`** (`flux/src/helpers/parseDuration.ts`) - parses Flux duration strings (e.g. `"1h30m"`, `"5m30s"`) into total milliseconds.
## Changes

### `flux/src/helpers/pluralName.test.ts` (new - 30 tests)
Covers all branches of the pluralisation switch:
- Words ending in `s` / `x` / `z` -> append `es`
- - Words ending in `y` with a consonant before -> replace with `ies`
- - Words ending in `y` with a vowel before -> append `s`
- - Words ending in `ch` / `sh` -> append `es`; other `h` endings -> append `s`
- - Words ending in `fe` -> convert to `ves`; `f` -> `ves`
- - Default -> append `s`
- - All nine real Flux CRD kinds: `GitRepository`, `HelmRepository`, `OCIRepository`, `HelmChart`, `HelmRelease`, `Kustomization`, `Bucket`, `ImagePolicy`, `ImageRepository`
- - Case-insensitivity verification
### `flux/src/helpers/parseDuration.ts` (new - extracted)
Moves `parseDuration` out of the `index.tsx` barrel (which pulls in React/Redux/`window` globals) into its own isolated module, mirroring the `remainingTime.ts` pattern. `index.tsx` re-exports it unchanged so no call sites are affected.

### `flux/src/helpers/parseDuration.test.ts` (new - 16 tests)
Covers single units (`h`/`m`/`s`), compound expressions (`1h30m`, `5m30s`, `1h30m45s`), typical Flux reconciliation intervals (`10m`, `1h`, `5m`), and edge cases (empty string, unrecognised input).

## Test Results

```
PASS src/helpers/parseDuration.test.ts  (16 tests)
PASS src/helpers/pluralName.test.ts     (30 tests)

Test Files  2 passed (2)
     Tests  46 passed (46)
```