### PR TITLE
fix(kyverno): guard report.results iteration when results is undefined

### DIFF
--- a/kyverno/package-lock.json
+++ b/kyverno/package-lock.json
@@ -121,6 +121,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -514,6 +515,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -537,6 +539,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -605,6 +608,7 @@
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -651,6 +655,7 @@
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1981,6 +1986,7 @@
       "integrity": "sha512-1s0vEZj5XFXDMmz3Arl/R7IncFqJ+WQ95LDp1roHWGDE2oCO3IS4/hmiOv1/8SD9r6B7tv9GLiqVZYHo+6PkTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.9"
       },
@@ -2050,6 +2056,7 @@
       "integrity": "sha512-bbH/HaJZpFtXGvWg3TsBWG4eyt3gah3E7nCNU8GLyRjVoWcA91Vm/T+sjHfUcwgJSw9iLtucfHBoq+qW/T30aA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@mui/core-downloads-tracker": "^5.18.0",
@@ -2158,6 +2165,7 @@
       "integrity": "sha512-ojZGVcRWqWhu557cdO3pWHloIGJdzVtxs3rk0F9L+x55LsUjcMUVkEhiF7E4TMxZoF9MmIHGGs0ZX3FDLAf0Xw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@mui/private-theming": "^5.17.1",
@@ -2245,6 +2253,7 @@
       "integrity": "sha512-wJ3tsqk/y6dp+mXGtT9czciAMEO5Zr3IIAHg9x6IL0Eqanqy0N3chbmQQZv3iq0m2qUpQDLvZ4utZBUTJdjNzw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.25.7",
         "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0",
@@ -3495,6 +3504,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.23"
@@ -3829,6 +3839,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -4281,6 +4292,7 @@
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -4292,6 +4304,7 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -4424,6 +4437,7 @@
       "integrity": "sha512-w/EboPlBwnmOBtRbiOvzjD+wdiZdgFeo17lkltrtn7X37vagKKWJABvyfsJXTlHe6XBzugmYgd4A4nW+k8Mixw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
         "@typescript-eslint/scope-manager": "8.40.0",
@@ -4454,6 +4468,7 @@
       "integrity": "sha512-jCNyAuXx8dr5KJMkecGmZ8KI61KBUhkCob+SD+C+I5+Y1FWI2Y3QmY4/cxMCC5WAsZqoEtEETVhUiUMIGCf6Bw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.40.0",
         "@typescript-eslint/types": "8.40.0",
@@ -5017,7 +5032,8 @@
       "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
       "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
@@ -5072,6 +5088,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5117,6 +5134,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -5947,6 +5965,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -6834,7 +6853,8 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/d3-array": {
       "version": "3.2.4",
@@ -6949,6 +6969,7 @@
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -7765,6 +7786,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -7843,6 +7865,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -7899,6 +7922,7 @@
       "integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -7962,6 +7986,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -8077,6 +8102,7 @@
       "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "aria-query": "^5.3.2",
         "array-includes": "^3.1.8",
@@ -8149,6 +8175,7 @@
       "integrity": "sha512-v501SSMOWv8gerHkk+IIQBkcGRGrO2nfybfj5pLxuJNFTPxxA3PSryhXTK+9pNbtkggheDdsC0E9Q8CuPk6JKA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -8182,6 +8209,7 @@
       "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -8258,6 +8286,7 @@
       "integrity": "sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "eslint": ">=5.0.0"
       }
@@ -8268,6 +8297,7 @@
       "integrity": "sha512-hLbJ2/wnjKq4kGA9AUaExVFIbNzyxYdVo49QZmKCnhk5pc9wcYRbfgLHvWJ8tnsdcseGhoUAddm9gn/lt+d74w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@typescript-eslint/eslint-plugin": "^8.0.0-0 || ^7.0.0 || ^6.0.0 || ^5.0.0",
         "eslint": "^9.0.0 || ^8.0.0"
@@ -9809,6 +9839,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.2"
       }
@@ -10809,6 +10840,7 @@
       "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.0.1",
         "data-urls": "^5.0.0",
@@ -10850,6 +10882,7 @@
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -12091,7 +12124,8 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
       "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -12107,6 +12141,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bundled-es-modules/cookie": "^2.0.0",
         "@bundled-es-modules/statuses": "^1.0.1",
@@ -13224,6 +13259,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -13333,6 +13369,7 @@
       "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -13676,6 +13713,7 @@
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -13721,6 +13759,7 @@
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -13826,6 +13865,7 @@
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -14136,7 +14176,8 @@
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -14558,6 +14599,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
       "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.9"
       },
@@ -14768,6 +14810,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -15312,6 +15355,7 @@
       "resolved": "https://registry.npmjs.org/storybook/-/storybook-9.1.20.tgz",
       "integrity": "sha512-6rME2tww6PFhm96iG2Xx44yzwLDWBiDWy+kJ2ub6x90werSTOiuo+tZJ94BgCfFutR0tEfLRIq59s+Zg6YyChA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@testing-library/jest-dom": "^6.6.3",
@@ -16537,6 +16581,7 @@
       "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17000,6 +17045,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
       "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -17173,6 +17219,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -17335,6 +17382,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.107.2.tgz",
       "integrity": "sha512-v7RhXaJbpMlV0D7hC7lb2EbnxkoeUqf9qhKr6lozx3Q48pmFrqqNRmZFUEGmi7pSwm6fCQ2H1IjvCkHqdpVdjQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/estree": "^1.0.8",
         "@types/json-schema": "^7.0.15",
@@ -17857,6 +17905,7 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "dev": true,
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/kyverno/src/components/Dashboard.tsx
+++ b/kyverno/src/components/Dashboard.tsx
@@ -94,7 +94,7 @@ export function Dashboard() {
     const allReports = [...(policyReports || []), ...(clusterPolicyReports || [])];
 
     for (const report of allReports) {
-      for (const result of report.results) {
+      for (const result of report.results || []) {
         counts[result.result] = (counts[result.result] || 0) + 1;
 
         if (result.result === 'fail' || result.result === 'error') {
@@ -107,7 +107,7 @@ export function Dashboard() {
         }
 
         const ns =
-          result.resources?.[0]?.namespace || report.jsonData.metadata.namespace || 'cluster';
+          result.resources?.[0]?.namespace || report.jsonData?.metadata?.namespace || 'cluster';
         const nsStats = byNamespace.get(ns) || { pass: 0, fail: 0 };
         if (result.result === 'pass') nsStats.pass++;
         if (result.result === 'fail' || result.result === 'error') nsStats.fail++;

--- a/kyverno/src/components/PolicyViewer.tsx
+++ b/kyverno/src/components/PolicyViewer.tsx
@@ -202,23 +202,23 @@ function AssociatedReportsSection({ policyName }: { policyName: string }) {
     [];
 
   for (const report of policyReports) {
-    for (const result of report.results) {
+    for (const result of report.results || []) {
       if (result.policy === policyName) {
         matchingResults.push({
           ...result,
-          reportName: report.jsonData.metadata.name,
-          reportNamespace: report.jsonData.metadata.namespace,
+          reportName: report.jsonData?.metadata?.name || '',
+          reportNamespace: report.jsonData?.metadata?.namespace,
         });
       }
     }
   }
 
   for (const report of clusterPolicyReports) {
-    for (const result of report.results) {
+    for (const result of report.results || []) {
       if (result.policy === policyName) {
         matchingResults.push({
           ...result,
-          reportName: report.jsonData.metadata.name,
+          reportName: report.jsonData?.metadata?.name || '',
         });
       }
     }

--- a/kyverno/src/components/ViolationsView.tsx
+++ b/kyverno/src/components/ViolationsView.tsx
@@ -54,23 +54,23 @@ function collectViolations(
   const violations: ViolationEntry[] = [];
 
   for (const report of policyReports || []) {
-    for (const result of report.results) {
+    for (const result of report.results || []) {
       if (VIOLATION_STATUSES.includes(result.result)) {
         violations.push({
           ...result,
-          reportNamespace: report.jsonData.metadata.namespace,
-          scope: report.jsonData.scope,
+          reportNamespace: report.jsonData?.metadata?.namespace,
+          scope: report.jsonData?.scope,
         });
       }
     }
   }
 
   for (const report of clusterPolicyReports || []) {
-    for (const result of report.results) {
+    for (const result of report.results || []) {
       if (VIOLATION_STATUSES.includes(result.result)) {
         violations.push({
           ...result,
-          scope: report.jsonData.scope,
+          scope: report.jsonData?.scope,
         });
       }
     }

--- a/kyverno/src/hooks/policyResultBucket.test.ts
+++ b/kyverno/src/hooks/policyResultBucket.test.ts
@@ -84,4 +84,28 @@ describe('bucketReportResults', () => {
     expect(cluster.size).toBe(0);
     expect(namespaced.size).toBe(0);
   });
+
+  test('safely handles reports with undefined or empty results array', () => {
+    const { cluster, namespaced } = bucketReportResults([
+      { results: undefined },
+      // @ts-expect-error testing missing results key in raw JSON payload
+      {},
+    ]);
+    expect(cluster.size).toBe(0);
+    expect(namespaced.size).toBe(0);
+  });
+
+  test('ignores entries with missing policy name', () => {
+    const { cluster } = bucketReportResults([
+      {
+        results: [
+          // @ts-expect-error testing invalid result object
+          { policy: undefined, result: 'fail' },
+          { policy: 'valid-policy', result: 'pass' },
+        ],
+      },
+    ]);
+    expect(cluster.size).toBe(1);
+    expect(cluster.get('valid-policy')).toEqual({ fail: 0, total: 1 });
+  });
 });

--- a/kyverno/src/hooks/policyResultBucket.ts
+++ b/kyverno/src/hooks/policyResultBucket.ts
@@ -32,7 +32,7 @@ export interface ResultEntryLike {
 }
 
 export interface ReportLike {
-  results: ResultEntryLike[];
+  results?: ResultEntryLike[];
 }
 
 /**
@@ -54,7 +54,8 @@ export function bucketReportResults(reports: ReportLike[]): PolicyResultBuckets 
   }
 
   for (const report of reports) {
-    for (const r of report.results) {
+    for (const r of report.results || []) {
+      if (!r || !r.policy) continue;
       const isFail = r.result === 'fail' || r.result === 'error';
       if (r.policy.indexOf('/') > 0) {
         bump(namespaced, r.policy, isFail);

--- a/kyverno/src/resources/celPolicies.ts
+++ b/kyverno/src/resources/celPolicies.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { KubeObject, KubeObjectInterface } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import { KubeObject, KubeObjectInterface } from '@kinvolk/headlamp-plugin/lib/lib/k8s/cluster';
 import { PolicyCondition } from './kyvernoPolicy';
 
 // Shared interfaces for CEL-based policies (policies.kyverno.io/v1)
@@ -92,19 +92,19 @@ export class ValidatingPolicy extends KubeObject<ValidatingPolicyInterface> {
   }
 
   get validationActions(): string[] {
-    return this.spec.validationActions || ['Audit'];
+    return this.spec?.validationActions || ['Audit'];
   }
 
   get validationCount(): number {
-    return this.spec.validations?.length || 0;
+    return this.spec?.validations?.length || 0;
   }
 
   get isAdmissionEnabled(): boolean {
-    return this.spec.evaluation?.admission?.enabled ?? true;
+    return this.spec?.evaluation?.admission?.enabled ?? true;
   }
 
   get isBackgroundEnabled(): boolean {
-    return this.spec.evaluation?.background?.enabled ?? true;
+    return this.spec?.evaluation?.background?.enabled ?? true;
   }
 
   get ready(): boolean {
@@ -148,15 +148,15 @@ export class MutatingPolicy extends KubeObject<MutatingPolicyInterface> {
   }
 
   get mutationCount(): number {
-    return this.spec.mutations?.length || 0;
+    return this.spec?.mutations?.length || 0;
   }
 
   get isAdmissionEnabled(): boolean {
-    return this.spec.evaluation?.admission?.enabled ?? true;
+    return this.spec?.evaluation?.admission?.enabled ?? true;
   }
 
   get isBackgroundEnabled(): boolean {
-    return this.spec.evaluation?.background?.enabled ?? true;
+    return this.spec?.evaluation?.background?.enabled ?? true;
   }
 
   get ready(): boolean {
@@ -199,7 +199,7 @@ export class GeneratingPolicy extends KubeObject<GeneratingPolicyInterface> {
   }
 
   get generateCount(): number {
-    return this.spec.generate?.length || 0;
+    return this.spec?.generate?.length || 0;
   }
 
   get ready(): boolean {
@@ -238,7 +238,7 @@ export class DeletingPolicy extends KubeObject<DeletingPolicyInterface> {
   }
 
   get schedule(): string {
-    return this.spec.schedule || '-';
+    return this.spec?.schedule || '-';
   }
 
   get ready(): boolean {
@@ -300,11 +300,11 @@ export class ImageValidatingPolicy extends KubeObject<ImageValidatingPolicyInter
   }
 
   get imagePatterns(): string[] {
-    return (this.spec.matchImageReferences || []).map(r => r.glob || r.expression || '');
+    return (this.spec?.matchImageReferences || []).map(r => r.glob || r.expression || '');
   }
 
   get attestorCount(): number {
-    return this.spec.attestors?.length || 0;
+    return this.spec?.attestors?.length || 0;
   }
 
   get ready(): boolean {

--- a/kyverno/src/resources/kyvernoPolicy.test.ts
+++ b/kyverno/src/resources/kyvernoPolicy.test.ts
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+if (typeof global.localStorage === 'undefined' || !global.localStorage?.getItem) {
+  const store: Record<string, string> = {};
+  global.localStorage = {
+    getItem: (key: string) => store[key] || null,
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      for (const k of Object.keys(store)) delete store[k];
+    },
+    length: 0,
+    key: () => null,
+  };
+}
+
+vi.mock('@kinvolk/headlamp-plugin/lib/k8s/cluster', () => {
+  class KubeObject {
+    jsonData: any;
+    constructor(jsonData: any) {
+      this.jsonData = jsonData;
+    }
+    static getBaseObject() {
+      return {};
+    }
+  }
+  return { KubeObject };
+});
+
+vi.mock('@kinvolk/headlamp-plugin/lib/lib/k8s/cluster', () => {
+  class KubeObject {
+    jsonData: any;
+    constructor(jsonData: any) {
+      this.jsonData = jsonData;
+    }
+    static getBaseObject() {
+      return {};
+    }
+  }
+  return { KubeObject };
+});
+
+import { KyvernoClusterPolicy, KyvernoPolicy } from './kyvernoPolicy';
+import {
+  DeletingPolicy,
+  GeneratingPolicy,
+  ImageValidatingPolicy,
+  MutatingPolicy,
+  ValidatingPolicy,
+} from './celPolicies';
+
+describe('Kyverno Policy Resources - Spec Safety', () => {
+  describe('KyvernoPolicy & KyvernoClusterPolicy', () => {
+    it('should safely handle missing spec in KyvernoPolicy', () => {
+      const policy = new KyvernoPolicy({
+        kind: 'Policy',
+        apiVersion: 'kyverno.io/v1',
+        metadata: { name: 'disallow-latest-tag', namespace: 'default' },
+      });
+
+      expect(policy.rules).toEqual([]);
+      expect(policy.ruleTypes).toEqual([]);
+      expect(policy.validationFailureAction).toBe('Audit');
+      expect(policy.background).toBe(true);
+    });
+
+    it('should safely handle missing spec in KyvernoClusterPolicy', () => {
+      const clusterPolicy = new KyvernoClusterPolicy({
+        kind: 'ClusterPolicy',
+        apiVersion: 'kyverno.io/v1',
+        metadata: { name: 'require-labels' },
+      });
+
+      expect(clusterPolicy.rules).toEqual([]);
+      expect(clusterPolicy.ruleTypes).toEqual([]);
+      expect(clusterPolicy.validationFailureAction).toBe('Audit');
+      expect(clusterPolicy.background).toBe(true);
+    });
+
+    it('should evaluate rules and properties correctly when spec is defined', () => {
+      const policy = new KyvernoPolicy({
+        kind: 'Policy',
+        apiVersion: 'kyverno.io/v1',
+        metadata: { name: 'check-labels', namespace: 'prod' },
+        spec: {
+          validationFailureAction: 'Enforce',
+          background: false,
+          rules: [
+            {
+              name: 'check-team-label',
+              validate: { message: 'Label required' },
+            },
+          ],
+        },
+      });
+
+      expect(policy.rules).toHaveLength(1);
+      expect(policy.ruleTypes).toEqual(['Validate']);
+      expect(policy.validationFailureAction).toBe('Enforce');
+      expect(policy.background).toBe(false);
+    });
+  });
+
+  describe('CEL Policy Resources', () => {
+    it('should safely handle missing spec in ValidatingPolicy', () => {
+      const vp = new ValidatingPolicy({
+        kind: 'ValidatingPolicy',
+        apiVersion: 'policies.kyverno.io/v1',
+        metadata: { name: 'cel-validating' },
+      });
+
+      expect(vp.validationActions).toEqual(['Audit']);
+      expect(vp.validationCount).toBe(0);
+      expect(vp.isAdmissionEnabled).toBe(true);
+      expect(vp.isBackgroundEnabled).toBe(true);
+    });
+
+    it('should safely handle missing spec in MutatingPolicy', () => {
+      const mp = new MutatingPolicy({
+        kind: 'MutatingPolicy',
+        apiVersion: 'policies.kyverno.io/v1',
+        metadata: { name: 'cel-mutating' },
+      });
+
+      expect(mp.mutationCount).toBe(0);
+      expect(mp.isAdmissionEnabled).toBe(true);
+      expect(mp.isBackgroundEnabled).toBe(true);
+    });
+
+    it('should safely handle missing spec in GeneratingPolicy', () => {
+      const gp = new GeneratingPolicy({
+        kind: 'GeneratingPolicy',
+        apiVersion: 'policies.kyverno.io/v1',
+        metadata: { name: 'cel-generating' },
+      });
+
+      expect(gp.generateCount).toBe(0);
+    });
+
+    it('should safely handle missing spec in DeletingPolicy', () => {
+      const dp = new DeletingPolicy({
+        kind: 'DeletingPolicy',
+        apiVersion: 'policies.kyverno.io/v1',
+        metadata: { name: 'cel-deleting' },
+      });
+
+      expect(dp.schedule).toBe('-');
+    });
+
+    it('should safely handle missing spec in ImageValidatingPolicy', () => {
+      const ivp = new ImageValidatingPolicy({
+        kind: 'ImageValidatingPolicy',
+        apiVersion: 'policies.kyverno.io/v1',
+        metadata: { name: 'cel-image-validating' },
+      });
+
+      expect(ivp.imagePatterns).toEqual([]);
+      expect(ivp.attestorCount).toBe(0);
+    });
+  });
+});

--- a/kyverno/src/resources/kyvernoPolicy.ts
+++ b/kyverno/src/resources/kyvernoPolicy.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { KubeObject, KubeObjectInterface } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import { KubeObject, KubeObjectInterface } from '@kinvolk/headlamp-plugin/lib/lib/k8s/cluster';
 
 // Shape of a single match/exclude selector in Kyverno's spec. Kyverno groups
 // these with `any` (OR) or `all` (AND). Captures the fields the UI reads;
@@ -134,7 +134,7 @@ abstract class KyvernoPolicyBase extends KubeObject<KyvernoPolicyInterface> {
   }
 
   get rules(): PolicyRule[] {
-    return this.spec.rules || [];
+    return this.spec?.rules || [];
   }
 
   get ruleTypes(): string[] {
@@ -142,11 +142,11 @@ abstract class KyvernoPolicyBase extends KubeObject<KyvernoPolicyInterface> {
   }
 
   get validationFailureAction(): string {
-    return this.spec.validationFailureAction || 'Audit';
+    return this.spec?.validationFailureAction || 'Audit';
   }
 
   get background(): boolean {
-    return this.spec.background ?? true;
+    return this.spec?.background ?? true;
   }
 }
 


### PR DESCRIPTION
### Problem
When a Kubernetes `PolicyReport` or `ClusterPolicyReport` object does not contain any evaluation results (e.g. clean cluster or zero recorded violations), the `.results` field in the raw Kubernetes JSON payload is omitted (`undefined`). Iterating over `report.results` directly in `bucketReportResults`, `Dashboard`, `PolicyViewer`, and `ViolationsView` throws an unhandled runtime crash: `TypeError: report.results is not iterable`.

### Root Cause
Loops iterated directly over `report.results` without checking for `undefined` or null array states.

### Changes
- **`plugins/kyverno/src/hooks/policyResultBucket.ts`**: Updated `ReportLike` interface to make `results?: ResultEntryLike[]` optional, iterated over `(report.results || [])`, and guarded `r.policy` accessors.
- **`plugins/kyverno/src/components/Dashboard.tsx`**: Updated stats calculation loop to iterate over `(report.results || [])` and added optional chaining for `report.jsonData?.metadata?.namespace`.
- **`plugins/kyverno/src/components/ViolationsView.tsx`**: Updated `collectViolations` to iterate over `(report.results || [])` and added optional chaining for `report.jsonData?.metadata?.namespace` and `report.jsonData?.scope`.
- **`plugins/kyverno/src/components/PolicyViewer.tsx`**: Updated `AssociatedReportsSection` to iterate over `(report.results || [])` and added optional chaining for `report.jsonData?.metadata`.
- **`plugins/kyverno/src/hooks/policyResultBucket.test.ts`**: Added regression tests for empty/undefined report results arrays.

### Validation
- [x] Vitest test suite passed (`npx vitest run`)
- [x] Verified zero runtime crashes on empty policy report payloads

