### PR TITLE
fix(knative): guard getAge against future and unparsable timestamps

### DIFF
--- a/knative/src/utils/time.test.ts
+++ b/knative/src/utils/time.test.ts
@@ -61,4 +61,13 @@ describe('getAge', () => {
     const fiveDaysAgo = MOCK_NOW - 5 * 24 * 60 * 60 * 1000;
     expect(getAge(new Date(fiveDaysAgo).toISOString())).toBe('5d');
   });
+
+  it('should clamp a future timestamp to 0m', () => {
+    const fiveMinutesAhead = MOCK_NOW + 5 * 60 * 1000;
+    expect(getAge(new Date(fiveMinutesAhead).toISOString())).toBe('0m');
+  });
+
+  it('should return empty string for an unparsable timestamp', () => {
+    expect(getAge('not-a-date')).toBe('');
+  });
 });

--- a/knative/src/utils/time.ts
+++ b/knative/src/utils/time.ts
@@ -17,7 +17,8 @@
 export function getAge(timestamp?: string): string {
   if (!timestamp) return '';
   const then = new Date(timestamp).getTime();
-  const diff = Date.now() - then;
+  if (isNaN(then)) return '';
+  const diff = Math.max(0, Date.now() - then);
   const mins = Math.floor(diff / 60000);
   if (mins < 60) return `${mins}m`;
   const hours = Math.floor(mins / 60);


### PR DESCRIPTION
## Problem

`getAge()` in `knative/src/utils/time.ts` renders future timestamps as negative minutes (e.g. `-5m`) and malformed timestamps as `NaNd`. Both leak implementation artifacts into user-visible Knative condition and revision age tables.

**Root cause:** `Date.now() - new Date(timestamp).getTime()` is unchecked. A valid future timestamp (realistic with browser/cluster clock skew) produces a negative diff that flows through to the minutes branch. An unparsable timestamp produces `NaN` that falls through comparisons to the days branch.

## Fix

Two guards added to the shared helper (smallest root-cause fix):

1. `if (isNaN(then)) return ''` — return the helper's established empty-string result for unparsable input.
2. `Math.max(0, Date.now() - then)` — clamp valid future timestamps to zero elapsed time, displaying `0m`.

No caller changes needed — both callers already guard with ternary before calling `getAge`.

## Tests

Two focused regression cases added to `knative/src/utils/time.test.ts`:
- Future timestamp (mock clock + 5 min) expects `0m`
- Unparsable string `'not-a-date'` expects `''`

## Validation

All passing from `knative/`:
- `npm run test` — 24/24 pass
- `npm run tsc` — clean
- `npm run lint` — clean
- `npm run format -- --check` — clean
- `npm run build` — clean
- `git diff --check` — clean

## Risks

- Clamping hides the magnitude of browser/cluster clock skew, but Headlamp has no skew-status model and negative elapsed time is misleading.
- Returning empty for invalid input follows the helper's existing missing-value contract.

Signed-off-by: Elvand-Lie <elvand.lie@users.noreply.github.com>
