### PR TITLE
fix(kyverno): scope Associated Report Results to policy namespace

### DIFF
--- a/kyverno/src/components/PolicyViewer.tsx
+++ b/kyverno/src/components/PolicyViewer.tsx
@@ -25,6 +25,7 @@ import {
   Table,
 } from '@kinvolk/headlamp-plugin/lib/components/common';
 import { Box, Chip, CircularProgress, Typography } from '@mui/material';
+import { filterResultsForPolicy } from '../hooks/policyResultBucket';
 import {
   KyvernoClusterPolicy,
   KyvernoPolicy,
@@ -181,7 +182,13 @@ function RulesTable({ rules }: { rules: PolicyRule[] }) {
   );
 }
 
-function AssociatedReportsSection({ policyName }: { policyName: string }) {
+function AssociatedReportsSection({
+  policyName,
+  namespace,
+}: {
+  policyName: string;
+  namespace?: string;
+}) {
   const { t } = useTranslation();
   const { items: policyReports } = PolicyReport.useList();
   const { items: clusterPolicyReports } = ClusterPolicyReport.useList();
@@ -198,31 +205,23 @@ function AssociatedReportsSection({ policyName }: { policyName: string }) {
     );
   }
 
-  const matchingResults: (PolicyReportResult & { reportName: string; reportNamespace?: string })[] =
-    [];
-
-  for (const report of policyReports) {
+  // A ClusterPolicy's results can land in either a namespaced PolicyReport
+  // (for namespaced resource matches) or a ClusterPolicyReport (for
+  // cluster-scoped resource matches), so both lists are merged and matched
+  // uniformly against the same namespace/name-prefixed key that
+  // usePolicyResultCounts already relies on elsewhere in this plugin.
+  const allResults: (PolicyReportResult & { reportName: string; reportNamespace?: string })[] = [];
+  for (const report of [...policyReports, ...clusterPolicyReports]) {
     for (const result of report.results) {
-      if (result.policy === policyName) {
-        matchingResults.push({
-          ...result,
-          reportName: report.jsonData.metadata.name,
-          reportNamespace: report.jsonData.metadata.namespace,
-        });
-      }
+      allResults.push({
+        ...result,
+        reportName: report.jsonData.metadata.name,
+        reportNamespace: report.jsonData.metadata.namespace,
+      });
     }
   }
 
-  for (const report of clusterPolicyReports) {
-    for (const result of report.results) {
-      if (result.policy === policyName) {
-        matchingResults.push({
-          ...result,
-          reportName: report.jsonData.metadata.name,
-        });
-      }
-    }
-  }
+  const matchingResults = filterResultsForPolicy(allResults, policyName, namespace);
 
   return (
     <SectionBox
@@ -318,7 +317,10 @@ function PolicyContent({ policy }: { policy: KyvernoPolicy | KyvernoClusterPolic
       <SectionBox title={t('Rules ({{count}})', { count: policy.rules.length })}>
         <RulesTable rules={policy.rules} />
       </SectionBox>
-      <AssociatedReportsSection policyName={policy.jsonData.metadata.name} />
+      <AssociatedReportsSection
+        policyName={policy.jsonData.metadata.name}
+        namespace={policy.jsonData.metadata.namespace}
+      />
       <YamlSection jsonData={policy.jsonData} />
     </Box>
   );

--- a/kyverno/src/hooks/policyResultBucket.test.ts
+++ b/kyverno/src/hooks/policyResultBucket.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { describe, expect, test } from 'vitest';
-import { bucketReportResults } from './policyResultBucket';
+import { bucketReportResults, filterResultsForPolicy } from './policyResultBucket';
 
 describe('bucketReportResults', () => {
   test('separates cluster-scoped from namespaced policies by slash prefix', () => {
@@ -83,5 +83,47 @@ describe('bucketReportResults', () => {
     const { cluster, namespaced } = bucketReportResults([]);
     expect(cluster.size).toBe(0);
     expect(namespaced.size).toBe(0);
+  });
+});
+
+describe('filterResultsForPolicy', () => {
+  test('matches a namespaced policy by its namespace/name-prefixed key', () => {
+    const results = [
+      { policy: 'default/require-labels', result: 'fail', rule: 'check-labels' },
+      { policy: 'default/require-labels', result: 'pass', rule: 'check-labels' },
+    ];
+
+    expect(filterResultsForPolicy(results, 'require-labels', 'default')).toHaveLength(2);
+  });
+
+  test('does not match the same-named policy in a different namespace', () => {
+    const results = [{ policy: 'team-a/require-labels', result: 'fail' }];
+
+    expect(filterResultsForPolicy(results, 'require-labels', 'team-b')).toEqual([]);
+  });
+
+  test('a same-named ClusterPolicy does not leak into a namespaced lookup', () => {
+    // Regression guard: a bare-name comparison (no prefix) would wrongly match
+    // this, since 'restrict-images' === 'restrict-images'.
+    const results = [{ policy: 'restrict-images', result: 'fail' }];
+
+    expect(filterResultsForPolicy(results, 'restrict-images', 'default')).toEqual([]);
+  });
+
+  test('matches a cluster-scoped policy by its bare name', () => {
+    const results = [
+      { policy: 'restrict-images', result: 'fail' },
+      { policy: 'default/restrict-images', result: 'pass' },
+    ];
+
+    expect(filterResultsForPolicy(results, 'restrict-images')).toEqual([
+      { policy: 'restrict-images', result: 'fail' },
+    ]);
+  });
+
+  test('returns an empty array when nothing matches', () => {
+    const results = [{ policy: 'default/other-policy', result: 'pass' }];
+
+    expect(filterResultsForPolicy(results, 'require-labels', 'default')).toEqual([]);
   });
 });

--- a/kyverno/src/hooks/policyResultBucket.ts
+++ b/kyverno/src/hooks/policyResultBucket.ts
@@ -66,3 +66,22 @@ export function bucketReportResults(reports: ReportLike[]): PolicyResultBuckets 
 
   return { cluster, namespaced };
 }
+
+/**
+ * Filters a flat list of report results down to the ones belonging to one
+ * specific policy, using the same `<namespace>/<name>` (or bare `<name>` for
+ * cluster-scoped) key as {@link bucketReportResults}.
+ *
+ * A ClusterPolicy's results can land in either a namespaced PolicyReport (for
+ * namespaced resource matches) or a ClusterPolicyReport (for cluster-scoped
+ * resource matches), so callers should pass results merged from both report
+ * lists rather than filtering them separately.
+ */
+export function filterResultsForPolicy<T extends ResultEntryLike>(
+  results: T[],
+  policyName: string,
+  namespace?: string
+): T[] {
+  const key = namespace ? `${namespace}/${policyName}` : policyName;
+  return results.filter(r => r.policy === key);
+}


### PR DESCRIPTION
Fixes #1148

## Description

`AssociatedReportsSection` on the policy detail page matches `PolicyReport`/`ClusterPolicyReport` results by comparing `result.policy === policyName`, using the bare policy name.

Kyverno prefixes namespaced-policy results as `<namespace>/<name>` — this is already the convention `bucketReportResults`/`usePolicyResultCounts` rely on elsewhere in this plugin (see `policyResultBucket.ts`). `AssociatedReportsSection` never applied it, so:

- For a namespaced `Policy`, the comparison (`result.policy` = `"default/require-labels"` vs `policyName` = `"require-labels"`) never matches — the "Associated Report Results" table is always empty on namespaced policy pages, regardless of real data.
- The two report lists were also scanned separately (`policyReports` then `clusterPolicyReports`), but a `ClusterPolicy`'s results can land in either report type depending on whether the matched resource is namespaced or cluster-scoped, so results could be missed even if the key comparison were fixed.

## Fix

- Extracted `filterResultsForPolicy()` into `policyResultBucket.ts`, reusing the same `<namespace>/<name>` (or bare `<name>` for cluster-scoped) key already established and tested there.
- `AssociatedReportsSection` now merges both report lists before filtering, and passes the policy's `namespace` down from `PolicyContent`.

## Testing

- Added 5 unit tests to `policyResultBucket.test.ts` covering: namespaced match, cross-namespace non-match, cluster/namespaced same-name non-collision, cluster-scoped match, no-match case. All 10 tests in the file pass.
- `tsc --noEmit` clean, `eslint --max-warnings 0` clean, `prettier --check` clean, `npm run build` succeeds.

## AI assistance disclosure

This PR was written in part with the assistance of generative AI (Claude).