### PR TITLE
kueue: add ProvisioningRequestConfig list and detail views

### DIFF
--- a/kueue/src/components/provisioningrequestconfigs/Detail.tsx
+++ b/kueue/src/components/provisioningrequestconfigs/Detail.tsx
@@ -1,0 +1,44 @@
+import { DetailsGrid } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { useParams } from 'react-router-dom';
+import { ProvisioningRequestConfig } from '../../resources/provisioningRequestConfig';
+import KueueAdminResourceAccess from '../common/KueueAdminResourceAccess';
+
+export default function ProvisioningRequestConfigDetail() {
+  const { name } = useParams<{ name: string }>();
+
+  return (
+    <KueueAdminResourceAccess
+      resourceClass={ProvisioningRequestConfig}
+      resourceLabel="ProvisioningRequestConfigs"
+      verb="get"
+    >
+      <DetailsGrid
+        resourceType={ProvisioningRequestConfig}
+        name={name}
+        withEvents
+        extraInfo={config =>
+          config
+            ? [
+                {
+                  name: 'Provisioning Class',
+                  value: config.provisioningClassName,
+                },
+                {
+                  name: 'Managed Resources',
+                  value: config.managedResourcesDisplay,
+                },
+                {
+                  name: 'Retry Strategy',
+                  value: config.retryStrategyDisplay,
+                },
+                {
+                  name: 'Pod Set Merge Policy',
+                  value: config.podSetMergePolicyDisplay,
+                },
+              ]
+            : []
+        }
+      />
+    </KueueAdminResourceAccess>
+  );
+}

--- a/kueue/src/components/provisioningrequestconfigs/List.tsx
+++ b/kueue/src/components/provisioningrequestconfigs/List.tsx
@@ -1,0 +1,37 @@
+import { ResourceListView } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { ProvisioningRequestConfig } from '../../resources/provisioningRequestConfig';
+import KueueAdminResourceAccess from '../common/KueueAdminResourceAccess';
+
+export default function ProvisioningRequestConfigList() {
+  return (
+    <KueueAdminResourceAccess
+      resourceClass={ProvisioningRequestConfig}
+      resourceLabel="ProvisioningRequestConfigs"
+      verb="list"
+    >
+      <ResourceListView
+        title="Kueue ProvisioningRequestConfigs"
+        resourceClass={ProvisioningRequestConfig}
+        columns={[
+          'name',
+          {
+            id: 'provisioningClassName',
+            label: 'Provisioning Class',
+            getValue: (config: ProvisioningRequestConfig) => config.provisioningClassName,
+          },
+          {
+            id: 'managedResources',
+            label: 'Managed Resources',
+            getValue: (config: ProvisioningRequestConfig) => config.managedResourcesDisplay,
+          },
+          {
+            id: 'retryStrategy',
+            label: 'Retry Strategy',
+            getValue: (config: ProvisioningRequestConfig) => config.retryStrategyDisplay,
+          },
+          'age',
+        ]}
+      />
+    </KueueAdminResourceAccess>
+  );
+}

--- a/kueue/src/index.tsx
+++ b/kueue/src/index.tsx
@@ -8,6 +8,8 @@ import ResourceFlavorList from './components/resourceflavors/List';
 import WorkloadDetail from './components/workloads/Detail';
 import WorkloadList from './components/workloads/List';
 import { kueueRouteNames, kueueRoutePaths } from './utils/kueueRoutes';
+import ProvisioningRequestConfigDetail from './components/provisioningrequestconfigs/Detail';
+import ProvisioningRequestConfigList from './components/provisioningrequestconfigs/List';
 
 registerSidebarEntry({
   parent: null,
@@ -43,6 +45,13 @@ registerSidebarEntry({
   name: 'kueue-workloads',
   label: 'Workloads',
   url: kueueRoutePaths.workloadsList,
+});
+
+registerSidebarEntry({
+  parent: 'kueue',
+  name: 'kueue-provisioningrequestconfigs',
+  label: 'ProvisioningRequestConfigs',
+  url: kueueRoutePaths.provisioningRequestConfigsList,
 });
 
 registerRoute({
@@ -107,4 +116,20 @@ registerRoute({
   name: kueueRouteNames.workloadDetail,
   exact: true,
   component: () => <WorkloadDetail />,
+});
+
+registerRoute({
+  path: kueueRoutePaths.provisioningRequestConfigsList,
+  sidebar: 'kueue-provisioningrequestconfigs',
+  name: kueueRouteNames.provisioningRequestConfigsList,
+  exact: true,
+  component: () => <ProvisioningRequestConfigList />,
+});
+
+registerRoute({
+  path: kueueRoutePaths.provisioningRequestConfigDetail,
+  sidebar: 'kueue-provisioningrequestconfigs',
+  name: kueueRouteNames.provisioningRequestConfigDetail,
+  exact: true,
+  component: () => <ProvisioningRequestConfigDetail />,
 });

--- a/kueue/src/resources/provisioningRequestConfig.test.ts
+++ b/kueue/src/resources/provisioningRequestConfig.test.ts
@@ -1,0 +1,68 @@
+import {
+  renderManagedResources,
+  renderPodSetMergePolicy,
+  renderProvisioningClassName,
+  renderRetryStrategy,
+} from './provisioningRequestConfigFormatters';
+
+describe('renderProvisioningClassName', () => {
+  it('returns a dash when missing', () => {
+    expect(renderProvisioningClassName()).toBe('-');
+    expect(renderProvisioningClassName('')).toBe('-');
+  });
+
+  it('returns the class name when present', () => {
+    expect(renderProvisioningClassName('check-capacity.autoscaling.x-k8s.io')).toBe(
+      'check-capacity.autoscaling.x-k8s.io'
+    );
+  });
+});
+
+describe('renderManagedResources', () => {
+  it('returns a dash when there are no managed resources', () => {
+    expect(renderManagedResources()).toBe('-');
+    expect(renderManagedResources([])).toBe('-');
+  });
+
+  it('renders a comma-separated list', () => {
+    expect(renderManagedResources(['nvidia.com/gpu', 'cpu', 'memory'])).toBe(
+      'nvidia.com/gpu, cpu, memory'
+    );
+  });
+});
+
+describe('renderRetryStrategy', () => {
+  it('returns a dash when there is no retry strategy', () => {
+    expect(renderRetryStrategy()).toBe('-');
+  });
+
+  it('returns a dash when the retry strategy has no fields set', () => {
+    expect(renderRetryStrategy({})).toBe('-');
+  });
+
+  it('renders only the fields that are present', () => {
+    expect(renderRetryStrategy({ backoffLimitCount: 2 })).toBe('limit: 2');
+  });
+
+  it('renders all fields when fully specified', () => {
+    expect(
+      renderRetryStrategy({ backoffLimitCount: 2, backoffBaseSeconds: 60, backoffMaxSeconds: 1800 })
+    ).toBe('limit: 2, base: 60s, max: 1800s');
+  });
+
+  it('renders backoffLimitCount of zero, not treating it as missing', () => {
+    expect(renderRetryStrategy({ backoffLimitCount: 0 })).toBe('limit: 0');
+  });
+});
+
+describe('renderPodSetMergePolicy', () => {
+  it('returns a dash when missing', () => {
+    expect(renderPodSetMergePolicy()).toBe('-');
+  });
+
+  it('returns the policy when present', () => {
+    expect(renderPodSetMergePolicy('IdenticalWorkloadSchedulingRequirements')).toBe(
+      'IdenticalWorkloadSchedulingRequirements'
+    );
+  });
+});

--- a/kueue/src/resources/provisioningRequestConfig.ts
+++ b/kueue/src/resources/provisioningRequestConfig.ts
@@ -1,0 +1,123 @@
+import { KubeObject, KubeObjectInterface } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import { kueueApiVersions } from '../utils/kueueApi';
+import { kueueRoutePaths } from '../utils/kueueRoutes';
+import {
+  renderManagedResources,
+  renderPodSetMergePolicy,
+  renderProvisioningClassName,
+  renderRetryStrategy,
+  type RetryStrategyLike,
+} from './provisioningRequestConfigFormatters';
+
+/**
+ * Retry strategy for a ProvisioningRequest created from this config.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#retrystrategy
+ */
+export interface RetryStrategy extends RetryStrategyLike {
+  /**
+   * Number of times a failed ProvisioningRequest is retried. Defaults to 3.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#retrystrategy
+   */
+  backoffLimitCount?: number;
+  /**
+   * Base, in seconds, used to calculate the backoff time before a retry.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#retrystrategy
+   */
+  backoffBaseSeconds?: number;
+  /**
+   * Maximum backoff time, in seconds, before a retry.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#retrystrategy
+   */
+  backoffMaxSeconds?: number;
+}
+
+/**
+ * Desired state of a Kueue ProvisioningRequestConfig.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#provisioningrequestconfigspec
+ */
+export interface ProvisioningRequestConfigSpec {
+  /**
+   * ProvisioningClass describing the mode used to provision resources.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#provisioningrequestconfigspec
+   */
+  provisioningClassName: string;
+  /**
+   * Resources managed by the autoscaling; if empty, all resources are managed.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#provisioningrequestconfigspec
+   */
+  managedResources?: string[];
+  /**
+   * Strategy for retrying a failed ProvisioningRequest.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#provisioningrequestconfigspec
+   */
+  retryStrategy?: RetryStrategy;
+  /**
+   * Policy for merging pod sets into the ProvisioningRequest.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#provisioningrequestconfigspec
+   */
+  podSetMergePolicy?: string;
+}
+
+/**
+ * Kubernetes ProvisioningRequestConfig object returned by the Kueue API.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#provisioningrequestconfig
+ */
+export interface KubeProvisioningRequestConfig extends KubeObjectInterface {
+  /**
+   * Kubernetes object metadata for the ProvisioningRequestConfig.
+   *
+   * @see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#objectmeta-v1-meta
+   */
+  metadata: KubeObjectInterface['metadata'];
+  /**
+   * ProvisioningRequestConfig desired state.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#provisioningrequestconfigspec
+   */
+  spec: ProvisioningRequestConfigSpec;
+}
+
+export class ProvisioningRequestConfig extends KubeObject<KubeProvisioningRequestConfig> {
+  static kind = 'ProvisioningRequestConfig';
+  static apiName = 'provisioningrequestconfigs';
+  static apiVersion = kueueApiVersions;
+  static isNamespaced = false;
+
+  static get detailsRoute() {
+    return kueueRoutePaths.provisioningRequestConfigDetail;
+  }
+
+  get spec(): ProvisioningRequestConfigSpec {
+    return this.jsonData.spec ?? ({} as ProvisioningRequestConfigSpec);
+  }
+
+  get provisioningClassName() {
+    return renderProvisioningClassName(this.spec.provisioningClassName);
+  }
+
+  get managedResources() {
+    return this.spec.managedResources || [];
+  }
+
+  get managedResourcesDisplay() {
+    return renderManagedResources(this.managedResources);
+  }
+
+  get retryStrategyDisplay() {
+    return renderRetryStrategy(this.spec.retryStrategy);
+  }
+
+  get podSetMergePolicyDisplay() {
+    return renderPodSetMergePolicy(this.spec.podSetMergePolicy);
+  }
+}

--- a/kueue/src/resources/provisioningRequestConfigFormatters.ts
+++ b/kueue/src/resources/provisioningRequestConfigFormatters.ts
@@ -1,0 +1,46 @@
+/** Retry strategy controlling how a ProvisioningRequest is retried on failure. */
+export interface RetryStrategyLike {
+  backoffLimitCount?: number;
+  backoffBaseSeconds?: number;
+  backoffMaxSeconds?: number;
+}
+
+/** Render the ProvisioningClass name, falling back when the API omits the field. */
+export function renderProvisioningClassName(provisioningClassName?: string) {
+  return provisioningClassName || '-';
+}
+
+/** Render the list of resources managed by autoscaling as a comma-separated list. */
+export function renderManagedResources(managedResources?: string[]) {
+  if (!managedResources || managedResources.length === 0) {
+    return '-';
+  }
+
+  return managedResources.join(', ');
+}
+
+/** Render the retry strategy as a short human-readable summary. */
+export function renderRetryStrategy(retryStrategy?: RetryStrategyLike) {
+  if (!retryStrategy) {
+    return '-';
+  }
+
+  const parts: string[] = [];
+
+  if (retryStrategy.backoffLimitCount !== undefined) {
+    parts.push(`limit: ${retryStrategy.backoffLimitCount}`);
+  }
+  if (retryStrategy.backoffBaseSeconds !== undefined) {
+    parts.push(`base: ${retryStrategy.backoffBaseSeconds}s`);
+  }
+  if (retryStrategy.backoffMaxSeconds !== undefined) {
+    parts.push(`max: ${retryStrategy.backoffMaxSeconds}s`);
+  }
+
+  return parts.length > 0 ? parts.join(', ') : '-';
+}
+
+/** Render the pod set merge policy, falling back when the API omits the field. */
+export function renderPodSetMergePolicy(podSetMergePolicy?: string) {
+  return podSetMergePolicy || '-';
+}

--- a/kueue/src/utils/kueueRoutes.ts
+++ b/kueue/src/utils/kueueRoutes.ts
@@ -7,6 +7,8 @@ export const kueueRouteNames = {
   resourceFlavorDetail: 'kueue-resourceflavor-detail',
   workloadsList: 'kueue-workloads-list',
   workloadDetail: 'kueue-workload-detail',
+  provisioningRequestConfigsList: 'kueue-provisioningrequestconfigs-list',
+  provisioningRequestConfigDetail: 'kueue-provisioningrequestconfig-detail',
 } as const;
 
 export const kueueRoutePaths = {
@@ -18,4 +20,6 @@ export const kueueRoutePaths = {
   resourceFlavorDetail: '/kueue/resourceflavors/:name',
   workloadsList: '/kueue/workloads',
   workloadDetail: '/kueue/workloads/:namespace/:name',
+  provisioningRequestConfigsList: '/kueue/provisioningrequestconfigs',
+  provisioningRequestConfigDetail: '/kueue/provisioningrequestconfigs/:name',
 } as const;


### PR DESCRIPTION
## What this PR does

Adds a new `ProvisioningRequestConfig` resource to the Kueue plugin, following the existing
patterns used by `ClusterQueue`, `LocalQueue`, `ResourceFlavor`, and `Workload`.
`ProvisioningRequestConfig` had no dedicated views in this plugin — it's the configuration
object referenced by `AdmissionCheck.spec.parameters` when using Kueue's autoscaler
integration (e.g. Cluster Autoscaler's ProvisioningRequest API).

- Adds `src/resources/provisioningRequestConfig.ts` — a `KubeObject`-based resource class
  typed against the real `ProvisioningRequestConfigSpec` fields (`provisioningClassName`,
  `managedResources`, `retryStrategy`, `podSetMergePolicy`), per the
  [Kueue API reference](https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#provisioningrequestconfig).
- Adds `src/resources/provisioningRequestConfigFormatters.ts` with exported, documented, pure
  functions: `renderProvisioningClassName`, `renderManagedResources`, `renderRetryStrategy`,
  `renderPodSetMergePolicy`.
- Adds `src/resources/provisioningRequestConfig.test.ts` with unit tests covering each
  formatter, including empty/undefined edge cases and a zero-value edge case for
  `backoffLimitCount`.
- Adds `src/components/provisioningrequestconfigs/List.tsx` and `Detail.tsx`, mirroring the
  `resourceflavors` components structure (cluster-scoped, using `KueueAdminResourceAccess`
  and `ResourceListView`/`DetailsGrid`).
- Registers the sidebar entry and routes in `index.tsx` and `utils/kueueRoutes.ts`.

## Testing

- `npm run test` — all 33 tests pass (11 new).
- `npm run build` — builds cleanly.
- Verified locally in a running Headlamp instance against a kind cluster: applied a real
  `ProvisioningRequestConfig` resource and confirmed both the List and Detail views correctly
  render the provisioning class, managed resources, and retry strategy.

## Why

`ProvisioningRequestConfig` is a core part of Kueue's autoscaler integration story
(referenced directly by `AdmissionCheck`), but had no dedicated view yet. This is a small,
additive, low-risk addition that gives users visibility into their provisioning configs
without touching any existing resource types.