### PR TITLE
Add OWNERS files for plugin directories (#651)

### DIFF
--- a/cert-manager/OWNERS
+++ b/cert-manager/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- yolossn
+reviewers:
+- yolossn


### PR DESCRIPTION
### What this PR does

Part of #651.

This adds a standard Kubernetes-style `OWNERS` file (approvers/reviewers)
to each plugin directory, plus a root-level `OWNERS` file, based on the
maintainers already listed in this repo's README.md table.

- Added root `OWNERS`
- Added `OWNERS` to: ai-assistant, app-catalog, backstage, cert-manager,
  cluster-api, flux, karpenter, keda, knative, kompose, kro, kyverno,
  minikube, opencost, plugin-catalog, prometheus, radius, strimzi, volcano

### What this PR does NOT do

- `.github/CODEOWNERS` was already up to date, so it was left unchanged.
- The CNCF-wide `project-maintainers.csv` change (in `cncf/foundation`)
  is being tracked separately in cncf/foundation#1157 by @illume, so it's
  out of scope here.

### Why

Per-directory `OWNERS` files let individual plugin maintainers be
recognized as approvers/reviewers for their specific plugin, following
the same convention used across other Kubernetes SIG/CNCF repos, as
requested in #651.