### PR TITLE
kueue: add AdmissionCheck list and detail views

### DIFF
--- a/kueue/src/components/admissionchecks/Detail.tsx
+++ b/kueue/src/components/admissionchecks/Detail.tsx
@@ -1,0 +1,40 @@
+import { DetailsGrid } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { useParams } from 'react-router-dom';
+import { AdmissionCheck } from '../../resources/admissionCheck';
+import KueueAdminResourceAccess from '../common/KueueAdminResourceAccess';
+
+export default function AdmissionCheckDetail() {
+  const { name } = useParams<{ name: string }>();
+
+  return (
+    <KueueAdminResourceAccess
+      resourceClass={AdmissionCheck}
+      resourceLabel="AdmissionChecks"
+      verb="get"
+    >
+      <DetailsGrid
+        resourceType={AdmissionCheck}
+        name={name}
+        withEvents
+        extraInfo={admissionCheck =>
+          admissionCheck
+            ? [
+                {
+                  name: 'Controller',
+                  value: admissionCheck.controllerName,
+                },
+                {
+                  name: 'Parameters',
+                  value: admissionCheck.parametersDisplay,
+                },
+                {
+                  name: 'Status',
+                  value: admissionCheck.statusDisplay,
+                },
+              ]
+            : []
+        }
+      />
+    </KueueAdminResourceAccess>
+  );
+}

--- a/kueue/src/components/admissionchecks/List.tsx
+++ b/kueue/src/components/admissionchecks/List.tsx
@@ -1,0 +1,37 @@
+import { ResourceListView } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { AdmissionCheck } from '../../resources/admissionCheck';
+import KueueAdminResourceAccess from '../common/KueueAdminResourceAccess';
+
+export default function AdmissionCheckList() {
+  return (
+    <KueueAdminResourceAccess
+      resourceClass={AdmissionCheck}
+      resourceLabel="AdmissionChecks"
+      verb="list"
+    >
+      <ResourceListView
+        title="Kueue AdmissionChecks"
+        resourceClass={AdmissionCheck}
+        columns={[
+          'name',
+          {
+            id: 'controllerName',
+            label: 'Controller',
+            getValue: (admissionCheck: AdmissionCheck) => admissionCheck.controllerName,
+          },
+          {
+            id: 'parameters',
+            label: 'Parameters',
+            getValue: (admissionCheck: AdmissionCheck) => admissionCheck.parametersDisplay,
+          },
+          {
+            id: 'status',
+            label: 'Status',
+            getValue: (admissionCheck: AdmissionCheck) => admissionCheck.statusDisplay,
+          },
+          'age',
+        ]}
+      />
+    </KueueAdminResourceAccess>
+  );
+}

--- a/kueue/src/index.tsx
+++ b/kueue/src/index.tsx
@@ -8,6 +8,8 @@ import ResourceFlavorList from './components/resourceflavors/List';
 import WorkloadDetail from './components/workloads/Detail';
 import WorkloadList from './components/workloads/List';
 import { kueueRouteNames, kueueRoutePaths } from './utils/kueueRoutes';
+import AdmissionCheckDetail from './components/admissionchecks/Detail';
+import AdmissionCheckList from './components/admissionchecks/List';
 
 registerSidebarEntry({
   parent: null,
@@ -59,6 +61,29 @@ registerRoute({
   name: kueueRouteNames.clusterQueueDetail,
   exact: true,
   component: () => <ClusterQueueDetail />,
+});
+
+registerSidebarEntry({
+  parent: 'kueue',
+  name: 'kueue-admissionchecks',
+  label: 'AdmissionChecks',
+  url: kueueRoutePaths.admissionChecksList,
+});
+
+registerRoute({
+  path: kueueRoutePaths.admissionChecksList,
+  sidebar: 'kueue-admissionchecks',
+  name: kueueRouteNames.admissionChecksList,
+  exact: true,
+  component: () => <AdmissionCheckList />,
+});
+
+registerRoute({
+  path: kueueRoutePaths.admissionCheckDetail,
+  sidebar: 'kueue-admissionchecks',
+  name: kueueRouteNames.admissionCheckDetail,
+  exact: true,
+  component: () => <AdmissionCheckDetail />,
 });
 
 registerRoute({

--- a/kueue/src/resources/admissionCheck.test.ts
+++ b/kueue/src/resources/admissionCheck.test.ts
@@ -1,0 +1,63 @@
+import {
+  renderAdmissionCheckStatus,
+  renderControllerName,
+  renderParameters,
+} from './admissionCheckFormatters';
+
+describe('renderControllerName', () => {
+  it('returns a dash when controllerName is missing', () => {
+    expect(renderControllerName()).toBe('-');
+    expect(renderControllerName('')).toBe('-');
+  });
+
+  it('returns the controller name when present', () => {
+    expect(renderControllerName('kueue.x-k8s.io/provisioning-request')).toBe(
+      'kueue.x-k8s.io/provisioning-request'
+    );
+  });
+});
+
+describe('renderParameters', () => {
+  it('returns a dash when parameters are missing', () => {
+    expect(renderParameters()).toBe('-');
+    expect(renderParameters({})).toBe('-');
+  });
+
+  it('renders kind/name when apiGroup is missing', () => {
+    expect(renderParameters({ kind: 'ProvisioningRequestConfig', name: 'prov-test-config' })).toBe(
+      'ProvisioningRequestConfig/prov-test-config'
+    );
+  });
+
+  it('renders kind/name with apiGroup when present', () => {
+    expect(
+      renderParameters({
+        apiGroup: 'kueue.x-k8s.io',
+        kind: 'ProvisioningRequestConfig',
+        name: 'prov-test-config',
+      })
+    ).toBe('ProvisioningRequestConfig/prov-test-config (kueue.x-k8s.io)');
+  });
+
+  it('falls back to Unknown kind when kind is missing but name is present', () => {
+    expect(renderParameters({ name: 'prov-test-config' })).toBe('Unknown/prov-test-config');
+  });
+});
+
+describe('renderAdmissionCheckStatus', () => {
+  it('returns Unknown when there is no active condition', () => {
+    expect(renderAdmissionCheckStatus()).toBe('Unknown');
+  });
+
+  it('returns Active when the condition status is True', () => {
+    expect(renderAdmissionCheckStatus({ type: 'Active', status: 'True' })).toBe('Active');
+  });
+
+  it('returns Inactive when the condition status is False', () => {
+    expect(renderAdmissionCheckStatus({ type: 'Active', status: 'False' })).toBe('Inactive');
+  });
+
+  it('returns Unknown when the condition status is Unknown', () => {
+    expect(renderAdmissionCheckStatus({ type: 'Active', status: 'Unknown' })).toBe('Unknown');
+  });
+});

--- a/kueue/src/resources/admissionCheck.ts
+++ b/kueue/src/resources/admissionCheck.ts
@@ -1,0 +1,145 @@
+import { KubeObject, KubeObjectInterface } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import { kueueApiVersions } from '../utils/kueueApi';
+import { kueueRoutePaths } from '../utils/kueueRoutes';
+import type { KueueCondition } from './clusterQueue';
+import {
+  renderAdmissionCheckStatus,
+  renderControllerName,
+  renderParameters,
+  type AdmissionCheckParametersLike,
+} from './admissionCheckFormatters';
+
+/**
+ * Reference to the parameters object configuring an AdmissionCheck.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#admissioncheckparametersreference
+ */
+export interface AdmissionCheckParametersReference extends AdmissionCheckParametersLike {
+  /**
+   * API group of the referenced parameters object.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#admissioncheckparametersreference
+   */
+  apiGroup?: string;
+  /**
+   * Kind of the referenced parameters object.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#admissioncheckparametersreference
+   */
+  kind?: string;
+  /**
+   * Name of the referenced parameters object.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#admissioncheckparametersreference
+   */
+  name?: string;
+}
+
+/**
+ * Desired state of a Kueue AdmissionCheck.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#admissioncheckspec
+ */
+export interface AdmissionCheckSpec {
+  /**
+   * Identifies the controller that processes this AdmissionCheck. Cannot be empty.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#admissioncheckspec
+   */
+  controllerName: string;
+  /**
+   * Reference to a configuration object with additional parameters for the check.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#admissioncheckspec
+   */
+  parameters?: AdmissionCheckParametersReference;
+  /**
+   * Deprecated: how long to keep a workload suspended after a failed check.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#admissioncheckspec
+   */
+  retryDelayMinutes?: number;
+}
+
+/**
+ * Observed state of a Kueue AdmissionCheck.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#admissioncheckstatus
+ */
+export interface AdmissionCheckStatus {
+  /**
+   * Latest observations of AdmissionCheck state, including an `Active` condition.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#admissioncheckstatus
+   */
+  conditions?: KueueCondition[];
+}
+
+/**
+ * Kubernetes AdmissionCheck object returned by the Kueue API.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#admissioncheck
+ */
+export interface KubeAdmissionCheck extends KubeObjectInterface {
+  /**
+   * Kubernetes object metadata for the AdmissionCheck.
+   *
+   * @see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#objectmeta-v1-meta
+   */
+  metadata: KubeObjectInterface['metadata'];
+  /**
+   * AdmissionCheck desired state.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#admissioncheckspec
+   */
+  spec: AdmissionCheckSpec;
+  /**
+   * AdmissionCheck observed state.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#admissioncheckstatus
+   */
+  status?: AdmissionCheckStatus;
+}
+
+export class AdmissionCheck extends KubeObject<KubeAdmissionCheck> {
+  static kind = 'AdmissionCheck';
+  static apiName = 'admissionchecks';
+  static apiVersion = kueueApiVersions;
+  static isNamespaced = false;
+
+  static get detailsRoute() {
+    return kueueRoutePaths.admissionCheckDetail;
+  }
+
+  get spec(): AdmissionCheckSpec {
+    return this.jsonData.spec ?? ({} as AdmissionCheckSpec);
+  }
+
+  get status(): AdmissionCheckStatus {
+    return this.jsonData.status ?? {};
+  }
+
+  get controllerName() {
+    return renderControllerName(this.spec.controllerName);
+  }
+
+  get parameters() {
+    return this.spec.parameters;
+  }
+
+  get parametersDisplay() {
+    return renderParameters(this.parameters);
+  }
+
+  get conditions() {
+    return this.status.conditions || [];
+  }
+
+  get activeCondition() {
+    return this.conditions.find(condition => condition.type === 'Active');
+  }
+
+  get statusDisplay() {
+    return renderAdmissionCheckStatus(this.activeCondition);
+  }
+}

--- a/kueue/src/resources/admissionCheckFormatters.ts
+++ b/kueue/src/resources/admissionCheckFormatters.ts
@@ -1,0 +1,45 @@
+import type { KueueCondition } from './clusterQueue';
+
+/** Minimal AdmissionCheck condition shape needed to summarize its Active state. */
+export type AdmissionCheckConditionLike = Pick<KueueCondition, 'type' | 'status' | 'reason' | 'message'>;
+
+/** Reference to the parameters object configuring an AdmissionCheck. */
+export interface AdmissionCheckParametersLike {
+  apiGroup?: string;
+  kind?: string;
+  name?: string;
+}
+
+/** Render the controller name that processes an AdmissionCheck. */
+export function renderControllerName(controllerName?: string) {
+  return controllerName || '-';
+}
+
+/** Render an AdmissionCheck's parameters reference as `kind/name (apiGroup)`. */
+export function renderParameters(parameters?: AdmissionCheckParametersLike) {
+  if (!parameters || !parameters.name) {
+    return '-';
+  }
+
+  const kind = parameters.kind || 'Unknown';
+  const apiGroup = parameters.apiGroup ? ` (${parameters.apiGroup})` : '';
+
+  return `${kind}/${parameters.name}${apiGroup}`;
+}
+
+/** Render the user-facing AdmissionCheck status from its Active condition. */
+export function renderAdmissionCheckStatus(activeCondition?: AdmissionCheckConditionLike) {
+  if (!activeCondition) {
+    return 'Unknown';
+  }
+
+  if (activeCondition.status === 'True') {
+    return 'Active';
+  }
+
+  if (activeCondition.status === 'False') {
+    return 'Inactive';
+  }
+
+  return 'Unknown';
+}

--- a/kueue/src/utils/kueueRoutes.ts
+++ b/kueue/src/utils/kueueRoutes.ts
@@ -7,6 +7,8 @@ export const kueueRouteNames = {
   resourceFlavorDetail: 'kueue-resourceflavor-detail',
   workloadsList: 'kueue-workloads-list',
   workloadDetail: 'kueue-workload-detail',
+  admissionChecksList: 'kueue-admissionchecks-list',
+  admissionCheckDetail: 'kueue-admissioncheck-detail',
 } as const;
 
 export const kueueRoutePaths = {
@@ -18,4 +20,6 @@ export const kueueRoutePaths = {
   resourceFlavorDetail: '/kueue/resourceflavors/:name',
   workloadsList: '/kueue/workloads',
   workloadDetail: '/kueue/workloads/:namespace/:name',
+  admissionChecksList: '/kueue/admissionchecks',
+  admissionCheckDetail: '/kueue/admissionchecks/:name',
 } as const;


### PR DESCRIPTION
## What this PR does

Adds a new `AdmissionCheck` resource to the Kueue plugin, following the existing patterns used
by `ClusterQueue`, `LocalQueue`, `ResourceFlavor`, and `Workload`. Previously, `AdmissionCheck`
and `ProvisioningRequestConfig` were the only Kueue CRDs with no dedicated views in this plugin.

- Adds `src/resources/admissionCheck.ts` — a `KubeObject`-based resource class typed against
  the real `AdmissionCheckSpec`/`AdmissionCheckStatus` fields (`controllerName`, `parameters`,
  `conditions`), per the [Kueue API reference](https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#admissioncheck).
- Adds `src/resources/admissionCheckFormatters.ts` with exported, documented, pure functions:
  `renderControllerName`, `renderParameters`, `renderAdmissionCheckStatus`.
- Adds `src/resources/admissionCheck.test.ts` with unit tests covering each formatter,
  including empty/undefined edge cases.
- Adds `src/components/admissionchecks/List.tsx` and `Detail.tsx`, mirroring the
  `resourceflavors` components structure (cluster-scoped, using `KueueAdminResourceAccess`
  and `ResourceListView`/`DetailsGrid`).
- Registers the sidebar entry and routes in `index.tsx` and `utils/kueueRoutes.ts`.

## Testing

- `npm run test` — all 44 tests pass (10 new).
- `npm run build` — builds cleanly.
- Verified locally in a running Headlamp instance against a kind cluster: applied a real
  `AdmissionCheck` resource and confirmed both the List and Detail views render its
  controller, parameters, and status correctly, and the empty-list state renders without
  errors when no AdmissionChecks exist.

## Why

`AdmissionCheck` is a core Kueue resource referenced directly by ClusterQueue's
`admissionChecksStrategy`, but had no dedicated view yet. This is a small, additive,
low-risk addition that gives users visibility into admission checks without touching any
existing resource types.