### PR TITLE
fix(flux): guard missing canary targetRef kind

### DIFF
--- a/flux/src/flagger/canaries.tsx
+++ b/flux/src/flagger/canaries.tsx
@@ -139,11 +139,11 @@ function CanaryList({ canaryResourceClass }) {
               const kind = item?.spec?.targetRef?.kind;
               const namespace = item?.spec?.targetRef?.namespace || item?.metadata?.namespace;
               const name = item?.spec?.targetRef?.name;
-              return (
+              return kind ? (
                 <Link routeName={`${kind.toLowerCase()}`} params={{ name, namespace }}>
                   {name}
                 </Link>
-              );
+              ) : null;
             },
           },
           {


### PR DESCRIPTION
## What does this PR do?

Guards `spec.targetRef.kind` before calling `.toLowerCase()` in the Canaries list.

When `targetRef.kind` is missing, the Target column previously crashed with:

`Cannot read properties of undefined (reading 'toLowerCase')`

This change returns `null` when `kind` is not set, matching the existing handling in `canarydetails.tsx`.

## Testing

- TypeScript check passes.
- ESLint check passes.
- `git diff --check` passes.
- Full test suite was attempted; unrelated `ai-assistant` dependency/test failures remain.

Fixes #1137