### PR TITLE
kueue: add MultiKueueConfig list and detail views

### DIFF
--- a/kueue/src/components/multikueueconfigs/Detail.tsx
+++ b/kueue/src/components/multikueueconfigs/Detail.tsx
@@ -1,0 +1,36 @@
+import { DetailsGrid } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { useParams } from 'react-router-dom';
+import { MultiKueueConfig } from '../../resources/multiKueueConfig';
+import KueueAdminResourceAccess from '../common/KueueAdminResourceAccess';
+
+export default function MultiKueueConfigDetail() {
+  const { name } = useParams<{ name: string }>();
+
+  return (
+    <KueueAdminResourceAccess
+      resourceClass={MultiKueueConfig}
+      resourceLabel="MultiKueueConfigs"
+      verb="get"
+    >
+      <DetailsGrid
+        resourceType={MultiKueueConfig}
+        name={name}
+        withEvents
+        extraInfo={config =>
+          config
+            ? [
+                {
+                  name: 'Clusters',
+                  value: config.clustersDisplay,
+                },
+                {
+                  name: 'Cluster Count',
+                  value: config.clusterCount,
+                },
+              ]
+            : []
+        }
+      />
+    </KueueAdminResourceAccess>
+  );
+}

--- a/kueue/src/components/multikueueconfigs/List.tsx
+++ b/kueue/src/components/multikueueconfigs/List.tsx
@@ -1,0 +1,32 @@
+import { ResourceListView } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { MultiKueueConfig } from '../../resources/multiKueueConfig';
+import KueueAdminResourceAccess from '../common/KueueAdminResourceAccess';
+
+export default function MultiKueueConfigList() {
+  return (
+    <KueueAdminResourceAccess
+      resourceClass={MultiKueueConfig}
+      resourceLabel="MultiKueueConfigs"
+      verb="list"
+    >
+      <ResourceListView
+        title="Kueue MultiKueueConfigs"
+        resourceClass={MultiKueueConfig}
+        columns={[
+          'name',
+          {
+            id: 'clusters',
+            label: 'Clusters',
+            getValue: (config: MultiKueueConfig) => config.clustersDisplay,
+          },
+          {
+            id: 'clusterCount',
+            label: 'Cluster Count',
+            getValue: (config: MultiKueueConfig) => config.clusterCount,
+          },
+          'age',
+        ]}
+      />
+    </KueueAdminResourceAccess>
+  );
+} 

--- a/kueue/src/components/provisioningrequestconfigs/Detail.tsx
+++ b/kueue/src/components/provisioningrequestconfigs/Detail.tsx
@@ -1,0 +1,44 @@
+import { DetailsGrid } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { useParams } from 'react-router-dom';
+import { ProvisioningRequestConfig } from '../../resources/provisioningRequestConfig';
+import KueueAdminResourceAccess from '../common/KueueAdminResourceAccess';
+
+export default function ProvisioningRequestConfigDetail() {
+  const { name } = useParams<{ name: string }>();
+
+  return (
+    <KueueAdminResourceAccess
+      resourceClass={ProvisioningRequestConfig}
+      resourceLabel="ProvisioningRequestConfigs"
+      verb="get"
+    >
+      <DetailsGrid
+        resourceType={ProvisioningRequestConfig}
+        name={name}
+        withEvents
+        extraInfo={config =>
+          config
+            ? [
+                {
+                  name: 'Provisioning Class',
+                  value: config.provisioningClassName,
+                },
+                {
+                  name: 'Managed Resources',
+                  value: config.managedResourcesDisplay,
+                },
+                {
+                  name: 'Retry Strategy',
+                  value: config.retryStrategyDisplay,
+                },
+                {
+                  name: 'Pod Set Merge Policy',
+                  value: config.podSetMergePolicyDisplay,
+                },
+              ]
+            : []
+        }
+      />
+    </KueueAdminResourceAccess>
+  );
+}

--- a/kueue/src/components/provisioningrequestconfigs/List.tsx
+++ b/kueue/src/components/provisioningrequestconfigs/List.tsx
@@ -1,0 +1,37 @@
+import { ResourceListView } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { ProvisioningRequestConfig } from '../../resources/provisioningRequestConfig';
+import KueueAdminResourceAccess from '../common/KueueAdminResourceAccess';
+
+export default function ProvisioningRequestConfigList() {
+  return (
+    <KueueAdminResourceAccess
+      resourceClass={ProvisioningRequestConfig}
+      resourceLabel="ProvisioningRequestConfigs"
+      verb="list"
+    >
+      <ResourceListView
+        title="Kueue ProvisioningRequestConfigs"
+        resourceClass={ProvisioningRequestConfig}
+        columns={[
+          'name',
+          {
+            id: 'provisioningClassName',
+            label: 'Provisioning Class',
+            getValue: (config: ProvisioningRequestConfig) => config.provisioningClassName,
+          },
+          {
+            id: 'managedResources',
+            label: 'Managed Resources',
+            getValue: (config: ProvisioningRequestConfig) => config.managedResourcesDisplay,
+          },
+          {
+            id: 'retryStrategy',
+            label: 'Retry Strategy',
+            getValue: (config: ProvisioningRequestConfig) => config.retryStrategyDisplay,
+          },
+          'age',
+        ]}
+      />
+    </KueueAdminResourceAccess>
+  );
+}

--- a/kueue/src/index.tsx
+++ b/kueue/src/index.tsx
@@ -10,6 +10,8 @@ import WorkloadList from './components/workloads/List';
 import { kueueRouteNames, kueueRoutePaths } from './utils/kueueRoutes';
 import ProvisioningRequestConfigDetail from './components/provisioningrequestconfigs/Detail';
 import ProvisioningRequestConfigList from './components/provisioningrequestconfigs/List';
+import MultiKueueConfigDetail from './components/multikueueconfigs/Detail';
+import MultiKueueConfigList from './components/multikueueconfigs/List';
 
 registerSidebarEntry({
   parent: null,
@@ -52,6 +54,13 @@ registerSidebarEntry({
   name: 'kueue-provisioningrequestconfigs',
   label: 'ProvisioningRequestConfigs',
   url: kueueRoutePaths.provisioningRequestConfigsList,
+});
+
+registerSidebarEntry({
+  parent: 'kueue',
+  name: 'kueue-multikueueconfigs',
+  label: 'MultiKueueConfigs',
+  url: kueueRoutePaths.multiKueueConfigsList,
 });
 
 registerRoute({
@@ -132,4 +141,20 @@ registerRoute({
   name: kueueRouteNames.provisioningRequestConfigDetail,
   exact: true,
   component: () => <ProvisioningRequestConfigDetail />,
+});
+
+registerRoute({
+  path: kueueRoutePaths.multiKueueConfigsList,
+  sidebar: 'kueue-multikueueconfigs',
+  name: kueueRouteNames.multiKueueConfigsList,
+  exact: true,
+  component: () => <MultiKueueConfigList />,
+});
+
+registerRoute({
+  path: kueueRoutePaths.multiKueueConfigDetail,
+  sidebar: 'kueue-multikueueconfigs',
+  name: kueueRouteNames.multiKueueConfigDetail,
+  exact: true,
+  component: () => <MultiKueueConfigDetail />,
 });

--- a/kueue/src/index.tsx
+++ b/kueue/src/index.tsx
@@ -8,6 +8,8 @@ import ResourceFlavorList from './components/resourceflavors/List';
 import WorkloadDetail from './components/workloads/Detail';
 import WorkloadList from './components/workloads/List';
 import { kueueRouteNames, kueueRoutePaths } from './utils/kueueRoutes';
+import ProvisioningRequestConfigDetail from './components/provisioningrequestconfigs/Detail';
+import ProvisioningRequestConfigList from './components/provisioningrequestconfigs/List';
 
 registerSidebarEntry({
   parent: null,
@@ -43,6 +45,13 @@ registerSidebarEntry({
   name: 'kueue-workloads',
   label: 'Workloads',
   url: kueueRoutePaths.workloadsList,
+});
+
+registerSidebarEntry({
+  parent: 'kueue',
+  name: 'kueue-provisioningrequestconfigs',
+  label: 'ProvisioningRequestConfigs',
+  url: kueueRoutePaths.provisioningRequestConfigsList,
 });
 
 registerRoute({
@@ -107,4 +116,20 @@ registerRoute({
   name: kueueRouteNames.workloadDetail,
   exact: true,
   component: () => <WorkloadDetail />,
+});
+
+registerRoute({
+  path: kueueRoutePaths.provisioningRequestConfigsList,
+  sidebar: 'kueue-provisioningrequestconfigs',
+  name: kueueRouteNames.provisioningRequestConfigsList,
+  exact: true,
+  component: () => <ProvisioningRequestConfigList />,
+});
+
+registerRoute({
+  path: kueueRoutePaths.provisioningRequestConfigDetail,
+  sidebar: 'kueue-provisioningrequestconfigs',
+  name: kueueRouteNames.provisioningRequestConfigDetail,
+  exact: true,
+  component: () => <ProvisioningRequestConfigDetail />,
 });

--- a/kueue/src/resources/multiKueueConfig.test.ts
+++ b/kueue/src/resources/multiKueueConfig.test.ts
@@ -1,0 +1,29 @@
+import { renderClusterCount, renderClusters } from './multiKueueConfigFormatters';
+
+describe('renderClusters', () => {
+  it('returns a dash when there are no clusters', () => {
+    expect(renderClusters()).toBe('-');
+    expect(renderClusters([])).toBe('-');
+  });
+
+  it('renders a single cluster', () => {
+    expect(renderClusters(['worker1'])).toBe('worker1');
+  });
+
+  it('renders multiple clusters as a comma-separated list, preserving order', () => {
+    expect(renderClusters(['worker-onprem', 'worker-aws', 'worker-gcp'])).toBe(
+      'worker-onprem, worker-aws, worker-gcp'
+    );
+  });
+});
+
+describe('renderClusterCount', () => {
+  it('returns 0 when there are no clusters', () => {
+    expect(renderClusterCount()).toBe(0);
+    expect(renderClusterCount([])).toBe(0);
+  });
+
+  it('returns the number of clusters', () => {
+    expect(renderClusterCount(['worker1', 'worker2', 'worker3'])).toBe(3);
+  });
+});

--- a/kueue/src/resources/multiKueueConfig.ts
+++ b/kueue/src/resources/multiKueueConfig.ts
@@ -1,0 +1,66 @@
+import { KubeObject, KubeObjectInterface } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import { kueueApiVersions } from '../utils/kueueApi';
+import { kueueRoutePaths } from '../utils/kueueRoutes';
+import { renderClusterCount, renderClusters } from './multiKueueConfigFormatters';
+
+/**
+ * Desired state of a Kueue MultiKueueConfig.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#multikueueconfigspec
+ */
+export interface MultiKueueConfigSpec {
+  /**
+   * Worker cluster names, referencing MultiKueueCluster objects, tried in priority order.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#multikueueconfigspec
+   * @see https://kueue.sigs.k8s.io/docs/concepts/multikueue/
+   */
+  clusters: string[];
+}
+
+/**
+ * Kubernetes MultiKueueConfig object returned by the Kueue API.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#multikueueconfig
+ */
+export interface KubeMultiKueueConfig extends KubeObjectInterface {
+  /**
+   * Kubernetes object metadata for the MultiKueueConfig.
+   *
+   * @see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#objectmeta-v1-meta
+   */
+  metadata: KubeObjectInterface['metadata'];
+  /**
+   * MultiKueueConfig desired state.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#multikueueconfigspec
+   */
+  spec: MultiKueueConfigSpec;
+}
+
+export class MultiKueueConfig extends KubeObject<KubeMultiKueueConfig> {
+  static kind = 'MultiKueueConfig';
+  static apiName = 'multikueueconfigs';
+  static apiVersion = kueueApiVersions;
+  static isNamespaced = false;
+
+  static get detailsRoute() {
+    return kueueRoutePaths.multiKueueConfigDetail;
+  }
+
+  get spec(): MultiKueueConfigSpec {
+    return this.jsonData.spec ?? ({ clusters: [] } as MultiKueueConfigSpec);
+  }
+
+  get clusters() {
+    return this.spec.clusters || [];
+  }
+
+  get clustersDisplay() {
+    return renderClusters(this.clusters);
+  }
+
+  get clusterCount() {
+    return renderClusterCount(this.clusters);
+  }
+}

--- a/kueue/src/resources/multiKueueConfigFormatters.ts
+++ b/kueue/src/resources/multiKueueConfigFormatters.ts
@@ -1,0 +1,13 @@
+/** Render a MultiKueueConfig's ordered list of worker cluster names. */
+export function renderClusters(clusters?: string[]) {
+  if (!clusters || clusters.length === 0) {
+    return '-';
+  }
+
+  return clusters.join(', ');
+}
+
+/** Render the number of worker clusters configured, preserving explicit zero. */
+export function renderClusterCount(clusters?: string[]) {
+  return clusters?.length ?? 0;
+}

--- a/kueue/src/resources/provisioningRequestConfig.test.ts
+++ b/kueue/src/resources/provisioningRequestConfig.test.ts
@@ -1,0 +1,68 @@
+import {
+  renderManagedResources,
+  renderPodSetMergePolicy,
+  renderProvisioningClassName,
+  renderRetryStrategy,
+} from './provisioningRequestConfigFormatters';
+
+describe('renderProvisioningClassName', () => {
+  it('returns a dash when missing', () => {
+    expect(renderProvisioningClassName()).toBe('-');
+    expect(renderProvisioningClassName('')).toBe('-');
+  });
+
+  it('returns the class name when present', () => {
+    expect(renderProvisioningClassName('check-capacity.autoscaling.x-k8s.io')).toBe(
+      'check-capacity.autoscaling.x-k8s.io'
+    );
+  });
+});
+
+describe('renderManagedResources', () => {
+  it('returns a dash when there are no managed resources', () => {
+    expect(renderManagedResources()).toBe('-');
+    expect(renderManagedResources([])).toBe('-');
+  });
+
+  it('renders a comma-separated list', () => {
+    expect(renderManagedResources(['nvidia.com/gpu', 'cpu', 'memory'])).toBe(
+      'nvidia.com/gpu, cpu, memory'
+    );
+  });
+});
+
+describe('renderRetryStrategy', () => {
+  it('returns a dash when there is no retry strategy', () => {
+    expect(renderRetryStrategy()).toBe('-');
+  });
+
+  it('returns a dash when the retry strategy has no fields set', () => {
+    expect(renderRetryStrategy({})).toBe('-');
+  });
+
+  it('renders only the fields that are present', () => {
+    expect(renderRetryStrategy({ backoffLimitCount: 2 })).toBe('limit: 2');
+  });
+
+  it('renders all fields when fully specified', () => {
+    expect(
+      renderRetryStrategy({ backoffLimitCount: 2, backoffBaseSeconds: 60, backoffMaxSeconds: 1800 })
+    ).toBe('limit: 2, base: 60s, max: 1800s');
+  });
+
+  it('renders backoffLimitCount of zero, not treating it as missing', () => {
+    expect(renderRetryStrategy({ backoffLimitCount: 0 })).toBe('limit: 0');
+  });
+});
+
+describe('renderPodSetMergePolicy', () => {
+  it('returns a dash when missing', () => {
+    expect(renderPodSetMergePolicy()).toBe('-');
+  });
+
+  it('returns the policy when present', () => {
+    expect(renderPodSetMergePolicy('IdenticalWorkloadSchedulingRequirements')).toBe(
+      'IdenticalWorkloadSchedulingRequirements'
+    );
+  });
+});

--- a/kueue/src/resources/provisioningRequestConfig.ts
+++ b/kueue/src/resources/provisioningRequestConfig.ts
@@ -1,0 +1,123 @@
+import { KubeObject, KubeObjectInterface } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import { kueueApiVersions } from '../utils/kueueApi';
+import { kueueRoutePaths } from '../utils/kueueRoutes';
+import {
+  renderManagedResources,
+  renderPodSetMergePolicy,
+  renderProvisioningClassName,
+  renderRetryStrategy,
+  type RetryStrategyLike,
+} from './provisioningRequestConfigFormatters';
+
+/**
+ * Retry strategy for a ProvisioningRequest created from this config.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#retrystrategy
+ */
+export interface RetryStrategy extends RetryStrategyLike {
+  /**
+   * Number of times a failed ProvisioningRequest is retried. Defaults to 3.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#retrystrategy
+   */
+  backoffLimitCount?: number;
+  /**
+   * Base, in seconds, used to calculate the backoff time before a retry.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#retrystrategy
+   */
+  backoffBaseSeconds?: number;
+  /**
+   * Maximum backoff time, in seconds, before a retry.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#retrystrategy
+   */
+  backoffMaxSeconds?: number;
+}
+
+/**
+ * Desired state of a Kueue ProvisioningRequestConfig.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#provisioningrequestconfigspec
+ */
+export interface ProvisioningRequestConfigSpec {
+  /**
+   * ProvisioningClass describing the mode used to provision resources.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#provisioningrequestconfigspec
+   */
+  provisioningClassName: string;
+  /**
+   * Resources managed by the autoscaling; if empty, all resources are managed.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#provisioningrequestconfigspec
+   */
+  managedResources?: string[];
+  /**
+   * Strategy for retrying a failed ProvisioningRequest.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#provisioningrequestconfigspec
+   */
+  retryStrategy?: RetryStrategy;
+  /**
+   * Policy for merging pod sets into the ProvisioningRequest.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#provisioningrequestconfigspec
+   */
+  podSetMergePolicy?: string;
+}
+
+/**
+ * Kubernetes ProvisioningRequestConfig object returned by the Kueue API.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#provisioningrequestconfig
+ */
+export interface KubeProvisioningRequestConfig extends KubeObjectInterface {
+  /**
+   * Kubernetes object metadata for the ProvisioningRequestConfig.
+   *
+   * @see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#objectmeta-v1-meta
+   */
+  metadata: KubeObjectInterface['metadata'];
+  /**
+   * ProvisioningRequestConfig desired state.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#provisioningrequestconfigspec
+   */
+  spec: ProvisioningRequestConfigSpec;
+}
+
+export class ProvisioningRequestConfig extends KubeObject<KubeProvisioningRequestConfig> {
+  static kind = 'ProvisioningRequestConfig';
+  static apiName = 'provisioningrequestconfigs';
+  static apiVersion = kueueApiVersions;
+  static isNamespaced = false;
+
+  static get detailsRoute() {
+    return kueueRoutePaths.provisioningRequestConfigDetail;
+  }
+
+  get spec(): ProvisioningRequestConfigSpec {
+    return this.jsonData.spec ?? ({} as ProvisioningRequestConfigSpec);
+  }
+
+  get provisioningClassName() {
+    return renderProvisioningClassName(this.spec.provisioningClassName);
+  }
+
+  get managedResources() {
+    return this.spec.managedResources || [];
+  }
+
+  get managedResourcesDisplay() {
+    return renderManagedResources(this.managedResources);
+  }
+
+  get retryStrategyDisplay() {
+    return renderRetryStrategy(this.spec.retryStrategy);
+  }
+
+  get podSetMergePolicyDisplay() {
+    return renderPodSetMergePolicy(this.spec.podSetMergePolicy);
+  }
+}

--- a/kueue/src/resources/provisioningRequestConfigFormatters.ts
+++ b/kueue/src/resources/provisioningRequestConfigFormatters.ts
@@ -1,0 +1,46 @@
+/** Retry strategy controlling how a ProvisioningRequest is retried on failure. */
+export interface RetryStrategyLike {
+  backoffLimitCount?: number;
+  backoffBaseSeconds?: number;
+  backoffMaxSeconds?: number;
+}
+
+/** Render the ProvisioningClass name, falling back when the API omits the field. */
+export function renderProvisioningClassName(provisioningClassName?: string) {
+  return provisioningClassName || '-';
+}
+
+/** Render the list of resources managed by autoscaling as a comma-separated list. */
+export function renderManagedResources(managedResources?: string[]) {
+  if (!managedResources || managedResources.length === 0) {
+    return '-';
+  }
+
+  return managedResources.join(', ');
+}
+
+/** Render the retry strategy as a short human-readable summary. */
+export function renderRetryStrategy(retryStrategy?: RetryStrategyLike) {
+  if (!retryStrategy) {
+    return '-';
+  }
+
+  const parts: string[] = [];
+
+  if (retryStrategy.backoffLimitCount !== undefined) {
+    parts.push(`limit: ${retryStrategy.backoffLimitCount}`);
+  }
+  if (retryStrategy.backoffBaseSeconds !== undefined) {
+    parts.push(`base: ${retryStrategy.backoffBaseSeconds}s`);
+  }
+  if (retryStrategy.backoffMaxSeconds !== undefined) {
+    parts.push(`max: ${retryStrategy.backoffMaxSeconds}s`);
+  }
+
+  return parts.length > 0 ? parts.join(', ') : '-';
+}
+
+/** Render the pod set merge policy, falling back when the API omits the field. */
+export function renderPodSetMergePolicy(podSetMergePolicy?: string) {
+  return podSetMergePolicy || '-';
+}

--- a/kueue/src/utils/kueueRoutes.ts
+++ b/kueue/src/utils/kueueRoutes.ts
@@ -9,6 +9,8 @@ export const kueueRouteNames = {
   workloadDetail: 'kueue-workload-detail',
   provisioningRequestConfigsList: 'kueue-provisioningrequestconfigs-list',
   provisioningRequestConfigDetail: 'kueue-provisioningrequestconfig-detail',
+  multiKueueConfigsList: 'kueue-multikueueconfigs-list',
+  multiKueueConfigDetail: 'kueue-multikueueconfig-detail',
 } as const;
 
 export const kueueRoutePaths = {
@@ -22,4 +24,6 @@ export const kueueRoutePaths = {
   workloadDetail: '/kueue/workloads/:namespace/:name',
   provisioningRequestConfigsList: '/kueue/provisioningrequestconfigs',
   provisioningRequestConfigDetail: '/kueue/provisioningrequestconfigs/:name',
+  multiKueueConfigsList: '/kueue/multikueueconfigs',
+  multiKueueConfigDetail: '/kueue/multikueueconfigs/:name',
 } as const;

--- a/kueue/src/utils/kueueRoutes.ts
+++ b/kueue/src/utils/kueueRoutes.ts
@@ -7,6 +7,8 @@ export const kueueRouteNames = {
   resourceFlavorDetail: 'kueue-resourceflavor-detail',
   workloadsList: 'kueue-workloads-list',
   workloadDetail: 'kueue-workload-detail',
+  provisioningRequestConfigsList: 'kueue-provisioningrequestconfigs-list',
+  provisioningRequestConfigDetail: 'kueue-provisioningrequestconfig-detail',
 } as const;
 
 export const kueueRoutePaths = {
@@ -18,4 +20,6 @@ export const kueueRoutePaths = {
   resourceFlavorDetail: '/kueue/resourceflavors/:name',
   workloadsList: '/kueue/workloads',
   workloadDetail: '/kueue/workloads/:namespace/:name',
+  provisioningRequestConfigsList: '/kueue/provisioningrequestconfigs',
+  provisioningRequestConfigDetail: '/kueue/provisioningrequestconfigs/:name',
 } as const;


### PR DESCRIPTION
## What this PR does

Adds initial Headlamp UI support for Kueue's `MultiKueueConfig` resource, following the same
pattern established by `ClusterQueue`, `LocalQueue`, `ResourceFlavor`, `Workload`, and
`ProvisioningRequestConfig`:

- `src/resources/multiKueueConfig.ts` — `MultiKueueConfig` resource class with a `spec.clusters`
  getter.
- `src/resources/multiKueueConfigFormatters.ts` — exported, documented, pure formatter functions
  for rendering the cluster list and cluster count.
- `src/resources/multiKueueConfig.test.ts` — unit tests for the formatters.
- `src/components/multikueueconfigs/List.tsx` and `Detail.tsx` — list and detail views.
- Registers a new `MultiKueueConfigs` sidebar entry and routes in `index.tsx` /
  `kueueRoutes.ts`.

## Testing

- `npm run test` — all 38 tests pass (5 new).
- `npm run build` — builds cleanly.
- Verified locally in a running Headlamp instance against a kind cluster with a real
  `MultiKueueConfig` resource — both the list and detail views render the cluster names and
  cluster count correctly.

## Why

MultiKueue is called out as a potential focus area for this term. This PR adds basic
visibility into `MultiKueueConfig` resources as a foundation that later work (e.g. manager/
worker cluster relationships, connectivity, workload routing) can build on.