### PR TITLE
fix(kueue): handle WaitingForReplacementPods workload condition

### DIFF
--- a/kueue/src/resources/workloadFormatters.test.ts
+++ b/kueue/src/resources/workloadFormatters.test.ts
@@ -103,6 +103,34 @@ describe('Workload formatters', () => {
         true
       )
     ).toBe('Running');
+    expect(
+      renderWorkloadStatus(
+        [
+          { type: 'Admitted', status: 'True' },
+          { type: 'WaitingForReplacementPods', status: 'True' },
+        ],
+        true
+      )
+    ).toBe('Waiting for replacement pods');
+    expect(
+      renderWorkloadStatus(
+        [
+          { type: 'Admitted', status: 'True' },
+          { type: 'PodsReady', status: 'True' },
+          { type: 'WaitingForReplacementPods', status: 'True' },
+        ],
+        true
+      )
+    ).toBe('Running');
+    expect(
+      renderWorkloadStatus(
+        [
+          { type: 'Admitted', status: 'True' },
+          { type: 'WaitingForReplacementPods', status: 'False' },
+        ],
+        true
+      )
+    ).toBe('Admitted');
     expect(renderWorkloadStatus([{ type: 'Admitted', status: 'True' }], true)).toBe('Admitted');
     expect(
       renderWorkloadStatus([], true, {

--- a/kueue/src/resources/workloadFormatters.ts
+++ b/kueue/src/resources/workloadFormatters.ts
@@ -17,6 +17,7 @@ const CONDITION_TYPES = {
   preempted: 'Preempted',
   requeued: 'Requeued',
   deactivationTarget: 'DeactivationTarget',
+  waitingForReplacementPods: 'WaitingForReplacementPods',
 } as const;
 
 /** Render text values with the plugin's standard empty-value fallback. */
@@ -131,7 +132,13 @@ export function renderWorkloadStatus(
   }
 
   if (admission || isConditionTrue(conditions, CONDITION_TYPES.admitted)) {
-    return isConditionTrue(conditions, CONDITION_TYPES.podsReady) ? 'Running' : 'Admitted';
+    if (isConditionTrue(conditions, CONDITION_TYPES.podsReady)) {
+      return 'Running';
+    }
+    if (isConditionTrue(conditions, CONDITION_TYPES.waitingForReplacementPods)) {
+      return 'Waiting for replacement pods';
+    }
+    return 'Admitted';
   }
 
   const quotaReservedCondition = findWorkloadCondition(conditions, CONDITION_TYPES.quotaReserved);


### PR DESCRIPTION
## Summary

When a Kueue Workload has `WaitingForReplacementPods=True` condition, the workload status formatter previously ignored this condition and reported `Admitted`.

This change adds `WaitingForReplacementPods` to `CONDITION_TYPES` and updates `renderWorkloadStatus()` to correctly surface `"Waiting for replacement pods"` when pods are being replaced.

Fixes #1155

## Changes

- Add `waitingForReplacementPods` to `CONDITION_TYPES` in `workloadFormatters.ts`.
- Update `renderWorkloadStatus()` under the admitted branch to check `WaitingForReplacementPods=True` after `PodsReady=True`.
- Add test coverage in `workloadFormatters.test.ts`.

## Testing

- Executed `cd kueue && ./node_modules/.bin/vitest run`
- 22/22 tests passing across 4 test files.
