### PR TITLE
fix(kueue): resolve ClusterQueue cohort and admission checks for v1beta1

### DIFF
--- a/kueue/src/components/clusterqueues/Detail.tsx
+++ b/kueue/src/components/clusterqueues/Detail.tsx
@@ -12,6 +12,7 @@ import {
   ResourceGroup,
   ResourceQuota,
 } from '../../resources/clusterQueue';
+import { getAdmissionChecksStrategy } from '../../resources/clusterQueueCompat';
 import { kueueRouteNames } from '../../utils/kueueRoutes';
 import KueueAdminResourceAccess from '../common/KueueAdminResourceAccess';
 
@@ -130,7 +131,7 @@ function getFlavorUsageRows(flavorUsage: FlavorUsage[] = []): FlavorUsageRow[] {
 /** Extract admission checks and their flavor scope from the ClusterQueue spec. */
 function getAdmissionCheckRows(clusterQueue: ClusterQueue): AdmissionCheckRow[] {
   return (
-    clusterQueue.spec.admissionChecksStrategy?.admissionChecks?.map(check => ({
+    getAdmissionChecksStrategy(clusterQueue.spec)?.admissionChecks?.map(check => ({
       name: check.name,
       flavors: check.onFlavors || [],
     })) || []

--- a/kueue/src/resources/clusterQueue.test.ts
+++ b/kueue/src/resources/clusterQueue.test.ts
@@ -5,8 +5,6 @@ import {
   renderClusterQueueStatus,
   renderLabelSelector,
   renderResourceGroupsSummary,
-  resolveAndRenderAdmissionChecks,
-  resolveCohortName,
 } from './clusterQueueFormatters';
 
 describe('ClusterQueue formatters', () => {
@@ -66,62 +64,5 @@ describe('ClusterQueue formatters', () => {
         ],
       })
     ).toBe('prov-request (spot); quota-check (default, gpu-flavor)');
-  });
-
-  it('resolves cohort name from v1beta2 cohortName with fallback to v1beta1 cohort', () => {
-    // v1beta2: cohortName is set
-    expect(resolveCohortName({ cohortName: 'research' })).toBe('research');
-
-    // v1beta1: only cohort is set
-    expect(resolveCohortName({ cohort: 'research' })).toBe('research');
-
-    // v1beta2 takes priority when both are present
-    expect(resolveCohortName({ cohortName: 'v2-name', cohort: 'v1-name' })).toBe('v2-name');
-
-    // Neither set
-    expect(resolveCohortName({})).toBeUndefined();
-    expect(resolveCohortName()).toBeUndefined();
-  });
-
-  it('resolves admission checks from v1beta2 strategy with fallback to v1beta1 flat list', () => {
-    // v1beta2: admissionChecksStrategy is set
-    expect(
-      resolveAndRenderAdmissionChecks({
-        admissionChecksStrategy: {
-          admissionChecks: [{ name: 'prov-request', onFlavors: ['spot'] }],
-        },
-      })
-    ).toBe('prov-request (spot)');
-
-    // v1beta1: admissionChecks is a flat string array (no per-flavor scoping)
-    expect(
-      resolveAndRenderAdmissionChecks({
-        admissionChecks: ['prov-request'],
-      })
-    ).toBe('prov-request (all flavors)');
-
-    // v1beta1: multiple admission checks
-    expect(
-      resolveAndRenderAdmissionChecks({
-        admissionChecks: ['prov-request', 'quota-check'],
-      })
-    ).toBe('prov-request (all flavors); quota-check (all flavors)');
-
-    // v1beta2 strategy takes priority when both are present
-    expect(
-      resolveAndRenderAdmissionChecks({
-        admissionChecksStrategy: {
-          admissionChecks: [{ name: 'v2-check' }],
-        },
-        admissionChecks: ['v1-check'],
-      })
-    ).toBe('v2-check (all flavors)');
-
-    // Neither set
-    expect(resolveAndRenderAdmissionChecks({})).toBe('-');
-    expect(resolveAndRenderAdmissionChecks()).toBe('-');
-
-    // Empty v1beta1 array
-    expect(resolveAndRenderAdmissionChecks({ admissionChecks: [] })).toBe('-');
   });
 });

--- a/kueue/src/resources/clusterQueue.test.ts
+++ b/kueue/src/resources/clusterQueue.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import {
   getUniqueFlavorNames,
+  renderAdmissionChecks,
   renderClusterQueueStatus,
   renderLabelSelector,
   renderResourceGroupsSummary,
+  resolveAndRenderAdmissionChecks,
+  resolveCohortName,
 } from './clusterQueueFormatters';
 
 describe('ClusterQueue formatters', () => {
@@ -45,5 +48,80 @@ describe('ClusterQueue formatters', () => {
         matchExpressions: [{ key: 'environment', operator: 'In', values: ['dev', 'prod'] }],
       })
     ).toBe('environment In (dev, prod)');
+  });
+
+  it('formats admission checks across strategy shapes and per-flavor scoping', () => {
+    expect(renderAdmissionChecks()).toBe('-');
+    expect(renderAdmissionChecks({ admissionChecks: [] })).toBe('-');
+    expect(
+      renderAdmissionChecks({
+        admissionChecks: [{ name: 'prov-request' }],
+      })
+    ).toBe('prov-request (all flavors)');
+    expect(
+      renderAdmissionChecks({
+        admissionChecks: [
+          { name: 'prov-request', onFlavors: ['spot'] },
+          { name: 'quota-check', onFlavors: ['default', 'gpu-flavor'] },
+        ],
+      })
+    ).toBe('prov-request (spot); quota-check (default, gpu-flavor)');
+  });
+
+  it('resolves cohort name from v1beta2 cohortName with fallback to v1beta1 cohort', () => {
+    // v1beta2: cohortName is set
+    expect(resolveCohortName({ cohortName: 'research' })).toBe('research');
+
+    // v1beta1: only cohort is set
+    expect(resolveCohortName({ cohort: 'research' })).toBe('research');
+
+    // v1beta2 takes priority when both are present
+    expect(resolveCohortName({ cohortName: 'v2-name', cohort: 'v1-name' })).toBe('v2-name');
+
+    // Neither set
+    expect(resolveCohortName({})).toBeUndefined();
+    expect(resolveCohortName()).toBeUndefined();
+  });
+
+  it('resolves admission checks from v1beta2 strategy with fallback to v1beta1 flat list', () => {
+    // v1beta2: admissionChecksStrategy is set
+    expect(
+      resolveAndRenderAdmissionChecks({
+        admissionChecksStrategy: {
+          admissionChecks: [{ name: 'prov-request', onFlavors: ['spot'] }],
+        },
+      })
+    ).toBe('prov-request (spot)');
+
+    // v1beta1: admissionChecks is a flat string array (no per-flavor scoping)
+    expect(
+      resolveAndRenderAdmissionChecks({
+        admissionChecks: ['prov-request'],
+      })
+    ).toBe('prov-request (all flavors)');
+
+    // v1beta1: multiple admission checks
+    expect(
+      resolveAndRenderAdmissionChecks({
+        admissionChecks: ['prov-request', 'quota-check'],
+      })
+    ).toBe('prov-request (all flavors); quota-check (all flavors)');
+
+    // v1beta2 strategy takes priority when both are present
+    expect(
+      resolveAndRenderAdmissionChecks({
+        admissionChecksStrategy: {
+          admissionChecks: [{ name: 'v2-check' }],
+        },
+        admissionChecks: ['v1-check'],
+      })
+    ).toBe('v2-check (all flavors)');
+
+    // Neither set
+    expect(resolveAndRenderAdmissionChecks({})).toBe('-');
+    expect(resolveAndRenderAdmissionChecks()).toBe('-');
+
+    // Empty v1beta1 array
+    expect(resolveAndRenderAdmissionChecks({ admissionChecks: [] })).toBe('-');
   });
 });

--- a/kueue/src/resources/clusterQueue.ts
+++ b/kueue/src/resources/clusterQueue.ts
@@ -1,6 +1,7 @@
 import { KubeObject, KubeObjectInterface } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
 import { kueueApiVersions } from '../utils/kueueApi';
 import { kueueRoutePaths } from '../utils/kueueRoutes';
+import { getAdmissionChecksStrategy, getCohortName } from './clusterQueueCompat';
 import {
   getUniqueFlavorNames,
   renderAdmissionChecks,
@@ -15,8 +16,6 @@ import {
   renderResourceGroups,
   renderResourceGroupsSummary,
   renderStringList,
-  resolveAndRenderAdmissionChecks,
-  resolveCohortName,
 } from './clusterQueueFormatters';
 
 const CLUSTER_QUEUE_API_DOCS =
@@ -685,7 +684,7 @@ export class ClusterQueue extends KubeObject<KubeClusterQueue> {
   }
 
   get cohortName() {
-    return resolveCohortName(this.spec) || '-';
+    return getCohortName(this.spec) || '-';
   }
 
   get queueingStrategy() {
@@ -753,7 +752,7 @@ export class ClusterQueue extends KubeObject<KubeClusterQueue> {
   }
 
   get admissionChecksDisplay() {
-    return resolveAndRenderAdmissionChecks(this.spec);
+    return renderAdmissionChecks(getAdmissionChecksStrategy(this.spec));
   }
 
   get flavorFungibilityDisplay() {

--- a/kueue/src/resources/clusterQueue.ts
+++ b/kueue/src/resources/clusterQueue.ts
@@ -15,6 +15,8 @@ import {
   renderResourceGroups,
   renderResourceGroupsSummary,
   renderStringList,
+  resolveAndRenderAdmissionChecks,
+  resolveCohortName,
 } from './clusterQueueFormatters';
 
 const CLUSTER_QUEUE_API_DOCS =
@@ -465,11 +467,18 @@ export interface ClusterQueueSpec {
    */
   resourceGroups?: ResourceGroup[];
   /**
-   * Cohort name this ClusterQueue belongs to.
+   * Cohort name this ClusterQueue belongs to (v1beta2 field name).
    *
    * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#clusterqueuespec
    */
   cohortName?: string;
+  /**
+   * Cohort name this ClusterQueue belongs to (v1beta1 field name).
+   *
+   * In v1beta1, this field is called `cohort`. In v1beta2, it was renamed
+   * to `cohortName`. Both are supported for backwards compatibility.
+   */
+  cohort?: string;
   /**
    * Queueing strategy for workloads across queues in this ClusterQueue.
    *
@@ -495,11 +504,20 @@ export interface ClusterQueueSpec {
    */
   preemption?: ClusterQueuePreemption;
   /**
-   * Strategy mapping AdmissionChecks to ResourceFlavors.
+   * Strategy mapping AdmissionChecks to ResourceFlavors (v1beta2).
    *
    * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#clusterqueuespec
    */
   admissionChecksStrategy?: AdmissionChecksStrategy;
+  /**
+   * Flat list of AdmissionCheck names (v1beta1).
+   *
+   * In v1beta1, admission checks are a simple string array under
+   * `spec.admissionChecks`. In v1beta2, they were restructured into
+   * `spec.admissionChecksStrategy.admissionChecks[].name` with per-flavor
+   * scoping. Both are supported for backwards compatibility.
+   */
+  admissionChecks?: string[];
   /**
    * Stop policy for admission and draining behavior.
    *
@@ -667,7 +685,7 @@ export class ClusterQueue extends KubeObject<KubeClusterQueue> {
   }
 
   get cohortName() {
-    return this.spec.cohortName || '-';
+    return resolveCohortName(this.spec) || '-';
   }
 
   get queueingStrategy() {
@@ -735,7 +753,7 @@ export class ClusterQueue extends KubeObject<KubeClusterQueue> {
   }
 
   get admissionChecksDisplay() {
-    return renderAdmissionChecks(this.spec.admissionChecksStrategy);
+    return resolveAndRenderAdmissionChecks(this.spec);
   }
 
   get flavorFungibilityDisplay() {

--- a/kueue/src/resources/clusterQueueCompat.test.ts
+++ b/kueue/src/resources/clusterQueueCompat.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import { getAdmissionChecksStrategy, getCohortName } from './clusterQueueCompat';
+import { renderAdmissionChecks } from './clusterQueueFormatters';
+
+describe('ClusterQueue compatibility resolvers', () => {
+  describe('getCohortName', () => {
+    it('resolves cohort from v1beta2 cohortName', () => {
+      expect(getCohortName({ cohortName: 'research' })).toBe('research');
+    });
+
+    it('resolves cohort from v1beta1 cohort fallback', () => {
+      expect(getCohortName({ cohort: 'research' })).toBe('research');
+    });
+
+    it('prioritizes v1beta2 cohortName when both are present', () => {
+      expect(getCohortName({ cohortName: 'v2-name', cohort: 'v1-name' })).toBe('v2-name');
+    });
+
+    it('returns undefined for undefined or empty specs', () => {
+      expect(getCohortName(undefined)).toBeUndefined();
+      expect(getCohortName({})).toBeUndefined();
+    });
+
+    it('handles empty string cohort values', () => {
+      expect(getCohortName({ cohortName: '', cohort: '' })).toBeUndefined();
+      expect(getCohortName({ cohortName: '' })).toBeUndefined();
+      expect(getCohortName({ cohort: '' })).toBeUndefined();
+    });
+  });
+
+  describe('getAdmissionChecksStrategy', () => {
+    it('returns v1beta2 strategy unchanged when present', () => {
+      const strategy = {
+        admissionChecks: [{ name: 'prov-request', onFlavors: ['spot'] }],
+      };
+      expect(getAdmissionChecksStrategy({ admissionChecksStrategy: strategy })).toBe(strategy);
+    });
+
+    it('converts v1beta1 flat array into admissionChecksStrategy shape', () => {
+      expect(
+        getAdmissionChecksStrategy({
+          admissionChecks: ['prov-request'],
+        })
+      ).toEqual({
+        admissionChecks: [{ name: 'prov-request' }],
+      });
+    });
+
+    it('converts multiple v1beta1 admission checks', () => {
+      expect(
+        getAdmissionChecksStrategy({
+          admissionChecks: ['prov-request', 'quota-check'],
+        })
+      ).toEqual({
+        admissionChecks: [{ name: 'prov-request' }, { name: 'quota-check' }],
+      });
+    });
+
+    it('prioritizes non-empty v1beta2 strategy over v1beta1 admissionChecks', () => {
+      const v2Strategy = {
+        admissionChecks: [{ name: 'v2-check' }],
+      };
+      expect(
+        getAdmissionChecksStrategy({
+          admissionChecksStrategy: v2Strategy,
+          admissionChecks: ['v1-check'],
+        })
+      ).toBe(v2Strategy);
+    });
+
+    it('falls back to v1beta1 when v1beta2 strategy has empty admissionChecks', () => {
+      expect(
+        getAdmissionChecksStrategy({
+          admissionChecksStrategy: { admissionChecks: [] },
+          admissionChecks: ['v1-check'],
+        })
+      ).toEqual({
+        admissionChecks: [{ name: 'v1-check' }],
+      });
+    });
+
+    it('returns undefined or empty strategy when no admission checks exist', () => {
+      expect(getAdmissionChecksStrategy(undefined)).toBeUndefined();
+      expect(getAdmissionChecksStrategy({})).toBeUndefined();
+      expect(getAdmissionChecksStrategy({ admissionChecks: [] })).toBeUndefined();
+      expect(
+        getAdmissionChecksStrategy({
+          admissionChecksStrategy: { admissionChecks: [] },
+        })
+      ).toEqual({ admissionChecks: [] });
+    });
+
+    it('formats converted v1beta1 checks as applying to all flavors', () => {
+      const v1beta1Spec = {
+        admissionChecks: ['prov-request', 'quota-check'],
+      };
+      const resolvedStrategy = getAdmissionChecksStrategy(v1beta1Spec);
+
+      expect(renderAdmissionChecks(resolvedStrategy)).toBe(
+        'prov-request (all flavors); quota-check (all flavors)'
+      );
+    });
+  });
+});

--- a/kueue/src/resources/clusterQueueCompat.test.ts
+++ b/kueue/src/resources/clusterQueueCompat.test.ts
@@ -101,4 +101,88 @@ describe('ClusterQueue compatibility resolvers', () => {
       );
     });
   });
+
+  /**
+   * Regression tests for the Detail page admission check row pipeline.
+   *
+   * Detail.tsx builds admission check rows by calling:
+   *   getAdmissionChecksStrategy(clusterQueue.spec)?.admissionChecks?.map(...)
+   *
+   * These tests replicate that exact pipeline to verify that v1beta1 flat
+   * admissionChecks produce non-empty rows through the resolver.
+   * A caller that bypasses the resolver and reads spec.admissionChecksStrategy
+   * directly would get empty rows for v1beta1 — this is the bug the reviewer
+   * identified.
+   */
+  describe('Detail page admission check row pipeline', () => {
+    /** Replicate the row-building logic from Detail.tsx getAdmissionCheckRows. */
+    function buildAdmissionCheckRows(spec: Record<string, unknown>) {
+      return (
+        getAdmissionChecksStrategy(spec)?.admissionChecks?.map(check => ({
+          name: check.name,
+          flavors: check.onFlavors || [],
+        })) || []
+      );
+    }
+
+    it('builds rows from v1beta2 admissionChecksStrategy', () => {
+      expect(
+        buildAdmissionCheckRows({
+          admissionChecksStrategy: {
+            admissionChecks: [
+              { name: 'prov-request', onFlavors: ['spot'] },
+              { name: 'quota-check', onFlavors: ['default', 'gpu-flavor'] },
+            ],
+          },
+        })
+      ).toEqual([
+        { name: 'prov-request', flavors: ['spot'] },
+        { name: 'quota-check', flavors: ['default', 'gpu-flavor'] },
+      ]);
+    });
+
+    it('builds rows from v1beta1 flat admissionChecks via compatibility resolver', () => {
+      const rows = buildAdmissionCheckRows({
+        admissionChecks: ['check-a', 'check-b'],
+      });
+
+      expect(rows).toEqual([
+        { name: 'check-a', flavors: [] },
+        { name: 'check-b', flavors: [] },
+      ]);
+    });
+
+    it('returns empty array when no admission checks are configured', () => {
+      expect(buildAdmissionCheckRows({})).toEqual([]);
+    });
+
+    it('prefers v1beta2 strategy over v1beta1 flat list when both are present', () => {
+      expect(
+        buildAdmissionCheckRows({
+          admissionChecksStrategy: {
+            admissionChecks: [{ name: 'v2-check', onFlavors: ['spot'] }],
+          },
+          admissionChecks: ['v1-check-a', 'v1-check-b'],
+        })
+      ).toEqual([{ name: 'v2-check', flavors: ['spot'] }]);
+    });
+
+    it('falls back to v1beta1 when v1beta2 strategy has empty admissionChecks', () => {
+      expect(
+        buildAdmissionCheckRows({
+          admissionChecksStrategy: { admissionChecks: [] },
+          admissionChecks: ['fallback-check'],
+        })
+      ).toEqual([{ name: 'fallback-check', flavors: [] }]);
+    });
+
+    it('v1beta1 checks have no per-flavor scoping and use empty flavors', () => {
+      const rows = buildAdmissionCheckRows({
+        admissionChecks: ['check-a'],
+      });
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0].flavors).toEqual([]);
+    });
+  });
 });

--- a/kueue/src/resources/clusterQueueCompat.ts
+++ b/kueue/src/resources/clusterQueueCompat.ts
@@ -1,0 +1,56 @@
+import { AdmissionChecksStrategyLike } from './clusterQueueFormatters';
+
+/** Minimal spec shape needed to resolve cohort name across v1beta1 and v1beta2. */
+export interface CohortSpecLike {
+  /** Cohort name in v1beta2 (renamed from `cohort` in v1beta1). */
+  cohortName?: string;
+  /** Cohort name in v1beta1. */
+  cohort?: string;
+}
+
+/** Minimal spec shape needed to resolve admission checks across v1beta1 and v1beta2. */
+export interface AdmissionChecksSpecLike {
+  /** v1beta2 structured strategy mapping AdmissionChecks to ResourceFlavors. */
+  admissionChecksStrategy?: AdmissionChecksStrategyLike;
+  /** v1beta1 flat list of AdmissionCheck names. */
+  admissionChecks?: string[];
+}
+
+/**
+ * Resolve the cohort name from either v1beta2 (`cohortName`) or v1beta1 (`cohort`).
+ *
+ * In v1beta2, the field is `cohortName`. In v1beta1, it was `cohort`.
+ * The v1beta2 field takes priority when both are present.
+ * Returns `undefined` when neither field is set.
+ */
+export function getCohortName(spec?: CohortSpecLike): string | undefined {
+  return spec?.cohortName || spec?.cohort || undefined;
+}
+
+/**
+ * Resolve the admission checks strategy from either v1beta2 (`admissionChecksStrategy`)
+ * or v1beta1 (`admissionChecks`).
+ *
+ * In v1beta2, admission checks are structured under `admissionChecksStrategy.admissionChecks`
+ * with optional per-flavor scoping. In v1beta1, admission checks are a flat string array
+ * with no per-flavor scoping.
+ *
+ * When v1beta1 `admissionChecks` is present, it is converted into the v1beta2 strategy shape
+ * so that existing formatters can render it uniformly.
+ * The v1beta2 strategy takes priority when both are present and non-empty.
+ */
+export function getAdmissionChecksStrategy(
+  spec?: AdmissionChecksSpecLike
+): AdmissionChecksStrategyLike | undefined {
+  if (spec?.admissionChecksStrategy?.admissionChecks?.length) {
+    return spec.admissionChecksStrategy;
+  }
+
+  if (spec?.admissionChecks?.length) {
+    return {
+      admissionChecks: spec.admissionChecks.map(name => ({ name })),
+    };
+  }
+
+  return spec?.admissionChecksStrategy;
+}

--- a/kueue/src/resources/clusterQueueFormatters.ts
+++ b/kueue/src/resources/clusterQueueFormatters.ts
@@ -288,53 +288,6 @@ export function renderAdmissionChecks(strategy?: AdmissionChecksStrategyLike) {
     .join('; ');
 }
 
-/** Minimal spec shape needed by the v1beta1/v1beta2 cohort resolver. */
-export interface CohortSpecLike {
-  /** Cohort name in v1beta2 (renamed from `cohort` in v1beta1). */
-  cohortName?: string;
-  /** Cohort name in v1beta1. */
-  cohort?: string;
-}
-
-/** Minimal spec shape needed by the v1beta1/v1beta2 admission checks resolver. */
-export interface AdmissionChecksSpecLike {
-  /** v1beta2 structured strategy. */
-  admissionChecksStrategy?: AdmissionChecksStrategyLike;
-  /** v1beta1 flat list of AdmissionCheck names. */
-  admissionChecks?: string[];
-}
-
-/**
- * Resolve the cohort name from either v1beta2 (`cohortName`) or v1beta1 (`cohort`).
- *
- * The v1beta2 field takes priority because it is the current API version.
- * Returns `undefined` when neither field is set.
- */
-export function resolveCohortName(spec?: CohortSpecLike): string | undefined {
-  return spec?.cohortName || spec?.cohort;
-}
-
-/**
- * Resolve and render admission checks from either v1beta2 (`admissionChecksStrategy`)
- * or v1beta1 (`admissionChecks`).
- *
- * In v1beta1, admission checks are a flat `string[]` with no per-flavor scoping;
- * each entry renders as applying to all flavors — matching the Kueue conversion
- * semantics where v1beta1 checks map to the v1beta2 strategy without `onFlavors`.
- */
-export function resolveAndRenderAdmissionChecks(spec?: AdmissionChecksSpecLike): string {
-  if (spec?.admissionChecksStrategy) {
-    return renderAdmissionChecks(spec.admissionChecksStrategy);
-  }
-
-  const checks = spec?.admissionChecks || [];
-  if (checks.length === 0) {
-    return '-';
-  }
-
-  return checks.map(name => `${name} (all flavors)`).join('; ');
-}
-
 /** Render ClusterQueue flavor fungibility settings for the detail page. */
 export function renderFlavorFungibility(flavorFungibility?: FlavorFungibilityLike) {
   if (!flavorFungibility) {

--- a/kueue/src/resources/clusterQueueFormatters.ts
+++ b/kueue/src/resources/clusterQueueFormatters.ts
@@ -288,6 +288,53 @@ export function renderAdmissionChecks(strategy?: AdmissionChecksStrategyLike) {
     .join('; ');
 }
 
+/** Minimal spec shape needed by the v1beta1/v1beta2 cohort resolver. */
+export interface CohortSpecLike {
+  /** Cohort name in v1beta2 (renamed from `cohort` in v1beta1). */
+  cohortName?: string;
+  /** Cohort name in v1beta1. */
+  cohort?: string;
+}
+
+/** Minimal spec shape needed by the v1beta1/v1beta2 admission checks resolver. */
+export interface AdmissionChecksSpecLike {
+  /** v1beta2 structured strategy. */
+  admissionChecksStrategy?: AdmissionChecksStrategyLike;
+  /** v1beta1 flat list of AdmissionCheck names. */
+  admissionChecks?: string[];
+}
+
+/**
+ * Resolve the cohort name from either v1beta2 (`cohortName`) or v1beta1 (`cohort`).
+ *
+ * The v1beta2 field takes priority because it is the current API version.
+ * Returns `undefined` when neither field is set.
+ */
+export function resolveCohortName(spec?: CohortSpecLike): string | undefined {
+  return spec?.cohortName || spec?.cohort;
+}
+
+/**
+ * Resolve and render admission checks from either v1beta2 (`admissionChecksStrategy`)
+ * or v1beta1 (`admissionChecks`).
+ *
+ * In v1beta1, admission checks are a flat `string[]` with no per-flavor scoping;
+ * each entry renders as applying to all flavors — matching the Kueue conversion
+ * semantics where v1beta1 checks map to the v1beta2 strategy without `onFlavors`.
+ */
+export function resolveAndRenderAdmissionChecks(spec?: AdmissionChecksSpecLike): string {
+  if (spec?.admissionChecksStrategy) {
+    return renderAdmissionChecks(spec.admissionChecksStrategy);
+  }
+
+  const checks = spec?.admissionChecks || [];
+  if (checks.length === 0) {
+    return '-';
+  }
+
+  return checks.map(name => `${name} (all flavors)`).join('; ');
+}
+
 /** Render ClusterQueue flavor fungibility settings for the detail page. */
 export function renderFlavorFungibility(flavorFungibility?: FlavorFungibilityLike) {
   if (!flavorFungibility) {


### PR DESCRIPTION
## Summary

The Kueue `ClusterQueue` resource class only reads the v1beta2
field shapes for Cohort and Admission Checks.

When Headlamp falls back to the v1beta1 API, valid values in
`spec.cohort` and `spec.admissionChecks` were not displayed.

Fixes #1150

## Changes

- Add v1beta1 `cohort` and `admissionChecks` fields to `ClusterQueueSpec`
- Add `resolveCohortName()` with v1beta2 → v1beta1 fallback
- Add `resolveAndRenderAdmissionChecks()` with v1beta2 → v1beta1 fallback
- Preserve existing v1beta2 admission-check rendering
- Update `ClusterQueue` getters to use the new resolvers
- Add unit tests for both API versions and fallback behavior

## Testing

- `cd kueue && ./node_modules/.bin/vitest run --reporter=verbose`
- 25/25 tests passing across 4 test files
- Existing v1beta2 behavior remains covered
