### PR TITLE
kyverno: include v2 reports in aggregate views

### DIFF
--- a/kyverno/src/components/CRDGuard.tsx
+++ b/kyverno/src/components/CRDGuard.tsx
@@ -38,6 +38,7 @@ export function CRDGuard({ requires, children, message }: CRDGuardProps) {
     ),
     cleanup: t('Kyverno cleanup policies (kyverno.io/v2) were not detected on this cluster.'),
     reports: t('Policy Reports (wgpolicyk8s.io/v1alpha2) were not detected on this cluster.'),
+    reportSources: t('Kyverno report sources were not detected on this cluster.'),
     exceptions: t('Policy Exceptions (kyverno.io/v2) were not detected on this cluster.'),
     kyvernoV2Reports: t(
       'Kyverno admission/background-scan reports (kyverno.io/v2) were not detected on this cluster.'

--- a/kyverno/src/components/ComplianceBadge.tsx
+++ b/kyverno/src/components/ComplianceBadge.tsx
@@ -20,7 +20,8 @@ import { Badge, Box, IconButton, Link, Menu, Tooltip, Typography } from '@mui/ma
 import { useMemo, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useKyvernoCRDs } from '../hooks/useKyvernoCRDs';
-import { ClusterPolicyReport, PolicyReport, PolicyResultStatus } from '../resources/policyReport';
+import { usePolicyReportSources } from '../hooks/usePolicyReportSources';
+import { PolicyResultStatus } from '../resources/policyReport';
 
 // App-bar actions render on every page, so the badge has to gate itself.
 // We only render when we're in a cluster context AND Kyverno is actually
@@ -31,7 +32,7 @@ export function ComplianceBadge() {
   const crds = useKyvernoCRDs();
 
   const hasKyvernoEngine = crds.legacy || crds.cel;
-  if (!cluster || crds.loading || !hasKyvernoEngine || !crds.reports) {
+  if (!cluster || crds.loading || !hasKyvernoEngine || !crds.reportSources) {
     return null;
   }
 
@@ -40,8 +41,7 @@ export function ComplianceBadge() {
 
 function ComplianceBadgeContent() {
   const { t } = useTranslation();
-  const { items: policyReports } = PolicyReport.useList();
-  const { items: clusterPolicyReports } = ClusterPolicyReport.useList();
+  const { reports, loading } = usePolicyReportSources();
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const history = useHistory();
   const cluster = K8s.useCluster();
@@ -56,10 +56,6 @@ function ComplianceBadgeContent() {
 
   const open = Boolean(anchorEl);
 
-  // Hide the badge until BOTH streams arrive — otherwise we'd briefly show a misleading
-  // "100% compliant" while only one list has resolved.
-  const isLoading = policyReports === null || clusterPolicyReports === null;
-
   const counts = useMemo(() => {
     const result: Record<PolicyResultStatus, number> = {
       pass: 0,
@@ -69,16 +65,7 @@ function ComplianceBadgeContent() {
       skip: 0,
     };
 
-    for (const report of policyReports || []) {
-      const s = report.summary;
-      result.pass += s.pass || 0;
-      result.fail += s.fail || 0;
-      result.warn += s.warn || 0;
-      result.error += s.error || 0;
-      result.skip += s.skip || 0;
-    }
-
-    for (const report of clusterPolicyReports || []) {
+    for (const report of reports) {
       const s = report.summary;
       result.pass += s.pass || 0;
       result.fail += s.fail || 0;
@@ -88,9 +75,9 @@ function ComplianceBadgeContent() {
     }
 
     return result;
-  }, [policyReports, clusterPolicyReports]);
+  }, [reports]);
 
-  if (isLoading) {
+  if (loading) {
     return null;
   }
 

--- a/kyverno/src/components/Dashboard.tsx
+++ b/kyverno/src/components/Dashboard.tsx
@@ -30,8 +30,9 @@ import {
   XAxis,
   YAxis,
 } from 'recharts';
+import { usePolicyReportSources } from '../hooks/usePolicyReportSources';
 import { KyvernoClusterPolicy, KyvernoPolicy } from '../resources/kyvernoPolicy';
-import { ClusterPolicyReport, PolicyReport, PolicyResultStatus } from '../resources/policyReport';
+import { PolicyResultStatus } from '../resources/policyReport';
 
 const STATUS_COLORS: Record<PolicyResultStatus, string> = {
   pass: '#4caf50',
@@ -76,8 +77,7 @@ export function Dashboard() {
   const { t } = useTranslation();
   const [clusterPolicies] = KyvernoClusterPolicy.useList();
   const [policies] = KyvernoPolicy.useList();
-  const { items: policyReports } = PolicyReport.useList();
-  const { items: clusterPolicyReports } = ClusterPolicyReport.useList();
+  const { reports, loading: reportsLoading } = usePolicyReportSources();
 
   const stats = useMemo(() => {
     const counts: Record<PolicyResultStatus, number> = {
@@ -91,9 +91,7 @@ export function Dashboard() {
     const bySeverity = new Map<string, number>();
     const byNamespace = new Map<string, { pass: number; fail: number }>();
 
-    const allReports = [...(policyReports || []), ...(clusterPolicyReports || [])];
-
-    for (const report of allReports) {
+    for (const report of reports) {
       for (const result of report.results) {
         counts[result.result] = (counts[result.result] || 0) + 1;
 
@@ -106,8 +104,7 @@ export function Dashboard() {
           bySeverity.set(result.severity, (bySeverity.get(result.severity) || 0) + 1);
         }
 
-        const ns =
-          result.resources?.[0]?.namespace || report.jsonData.metadata.namespace || 'cluster';
+        const ns = result.resources?.[0]?.namespace || report.metadata.namespace || 'cluster';
         const nsStats = byNamespace.get(ns) || { pass: 0, fail: 0 };
         if (result.result === 'pass') nsStats.pass++;
         if (result.result === 'fail' || result.result === 'error') nsStats.fail++;
@@ -137,7 +134,7 @@ export function Dashboard() {
       bySeverity,
       byNamespace,
     };
-  }, [clusterPolicies, policies, policyReports, clusterPolicyReports]);
+  }, [clusterPolicies, policies, reports]);
 
   const statusData = useMemo(() => {
     return (['pass', 'fail', 'warn', 'error', 'skip'] as PolicyResultStatus[])
@@ -177,11 +174,7 @@ export function Dashboard() {
 
   // Loading until ALL streams resolve — otherwise totals/compliance flash partial values
   // as each useList settles.
-  const isLoading =
-    clusterPolicies === null ||
-    policies === null ||
-    policyReports === null ||
-    clusterPolicyReports === null;
+  const isLoading = clusterPolicies === null || policies === null || reportsLoading;
 
   const complianceColor =
     stats.compliancePct === null

--- a/kyverno/src/components/PolicyViewer.tsx
+++ b/kyverno/src/components/PolicyViewer.tsx
@@ -25,6 +25,7 @@ import {
   Table,
 } from '@kinvolk/headlamp-plugin/lib/components/common';
 import { Box, Chip, CircularProgress, Typography } from '@mui/material';
+import { usePolicyReportSources } from '../hooks/usePolicyReportSources';
 import {
   KyvernoClusterPolicy,
   KyvernoPolicy,
@@ -32,7 +33,7 @@ import {
   PolicyCondition,
   PolicyRule,
 } from '../resources/kyvernoPolicy';
-import { ClusterPolicyReport, PolicyReport, PolicyReportResult } from '../resources/policyReport';
+import { PolicyReportResult } from '../resources/policyReport';
 import { ResultStatusChip, SeverityChip } from './common';
 
 interface PolicyViewerProps {
@@ -183,12 +184,9 @@ function RulesTable({ rules }: { rules: PolicyRule[] }) {
 
 function AssociatedReportsSection({ policyName }: { policyName: string }) {
   const { t } = useTranslation();
-  const { items: policyReports } = PolicyReport.useList();
-  const { items: clusterPolicyReports } = ClusterPolicyReport.useList();
+  const { reports, loading: reportsLoading } = usePolicyReportSources();
 
-  // Wait for BOTH streams before rendering — otherwise we'd briefly show a
-  // partial result set as soon as the first list resolves.
-  if (policyReports === null || clusterPolicyReports === null) {
+  if (reportsLoading) {
     return (
       <SectionBox title={t('Associated Report Results')}>
         <Box sx={{ display: 'flex', justifyContent: 'center', py: 2 }}>
@@ -201,24 +199,13 @@ function AssociatedReportsSection({ policyName }: { policyName: string }) {
   const matchingResults: (PolicyReportResult & { reportName: string; reportNamespace?: string })[] =
     [];
 
-  for (const report of policyReports) {
+  for (const report of reports) {
     for (const result of report.results) {
       if (result.policy === policyName) {
         matchingResults.push({
           ...result,
           reportName: report.jsonData.metadata.name,
           reportNamespace: report.jsonData.metadata.namespace,
-        });
-      }
-    }
-  }
-
-  for (const report of clusterPolicyReports) {
-    for (const result of report.results) {
-      if (result.policy === policyName) {
-        matchingResults.push({
-          ...result,
-          reportName: report.jsonData.metadata.name,
         });
       }
     }

--- a/kyverno/src/components/ViolationsView.tsx
+++ b/kyverno/src/components/ViolationsView.tsx
@@ -29,9 +29,8 @@ import {
   Typography,
 } from '@mui/material';
 import { useMemo, useState } from 'react';
+import { PolicyReportSource, usePolicyReportSources } from '../hooks/usePolicyReportSources';
 import {
-  ClusterPolicyReport,
-  PolicyReport,
   PolicyReportInterface,
   PolicyReportResult,
   PolicyResultStatus,
@@ -47,30 +46,16 @@ interface ViolationEntry extends PolicyReportResult {
 
 const VIOLATION_STATUSES: PolicyResultStatus[] = ['fail', 'warn', 'error'];
 
-function collectViolations(
-  policyReports: PolicyReport[] | null,
-  clusterPolicyReports: ClusterPolicyReport[] | null
-): ViolationEntry[] {
+function collectViolations(reports: PolicyReportSource[]): ViolationEntry[] {
   const violations: ViolationEntry[] = [];
 
-  for (const report of policyReports || []) {
+  for (const report of reports) {
     for (const result of report.results) {
       if (VIOLATION_STATUSES.includes(result.result)) {
         violations.push({
           ...result,
-          reportNamespace: report.jsonData.metadata.namespace,
-          scope: report.jsonData.scope,
-        });
-      }
-    }
-  }
-
-  for (const report of clusterPolicyReports || []) {
-    for (const result of report.results) {
-      if (VIOLATION_STATUSES.includes(result.result)) {
-        violations.push({
-          ...result,
-          scope: report.jsonData.scope,
+          reportNamespace: report.metadata.namespace,
+          scope: report.scope,
         });
       }
     }
@@ -154,8 +139,7 @@ function StatusFilterChips({
 
 export function ViolationsView() {
   const { t } = useTranslation();
-  const { items: policyReports } = PolicyReport.useList();
-  const { items: clusterPolicyReports } = ClusterPolicyReport.useList();
+  const { reports, loading: reportsLoading } = usePolicyReportSources();
   const [groupBy, setGroupBy] = useState<GroupBy>('none');
   const [statusFilter, setStatusFilter] = useState<PolicyResultStatus[]>(VIOLATION_STATUSES);
   const [severityFilter, setSeverityFilter] = useState<string>('all');
@@ -206,10 +190,7 @@ export function ViolationsView() {
     [t]
   );
 
-  const allViolations = useMemo(
-    () => collectViolations(policyReports, clusterPolicyReports),
-    [policyReports, clusterPolicyReports]
-  );
+  const allViolations = useMemo(() => collectViolations(reports), [reports]);
 
   const filteredViolations = useMemo(() => {
     return allViolations.filter(v => {
@@ -241,10 +222,7 @@ export function ViolationsView() {
     return Array.from(set).sort();
   }, [allViolations]);
 
-  // Wait for BOTH streams — partial data here would silently undercount violations.
-  const isLoading = policyReports === null || clusterPolicyReports === null;
-
-  if (isLoading) {
+  if (reportsLoading) {
     return (
       <SectionBox title={t('Violations')}>
         <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>

--- a/kyverno/src/hooks/policyReportSources.test.ts
+++ b/kyverno/src/hooks/policyReportSources.test.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, test } from 'vitest';
+import { combineReportSources } from './policyReportSources';
+
+describe('combineReportSources', () => {
+  test('combines legacy and Kyverno v2 report source lists', () => {
+    const { reports, loading } = combineReportSources([
+      { items: ['policy-report'] },
+      { items: ['cluster-policy-report'] },
+      { items: ['ephemeral-report'] },
+      { items: ['cluster-ephemeral-report'] },
+    ]);
+
+    expect(reports).toEqual([
+      'policy-report',
+      'cluster-policy-report',
+      'ephemeral-report',
+      'cluster-ephemeral-report',
+    ]);
+    expect(loading).toBe(false);
+  });
+
+  test('waits for source lists that are still loading', () => {
+    const { reports, loading } = combineReportSources([
+      { items: ['policy-report'] },
+      { items: null },
+    ]);
+
+    expect(reports).toEqual(['policy-report']);
+    expect(loading).toBe(true);
+  });
+
+  test('treats unavailable source lists as empty', () => {
+    const { reports, loading } = combineReportSources([
+      { items: ['policy-report'] },
+      { items: null, error: new Error('not found') },
+    ]);
+
+    expect(reports).toEqual(['policy-report']);
+    expect(loading).toBe(false);
+  });
+});

--- a/kyverno/src/hooks/policyReportSources.ts
+++ b/kyverno/src/hooks/policyReportSources.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface ReportSourceList<T> {
+  items: T[] | null;
+  error?: unknown;
+}
+
+export interface CombinedReportSources<T> {
+  reports: T[];
+  loading: boolean;
+}
+
+export function combineReportSources<T>(
+  sourceLists: ReportSourceList<T>[]
+): CombinedReportSources<T> {
+  return {
+    reports: sourceLists.flatMap(source => source.items || []),
+    loading: sourceLists.some(source => source.items === null && !source.error),
+  };
+}

--- a/kyverno/src/hooks/policyResultBucket.test.ts
+++ b/kyverno/src/hooks/policyResultBucket.test.ts
@@ -79,6 +79,19 @@ describe('bucketReportResults', () => {
     expect(cluster.get('p')).toEqual({ fail: 1, total: 3 });
   });
 
+  test('buckets unprefixed namespaced Kyverno report results by report namespace', () => {
+    const { cluster, namespaced } = bucketReportResults([
+      {
+        kind: 'EphemeralReport',
+        metadata: { namespace: 'lfx-demo' },
+        results: [{ policy: 'v2-aggregate-gap-demo', result: 'fail' }],
+      },
+    ]);
+
+    expect(namespaced.get('lfx-demo/v2-aggregate-gap-demo')).toEqual({ fail: 1, total: 1 });
+    expect(cluster.get('v2-aggregate-gap-demo')).toBeUndefined();
+  });
+
   test('returns empty buckets for empty input', () => {
     const { cluster, namespaced } = bucketReportResults([]);
     expect(cluster.size).toBe(0);

--- a/kyverno/src/hooks/policyResultBucket.ts
+++ b/kyverno/src/hooks/policyResultBucket.ts
@@ -32,15 +32,26 @@ export interface ResultEntryLike {
 }
 
 export interface ReportLike {
+  kind?: string;
+  metadata?: {
+    namespace?: string;
+  };
   results: ResultEntryLike[];
 }
 
+const NAMESPACED_KYVERNO_REPORT_KINDS = new Set([
+  'AdmissionReport',
+  'BackgroundScanReport',
+  'EphemeralReport',
+]);
+
 /**
- * Splits PolicyReport result entries by policy scope.
+ * Splits normalized report result entries by policy scope.
  *
- * Kyverno prefixes namespaced-policy results with `<namespace>/<name>`; cluster
- * policies stay unprefixed. The two maps keep these spaces separate so a
- * ClusterPolicy and a same-named Policy in some namespace don't merge counts.
+ * Legacy reports can prefix namespaced-policy results with `<namespace>/<name>`;
+ * namespaced Kyverno report sources expose their namespace on the report. The
+ * two maps keep these spaces separate so a ClusterPolicy and a same-named
+ * Policy in some namespace don't merge counts.
  */
 export function bucketReportResults(reports: ReportLike[]): PolicyResultBuckets {
   const cluster = new Map<string, PolicyResultCounts>();
@@ -58,6 +69,12 @@ export function bucketReportResults(reports: ReportLike[]): PolicyResultBuckets 
       const isFail = r.result === 'fail' || r.result === 'error';
       if (r.policy.indexOf('/') > 0) {
         bump(namespaced, r.policy, isFail);
+      } else if (
+        report.kind &&
+        NAMESPACED_KYVERNO_REPORT_KINDS.has(report.kind) &&
+        report.metadata?.namespace
+      ) {
+        bump(namespaced, `${report.metadata.namespace}/${r.policy}`, isFail);
       } else {
         bump(cluster, r.policy, isFail);
       }

--- a/kyverno/src/hooks/useKyvernoCRDs.ts
+++ b/kyverno/src/hooks/useKyvernoCRDs.ts
@@ -22,6 +22,7 @@ export interface KyvernoCRDStatus {
   cel: boolean; // policies.kyverno.io/v1 (ValidatingPolicy, MutatingPolicy, etc.)
   cleanup: boolean; // kyverno.io/v2 (CleanupPolicy, ClusterCleanupPolicy)
   reports: boolean; // wgpolicyk8s.io/v1alpha2 (PolicyReport, ClusterPolicyReport)
+  reportSources: boolean; // Any report source included by aggregate views
   exceptions: boolean; // kyverno.io/v2 (PolicyException)
   kyvernoV2Reports: boolean; // kyverno.io/v2 (Admission/BackgroundScan reports)
   ephemeralReports: boolean; // reports.kyverno.io/v1 (EphemeralReport, ClusterEphemeralReport)
@@ -33,6 +34,7 @@ const initialStatus: KyvernoCRDStatus = {
   cel: false,
   cleanup: false,
   reports: false,
+  reportSources: false,
   exceptions: false,
   kyvernoV2Reports: false,
   ephemeralReports: false,
@@ -91,6 +93,7 @@ async function probeCluster(cluster: string): Promise<KyvernoCRDStatus> {
       cel,
       cleanup,
       reports,
+      reportSources: reports || ephemeralReports,
       exceptions,
       kyvernoV2Reports,
       ephemeralReports,

--- a/kyverno/src/hooks/usePolicyReportSources.ts
+++ b/kyverno/src/hooks/usePolicyReportSources.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useMemo } from 'react';
+import { ClusterEphemeralReport, EphemeralReport } from '../resources/kyvernoReports';
+import { ClusterPolicyReport, PolicyReport } from '../resources/policyReport';
+import { combineReportSources } from './policyReportSources';
+
+export type PolicyReportSource =
+  | PolicyReport
+  | ClusterPolicyReport
+  | EphemeralReport
+  | ClusterEphemeralReport;
+
+export interface PolicyReportSources {
+  reports: PolicyReportSource[];
+  loading: boolean;
+}
+
+export function usePolicyReportSources(): PolicyReportSources {
+  const { items: policyReports, error: policyReportsError } = PolicyReport.useList();
+  const { items: clusterPolicyReports, error: clusterPolicyReportsError } =
+    ClusterPolicyReport.useList();
+  const { items: ephemeralReports, error: ephemeralReportsError } = EphemeralReport.useList();
+  const { items: clusterEphemeralReports, error: clusterEphemeralReportsError } =
+    ClusterEphemeralReport.useList();
+
+  return useMemo(
+    () =>
+      combineReportSources<PolicyReportSource>([
+        { items: policyReports, error: policyReportsError },
+        { items: clusterPolicyReports, error: clusterPolicyReportsError },
+        { items: ephemeralReports, error: ephemeralReportsError },
+        { items: clusterEphemeralReports, error: clusterEphemeralReportsError },
+      ]),
+    [
+      policyReports,
+      policyReportsError,
+      clusterPolicyReports,
+      clusterPolicyReportsError,
+      ephemeralReports,
+      ephemeralReportsError,
+      clusterEphemeralReports,
+      clusterEphemeralReportsError,
+    ]
+  );
+}

--- a/kyverno/src/hooks/usePolicyResultCounts.ts
+++ b/kyverno/src/hooks/usePolicyResultCounts.ts
@@ -15,8 +15,8 @@
  */
 
 import { useMemo } from 'react';
-import { ClusterPolicyReport, PolicyReport } from '../resources/policyReport';
 import { bucketReportResults, PolicyResultCounts } from './policyResultBucket';
+import { usePolicyReportSources } from './usePolicyReportSources';
 
 export type { PolicyResultCounts };
 
@@ -27,27 +27,22 @@ export interface PolicyResultLookup {
 }
 
 /**
- * Aggregates PolicyReport / ClusterPolicyReport results by policy name so list
- * views can show "X of Y failed" without each row re-walking every report.
+ * Aggregates normalized report-source results by policy name so list views can
+ * show "X of Y failed" without each row re-walking every report.
  *
  * The actual bucketing logic lives in `policyResultBucket.ts` so it can be
  * unit-tested without the Headlamp SDK shim.
  */
 export function usePolicyResultCounts(): PolicyResultLookup {
-  const { items: policyReports } = PolicyReport.useList();
-  const { items: clusterPolicyReports } = ClusterPolicyReport.useList();
+  const { reports, loading } = usePolicyReportSources();
 
   return useMemo(() => {
-    const { cluster, namespaced } = bucketReportResults([
-      ...(policyReports || []),
-      ...(clusterPolicyReports || []),
-    ]);
+    const { cluster, namespaced } = bucketReportResults(reports);
 
     return {
       forCluster: name => cluster.get(name),
       forNamespaced: (name, namespace) => namespaced.get(`${namespace}/${name}`),
-      // Loading until BOTH streams resolve — partial data would undercount per-row totals.
-      loading: policyReports === null || clusterPolicyReports === null,
+      loading,
     };
-  }, [policyReports, clusterPolicyReports]);
+  }, [reports, loading]);
 }

--- a/kyverno/src/index.tsx
+++ b/kyverno/src/index.tsx
@@ -321,7 +321,7 @@ registerKyvernoPage({
   parent: 'Kyverno',
   label: 'Violations',
   path: '/kyverno/violations',
-  requires: 'reports',
+  requires: 'reportSources',
   component: () => <ViolationsView />,
 });
 


### PR DESCRIPTION
## Summary

- add a shared Kyverno report-source hook for PolicyReport, ClusterPolicyReport, EphemeralReport, and ClusterEphemeralReport
- switch Overview, Violations, ComplianceBadge, usePolicyResultCounts, and PolicyViewer to read the shared normalized source list
- allow aggregate report routes/actions when any supported report source exists, and bucket namespaced v2 report results by report namespace
- add regression tests for source merging and namespaced v2 report bucketing

Fixes #1135

## Validation

- `npx -y node@22 node_modules/.bin/headlamp-plugin lint`
- `npx -y node@22 node_modules/.bin/headlamp-plugin tsc`
- `npx -y node@22 node_modules/.bin/headlamp-plugin test`
- `npx -y node@22 node_modules/.bin/headlamp-plugin build`
- Live Headlamp check on `kind-lfx-headlamp` with a temporary `EphemeralReport`: `Violations` showed `Violations (4)`, Overview showed `Fail: 4`, the compliance badge showed `4`, the matching policy row showed `1 / 1 failed`, and PolicyViewer showed `Associated Report Results (1)`.