### PR TITLE
kueue: add MultiKueueConfig list and detail views

### DIFF
--- a/kueue/src/components/multikueueconfigs/Detail.tsx
+++ b/kueue/src/components/multikueueconfigs/Detail.tsx
@@ -1,0 +1,36 @@
+import { DetailsGrid } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { useParams } from 'react-router-dom';
+import { MultiKueueConfig } from '../../resources/multiKueueConfig';
+import KueueAdminResourceAccess from '../common/KueueAdminResourceAccess';
+
+export default function MultiKueueConfigDetail() {
+  const { name } = useParams<{ name: string }>();
+
+  return (
+    <KueueAdminResourceAccess
+      resourceClass={MultiKueueConfig}
+      resourceLabel="MultiKueueConfigs"
+      verb="get"
+    >
+      <DetailsGrid
+        resourceType={MultiKueueConfig}
+        name={name}
+        withEvents
+        extraInfo={config =>
+          config
+            ? [
+                {
+                  name: 'Clusters',
+                  value: config.clustersDisplay,
+                },
+                {
+                  name: 'Cluster Count',
+                  value: config.clusterCount,
+                },
+              ]
+            : []
+        }
+      />
+    </KueueAdminResourceAccess>
+  );
+}

--- a/kueue/src/components/multikueueconfigs/List.tsx
+++ b/kueue/src/components/multikueueconfigs/List.tsx
@@ -1,0 +1,32 @@
+import { ResourceListView } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { MultiKueueConfig } from '../../resources/multiKueueConfig';
+import KueueAdminResourceAccess from '../common/KueueAdminResourceAccess';
+
+export default function MultiKueueConfigList() {
+  return (
+    <KueueAdminResourceAccess
+      resourceClass={MultiKueueConfig}
+      resourceLabel="MultiKueueConfigs"
+      verb="list"
+    >
+      <ResourceListView
+        title="Kueue MultiKueueConfigs"
+        resourceClass={MultiKueueConfig}
+        columns={[
+          'name',
+          {
+            id: 'clusters',
+            label: 'Clusters',
+            getValue: (config: MultiKueueConfig) => config.clustersDisplay,
+          },
+          {
+            id: 'clusterCount',
+            label: 'Cluster Count',
+            getValue: (config: MultiKueueConfig) => config.clusterCount,
+          },
+          'age',
+        ]}
+      />
+    </KueueAdminResourceAccess>
+  );
+} 

--- a/kueue/src/index.tsx
+++ b/kueue/src/index.tsx
@@ -7,6 +7,8 @@ import ResourceFlavorDetail from './components/resourceflavors/Detail';
 import ResourceFlavorList from './components/resourceflavors/List';
 import WorkloadDetail from './components/workloads/Detail';
 import WorkloadList from './components/workloads/List';
+import MultiKueueConfigDetail from './components/multikueueconfigs/Detail';
+import MultiKueueConfigList from './components/multikueueconfigs/List';
 import { kueueRouteNames, kueueRoutePaths } from './utils/kueueRoutes';
 
 registerSidebarEntry({
@@ -43,6 +45,13 @@ registerSidebarEntry({
   name: 'kueue-workloads',
   label: 'Workloads',
   url: kueueRoutePaths.workloadsList,
+});
+
+registerSidebarEntry({
+  parent: 'kueue',
+  name: 'kueue-multikueueconfigs',
+  label: 'MultiKueueConfigs',
+  url: kueueRoutePaths.multiKueueConfigsList,
 });
 
 registerRoute({
@@ -107,4 +116,20 @@ registerRoute({
   name: kueueRouteNames.workloadDetail,
   exact: true,
   component: () => <WorkloadDetail />,
+});
+
+registerRoute({
+  path: kueueRoutePaths.multiKueueConfigsList,
+  sidebar: 'kueue-multikueueconfigs',
+  name: kueueRouteNames.multiKueueConfigsList,
+  exact: true,
+  component: () => <MultiKueueConfigList />,
+});
+
+registerRoute({
+  path: kueueRoutePaths.multiKueueConfigDetail,
+  sidebar: 'kueue-multikueueconfigs',
+  name: kueueRouteNames.multiKueueConfigDetail,
+  exact: true,
+  component: () => <MultiKueueConfigDetail />,
 });

--- a/kueue/src/resources/multiKueueConfig.test.ts
+++ b/kueue/src/resources/multiKueueConfig.test.ts
@@ -1,0 +1,29 @@
+import { renderClusterCount, renderClusters } from './multiKueueConfigFormatters';
+
+describe('renderClusters', () => {
+  it('returns a dash when there are no clusters', () => {
+    expect(renderClusters()).toBe('-');
+    expect(renderClusters([])).toBe('-');
+  });
+
+  it('renders a single cluster', () => {
+    expect(renderClusters(['worker1'])).toBe('worker1');
+  });
+
+  it('renders multiple clusters as a comma-separated list, preserving order', () => {
+    expect(renderClusters(['worker-onprem', 'worker-aws', 'worker-gcp'])).toBe(
+      'worker-onprem, worker-aws, worker-gcp'
+    );
+  });
+});
+
+describe('renderClusterCount', () => {
+  it('returns 0 when there are no clusters', () => {
+    expect(renderClusterCount()).toBe(0);
+    expect(renderClusterCount([])).toBe(0);
+  });
+
+  it('returns the number of clusters', () => {
+    expect(renderClusterCount(['worker1', 'worker2', 'worker3'])).toBe(3);
+  });
+});

--- a/kueue/src/resources/multiKueueConfig.ts
+++ b/kueue/src/resources/multiKueueConfig.ts
@@ -1,0 +1,66 @@
+import { KubeObject, KubeObjectInterface } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
+import { kueueApiVersions } from '../utils/kueueApi';
+import { kueueRoutePaths } from '../utils/kueueRoutes';
+import { renderClusterCount, renderClusters } from './multiKueueConfigFormatters';
+
+/**
+ * Desired state of a Kueue MultiKueueConfig.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#multikueueconfigspec
+ */
+export interface MultiKueueConfigSpec {
+  /**
+   * Worker cluster names, referencing MultiKueueCluster objects, tried in priority order.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#multikueueconfigspec
+   * @see https://kueue.sigs.k8s.io/docs/concepts/multikueue/
+   */
+  clusters: string[];
+}
+
+/**
+ * Kubernetes MultiKueueConfig object returned by the Kueue API.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#multikueueconfig
+ */
+export interface KubeMultiKueueConfig extends KubeObjectInterface {
+  /**
+   * Kubernetes object metadata for the MultiKueueConfig.
+   *
+   * @see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#objectmeta-v1-meta
+   */
+  metadata: KubeObjectInterface['metadata'];
+  /**
+   * MultiKueueConfig desired state.
+   *
+   * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#multikueueconfigspec
+   */
+  spec: MultiKueueConfigSpec;
+}
+
+export class MultiKueueConfig extends KubeObject<KubeMultiKueueConfig> {
+  static kind = 'MultiKueueConfig';
+  static apiName = 'multikueueconfigs';
+  static apiVersion = kueueApiVersions;
+  static isNamespaced = false;
+
+  static get detailsRoute() {
+    return kueueRoutePaths.multiKueueConfigDetail;
+  }
+
+  get spec(): MultiKueueConfigSpec {
+    return this.jsonData.spec ?? ({ clusters: [] } as MultiKueueConfigSpec);
+  }
+
+  get clusters() {
+    return this.spec.clusters || [];
+  }
+
+  get clustersDisplay() {
+    return renderClusters(this.clusters);
+  }
+
+  get clusterCount() {
+    return renderClusterCount(this.clusters);
+  }
+}

--- a/kueue/src/resources/multiKueueConfigFormatters.ts
+++ b/kueue/src/resources/multiKueueConfigFormatters.ts
@@ -1,0 +1,13 @@
+/** Render a MultiKueueConfig's ordered list of worker cluster names. */
+export function renderClusters(clusters?: string[]) {
+  if (!clusters || clusters.length === 0) {
+    return '-';
+  }
+
+  return clusters.join(', ');
+}
+
+/** Render the number of worker clusters configured, preserving explicit zero. */
+export function renderClusterCount(clusters?: string[]) {
+  return clusters?.length ?? 0;
+}

--- a/kueue/src/utils/kueueRoutes.ts
+++ b/kueue/src/utils/kueueRoutes.ts
@@ -7,6 +7,8 @@ export const kueueRouteNames = {
   resourceFlavorDetail: 'kueue-resourceflavor-detail',
   workloadsList: 'kueue-workloads-list',
   workloadDetail: 'kueue-workload-detail',
+  multiKueueConfigsList: 'kueue-multikueueconfigs-list',
+  multiKueueConfigDetail: 'kueue-multikueueconfig-detail',
 } as const;
 
 export const kueueRoutePaths = {
@@ -18,4 +20,6 @@ export const kueueRoutePaths = {
   resourceFlavorDetail: '/kueue/resourceflavors/:name',
   workloadsList: '/kueue/workloads',
   workloadDetail: '/kueue/workloads/:namespace/:name',
+  multiKueueConfigsList: '/kueue/multikueueconfigs',
+  multiKueueConfigDetail: '/kueue/multikueueconfigs/:name',
 } as const;


### PR DESCRIPTION
## What this PR does

Adds initial Headlamp UI support for Kueue's `MultiKueueConfig` resource, following the same
pattern established by `ClusterQueue`, `LocalQueue`, `ResourceFlavor`, and `Workload`:

- `src/resources/multiKueueConfig.ts` — `MultiKueueConfig` resource class with a `spec.clusters`
  getter.
- `src/resources/multiKueueConfigFormatters.ts` — exported, documented, pure formatter functions
  for rendering the cluster list and cluster count.
- `src/resources/multiKueueConfig.test.ts` — unit tests for the formatters.
- `src/components/multikueueconfigs/List.tsx` and `Detail.tsx` — list and detail views.
- Registers a new `MultiKueueConfigs` sidebar entry and routes in `index.tsx` /
  `kueueRoutes.ts`.

## Testing

- `npm run test` — all 27 tests pass (5 new).
- `npm run build` — builds cleanly.
- Verified locally in a running Headlamp instance against a kind cluster with a real
  `MultiKueueConfig` resource — both the list and detail views render the cluster names and
  cluster count correctly.

## Why

MultiKueue is called out as a potential focus area for this term. This PR adds basic
visibility into `MultiKueueConfig` resources as a foundation that later work (e.g. manager/
worker cluster relationships, connectivity, workload routing) can build on.