### PR TITLE
kueue: fix ClusterQueue flavor names to match ResourceFlavor examples

### DIFF
--- a/kueue/test-files/deploy/clusterqueue-team-a.yaml
+++ b/kueue/test-files/deploy/clusterqueue-team-a.yaml
@@ -13,13 +13,13 @@ spec:
         - cpu
         - memory
       flavors:
-        - name: default
+        - name: default-flavor
           resources:
             - name: cpu
               nominalQuota: "8"
             - name: memory
               nominalQuota: 32Gi
-        - name: spot
+        - name: spot-flavor
           resources:
             - name: cpu
               nominalQuota: "16"


### PR DESCRIPTION
## Summary
- `kueue/test-files/deploy/clusterqueue-team-a.yaml` referenced flavors named `default` and `spot`, but the corresponding `ResourceFlavor` test manifests (`resourceflavor-default.yaml` / `resourceflavor-spot.yaml`) are named `default-flavor` and `spot-flavor`.
- Following the documented steps (apply ResourceFlavors, then ClusterQueue, then a Job), the ClusterQueue never becomes ready to admit workloads because it points at flavors that don't exist.
- Renamed the flavor references in the ClusterQueue to `default-flavor` / `spot-flavor` so they match the ResourceFlavor examples.

## Root cause
The `ClusterQueue` test file was added in #864 with flavor names `default`/`spot`. The `ResourceFlavor` example files were added later already named `default-flavor`/`spot-flavor`, and the `ClusterQueue` was never updated to match.

## Verification
Reproduced against a live cluster (minikube + Kueue v0.19.1, `v1beta2` API):
- Before fix: `kubectl get clusterqueue team-a` → `status.conditions: Active=False, reason=FlavorNotFound`. No workload can ever be admitted.
- After fix: `Active=True, reason=Ready, message="Can admit new workloads"`.
- Ran the full flow (ResourceFlavors → ClusterQueue → LocalQueue → sample Job): the sample Job's workload reached `QuotaReserved=True`, `Admitted=True`, and pods ran successfully.

## Test plan
- [x] Applied `resourceflavor-default.yaml`, `resourceflavor-spot.yaml`, `resourceflavor-topology.yaml`, then the original `clusterqueue-team-a.yaml` — confirmed `Active=False (FlavorNotFound)`.
- [x] Re-applied with the fix — confirmed `Active=True (Ready)`.
- [x] Applied `localqueue-team-a.yaml` and `job-sample-workload.yaml` — confirmed the Job's Workload was admitted and pods ran to completion.