### PR TITLE
argocd: Add managed-resource API availability insights

### DIFF
--- a/argocd/README.md
+++ b/argocd/README.md
@@ -6,11 +6,19 @@ To learn more about Argo CD, see the [Argo CD Getting Started Guide](https://arg
 
 ## Features
 
+- **Managed Resource API Availability** — Compares each API reported in `Application.status.resources` with the APIs served by the selected local Kubernetes cluster. Missing kinds and unserved versions are highlighted without fetching arbitrary live objects.
+
 - **Application List View** — Lists all Argo CD `Application` resources in the cluster with columns for project, source repo, target revision, sync status, and health status (rendered as color-coded badges).
 - **Application Detail View** — Displays detailed metadata for a single Application: project, source, destination, sync status, health status, and Kubernetes events.
 - **Sync Action** — Triggers a sync by patching the Application's `.operation` field via the Kubernetes API. The Argo CD application-controller picks this up exactly as it would from the Argo CD UI.
 - **Refresh Action** — Requests a refresh by setting the `argocd.argoproj.io/refresh` annotation (supports `normal` and `hard` refresh types).
 - **Argo CD Sidebar Icon** — Registers the official Argo CD octopus logo as an offline Iconify icon (CSP-safe, no external fetch).
+
+### API availability scope
+
+The Managed Resources table checks whether the selected Kubernetes cluster serves the exact API group, version, and kind reported by Argo CD. For example, it can show that a resource uses an API version that the cluster no longer serves.
+
+This is an **API availability check**, not a full controller compatibility test. A matching API does not prove that an installed controller implements every field or feature, and it does not prove that application traffic works. Remote or unverified Application destinations are not queried and are shown as `Not checked — remote`.
 
 ### Why the Kubernetes API instead of the Argo CD REST API?
 

--- a/argocd/src/api/apiDiscovery.test.ts
+++ b/argocd/src/api/apiDiscovery.test.ts
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { request } = vi.hoisted(() => ({ request: vi.fn() }));
+
+vi.mock('@kinvolk/headlamp-plugin/lib', () => ({
+  ApiProxy: { request },
+}));
+
+import {
+  apiResourceKey,
+  discoverApiCatalog,
+  DISCOVERY_CACHE_TTL_MS,
+  DISCOVERY_CONCURRENCY,
+  resetApiDiscoveryCache,
+} from './apiDiscovery';
+
+describe('discoverApiCatalog', () => {
+  beforeEach(() => {
+    request.mockReset();
+    resetApiDiscoveryCache();
+  });
+
+  it('reads core and grouped resources from aggregated discovery', async () => {
+    request.mockImplementation((path: string) => {
+      if (path === '/api') {
+        return Promise.resolve(aggregatedGroup('core', 'v1', 'Service', 'services'));
+      }
+      return Promise.resolve(
+        aggregatedGroup('apps', 'v1', 'Deployment', 'deployments', 'Namespaced')
+      );
+    });
+
+    const catalog = await discoverApiCatalog('cluster-a', [
+      { group: '', version: 'v1', kind: 'Service' },
+      { group: 'apps', version: 'v1', kind: 'Deployment' },
+    ]);
+
+    expect(catalog.resources.get(apiResourceKey('', 'Service'))?.versions).toEqual(new Set(['v1']));
+    expect(catalog.resources.get(apiResourceKey('apps', 'Deployment'))?.versions).toEqual(
+      new Set(['v1'])
+    );
+    expect(catalog.completeGroups).toEqual(new Set(['', 'apps']));
+  });
+
+  it('falls back to the legacy discovery endpoints and ignores subresources', async () => {
+    request.mockImplementation((path: string, params: { headers?: unknown }) => {
+      if (params.headers && path === '/api') return Promise.resolve({ versions: ['v1'] });
+      if (params.headers && path === '/apis') {
+        return Promise.resolve({
+          groups: [
+            {
+              name: 'apps',
+              versions: [{ version: 'v1' }],
+              preferredVersion: { version: 'v1' },
+            },
+          ],
+        });
+      }
+      if (path === '/api/v1') {
+        return Promise.resolve({
+          resources: [
+            { name: 'services', kind: 'Service', namespaced: true },
+            { name: 'pods/status', kind: 'Pod', namespaced: true },
+          ],
+        });
+      }
+      return Promise.resolve({
+        resources: [{ name: 'deployments', kind: 'Deployment', namespaced: true }],
+      });
+    });
+
+    const catalog = await discoverApiCatalog('cluster-a', [
+      { group: '', version: 'v1', kind: 'Service' },
+      { group: 'apps', version: 'v1', kind: 'Deployment' },
+    ]);
+
+    expect(catalog.resources.has(apiResourceKey('', 'Service'))).toBe(true);
+    expect(catalog.resources.has(apiResourceKey('', 'Pod'))).toBe(false);
+    expect(catalog.resources.has(apiResourceKey('apps', 'Deployment'))).toBe(true);
+  });
+
+  it('shares successful requests within the cache TTL and isolates clusters', async () => {
+    request.mockResolvedValue(aggregatedGroup('apps', 'v1', 'Deployment', 'deployments'));
+    const descriptors = [{ group: 'apps', version: 'v1', kind: 'Deployment' }];
+
+    await discoverApiCatalog('cluster-a', descriptors);
+    await discoverApiCatalog('cluster-a', descriptors);
+    await discoverApiCatalog('cluster-b', descriptors);
+
+    expect(request).toHaveBeenCalledTimes(4);
+    expect(request.mock.calls.map(call => call[1].cluster)).toEqual([
+      'cluster-a',
+      'cluster-a',
+      'cluster-b',
+      'cluster-b',
+    ]);
+  });
+
+  it('refreshes successful requests after the cache TTL', async () => {
+    let now = 1_000;
+    vi.spyOn(Date, 'now').mockImplementation(() => now);
+    request.mockResolvedValue(aggregatedGroup('apps', 'v1', 'Deployment', 'deployments'));
+    const descriptors = [{ group: 'apps', version: 'v1', kind: 'Deployment' }];
+
+    await discoverApiCatalog('cluster-a', descriptors);
+    now += DISCOVERY_CACHE_TTL_MS + 1;
+    await discoverApiCatalog('cluster-a', descriptors);
+
+    expect(request).toHaveBeenCalledTimes(4);
+    vi.restoreAllMocks();
+  });
+
+  it('does not retain failed requests in the cache', async () => {
+    request
+      .mockRejectedValueOnce(new Error('temporary failure'))
+      .mockResolvedValueOnce(aggregatedGroup('apps', 'v1', 'Deployment', 'deployments'))
+      .mockResolvedValueOnce(aggregatedGroup('apps', 'v1', 'Deployment', 'deployments'));
+
+    await discoverApiCatalog('cluster-a', [{ group: '', version: 'v1', kind: 'Service' }]);
+    await discoverApiCatalog('cluster-a', [{ group: '', version: 'v1', kind: 'Service' }]);
+
+    expect(request.mock.calls.filter(call => call[0] === '/api')).toHaveLength(2);
+  });
+
+  it('limits legacy version discovery requests', async () => {
+    let active = 0;
+    let maximum = 0;
+    request.mockImplementation((path: string, params: { headers?: unknown }) => {
+      if (params.headers && path === '/api') return Promise.resolve({ versions: [] });
+      if (params.headers && path === '/apis') {
+        return Promise.resolve({
+          groups: Array.from({ length: 8 }, (_, index) => ({
+            name: `group${index}.example.io`,
+            versions: [{ version: 'v1' }],
+          })),
+        });
+      }
+
+      active += 1;
+      maximum = Math.max(maximum, active);
+      return new Promise(resolve =>
+        setTimeout(() => {
+          active -= 1;
+          resolve({ resources: [] });
+        }, 5)
+      );
+    });
+
+    await discoverApiCatalog(
+      'cluster-a',
+      Array.from({ length: 8 }, (_, index) => ({
+        group: `group${index}.example.io`,
+        version: 'v1',
+        kind: 'Example',
+      }))
+    );
+
+    expect(maximum).toBe(DISCOVERY_CONCURRENCY);
+  });
+});
+
+function aggregatedGroup(
+  group: string,
+  version: string,
+  kind: string,
+  resource: string,
+  scope = 'Namespaced'
+) {
+  return {
+    apiVersion: 'apidiscovery.k8s.io/v2',
+    kind: 'APIGroupDiscoveryList',
+    items: [
+      {
+        metadata: { name: group },
+        versions: [
+          {
+            version,
+            freshness: 'Current',
+            resources: [{ resource, scope, responseKind: { group, version, kind } }],
+          },
+        ],
+      },
+    ],
+  };
+}

--- a/argocd/src/api/apiDiscovery.ts
+++ b/argocd/src/api/apiDiscovery.ts
@@ -1,0 +1,396 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ApiProxy } from '@kinvolk/headlamp-plugin/lib';
+
+export const DISCOVERY_CACHE_TTL_MS = 30_000;
+export const DISCOVERY_CONCURRENCY = 6;
+export const AGGREGATED_DISCOVERY_ACCEPT =
+  'application/json;v=v2;g=apidiscovery.k8s.io;as=APIGroupDiscoveryList,application/json';
+
+export interface ApiDescriptor {
+  group: string;
+  version: string;
+  kind: string;
+}
+
+export interface DiscoveredApiResource {
+  group: string;
+  kind: string;
+  versions: Set<string>;
+  namespaced?: boolean;
+  resourceNames: Set<string>;
+}
+
+/** Normalized Kubernetes API catalogue used by availability evaluation. */
+export interface ApiCatalog {
+  resources: Map<string, DiscoveredApiResource>;
+  preferredVersions: Map<string, string>;
+  knownGroups: Set<string>;
+  completeGroups: Set<string>;
+  failedGroups: Set<string>;
+  coreRootComplete: boolean;
+  groupedRootComplete: boolean;
+}
+
+interface CachedRequest {
+  promise: Promise<unknown>;
+  expiresAt: number;
+}
+
+interface AggregatedVersion {
+  version?: unknown;
+  freshness?: unknown;
+  resources?: unknown;
+}
+
+interface AggregatedGroup {
+  metadata?: { name?: unknown };
+  versions?: unknown;
+}
+
+interface AggregatedResource {
+  resource?: unknown;
+  scope?: unknown;
+  responseKind?: { group?: unknown; version?: unknown; kind?: unknown };
+}
+
+interface GroupDiscovery {
+  name?: unknown;
+  versions?: unknown;
+  preferredVersion?: { version?: unknown };
+}
+
+const requestCache = new Map<string, CachedRequest>();
+
+function newCatalog(): ApiCatalog {
+  return {
+    resources: new Map(),
+    preferredVersions: new Map(),
+    knownGroups: new Set(),
+    completeGroups: new Set(),
+    failedGroups: new Set(),
+    coreRootComplete: false,
+    groupedRootComplete: false,
+  };
+}
+
+export function apiResourceKey(group: string, kind: string): string {
+  return `${group}/${kind}`;
+}
+
+function groupVersionKey(group: string, version: string): string {
+  return `${group}/${version}`;
+}
+
+function isSafeApiSegment(value: string): boolean {
+  return /^[a-z0-9][a-z0-9.-]*$/i.test(value);
+}
+
+function normalizeGroup(group: unknown): string {
+  return group === 'core' || group === undefined || group === null ? '' : String(group);
+}
+
+function cachedRequest(path: string, cluster: string, aggregated = false): Promise<unknown> {
+  const key = `${cluster}|${aggregated ? 'aggregated' : 'standard'}|${path}`;
+  const now = Date.now();
+  const cached = requestCache.get(key);
+  if (cached && (cached.expiresAt === 0 || cached.expiresAt > now)) {
+    return cached.promise;
+  }
+
+  const params: RequestInit & { cluster: string } = { cluster };
+  if (aggregated) {
+    params.headers = { Accept: AGGREGATED_DISCOVERY_ACCEPT };
+  }
+
+  const entry: CachedRequest = {
+    expiresAt: 0,
+    promise: Promise.resolve(),
+  };
+  entry.promise = ApiProxy.request(path, params, false)
+    .then(result => {
+      entry.expiresAt = Date.now() + DISCOVERY_CACHE_TTL_MS;
+      return result;
+    })
+    .catch(error => {
+      requestCache.delete(key);
+      throw error;
+    });
+  requestCache.set(key, entry);
+  return entry.promise;
+}
+
+/** Clears discovery request state. Exported only to keep tests deterministic. */
+export function resetApiDiscoveryCache(): void {
+  requestCache.clear();
+}
+
+function isAggregatedDiscovery(value: unknown): value is {
+  kind?: string;
+  apiVersion?: string;
+  items?: unknown[];
+} {
+  if (!value || typeof value !== 'object') return false;
+  const data = value as Record<string, unknown>;
+  return data.kind === 'APIGroupDiscoveryList' || data.apiVersion === 'apidiscovery.k8s.io/v2';
+}
+
+function addResource(
+  catalog: ApiCatalog,
+  group: string,
+  version: string,
+  kind: string,
+  resourceName: string,
+  namespaced?: boolean
+): void {
+  if (!version || !kind || !resourceName || resourceName.includes('/')) return;
+  const key = apiResourceKey(group, kind);
+  const existing = catalog.resources.get(key) ?? {
+    group,
+    kind,
+    versions: new Set<string>(),
+    resourceNames: new Set<string>(),
+  };
+  existing.versions.add(version);
+  existing.resourceNames.add(resourceName);
+  if (namespaced !== undefined) existing.namespaced = namespaced;
+  catalog.resources.set(key, existing);
+}
+
+function parseAggregatedDiscovery(
+  value: unknown,
+  catalog: ApiCatalog,
+  source: 'core' | 'grouped'
+): void {
+  if (!isAggregatedDiscovery(value)) return;
+  if (source === 'core') catalog.coreRootComplete = true;
+  else catalog.groupedRootComplete = true;
+
+  const items = Array.isArray(value.items) ? value.items : [];
+  for (const rawItem of items) {
+    if (!rawItem || typeof rawItem !== 'object') continue;
+    const item = rawItem as AggregatedGroup;
+    const metadataGroup = normalizeGroup(item.metadata?.name);
+    const versions = Array.isArray(item.versions) ? item.versions : [];
+    const firstVersion = versions
+      .map(entry => (entry as AggregatedVersion | undefined)?.version)
+      .find((version): version is string => typeof version === 'string');
+    if (firstVersion) catalog.preferredVersions.set(metadataGroup, firstVersion);
+    catalog.knownGroups.add(metadataGroup);
+
+    let complete = true;
+    for (const rawVersion of versions) {
+      if (!rawVersion || typeof rawVersion !== 'object') continue;
+      const versionEntry = rawVersion as AggregatedVersion;
+      const version = typeof versionEntry.version === 'string' ? versionEntry.version : '';
+      if (versionEntry.freshness && versionEntry.freshness !== 'Current') {
+        complete = false;
+        continue;
+      }
+      for (const rawResource of Array.isArray(versionEntry.resources)
+        ? versionEntry.resources
+        : []) {
+        if (!rawResource || typeof rawResource !== 'object') continue;
+        const resource = rawResource as AggregatedResource;
+        const responseKind = resource.responseKind ?? {};
+        const group = normalizeGroup(responseKind.group ?? metadataGroup);
+        addResource(
+          catalog,
+          group,
+          String(responseKind.version ?? version),
+          String(responseKind.kind ?? ''),
+          String(resource.resource ?? ''),
+          resource.scope === 'Namespaced' ? true : resource.scope === 'Cluster' ? false : undefined
+        );
+      }
+    }
+
+    if (complete) catalog.completeGroups.add(metadataGroup);
+    else catalog.failedGroups.add(metadataGroup);
+  }
+}
+
+function parseCoreRoot(value: unknown): string[] {
+  if (!value || typeof value !== 'object') return [];
+  const versions = (value as Record<string, unknown>).versions;
+  return Array.isArray(versions)
+    ? versions.filter((version): version is string => typeof version === 'string')
+    : [];
+}
+
+interface GroupRootResult {
+  versions: Map<string, string[]>;
+  preferredVersions: Map<string, string>;
+}
+
+function parseGroupedRoot(value: unknown): GroupRootResult {
+  const result: GroupRootResult = { versions: new Map(), preferredVersions: new Map() };
+  if (!value || typeof value !== 'object') return result;
+  const groups = (value as Record<string, unknown>).groups;
+  if (!Array.isArray(groups)) return result;
+
+  for (const rawGroup of groups) {
+    if (!rawGroup || typeof rawGroup !== 'object') continue;
+    const group = rawGroup as GroupDiscovery;
+    if (typeof group.name !== 'string' || !group.name) continue;
+    const versions = (Array.isArray(group.versions) ? group.versions : [])
+      .map(entry => (entry as { version?: unknown } | undefined)?.version)
+      .filter((version: unknown): version is string => typeof version === 'string');
+    result.versions.set(group.name, versions);
+    if (typeof group.preferredVersion?.version === 'string') {
+      result.preferredVersions.set(group.name, group.preferredVersion.version);
+    }
+  }
+  return result;
+}
+
+function parseApiResourceList(value: unknown, catalog: ApiCatalog, group: string, version: string) {
+  if (!value || typeof value !== 'object') return;
+  const resources = (value as Record<string, unknown>).resources;
+  if (!Array.isArray(resources)) return;
+  for (const rawResource of resources) {
+    if (!rawResource || typeof rawResource !== 'object') continue;
+    const resource = rawResource as Record<string, unknown>;
+    addResource(
+      catalog,
+      group,
+      version,
+      typeof resource.kind === 'string' ? resource.kind : '',
+      typeof resource.name === 'string' ? resource.name : '',
+      typeof resource.namespaced === 'boolean' ? resource.namespaced : undefined
+    );
+  }
+}
+
+async function runWithConcurrency<T>(
+  tasks: Array<() => Promise<T>>,
+  limit = DISCOVERY_CONCURRENCY
+): Promise<T[]> {
+  const results = new Array<T>(tasks.length);
+  let next = 0;
+
+  async function worker() {
+    while (next < tasks.length) {
+      const index = next++;
+      results[index] = await tasks[index]();
+    }
+  }
+
+  await Promise.all(Array.from({ length: Math.min(limit, tasks.length) }, () => worker()));
+  return results;
+}
+
+interface VersionRequest {
+  group: string;
+  version: string;
+  path: string;
+}
+
+function apiVersionPath(group: string, version: string): string | null {
+  if (!isSafeApiSegment(version) || (group && !isSafeApiSegment(group))) return null;
+  return group
+    ? `/apis/${encodeURIComponent(group)}/${encodeURIComponent(version)}`
+    : `/api/${encodeURIComponent(version)}`;
+}
+
+/**
+ * Discovers the APIs relevant to an Application's managed resources.
+ *
+ * Aggregated discovery is preferred. Older clusters fall back to fetching only
+ * the groups used by the supplied descriptors.
+ */
+export async function discoverApiCatalog(
+  cluster: string,
+  descriptors: ApiDescriptor[]
+): Promise<ApiCatalog> {
+  const catalog = newCatalog();
+  const relevantGroups = new Set(descriptors.map(descriptor => descriptor.group || ''));
+
+  const [coreResult, groupedResult] = await Promise.allSettled([
+    cachedRequest('/api', cluster, true),
+    cachedRequest('/apis', cluster, true),
+  ]);
+
+  const coreAggregated =
+    coreResult.status === 'fulfilled' && isAggregatedDiscovery(coreResult.value);
+  const groupedAggregated =
+    groupedResult.status === 'fulfilled' && isAggregatedDiscovery(groupedResult.value);
+
+  if (coreAggregated) parseAggregatedDiscovery(coreResult.value, catalog, 'core');
+  if (groupedAggregated) parseAggregatedDiscovery(groupedResult.value, catalog, 'grouped');
+
+  const versionsByGroup = new Map<string, string[]>();
+
+  if (!coreAggregated && relevantGroups.has('')) {
+    if (coreResult.status === 'fulfilled') {
+      const versions = parseCoreRoot(coreResult.value);
+      catalog.coreRootComplete = true;
+      catalog.knownGroups.add('');
+      versionsByGroup.set('', versions);
+      if (versions[0]) catalog.preferredVersions.set('', versions[0]);
+    } else {
+      catalog.failedGroups.add('');
+    }
+  }
+
+  if (!groupedAggregated && [...relevantGroups].some(group => group !== '')) {
+    if (groupedResult.status === 'fulfilled') {
+      const parsed = parseGroupedRoot(groupedResult.value);
+      catalog.groupedRootComplete = true;
+      for (const [group, versions] of parsed.versions) {
+        catalog.knownGroups.add(group);
+        if (relevantGroups.has(group)) versionsByGroup.set(group, versions);
+      }
+      for (const [group, preferred] of parsed.preferredVersions) {
+        catalog.preferredVersions.set(group, preferred);
+      }
+    } else {
+      for (const group of relevantGroups) {
+        if (group) catalog.failedGroups.add(group);
+      }
+    }
+  }
+
+  const requests: VersionRequest[] = [];
+  for (const [group, versions] of versionsByGroup) {
+    for (const version of new Set(versions)) {
+      const path = apiVersionPath(group, version);
+      if (path) requests.push({ group, version, path });
+      else catalog.failedGroups.add(group);
+    }
+  }
+
+  const failures = new Set<string>();
+  await runWithConcurrency(
+    requests.map(requestInfo => async () => {
+      try {
+        const response = await cachedRequest(requestInfo.path, cluster);
+        parseApiResourceList(response, catalog, requestInfo.group, requestInfo.version);
+      } catch {
+        failures.add(groupVersionKey(requestInfo.group, requestInfo.version));
+        catalog.failedGroups.add(requestInfo.group);
+      }
+    })
+  );
+
+  for (const [group, versions] of versionsByGroup) {
+    const complete = versions.every(version => !failures.has(groupVersionKey(group, version)));
+    if (complete) catalog.completeGroups.add(group);
+  }
+
+  return catalog;
+}

--- a/argocd/src/components/applications/Detail.tsx
+++ b/argocd/src/components/applications/Detail.tsx
@@ -26,13 +26,20 @@ import {
   StatusLabel,
 } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 import { ConditionsTable } from '@kinvolk/headlamp-plugin/lib/components/common';
-import { Box, Link as MuiLink, Tooltip, Typography } from '@mui/material';
+import { Alert, Box, Link as MuiLink, Tooltip, Typography } from '@mui/material';
 import type { Theme } from '@mui/material/styles';
 import type { ComponentProps, ReactNode } from 'react';
 import { useParams } from 'react-router-dom';
 import { refreshApplication, syncApplication } from '../../api/argoClient';
 import { useArgoOperation } from '../../hooks/useArgoOperation';
 import { ArgoApplication, ManagedResource, RevisionHistory } from '../../resources/application';
+import {
+  ApiAvailability,
+  canOpenManagedResourcesInCurrentCluster,
+  getApiAvailabilityPresentation,
+  managedResourceApiKey,
+  useManagedResourceApiAvailability,
+} from './apiAvailability';
 import { getManagedResourceLink } from './managedResourceLinks';
 import { getHealthIcon, getHealthStatus, getSyncIcon, getSyncStatus } from './statusHelpers';
 
@@ -270,70 +277,111 @@ function formatDestinationCluster(destination: string) {
  * @returns A section box definition containing the managed resources table, or null if no resources exist.
  */
 function getManagedResourcesSection(app: ArgoApplication) {
-  const resources = app.managedResources;
-  if (!resources.length) return null;
+  if (!app.managedResources.length) return null;
 
   return {
     id: 'managed-resources',
-    section: (
-      <SectionBox title="Managed Resources">
-        <ManagedResourcesOverview resources={resources} />
-        <SimpleTable
-          data={resources}
-          columns={[
-            {
-              label: 'Kind',
-              getter: (r: ManagedResource) => <ResourceKindLabel resource={r} />,
-              sort: (a: ManagedResource, b: ManagedResource) => a.kind.localeCompare(b.kind),
-            },
-            {
-              label: 'Name',
-              getter: (r: ManagedResource) => getManagedResourceLink(r),
-              sort: (a: ManagedResource, b: ManagedResource) => a.name.localeCompare(b.name),
-            },
-            {
-              label: 'Namespace',
-              getter: (r: ManagedResource) => r.namespace ?? '-',
-              sort: true,
-            },
-            {
-              label: 'Sync',
-              getter: (r: ManagedResource) => (
-                <StatusLabel status={getSyncStatus(getManagedResourceSync(r))}>
-                  <Icon
-                    icon={getSyncIcon(getManagedResourceSync(r))}
-                    style={{ marginRight: '4px' }}
-                  />
-                  {getManagedResourceSync(r)}
-                </StatusLabel>
-              ),
-              sort: (a: ManagedResource, b: ManagedResource) =>
-                getManagedResourceSync(a).localeCompare(getManagedResourceSync(b)),
-            },
-            {
-              label: 'Health',
-              getter: (r: ManagedResource) => (
-                <StatusLabel status={getHealthStatus(getManagedResourceHealth(r))}>
-                  <Icon
-                    icon={getHealthIcon(getManagedResourceHealth(r))}
-                    style={{ marginRight: '4px' }}
-                  />
-                  {getManagedResourceHealth(r)}
-                </StatusLabel>
-              ),
-              sort: (a: ManagedResource, b: ManagedResource) =>
-                getManagedResourceHealth(a).localeCompare(getManagedResourceHealth(b)),
-            },
-            {
-              label: 'API',
-              getter: (r: ManagedResource) => getManagedResourceApi(r),
-              sort: true,
-            },
-          ]}
-        />
-      </SectionBox>
-    ),
+    section: <ManagedResourcesSection application={app} />,
   };
+}
+
+function ManagedResourcesSection(props: { application: ArgoApplication }) {
+  const resources = props.application.managedResources;
+  const { availability, loading } = useManagedResourceApiAvailability(props.application);
+  const canOpenResources = canOpenManagedResourcesInCurrentCluster(props.application);
+  const hasUnavailableApi = [...availability.values()].some(result =>
+    ['version-not-served', 'resource-not-found'].includes(result.state)
+  );
+
+  return (
+    <SectionBox title="Managed Resources">
+      <ManagedResourcesOverview resources={resources} />
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        API availability checks whether Kubernetes offers this resource API. It does not verify
+        controller feature support or application traffic.
+      </Typography>
+      {hasUnavailableApi && (
+        <Alert severity="warning" sx={{ mb: 2 }}>
+          One or more resource APIs reported by Argo CD are not available in the selected cluster.
+        </Alert>
+      )}
+      <SimpleTable
+        data={resources}
+        columns={[
+          {
+            label: 'Kind',
+            getter: (r: ManagedResource) => <ResourceKindLabel resource={r} />,
+            sort: (a: ManagedResource, b: ManagedResource) => a.kind.localeCompare(b.kind),
+          },
+          {
+            label: 'Name',
+            getter: (r: ManagedResource) => (canOpenResources ? getManagedResourceLink(r) : r.name),
+            sort: (a: ManagedResource, b: ManagedResource) => a.name.localeCompare(b.name),
+          },
+          {
+            label: 'Namespace',
+            getter: (r: ManagedResource) => r.namespace ?? '-',
+            sort: true,
+          },
+          {
+            label: 'Sync',
+            getter: (r: ManagedResource) => (
+              <StatusLabel status={getSyncStatus(getManagedResourceSync(r))}>
+                <Icon
+                  icon={getSyncIcon(getManagedResourceSync(r))}
+                  style={{ marginRight: '4px' }}
+                />
+                {getManagedResourceSync(r)}
+              </StatusLabel>
+            ),
+            sort: (a: ManagedResource, b: ManagedResource) =>
+              getManagedResourceSync(a).localeCompare(getManagedResourceSync(b)),
+          },
+          {
+            label: 'Health',
+            getter: (r: ManagedResource) => (
+              <StatusLabel status={getHealthStatus(getManagedResourceHealth(r))}>
+                <Icon
+                  icon={getHealthIcon(getManagedResourceHealth(r))}
+                  style={{ marginRight: '4px' }}
+                />
+                {getManagedResourceHealth(r)}
+              </StatusLabel>
+            ),
+            sort: (a: ManagedResource, b: ManagedResource) =>
+              getManagedResourceHealth(a).localeCompare(getManagedResourceHealth(b)),
+          },
+          {
+            label: 'Resource API',
+            getter: (r: ManagedResource) => getManagedResourceApi(r),
+            sort: true,
+          },
+          {
+            label: 'Cluster API',
+            getter: (r: ManagedResource) => (
+              <ApiAvailabilityLabel
+                result={availability.get(managedResourceApiKey(r))}
+                loading={loading}
+              />
+            ),
+            sort: (r: ManagedResource) =>
+              availability.get(managedResourceApiKey(r))?.state ?? 'checking',
+          },
+        ]}
+      />
+    </SectionBox>
+  );
+}
+
+function ApiAvailabilityLabel(props: { result: ApiAvailability | undefined; loading: boolean }) {
+  const presentation = getApiAvailabilityPresentation(props.result, props.loading);
+  return (
+    <Tooltip title={presentation.tooltip}>
+      <span>
+        <StatusLabel status={presentation.status}>{presentation.label}</StatusLabel>
+      </span>
+    </Tooltip>
+  );
 }
 
 function ManagedResourcesOverview(props: { resources: ManagedResource[] }) {

--- a/argocd/src/components/applications/apiAvailability.test.ts
+++ b/argocd/src/components/applications/apiAvailability.test.ts
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+const { getCluster } = vi.hoisted(() => ({ getCluster: vi.fn(() => 'cluster-a') }));
+
+vi.mock('@kinvolk/headlamp-plugin/lib', () => ({ Utils: { getCluster } }));
+
+import { ApiCatalog, apiResourceKey } from '../../api/apiDiscovery';
+import type { ArgoApplication, ManagedResource } from '../../resources/application';
+import {
+  canOpenManagedResourcesInCurrentCluster,
+  evaluateApiAvailability,
+  getApiAvailabilityPresentation,
+  isLocalApplicationDestination,
+  loadManagedResourceApiAvailability,
+  managedResourceApiKey,
+  useManagedResourceApiAvailability,
+} from './apiAvailability';
+
+const deployment: ManagedResource = {
+  group: 'apps',
+  version: 'v1beta1',
+  kind: 'Deployment',
+  namespace: 'default',
+  name: 'guestbook-ui',
+};
+
+describe('managed-resource API availability', () => {
+  it('recognizes only explicit in-cluster destinations as local', () => {
+    expect(isLocalApplicationDestination(application([deployment], { name: 'in-cluster' }))).toBe(
+      true
+    );
+    expect(
+      isLocalApplicationDestination(
+        application([deployment], { server: 'https://kubernetes.default.svc' })
+      )
+    ).toBe(true);
+    expect(
+      isLocalApplicationDestination(
+        application([deployment], { server: 'https://remote.example.test' })
+      )
+    ).toBe(false);
+    expect(
+      canOpenManagedResourcesInCurrentCluster(
+        application([deployment], { server: 'https://remote.example.test' })
+      )
+    ).toBe(false);
+  });
+
+  it('reports an exact served group, version, and kind as available', () => {
+    expect(evaluateApiAvailability(deployment, catalog(['v1beta1']))).toEqual({
+      state: 'available',
+      servedVersions: ['v1beta1'],
+    });
+  });
+
+  it('reports alternative served versions without treating them as a match', () => {
+    expect(evaluateApiAvailability(deployment, catalog(['v1', 'v1beta2']))).toEqual({
+      state: 'version-not-served',
+      servedVersions: ['v1', 'v1beta2'],
+    });
+  });
+
+  it('does not report a version as unavailable when its group discovery is incomplete', () => {
+    const incomplete = catalog(['v1']);
+    incomplete.completeGroups.clear();
+    incomplete.failedGroups.add('apps');
+
+    expect(evaluateApiAvailability(deployment, incomplete)).toEqual({
+      state: 'unknown',
+      servedVersions: [],
+    });
+  });
+
+  it('distinguishes a missing API from incomplete discovery', () => {
+    const complete = catalog([]);
+    complete.resources.clear();
+    expect(evaluateApiAvailability(deployment, complete).state).toBe('resource-not-found');
+
+    const incomplete = catalog([]);
+    incomplete.resources.clear();
+    incomplete.completeGroups.clear();
+    incomplete.failedGroups.add('apps');
+    expect(evaluateApiAvailability(deployment, incomplete).state).toBe('unknown');
+  });
+
+  it('does not perform discovery for a remote Application', async () => {
+    const discover = vi.fn();
+    const app = application([deployment], { server: 'https://remote.example.test' });
+
+    const result = await loadManagedResourceApiAvailability(app, 'cluster-a', discover);
+
+    expect(discover).not.toHaveBeenCalled();
+    expect(result.get(managedResourceApiKey(deployment))).toEqual({
+      state: 'remote',
+      servedVersions: [],
+    });
+  });
+
+  it('provides concise labels and served-version details for the table', () => {
+    expect(getApiAvailabilityPresentation(undefined, true).label).toBe('Checking…');
+    expect(
+      getApiAvailabilityPresentation(
+        { state: 'version-not-served', servedVersions: ['v1', 'v1beta2'] },
+        false
+      )
+    ).toEqual({
+      label: 'Version not served',
+      status: 'warning',
+      tooltip: 'Other served versions: v1, v1beta2',
+    });
+    expect(
+      getApiAvailabilityPresentation({ state: 'remote', servedVersions: [] }, false).label
+    ).toBe('Not checked — remote');
+  });
+
+  it('ignores a late discovery response after the Application changes', async () => {
+    let resolveFirst: ((value: ApiCatalog) => void) | undefined;
+    const firstDiscovery = new Promise<ApiCatalog>(resolve => {
+      resolveFirst = resolve;
+    });
+    const discover = vi
+      .fn()
+      .mockReturnValueOnce(firstDiscovery)
+      .mockResolvedValueOnce(catalog(['v1beta1']));
+    const firstApp = application([deployment], { name: 'in-cluster' });
+    const service: ManagedResource = {
+      group: '',
+      version: 'v1',
+      kind: 'Service',
+      namespace: 'default',
+      name: 'guestbook-ui',
+    };
+    const secondApp = application([service], { name: 'in-cluster' });
+
+    const { result, rerender } = renderHook(
+      ({ app }) => useManagedResourceApiAvailability(app, discover),
+      { initialProps: { app: firstApp } }
+    );
+    rerender({ app: secondApp });
+    await act(async () => undefined);
+
+    await act(async () => resolveFirst?.(catalog(['v1'])));
+
+    expect(result.current.availability.has(managedResourceApiKey(deployment))).toBe(false);
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('clears old availability while a new local discovery is loading', async () => {
+    let resolveSecond: ((value: ApiCatalog) => void) | undefined;
+    const secondDiscovery = new Promise<ApiCatalog>(resolve => {
+      resolveSecond = resolve;
+    });
+    const discover = vi
+      .fn()
+      .mockResolvedValueOnce(catalog(['v1beta1']))
+      .mockReturnValueOnce(secondDiscovery);
+    const firstApp = application([deployment], { name: 'in-cluster' });
+    const service: ManagedResource = {
+      group: '',
+      version: 'v1',
+      kind: 'Service',
+      namespace: 'default',
+      name: 'guestbook-ui',
+    };
+    const secondApp = application([service], { name: 'in-cluster' });
+
+    const { result, rerender } = renderHook(
+      ({ app }) => useManagedResourceApiAvailability(app, discover),
+      { initialProps: { app: firstApp } }
+    );
+    await act(async () => undefined);
+
+    rerender({ app: secondApp });
+
+    expect(result.current.availability).toEqual(new Map());
+    expect(result.current.loading).toBe(true);
+
+    await act(async () => resolveSecond?.(catalog(['v1'])));
+  });
+});
+
+function application(
+  resources: ManagedResource[],
+  destination: { server?: string; name?: string }
+): ArgoApplication {
+  return {
+    spec: { destination },
+    managedResources: resources,
+  } as ArgoApplication;
+}
+
+function catalog(versions: string[]): ApiCatalog {
+  return {
+    resources: new Map([
+      [
+        apiResourceKey('apps', 'Deployment'),
+        {
+          group: 'apps',
+          kind: 'Deployment',
+          versions: new Set(versions),
+          resourceNames: new Set(['deployments']),
+        },
+      ],
+    ]),
+    preferredVersions: new Map([['apps', 'v1']]),
+    knownGroups: new Set(['apps']),
+    completeGroups: new Set(['apps']),
+    failedGroups: new Set(),
+    coreRootComplete: true,
+    groupedRootComplete: true,
+  };
+}

--- a/argocd/src/components/applications/apiAvailability.ts
+++ b/argocd/src/components/applications/apiAvailability.ts
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Utils } from '@kinvolk/headlamp-plugin/lib';
+import { useEffect, useMemo, useState } from 'react';
+import {
+  ApiCatalog,
+  ApiDescriptor,
+  apiResourceKey,
+  discoverApiCatalog,
+} from '../../api/apiDiscovery';
+import type { ArgoApplication, ManagedResource } from '../../resources/application';
+
+export type ApiAvailabilityState =
+  | 'available'
+  | 'version-not-served'
+  | 'resource-not-found'
+  | 'unknown'
+  | 'remote';
+
+export interface ApiAvailability {
+  state: ApiAvailabilityState;
+  servedVersions: string[];
+}
+
+export interface ApiAvailabilityPresentation {
+  label: string;
+  status: 'success' | 'warning' | 'error' | 'info' | '';
+  tooltip: string;
+}
+
+export type ApiAvailabilityMap = Map<string, ApiAvailability>;
+
+function availabilityForState(
+  resources: ManagedResource[],
+  state: 'remote' | 'unknown'
+): ApiAvailabilityMap {
+  return new Map(
+    resources.map(resource => [
+      managedResourceApiKey(resource),
+      { state, servedVersions: [] } as ApiAvailability,
+    ])
+  );
+}
+
+export function isLocalApplicationDestination(application: ArgoApplication): boolean {
+  const destination = application.spec.destination;
+  return (
+    destination?.server === 'https://kubernetes.default.svc' || destination?.name === 'in-cluster'
+  );
+}
+
+/** Native resource links are safe only for an explicitly local destination. */
+export function canOpenManagedResourcesInCurrentCluster(application: ArgoApplication): boolean {
+  return isLocalApplicationDestination(application);
+}
+
+export function managedResourceDescriptor(resource: ManagedResource): ApiDescriptor {
+  return {
+    group: resource.group ?? '',
+    version: resource.version ?? '',
+    kind: resource.kind,
+  };
+}
+
+export function managedResourceApiKey(resource: ManagedResource): string {
+  const descriptor = managedResourceDescriptor(resource);
+  return `${descriptor.group}/${descriptor.version}/${descriptor.kind}`;
+}
+
+export function evaluateApiAvailability(
+  resource: ManagedResource,
+  catalog: ApiCatalog
+): ApiAvailability {
+  const descriptor = managedResourceDescriptor(resource);
+  const discovered = catalog.resources.get(apiResourceKey(descriptor.group, descriptor.kind));
+
+  if (discovered?.versions.has(descriptor.version)) {
+    return { state: 'available', servedVersions: [...discovered.versions].sort() };
+  }
+
+  if (discovered && catalog.completeGroups.has(descriptor.group)) {
+    return { state: 'version-not-served', servedVersions: [...discovered.versions].sort() };
+  }
+
+  const groupWasCompletelyRead = catalog.completeGroups.has(descriptor.group);
+  const groupIsKnown = catalog.knownGroups.has(descriptor.group);
+  const rootWasCompletelyRead = descriptor.group
+    ? catalog.groupedRootComplete
+    : catalog.coreRootComplete;
+
+  if (groupWasCompletelyRead || (rootWasCompletelyRead && !groupIsKnown)) {
+    return { state: 'resource-not-found', servedVersions: [] };
+  }
+
+  return { state: 'unknown', servedVersions: [] };
+}
+
+export function getApiAvailabilityPresentation(
+  result: ApiAvailability | undefined,
+  loading: boolean
+): ApiAvailabilityPresentation {
+  if (loading && !result) {
+    return {
+      label: 'Checking…',
+      status: 'info',
+      tooltip: 'Reading the selected cluster API list.',
+    };
+  }
+
+  switch (result?.state) {
+    case 'available':
+      return {
+        label: 'Available',
+        status: 'success',
+        tooltip: `Served versions: ${result.servedVersions.join(', ')}`,
+      };
+    case 'version-not-served':
+      return {
+        label: 'Version not served',
+        status: 'warning',
+        tooltip: `Other served versions: ${result.servedVersions.join(', ')}`,
+      };
+    case 'resource-not-found':
+      return {
+        label: 'API not found',
+        status: 'error',
+        tooltip: 'This resource kind was not found in the selected cluster API list.',
+      };
+    case 'remote':
+      return {
+        label: 'Not checked — remote',
+        status: '',
+        tooltip: 'The Application targets a remote or unverified cluster.',
+      };
+    default:
+      return {
+        label: 'Unknown',
+        status: '',
+        tooltip: 'The cluster API list could not be read completely.',
+      };
+  }
+}
+
+export async function loadManagedResourceApiAvailability(
+  application: ArgoApplication,
+  cluster: string,
+  discover = discoverApiCatalog
+): Promise<ApiAvailabilityMap> {
+  const resources = application.managedResources;
+  if (!isLocalApplicationDestination(application)) {
+    return availabilityForState(resources, 'remote');
+  }
+
+  const catalog = await discover(cluster, resources.map(managedResourceDescriptor));
+  return new Map(
+    resources.map(resource => [
+      managedResourceApiKey(resource),
+      evaluateApiAvailability(resource, catalog),
+    ])
+  );
+}
+
+export function useManagedResourceApiAvailability(
+  application: ArgoApplication,
+  discover = discoverApiCatalog
+) {
+  const resourcesKey = JSON.stringify(application.managedResources.map(managedResourceDescriptor));
+  const cluster = Utils.getCluster() ?? '';
+  const remote = !isLocalApplicationDestination(application);
+  const [availability, setAvailability] = useState<ApiAvailabilityMap>(() =>
+    remote ? availabilityForState(application.managedResources, 'remote') : new Map()
+  );
+  const [loading, setLoading] = useState(!remote);
+
+  useEffect(() => {
+    let active = true;
+
+    if (remote) {
+      setAvailability(availabilityForState(application.managedResources, 'remote'));
+      setLoading(false);
+      return () => {
+        active = false;
+      };
+    }
+
+    if (!cluster) {
+      setAvailability(availabilityForState(application.managedResources, 'unknown'));
+      setLoading(false);
+      return () => {
+        active = false;
+      };
+    }
+
+    setAvailability(new Map());
+    setLoading(true);
+
+    loadManagedResourceApiAvailability(application, cluster, discover)
+      .then(result => {
+        if (active) setAvailability(result);
+      })
+      .catch(() => {
+        if (!active) return;
+        setAvailability(availabilityForState(application.managedResources, 'unknown'));
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [application, cluster, discover, remote, resourcesKey]);
+
+  return useMemo(() => ({ availability, loading }), [availability, loading]);
+}


### PR DESCRIPTION
## Summary

This PR adds dynamic Kubernetes API-availability insights to the Argo CD Application detail page. For each resource reported by `Application.status.resources`, Headlamp compares the reported API group, version, and kind with the APIs served by the selected local Kubernetes cluster.

## Why

Argo CD can report an Application as Synced and Healthy even when its manifest uses an API version that is no longer served by the cluster. Showing the reported Resource API next to the selected cluster's API availability helps operators spot that kind of mismatch earlier.

## Changes

- Add a cached Kubernetes discovery client that prefers aggregated discovery and falls back to legacy discovery for older clusters.
- Compare group, version, and kind exactly; ignore discovery subresources.
- Add `Resource API` and `Cluster API` columns to Managed Resources.
- Show Available, Version not served, API not found, Unknown, or Not checked — remote with concise tooltips.
- Keep remote or unverified Application destinations safe: no discovery request and no native resource links to the selected local cluster.
- Document the scope: API availability is not a controller-feature or traffic diagnosis.

## Validation

- Prettier formatting check passed.
- ESLint passed with zero warnings.
- TypeScript passed with no emit.
- All 5 test files and 31 tests passed.
- Production build passed.

## Steps to test

1. Open an in-cluster Argo CD Application with managed resources.
2. In Managed Resources, verify `Resource API` shows the API reported by Argo CD and `Cluster API` becomes Available when the selected cluster serves it.
3. Use an Application/resource with an older or unavailable API version to verify Version not served or API not found.
4. Open an Application targeting a remote or unverified destination. Verify Cluster API says Not checked — remote and managed-resource names do not open local Kubernetes details.

## Limitation

A matching API only means the Kubernetes API server serves that resource API. It does not prove a controller implements every field or feature, and it does not prove traffic is working.