### PR TITLE
argocd: Add Open in Argo CD Application action

### DIFF
--- a/argocd/README.md
+++ b/argocd/README.md
@@ -10,6 +10,7 @@ To learn more about Argo CD, see the [Argo CD Getting Started Guide](https://arg
 - **Application Detail View** — Displays detailed metadata for a single Application: project, source, destination, sync status, health status, and Kubernetes events.
 - **Sync Action** — Triggers a sync by patching the Application's `.operation` field via the Kubernetes API. The Argo CD application-controller picks this up exactly as it would from the Argo CD UI.
 - **Refresh Action** — Requests a refresh by setting the `argocd.argoproj.io/refresh` annotation (supports `normal` and `hard` refresh types).
+- **Open in Argo CD** — Opens the current Application in the configured Argo CD web UI when `argocd-cm.data.url` is available.
 - **Argo CD Sidebar Icon** — Registers the official Argo CD octopus logo as an offline Iconify icon (CSP-safe, no external fetch).
 
 ### Why the Kubernetes API instead of the Argo CD REST API?
@@ -52,6 +53,28 @@ rules:
 
 If the user lacks `patch` permission, the Sync/Refresh buttons are hidden. If a patch request is still attempted and returns 403, the plugin shows a clear error message explaining which RBAC permission is missing.
 
+### Optional Argo CD UI link permission
+
+The **Open in Argo CD** action reads only the `url` key from the existing `argocd-cm`
+ConfigMap. Grant this permission in the namespace where the Argo CD application controller
+runs if you want the action to appear:
+
+```yaml
+- apiGroups: [""]
+  resources: ["configmaps"]
+  resourceNames: ["argocd-cm"]
+  verbs: ["get"]
+```
+
+The plugin first uses `Application.status.controllerNamespace` to find the ConfigMap and falls
+back to the Application namespace for standard single-namespace installations. It never searches
+other namespaces. The action is hidden when the ConfigMap is missing, access is denied, or `url`
+is not a valid HTTP(S) URL.
+
+Opening the link does not require an Argo CD API token and does not make an Argo CD API request.
+Argo CD handles authentication in the new browser tab. Advanced diagnostics, diffs, and resource
+actions remain available in the native Argo CD UI.
+
 ## Development
 
 Run `npm install` and then `npm run start` to begin development.
@@ -80,18 +103,28 @@ If you don't have a full Argo CD installation, you can use the provided test man
    kubectl apply -f test-files/deploy/application.yaml
    ```
 
-4. **Build and install the plugin**:
+4. **Optionally configure the mock Argo CD UI link**:
+
+   ```bash
+   kubectl apply -f test-files/deploy/argocd-cm.yaml
+   ```
+
+   This manifest uses the reserved `.invalid` domain for safe UI testing. Do not apply it over a
+   real Argo CD installation; configure the `url` key on that installation's existing
+   `argocd-cm` instead.
+
+5. **Build and install the plugin**:
 
    ```bash
    npm install
    npm run build
    ```
 
-5. Copy the contents of the `dist/` folder to your Headlamp plugins directory:
+6. Copy the contents of the `dist/` folder to your Headlamp plugins directory:
    - **Linux/macOS**: `~/.config/Headlamp/plugins/argocd/`
    - **Windows**: `%APPDATA%\Headlamp\Config\plugins\argocd\`
 
-6. **Launch Headlamp** and navigate to the **Argo CD > Applications** sidebar entry to see the mock `guestbook` application.
+7. **Launch Headlamp** and navigate to the **Argo CD > Applications** sidebar entry to see the mock `guestbook` application.
 
 ### Verifying the mock data
 

--- a/argocd/src/components/applications/Detail.test.tsx
+++ b/argocd/src/components/applications/Detail.test.tsx
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { cleanup, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@kinvolk/headlamp-plugin/lib/CommonComponents', () => ({
+  ActionButton: ({ description }: { description: string }) => <button>{description}</button>,
+  AuthVisible: ({ children }: { children: ReactNode }) => children,
+  DateLabel: () => null,
+  DetailsGrid: (props: {
+    actions: (application: unknown) => Array<{ id: string; action: ReactNode }>;
+  }) => (
+    <div>
+      {props.actions({ metadata: { name: 'guestbook', namespace: 'argocd' } }).map(entry => (
+        <div data-testid={entry.id} key={entry.id}>
+          {entry.action}
+        </div>
+      ))}
+    </div>
+  ),
+  NameValueTable: () => null,
+  SectionBox: () => null,
+  SimpleTable: () => null,
+  StatusLabel: () => null,
+}));
+
+vi.mock('@kinvolk/headlamp-plugin/lib/components/common', () => ({
+  ConditionsTable: () => null,
+}));
+
+vi.mock('../../api/argoClient', () => ({
+  refreshApplication: vi.fn(),
+  syncApplication: vi.fn(),
+}));
+
+vi.mock('../../hooks/useArgoOperation', () => ({
+  useArgoOperation: () => ({ execute: vi.fn(), isLoading: false }),
+}));
+
+vi.mock('../../resources/application', () => ({
+  ArgoApplication: class ArgoApplication {},
+}));
+
+vi.mock('./managedResourceLinks', () => ({
+  getManagedResourceLink: vi.fn(),
+}));
+
+vi.mock('./openInArgoCD', () => ({
+  OpenInArgoCDAction: () => <button>Open in Argo CD</button>,
+}));
+
+vi.mock('./statusHelpers', () => ({
+  getHealthIcon: vi.fn(),
+  getHealthStatus: vi.fn(),
+  getSyncIcon: vi.fn(),
+  getSyncStatus: vi.fn(),
+}));
+
+vi.mock('react-router-dom', () => ({
+  useParams: () => ({ namespace: 'argocd', name: 'guestbook' }),
+}));
+
+import ApplicationDetail from './Detail';
+
+afterEach(cleanup);
+
+describe('ApplicationDetail actions', () => {
+  it('keeps Sync and Refresh alongside the Open in Argo CD action', () => {
+    render(<ApplicationDetail />);
+
+    expect(screen.getByTestId('argocd-sync')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Sync' })).toBeTruthy();
+    expect(screen.getByTestId('argocd-refresh')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Refresh' })).toBeTruthy();
+    expect(screen.getByTestId('argocd-open-external')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Open in Argo CD' })).toBeTruthy();
+  });
+});

--- a/argocd/src/components/applications/Detail.tsx
+++ b/argocd/src/components/applications/Detail.tsx
@@ -34,6 +34,7 @@ import { refreshApplication, syncApplication } from '../../api/argoClient';
 import { useArgoOperation } from '../../hooks/useArgoOperation';
 import { ArgoApplication, ManagedResource, RevisionHistory } from '../../resources/application';
 import { getManagedResourceLink } from './managedResourceLinks';
+import { OpenInArgoCDAction } from './openInArgoCD';
 import { getHealthIcon, getHealthStatus, getSyncIcon, getSyncStatus } from './statusHelpers';
 
 type HeadlampStatus = ComponentProps<typeof StatusLabel>['status'];
@@ -93,6 +94,10 @@ export default function ApplicationDetail(props: { namespace?: string; name?: st
                     />
                   </AuthVisible>
                 ),
+              },
+              {
+                id: 'argocd-open-external',
+                action: <OpenInArgoCDAction application={app} />,
               },
             ]
           : []

--- a/argocd/src/components/applications/openInArgoCD.test.tsx
+++ b/argocd/src/components/applications/openInArgoCD.test.tsx
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockConfigMapUseGet } = vi.hoisted(() => ({
+  mockConfigMapUseGet: vi.fn(),
+}));
+
+vi.mock('@kinvolk/headlamp-plugin/lib', () => ({
+  K8s: {
+    ResourceClasses: {
+      ConfigMap: {
+        useGet: mockConfigMapUseGet,
+      },
+    },
+  },
+}));
+
+vi.mock('@kinvolk/headlamp-plugin/lib/CommonComponents', () => ({
+  ActionButton: (props: {
+    description: string;
+    longDescription?: string;
+    icon: string;
+    onClick: () => void;
+  }) => (
+    <button
+      aria-label={props.description}
+      data-icon={props.icon}
+      data-long-description={props.longDescription}
+      onClick={props.onClick}
+    />
+  ),
+}));
+
+import type { ArgoApplication } from '../../resources/application';
+import {
+  buildArgoApplicationUrl,
+  getArgoConfigNamespace,
+  OpenInArgoCDAction,
+} from './openInArgoCD';
+
+function hookResponse(options: { url?: string; error?: unknown; isLoading?: boolean }) {
+  return Object.assign(
+    [options.url === undefined ? null : { data: { url: options.url } }, options.error ?? null],
+    { isLoading: options.isLoading ?? false }
+  );
+}
+
+function application(options?: {
+  controllerNamespace?: string;
+  namespace?: string;
+  name?: string;
+  cluster?: string;
+}) {
+  return {
+    cluster: options?.cluster ?? 'kind-test',
+    controllerNamespace: options?.controllerNamespace,
+    metadata: {
+      namespace: options?.namespace ?? 'applications',
+      name: options?.name ?? 'guestbook',
+    },
+  } as ArgoApplication;
+}
+
+afterEach(cleanup);
+
+beforeEach(() => {
+  mockConfigMapUseGet.mockReset();
+  vi.restoreAllMocks();
+});
+
+describe('buildArgoApplicationUrl', () => {
+  it.each([
+    ['http://argo.example.com', 'http://argo.example.com/applications/argocd/guestbook'],
+    ['https://argo.example.com/', 'https://argo.example.com/applications/argocd/guestbook'],
+    [
+      '  https://argo.example.com/argo-cd///  ',
+      'https://argo.example.com/argo-cd/applications/argocd/guestbook',
+    ],
+    [
+      'https://argo.example.com/argo-cd?old=value#section',
+      'https://argo.example.com/argo-cd/applications/argocd/guestbook',
+    ],
+  ])('builds a safe Application URL from %s', (configuredUrl, expected) => {
+    expect(buildArgoApplicationUrl(configuredUrl, 'argocd', 'guestbook')).toBe(expected);
+  });
+
+  it('encodes the Application namespace and name as path segments', () => {
+    expect(buildArgoApplicationUrl('https://argo.example.com', 'team one', 'guest/book')).toBe(
+      'https://argo.example.com/applications/team%20one/guest%2Fbook'
+    );
+  });
+
+  it.each([
+    undefined,
+    '',
+    'not a URL',
+    '/relative/path',
+    'javascript:alert(1)',
+    'data:text/plain,hello',
+    'ftp://argo.example.com',
+    'https://user:password@argo.example.com',
+  ])('rejects an unsafe or incomplete configured URL: %s', configuredUrl => {
+    expect(buildArgoApplicationUrl(configuredUrl, 'argocd', 'guestbook')).toBeNull();
+  });
+
+  it('rejects missing Application identity fields', () => {
+    expect(buildArgoApplicationUrl('https://argo.example.com', undefined, 'guestbook')).toBeNull();
+    expect(buildArgoApplicationUrl('https://argo.example.com', 'argocd', undefined)).toBeNull();
+  });
+});
+
+describe('getArgoConfigNamespace', () => {
+  it('prefers the namespace reported by the Argo CD controller', () => {
+    expect(getArgoConfigNamespace(application({ controllerNamespace: 'argocd' }))).toBe('argocd');
+  });
+
+  it('falls back to the Application namespace', () => {
+    expect(getArgoConfigNamespace(application({ namespace: 'applications' }))).toBe('applications');
+  });
+});
+
+describe('OpenInArgoCDAction', () => {
+  it('renders the offline Argo action and opens the exact Application URL', () => {
+    mockConfigMapUseGet.mockReturnValue(hookResponse({ url: 'https://argo.example.com/argo-cd' }));
+    const open = vi.spyOn(window, 'open').mockImplementation(() => null);
+
+    render(<OpenInArgoCDAction application={application({ controllerNamespace: 'argocd' })} />);
+
+    const button = screen.getByRole('button', { name: 'Open in Argo CD' });
+    expect(button.getAttribute('data-icon')).toBe('simple-icons:argo');
+    expect(button.getAttribute('data-long-description')).toBe(
+      'Open this Application in the configured Argo CD UI in a new tab.'
+    );
+    expect(mockConfigMapUseGet).toHaveBeenCalledWith('argocd-cm', 'argocd', {
+      cluster: 'kind-test',
+    });
+
+    fireEvent.click(button);
+    expect(open).toHaveBeenCalledWith(
+      'https://argo.example.com/argo-cd/applications/applications/guestbook',
+      '_blank',
+      'noopener,noreferrer'
+    );
+  });
+
+  it('uses the Application namespace fallback for the ConfigMap lookup', () => {
+    mockConfigMapUseGet.mockReturnValue(hookResponse({ url: 'https://argo.example.com' }));
+    render(<OpenInArgoCDAction application={application({ namespace: 'applications' })} />);
+
+    expect(mockConfigMapUseGet).toHaveBeenCalledWith('argocd-cm', 'applications', {
+      cluster: 'kind-test',
+    });
+  });
+
+  it.each([
+    ['loading', hookResponse({ isLoading: true })],
+    ['not found', hookResponse({ error: { status: 404 } })],
+    ['forbidden', hookResponse({ error: { status: 403 } })],
+    ['missing URL', hookResponse({})],
+    ['invalid URL', hookResponse({ url: 'javascript:alert(1)' })],
+  ])('hides the action when configuration is %s', (_case, response) => {
+    mockConfigMapUseGet.mockReturnValue(response);
+    render(<OpenInArgoCDAction application={application()} />);
+
+    expect(screen.queryByRole('button', { name: 'Open in Argo CD' })).toBeNull();
+  });
+
+  it('does not query ConfigMaps when the Application has no namespace', () => {
+    render(<OpenInArgoCDAction application={application({ namespace: '' })} />);
+
+    expect(mockConfigMapUseGet).not.toHaveBeenCalled();
+  });
+});

--- a/argocd/src/components/applications/openInArgoCD.tsx
+++ b/argocd/src/components/applications/openInArgoCD.tsx
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { K8s } from '@kinvolk/headlamp-plugin/lib';
+import { ActionButton } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import type { ArgoApplication } from '../../resources/application';
+
+const { ConfigMap } = K8s.ResourceClasses;
+
+type ApplicationLocation = Pick<ArgoApplication, 'cluster' | 'controllerNamespace' | 'metadata'>;
+
+/**
+ * Selects the one namespace where the plugin may read Argo CD configuration.
+ *
+ * Argo CD's reported controller namespace takes priority. The Application
+ * namespace is a compatibility fallback for standard single-namespace
+ * installations. The plugin intentionally never searches other namespaces.
+ */
+export function getArgoConfigNamespace(application: ApplicationLocation): string | undefined {
+  return application.controllerNamespace?.trim() || application.metadata.namespace?.trim();
+}
+
+/**
+ * Builds a safe link to an Application in the native Argo CD UI.
+ *
+ * @returns An absolute HTTP(S) URL, or `null` when the configured value is unsafe or incomplete.
+ */
+export function buildArgoApplicationUrl(
+  configuredUrl: string | undefined,
+  applicationNamespace: string | undefined,
+  applicationName: string | undefined
+): string | null {
+  if (!configuredUrl?.trim() || !applicationNamespace || !applicationName) {
+    return null;
+  }
+
+  try {
+    const url = new URL(configuredUrl.trim());
+    if (
+      (url.protocol !== 'http:' && url.protocol !== 'https:') ||
+      !url.hostname ||
+      url.username ||
+      url.password
+    ) {
+      return null;
+    }
+
+    const basePath = url.pathname.replace(/\/+$/, '');
+    url.pathname = `${basePath}/applications/${encodeURIComponent(
+      applicationNamespace
+    )}/${encodeURIComponent(applicationName)}`;
+    url.search = '';
+    url.hash = '';
+
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+/** Renders the external Argo CD header action after its ConfigMap is resolved. */
+function ConfiguredOpenInArgoCDAction(props: {
+  application: ApplicationLocation;
+  configNamespace: string;
+}) {
+  const { application, configNamespace } = props;
+  const response = ConfigMap.useGet('argocd-cm', configNamespace, {
+    cluster: application.cluster || undefined,
+  });
+  const [configMap, error] = response;
+  const applicationUrl = buildArgoApplicationUrl(
+    configMap?.data?.url,
+    application.metadata.namespace,
+    application.metadata.name
+  );
+
+  if (response.isLoading || error || !applicationUrl) {
+    return null;
+  }
+
+  return (
+    <ActionButton
+      description="Open in Argo CD"
+      longDescription="Open this Application in the configured Argo CD UI in a new tab."
+      icon="simple-icons:argo"
+      onClick={() => window.open(applicationUrl, '_blank', 'noopener,noreferrer')}
+    />
+  );
+}
+
+/**
+ * Shows a safe link to the native Argo CD UI when `argocd-cm.data.url` is available.
+ */
+export function OpenInArgoCDAction(props: { application: ApplicationLocation }) {
+  const configNamespace = getArgoConfigNamespace(props.application);
+  if (!configNamespace) {
+    return null;
+  }
+
+  return (
+    <ConfiguredOpenInArgoCDAction
+      application={props.application}
+      configNamespace={configNamespace}
+    />
+  );
+}

--- a/argocd/src/resources/application.test.ts
+++ b/argocd/src/resources/application.test.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@kinvolk/headlamp-plugin/lib', () => ({
+  K8s: {
+    cluster: {
+      KubeObject: class KubeObject {
+        jsonData: any;
+        metadata: any;
+
+        constructor(jsonData: any) {
+          this.jsonData = jsonData;
+          this.metadata = jsonData.metadata;
+        }
+      },
+    },
+  },
+}));
+
+import { ArgoApplication, type KubeArgoApplication } from './application';
+
+function createApplication(controllerNamespace?: string) {
+  return new ArgoApplication({
+    apiVersion: 'argoproj.io/v1alpha1',
+    kind: 'Application',
+    metadata: {
+      name: 'guestbook',
+      namespace: 'applications',
+      creationTimestamp: '2025-01-01T00:00:00Z',
+      uid: 'guestbook-uid',
+    },
+    spec: {
+      project: 'default',
+      destination: { namespace: 'default', server: 'https://kubernetes.default.svc' },
+    },
+    status: controllerNamespace ? { controllerNamespace } : undefined,
+  } as KubeArgoApplication);
+}
+
+describe('ArgoApplication controllerNamespace', () => {
+  it('returns the namespace reported by Argo CD', () => {
+    expect(createApplication('argocd').controllerNamespace).toBe('argocd');
+  });
+
+  it('returns undefined when Argo CD has not reported a controller namespace', () => {
+    expect(createApplication().controllerNamespace).toBeUndefined();
+  });
+});

--- a/argocd/src/resources/application.ts
+++ b/argocd/src/resources/application.ts
@@ -120,6 +120,8 @@ export interface ArgoCondition {
  * of the application in the target cluster.
  */
 export interface ArgoApplicationStatus {
+  /** Namespace where the Argo CD application controller is running. */
+  controllerNamespace?: string;
   /** The health assessment of the application. */
   health?: {
     /** The health status string (e.g., "Healthy", "Degraded", "Progressing", "Missing"). */
@@ -183,6 +185,11 @@ export class ArgoApplication extends KubeObject<KubeArgoApplication> {
   /** Returns the application's observed runtime status, or undefined if not yet available. */
   get status(): ArgoApplicationStatus | undefined {
     return this.jsonData.status;
+  }
+
+  /** Returns the namespace reported by the Argo CD application controller. */
+  get controllerNamespace(): string | undefined {
+    return this.status?.controllerNamespace;
   }
 
   /** Returns the Argo CD project name this application belongs to. Defaults to "default". */

--- a/argocd/test-files/deploy/argocd-cm.yaml
+++ b/argocd/test-files/deploy/argocd-cm.yaml
@@ -1,0 +1,12 @@
+# Mock Argo CD configuration for local plugin UI testing only.
+#
+# The reserved .invalid domain cannot resolve on the public internet. Replace
+# this value with your real Argo CD URL when manually testing navigation.
+# Do not apply this mock ConfigMap over an existing Argo CD installation.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cm
+  namespace: argocd
+data:
+  url: https://argocd.example.invalid/argo-cd


### PR DESCRIPTION
## Summary

This PR adds a safe **Open in Argo CD** action to the existing Argo CD Application detail header. The Argo icon opens the exact Application in the configured native Argo CD UI in a new browser tab.

## Why

Headlamp provides Kubernetes-native visibility and operations. Argo CD's own UI remains the right place for advanced diffs, diagnostics, and resource actions. This gives operators a safe direct path from an Application in Headlamp to that same Application in Argo CD.

## Changes

- Added optional `status.controllerNamespace` metadata and an Application getter.
- Reads only the `argocd-cm` ConfigMap using Headlamp's public ConfigMap API.
- Looks up the ConfigMap in `status.controllerNamespace`, falling back to the Application namespace.
- Shows the action only when `argocd-cm.data.url` is a valid absolute HTTP or HTTPS URL.
- Safely builds `/applications/<namespace>/<name>` URLs, preserving configured installation paths and encoding names.
- Rejects unsafe, malformed, relative, credential-bearing, or missing-host URLs.
- Opens the external UI with `noopener,noreferrer`.
- Documents the optional least-privilege ConfigMap permission and adds a fake local test manifest.

## Validation

- Prettier formatting check passed.
- ESLint passed with zero warnings.
- TypeScript passed with no emit.
- All 6 test files and 45 tests passed.
- Production build passed.

## Manual test

- Configured a local Argo CD UI URL.
- Confirmed the Argo icon appears beside Sync and Refresh on the Application detail page.
- Confirmed it opens the exact `guestbook` Application in the native Argo CD UI.
- Confirmed native Argo CD authentication, application tree, and advanced actions remain handled by Argo CD itself.

## Permissions

The optional action requires only:

```yaml
- apiGroups: [""]
  resources: ["configmaps"]
  resourceNames: ["argocd-cm"]
  verbs: ["get"]
```

When the ConfigMap is unavailable, forbidden, missing a URL, or contains an invalid URL, the action is simply hidden.