### PR TITLE
kueue: Workload: read v1beta1 fields for priority class and execution time

### DIFF
--- a/kueue/src/resources/workload.ts
+++ b/kueue/src/resources/workload.ts
@@ -25,6 +25,8 @@ import {
   renderRequeueState,
   renderText,
   renderWorkloadStatus,
+  resolveAccumulatedPastExecutionTimeSeconds,
+  resolvePriorityClassName,
 } from './workloadFormatters';
 
 const WORKLOAD_API_DOCS = 'https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#workload';
@@ -264,6 +266,12 @@ export interface WorkloadSpec {
    * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#workloadspec
    */
   priorityClassRef?: PriorityClassRef;
+  /**
+   * v1beta1 priority class name, replaced by `priorityClassRef.name` in v1beta2.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta1/#workloadspec
+   */
+  priorityClassName?: string;
   /**
    * Numeric priority used for admission ordering.
    *
@@ -568,6 +576,13 @@ export interface WorkloadStatus {
    */
   accumulatedPastExecutionTimeSeconds?: number;
   /**
+   * v1beta1 spelling of `accumulatedPastExecutionTimeSeconds`, misspelled in Kueue's own
+   * v1beta1 wire format.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta1/#workloadstatus
+   */
+  accumulatedPastExexcutionTimeSeconds?: number;
+  /**
    * Scheduling statistics.
    *
    * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#workloadstatus
@@ -657,7 +672,7 @@ export class Workload extends KubeObject<KubeWorkload> {
   }
 
   get priorityClassName() {
-    return this.spec.priorityClassRef?.name;
+    return resolvePriorityClassName(this.spec);
   }
 
   get priorityClassDisplay() {
@@ -737,7 +752,7 @@ export class Workload extends KubeObject<KubeWorkload> {
   }
 
   get accumulatedPastExecutionTimeSecondsDisplay() {
-    return renderNumber(this.status.accumulatedPastExecutionTimeSeconds);
+    return renderNumber(resolveAccumulatedPastExecutionTimeSeconds(this.status));
   }
 
   get clusterNameDisplay() {

--- a/kueue/src/resources/workloadFormatters.test.ts
+++ b/kueue/src/resources/workloadFormatters.test.ts
@@ -25,6 +25,8 @@ import {
   renderStringMap,
   renderText,
   renderWorkloadStatus,
+  resolveAccumulatedPastExecutionTimeSeconds,
+  resolvePriorityClassName,
 } from './workloadFormatters';
 
 describe('Workload formatters', () => {
@@ -52,6 +54,39 @@ describe('Workload formatters', () => {
     expect(renderPriority()).toBe('-');
     expect(renderPriorityClassName('high-priority')).toBe('high-priority');
     expect(renderPriorityClassName()).toBe('-');
+  });
+
+  it('resolves priority class name from either the v1beta2 or v1beta1 Workload shape', () => {
+    expect(resolvePriorityClassName({ priorityClassRef: { name: 'high-priority' } })).toBe(
+      'high-priority'
+    );
+    expect(resolvePriorityClassName({ priorityClassName: 'high-priority' })).toBe('high-priority');
+    expect(
+      resolvePriorityClassName({
+        priorityClassRef: { name: 'v1beta2-priority' },
+        priorityClassName: 'v1beta1-priority',
+      })
+    ).toBe('v1beta2-priority');
+    expect(resolvePriorityClassName({})).toBeUndefined();
+  });
+
+  it('resolves accumulated past execution time from either the v1beta2 or v1beta1 Workload shape', () => {
+    expect(
+      resolveAccumulatedPastExecutionTimeSeconds({ accumulatedPastExecutionTimeSeconds: 120 })
+    ).toBe(120);
+    expect(
+      resolveAccumulatedPastExecutionTimeSeconds({ accumulatedPastExexcutionTimeSeconds: 120 })
+    ).toBe(120);
+    expect(
+      resolveAccumulatedPastExecutionTimeSeconds({ accumulatedPastExexcutionTimeSeconds: 0 })
+    ).toBe(0);
+    expect(
+      resolveAccumulatedPastExecutionTimeSeconds({
+        accumulatedPastExecutionTimeSeconds: 200,
+        accumulatedPastExexcutionTimeSeconds: 100,
+      })
+    ).toBe(200);
+    expect(resolveAccumulatedPastExecutionTimeSeconds({})).toBeUndefined();
   });
 
   it('finds Workload conditions by type', () => {

--- a/kueue/src/resources/workloadFormatters.ts
+++ b/kueue/src/resources/workloadFormatters.ts
@@ -53,6 +53,34 @@ export function renderPriorityClassName(priorityClassName?: string) {
   return renderText(priorityClassName);
 }
 
+/** Priority class fields present on either the v1beta2 or v1beta1 WorkloadSpec shape. */
+export interface PriorityClassCompatSpec {
+  /** v1beta2 priority class reference. */
+  priorityClassRef?: { name?: string };
+  /** v1beta1 priority class name, replaced by `priorityClassRef.name` in v1beta2. */
+  priorityClassName?: string;
+}
+
+/** Resolve the priority class name from the v1beta2 or v1beta1 WorkloadSpec shape. */
+export function resolvePriorityClassName(spec: PriorityClassCompatSpec) {
+  return spec.priorityClassRef?.name || spec.priorityClassName;
+}
+
+/** Accumulated past execution time fields present on either API version's WorkloadStatus. */
+export interface AccumulatedPastExecutionTimeCompatStatus {
+  /** v1beta2 accumulated past execution time, correctly spelled. */
+  accumulatedPastExecutionTimeSeconds?: number;
+  /** v1beta1 accumulated past execution time, misspelled in Kueue's own wire format. */
+  accumulatedPastExexcutionTimeSeconds?: number;
+}
+
+/** Resolve accumulated past execution time from the v1beta2 or v1beta1 WorkloadStatus shape. */
+export function resolveAccumulatedPastExecutionTimeSeconds(
+  status: AccumulatedPastExecutionTimeCompatStatus
+) {
+  return status.accumulatedPastExecutionTimeSeconds ?? status.accumulatedPastExexcutionTimeSeconds;
+}
+
 /** Find a named Workload condition from status.conditions. */
 export function findWorkloadCondition(conditions: WorkloadConditionLike[] = [], type: string) {
   return conditions.find(condition => condition.type === type);


### PR DESCRIPTION
## What was broken

While reviewing the Kueue plugin, I found this compatibility issue and opened #1153 to track it. This PR fixes the issue by handling both the `v1beta2` and `v1beta1` Workload field formats.

The Kueue Workload plugin supports both `v1beta2` and `v1beta1`, but two Workload fields were being read only from their `v1beta2` representation.

Because of this, the following fields showed `-` for `v1beta1` Workloads even when values were present:

* Priority Class
* Accumulated Past Execution Time Seconds

## What changed

Added compatibility handling for both `v1beta2` and `v1beta1` Workload field formats.

* Added `resolvePriorityClassName` to resolve the Priority Class from `priorityClassRef.name` (`v1beta2`) or fall back to `priorityClassName` (`v1beta1`).
* Added `resolveAccumulatedPastExecutionTimeSeconds` to resolve the execution time from the `v1beta2` field or fall back to the misspelled `v1beta1` field.
* Updated the Workload getters to use these resolver functions.
* Added the corresponding `v1beta1` fields to the Workload interfaces with comments explaining the version differences.
* Preserved explicit `0` values for accumulated execution time.

When both versions of a field are present, the `v1beta2` value takes precedence.

## Tests

Added tests covering:

* `v1beta2` field only
* `v1beta1` field only
* Both fields present
* Neither field present
* Explicit `0` value for accumulated execution time

## Verification

All checks pass:

* Tests: **24/24 passing**
* TypeScript: **0 errors**
* ESLint: **0 errors/warnings**
* Production build: **successful**

Fixes #1153
