### PR TITLE
kueue: Fix sample ResourceFlavor references

### DIFF
--- a/kueue/test-files/deploy/clusterqueue-team-a.yaml
+++ b/kueue/test-files/deploy/clusterqueue-team-a.yaml
@@ -13,13 +13,13 @@ spec:
         - cpu
         - memory
       flavors:
-        - name: default
+        - name: default-flavor
           resources:
             - name: cpu
               nominalQuota: "8"
             - name: memory
               nominalQuota: 32Gi
-        - name: spot
+        - name: spot-flavor
           resources:
             - name: cpu
               nominalQuota: "16"


### PR DESCRIPTION
## Summary
- align the sample ClusterQueue flavor references with the supplied ResourceFlavor manifests
- allow the sample ClusterQueue to become active and admit workloads

Fixes #1191

## Testing
- `kubectl apply --dry-run=client -f kueue/test-files/deploy/clusterqueue-team-a.yaml`
- verified the equivalent correction on a fresh kind cluster with Kueue v0.19.0