### PR TITLE
kueue: Open resource details in a side panel instead of full navigation

### DIFF
--- a/kueue/src/components/clusterqueues/Detail.tsx
+++ b/kueue/src/components/clusterqueues/Detail.tsx
@@ -1,10 +1,12 @@
+import { Icon } from '@iconify/react';
+import { Activity } from '@kinvolk/headlamp-plugin/lib';
 import {
   ConditionsSection,
   DetailsGrid,
-  Link,
   SectionBox,
   SimpleTable,
 } from '@kinvolk/headlamp-plugin/lib/components/common';
+import { Link as MuiLink } from '@mui/material';
 import { useParams } from 'react-router-dom';
 import {
   ClusterQueue,
@@ -12,8 +14,8 @@ import {
   ResourceGroup,
   ResourceQuota,
 } from '../../resources/clusterQueue';
-import { kueueRouteNames } from '../../utils/kueueRoutes';
 import KueueAdminResourceAccess from '../common/KueueAdminResourceAccess';
+import { openResourceFlavorActivity } from '../resourceflavors/Detail';
 
 /** Flattened row rendered in the ClusterQueue resource groups table. */
 interface ResourceGroupRow {
@@ -53,12 +55,16 @@ interface AdmissionCheckRow {
   flavors: string[];
 }
 
-/** Render a ResourceFlavor name as a Headlamp link to its detail page. */
-function renderFlavorLink(flavorName: string) {
+/** Render a ResourceFlavor name as a link that opens its details in a side panel. */
+function renderFlavorLink(flavorName: string, cluster?: string) {
   return (
-    <Link routeName={kueueRouteNames.resourceFlavorDetail} params={{ name: flavorName }}>
+    <MuiLink
+      component="button"
+      sx={{ textAlign: 'left' }}
+      onClick={() => openResourceFlavorActivity(flavorName, cluster)}
+    >
       {flavorName}
-    </Link>
+    </MuiLink>
   );
 }
 
@@ -163,7 +169,7 @@ function getResourceGroupsSection(clusterQueue: ClusterQueue) {
             {
               label: 'ResourceFlavor',
               getter: (row: ResourceGroupRow) =>
-                row.flavor === '-' ? '-' : renderFlavorLink(row.flavor),
+                row.flavor === '-' ? '-' : renderFlavorLink(row.flavor, clusterQueue.cluster),
             },
             {
               label: 'Resource',
@@ -189,7 +195,12 @@ function getResourceGroupsSection(clusterQueue: ClusterQueue) {
 }
 
 /** Build a table section for ClusterQueue status flavor reservations or usage. */
-function getFlavorUsageSection(title: string, id: string, flavorUsage?: FlavorUsage[]) {
+function getFlavorUsageSection(
+  title: string,
+  id: string,
+  flavorUsage?: FlavorUsage[],
+  cluster?: string
+) {
   const rows = getFlavorUsageRows(flavorUsage);
 
   if (rows.length === 0) {
@@ -206,7 +217,7 @@ function getFlavorUsageSection(title: string, id: string, flavorUsage?: FlavorUs
             {
               label: 'ResourceFlavor',
               getter: (row: FlavorUsageRow) =>
-                row.flavor === '-' ? '-' : renderFlavorLink(row.flavor),
+                row.flavor === '-' ? '-' : renderFlavorLink(row.flavor, cluster),
             },
             {
               label: 'Resource',
@@ -254,7 +265,7 @@ function getAdmissionChecksSection(clusterQueue: ClusterQueue) {
                     {row.flavors.map((flavor, index) => (
                       <span key={flavor}>
                         {index > 0 ? ', ' : ''}
-                        {renderFlavorLink(flavor)}
+                        {renderFlavorLink(flavor, clusterQueue.cluster)}
                       </span>
                     ))}
                   </>
@@ -281,9 +292,22 @@ function getConditionsSection(clusterQueue: ClusterQueue) {
   };
 }
 
+/** Open a ClusterQueue's details in a side panel instead of navigating away. */
+export function openClusterQueueActivity(name: string, cluster?: string) {
+  Activity.launch({
+    id: `kueue-clusterqueue-${cluster ?? ''}-${name}`,
+    location: 'split-right',
+    icon: <Icon icon="mdi:queue-first-in-last-out" />,
+    title: name,
+    cluster,
+    content: <ClusterQueueDetail name={name} />,
+  });
+}
+
 /** Detail view for a cluster-scoped Kueue ClusterQueue resource. */
-export default function ClusterQueueDetail() {
-  const { name } = useParams<{ name: string }>();
+export default function ClusterQueueDetail(props: { name?: string }) {
+  const { name: nameParam } = useParams<{ name: string }>();
+  const name = props.name ?? nameParam;
 
   return (
     <KueueAdminResourceAccess resourceClass={ClusterQueue} resourceLabel="ClusterQueues" verb="get">
@@ -362,12 +386,14 @@ export default function ClusterQueueDetail() {
                 getFlavorUsageSection(
                   'Flavor Reservations',
                   'flavor-reservations',
-                  clusterQueue.status.flavorsReservation
+                  clusterQueue.status.flavorsReservation,
+                  clusterQueue.cluster
                 ),
                 getFlavorUsageSection(
                   'Flavor Usage',
                   'flavor-usage',
-                  clusterQueue.status.flavorsUsage
+                  clusterQueue.status.flavorsUsage,
+                  clusterQueue.cluster
                 ),
               ].filter(Boolean)
             : []

--- a/kueue/src/components/clusterqueues/List.tsx
+++ b/kueue/src/components/clusterqueues/List.tsx
@@ -1,6 +1,8 @@
 import { ResourceListView } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { Link as MuiLink } from '@mui/material';
 import { ClusterQueue } from '../../resources/clusterQueue';
 import KueueAdminResourceAccess from '../common/KueueAdminResourceAccess';
+import { openClusterQueueActivity } from './Detail';
 
 export default function ClusterQueueList() {
   return (
@@ -13,7 +15,22 @@ export default function ClusterQueueList() {
         title="Kueue ClusterQueues"
         resourceClass={ClusterQueue}
         columns={[
-          'name',
+          {
+            id: 'name',
+            label: 'Name',
+            getValue: (clusterQueue: ClusterQueue) => clusterQueue.metadata.name,
+            render: (clusterQueue: ClusterQueue) => (
+              <MuiLink
+                component="button"
+                sx={{ textAlign: 'left' }}
+                onClick={() =>
+                  openClusterQueueActivity(clusterQueue.metadata.name, clusterQueue.cluster)
+                }
+              >
+                {clusterQueue.metadata.name}
+              </MuiLink>
+            ),
+          },
           {
             id: 'cohort',
             label: 'Cohort',

--- a/kueue/src/components/localqueues/Detail.tsx
+++ b/kueue/src/components/localqueues/Detail.tsx
@@ -1,14 +1,13 @@
-import {
-  ConditionsSection,
-  DetailsGrid,
-  Link,
-} from '@kinvolk/headlamp-plugin/lib/components/common';
+import { Icon } from '@iconify/react';
+import { Activity } from '@kinvolk/headlamp-plugin/lib';
+import { ConditionsSection, DetailsGrid } from '@kinvolk/headlamp-plugin/lib/components/common';
+import { Link as MuiLink } from '@mui/material';
 import { useParams } from 'react-router-dom';
 import { LocalQueue } from '../../resources/localQueue';
-import { kueueRouteNames } from '../../utils/kueueRoutes';
+import { openClusterQueueActivity } from '../clusterqueues/Detail';
 import KueueAdminResourceAccess from '../common/KueueAdminResourceAccess';
 
-/** Render a ClusterQueue reference as a detail-page link. */
+/** Render a ClusterQueue reference as a link that opens its details in a side panel. */
 function renderClusterQueueLink(localQueue: LocalQueue) {
   const clusterQueueName = localQueue.clusterQueueName;
 
@@ -17,10 +16,26 @@ function renderClusterQueueLink(localQueue: LocalQueue) {
   }
 
   return (
-    <Link routeName={kueueRouteNames.clusterQueueDetail} params={{ name: clusterQueueName }}>
+    <MuiLink
+      component="button"
+      sx={{ textAlign: 'left' }}
+      onClick={() => openClusterQueueActivity(clusterQueueName, localQueue.cluster)}
+    >
       {clusterQueueName}
-    </Link>
+    </MuiLink>
   );
+}
+
+/** Open a LocalQueue's details in a side panel instead of navigating away. */
+export function openLocalQueueActivity(namespace: string, name: string, cluster?: string) {
+  Activity.launch({
+    id: `kueue-localqueue-${cluster ?? ''}-${namespace}-${name}`,
+    location: 'split-right',
+    icon: <Icon icon="mdi:format-list-bulleted" />,
+    title: `${namespace}/${name}`,
+    cluster,
+    content: <LocalQueueDetail namespace={namespace} name={name} />,
+  });
 }
 
 /** Build the standard Headlamp conditions section for LocalQueue status. */
@@ -35,8 +50,10 @@ function getConditionsSection(localQueue: LocalQueue) {
   };
 }
 
-export default function LocalQueueDetail() {
-  const { namespace, name } = useParams<{ namespace: string; name: string }>();
+export default function LocalQueueDetail(props: { namespace?: string; name?: string }) {
+  const params = useParams<{ namespace: string; name: string }>();
+  const namespace = props.namespace ?? params.namespace;
+  const name = props.name ?? params.name;
 
   return (
     <KueueAdminResourceAccess

--- a/kueue/src/components/localqueues/List.tsx
+++ b/kueue/src/components/localqueues/List.tsx
@@ -1,7 +1,9 @@
 import { ResourceListView } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { Link as MuiLink } from '@mui/material';
 import { ClusterQueue } from '../../resources/clusterQueue';
 import { LocalQueue } from '../../resources/localQueue';
 import KueueAdminResourceAccess from '../common/KueueAdminResourceAccess';
+import { openLocalQueueActivity } from './Detail';
 
 export default function LocalQueueList() {
   return (
@@ -15,7 +17,26 @@ export default function LocalQueueList() {
         title="Kueue LocalQueues"
         resourceClass={LocalQueue}
         columns={[
-          'name',
+          {
+            id: 'name',
+            label: 'Name',
+            getValue: (localQueue: LocalQueue) => localQueue.metadata.name,
+            render: (localQueue: LocalQueue) => (
+              <MuiLink
+                component="button"
+                sx={{ textAlign: 'left' }}
+                onClick={() =>
+                  openLocalQueueActivity(
+                    localQueue.metadata.namespace,
+                    localQueue.metadata.name,
+                    localQueue.cluster
+                  )
+                }
+              >
+                {localQueue.metadata.name}
+              </MuiLink>
+            ),
+          },
           'namespace',
           {
             id: 'clusterQueue',

--- a/kueue/src/components/resourceflavors/Detail.tsx
+++ b/kueue/src/components/resourceflavors/Detail.tsx
@@ -1,10 +1,25 @@
+import { Icon } from '@iconify/react';
+import { Activity } from '@kinvolk/headlamp-plugin/lib';
 import { DetailsGrid } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 import { useParams } from 'react-router-dom';
 import { ResourceFlavor } from '../../resources/resourceFlavor';
 import KueueAdminResourceAccess from '../common/KueueAdminResourceAccess';
 
-export default function ResourceFlavorDetail() {
-  const { name } = useParams<{ name: string }>();
+/** Open a ResourceFlavor's details in a side panel instead of navigating away. */
+export function openResourceFlavorActivity(name: string, cluster?: string) {
+  Activity.launch({
+    id: `kueue-resourceflavor-${cluster ?? ''}-${name}`,
+    location: 'split-right',
+    icon: <Icon icon="mdi:cube-outline" />,
+    title: name,
+    cluster,
+    content: <ResourceFlavorDetail name={name} />,
+  });
+}
+
+export default function ResourceFlavorDetail(props: { name?: string }) {
+  const { name: nameParam } = useParams<{ name: string }>();
+  const name = props.name ?? nameParam;
 
   return (
     <KueueAdminResourceAccess

--- a/kueue/src/components/resourceflavors/List.tsx
+++ b/kueue/src/components/resourceflavors/List.tsx
@@ -1,6 +1,8 @@
 import { ResourceListView } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { Link as MuiLink } from '@mui/material';
 import { ResourceFlavor } from '../../resources/resourceFlavor';
 import KueueAdminResourceAccess from '../common/KueueAdminResourceAccess';
+import { openResourceFlavorActivity } from './Detail';
 
 export default function ResourceFlavorList() {
   return (
@@ -13,7 +15,22 @@ export default function ResourceFlavorList() {
         title="Kueue ResourceFlavors"
         resourceClass={ResourceFlavor}
         columns={[
-          'name',
+          {
+            id: 'name',
+            label: 'Name',
+            getValue: (resourceFlavor: ResourceFlavor) => resourceFlavor.metadata.name,
+            render: (resourceFlavor: ResourceFlavor) => (
+              <MuiLink
+                component="button"
+                sx={{ textAlign: 'left' }}
+                onClick={() =>
+                  openResourceFlavorActivity(resourceFlavor.metadata.name, resourceFlavor.cluster)
+                }
+              >
+                {resourceFlavor.metadata.name}
+              </MuiLink>
+            ),
+          },
           {
             id: 'nodeLabels',
             label: 'Node Labels',

--- a/kueue/src/components/workloads/Detail.tsx
+++ b/kueue/src/components/workloads/Detail.tsx
@@ -1,10 +1,12 @@
+import { Icon } from '@iconify/react';
+import { Activity } from '@kinvolk/headlamp-plugin/lib';
 import {
   ConditionsSection,
   DetailsGrid,
-  Link,
   SectionBox,
   SimpleTable,
 } from '@kinvolk/headlamp-plugin/lib/components/common';
+import { Link as MuiLink } from '@mui/material';
 import { useParams } from 'react-router-dom';
 import {
   AdmissionCheckState,
@@ -21,8 +23,9 @@ import {
   renderStringMap,
   renderText,
 } from '../../resources/workloadFormatters';
-import { kueueRouteNames } from '../../utils/kueueRoutes';
+import { openClusterQueueActivity } from '../clusterqueues/Detail';
 import KueueAdminResourceAccess from '../common/KueueAdminResourceAccess';
+import { openLocalQueueActivity } from '../localqueues/Detail';
 
 /** Row rendered for Workload spec.podSets. */
 interface PodSetRow {
@@ -98,7 +101,7 @@ interface EvictionRow {
   count: number;
 }
 
-/** Render the LocalQueue reference as a detail-page link when possible. */
+/** Render the LocalQueue reference as a link that opens its details in a side panel. */
 function renderLocalQueueLink(workload: Workload) {
   const queueName = workload.queueName;
   const namespace = workload.metadata.namespace;
@@ -108,13 +111,17 @@ function renderLocalQueueLink(workload: Workload) {
   }
 
   return (
-    <Link routeName={kueueRouteNames.localQueueDetail} params={{ namespace, name: queueName }}>
+    <MuiLink
+      component="button"
+      sx={{ textAlign: 'left' }}
+      onClick={() => openLocalQueueActivity(namespace, queueName, workload.cluster)}
+    >
       {queueName}
-    </Link>
+    </MuiLink>
   );
 }
 
-/** Render the admitted ClusterQueue as a detail-page link when possible. */
+/** Render the admitted ClusterQueue as a link that opens its details in a side panel. */
 function renderClusterQueueLink(workload: Workload) {
   const clusterQueue = workload.admissionClusterQueue;
 
@@ -123,9 +130,13 @@ function renderClusterQueueLink(workload: Workload) {
   }
 
   return (
-    <Link routeName={kueueRouteNames.clusterQueueDetail} params={{ name: clusterQueue }}>
+    <MuiLink
+      component="button"
+      sx={{ textAlign: 'left' }}
+      onClick={() => openClusterQueueActivity(clusterQueue, workload.cluster)}
+    >
       {clusterQueue}
-    </Link>
+    </MuiLink>
   );
 }
 
@@ -453,8 +464,22 @@ function getConditionsSection(workload: Workload) {
   };
 }
 
-export default function WorkloadDetail() {
-  const { namespace, name } = useParams<{ namespace: string; name: string }>();
+/** Open a Workload's details in a side panel instead of navigating away. */
+export function openWorkloadActivity(namespace: string, name: string, cluster?: string) {
+  Activity.launch({
+    id: `kueue-workload-${cluster ?? ''}-${namespace}-${name}`,
+    location: 'split-right',
+    icon: <Icon icon="mdi:briefcase-outline" />,
+    title: `${namespace}/${name}`,
+    cluster,
+    content: <WorkloadDetail namespace={namespace} name={name} />,
+  });
+}
+
+export default function WorkloadDetail(props: { namespace?: string; name?: string }) {
+  const params = useParams<{ namespace: string; name: string }>();
+  const namespace = props.namespace ?? params.namespace;
+  const name = props.name ?? params.name;
 
   return (
     <KueueAdminResourceAccess

--- a/kueue/src/components/workloads/List.tsx
+++ b/kueue/src/components/workloads/List.tsx
@@ -1,6 +1,8 @@
 import { ResourceListView } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { Link as MuiLink } from '@mui/material';
 import { Workload } from '../../resources/workload';
 import KueueAdminResourceAccess from '../common/KueueAdminResourceAccess';
+import { openWorkloadActivity } from './Detail';
 
 export default function WorkloadList() {
   return (
@@ -14,7 +16,26 @@ export default function WorkloadList() {
         title="Kueue Workloads"
         resourceClass={Workload}
         columns={[
-          'name',
+          {
+            id: 'name',
+            label: 'Name',
+            getValue: (workload: Workload) => workload.metadata.name,
+            render: (workload: Workload) => (
+              <MuiLink
+                component="button"
+                sx={{ textAlign: 'left' }}
+                onClick={() =>
+                  openWorkloadActivity(
+                    workload.metadata.namespace,
+                    workload.metadata.name,
+                    workload.cluster
+                  )
+                }
+              >
+                {workload.metadata.name}
+              </MuiLink>
+            ),
+          },
           'namespace',
           {
             id: 'queue',


### PR DESCRIPTION
## Summary
- Clicking a ClusterQueue, LocalQueue, ResourceFlavor, or Workload name (and cross-links between them, e.g. ClusterQueue → ResourceFlavor, LocalQueue → ClusterQueue, Workload → LocalQueue/ClusterQueue) previously navigated to a full-page detail view instead of opening in Headlamp's side panel.
- Root cause: Headlamp core's drawer/split-panel feature only activates for kinds present in its hardcoded `kindComponentMap` (see `frontend/src/components/resourceMap/details/KubeNodeDetails.tsx`). Kueue's CRDs aren't in that map, so `Link`'s default navigation always won.
- Fix follows the pattern already used by the `kyverno` and `kmesh` plugins in this repo: each list's name column (and each cross-link) now calls `Activity.launch({ location: 'split-right', ... })` with the same `Detail` component as content, so it opens as a side panel with a "Fullscreen" option to maximize.
- Each `Detail` component now accepts optional `name`/`namespace` props (falling back to `useParams()`), so the same component works both as a routed page and as `Activity` content.

## Test plan
- [x] `npm run tsc` passes with no errors
- [x] `npm run lint` passes with no errors/warnings
- [x] Manually verify in a running Headlamp instance: clicking names in ClusterQueues, LocalQueues, ResourceFlavors, and Workloads lists opens a side panel (not a full navigation), and the panel's menu has a working "Fullscreen" option
- [x] Manually verify cross-links (ClusterQueue's ResourceFlavor references, LocalQueue's ClusterQueue reference, Workload's LocalQueue/ClusterQueue references) also open in the side panel