### PR TITLE
fix(flux): clear the reconciliation timeout on unmount

### DIFF
--- a/flux/src/common/RemainingTimeDisplay.test.tsx
+++ b/flux/src/common/RemainingTimeDisplay.test.tsx
@@ -65,11 +65,15 @@ describe('RemainingTimeDisplay', () => {
     const clearSpy = vi.spyOn(window, 'clearTimeout');
 
     const { unmount } = render(<RemainingTimeDisplay item={itemDueIn('5m')} />);
+
+    // The handle this component scheduled, which is the one unmount has to clear.
     expect(setSpy).toHaveBeenCalled();
+    const scheduled = setSpy.mock.results.at(-1)?.value;
+    expect(scheduled).toBeDefined();
 
     clearSpy.mockClear();
     unmount();
 
-    expect(clearSpy).toHaveBeenCalled();
+    expect(clearSpy).toHaveBeenCalledWith(scheduled);
   });
 });

--- a/flux/src/common/RemainingTimeDisplay.test.tsx
+++ b/flux/src/common/RemainingTimeDisplay.test.tsx
@@ -1,5 +1,28 @@
-import { describe, expect, it } from 'vitest';
+import { render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { formatRemainingTime } from './remainingTime';
+import RemainingTimeDisplay from './RemainingTimeDisplay';
+
+vi.mock('@kinvolk/headlamp-plugin/lib', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@kinvolk/headlamp-plugin/lib/components/common', () => ({
+  HoverInfoLabel: ({ label }: { label: string }) => <span>{label}</span>,
+}));
+
+vi.mock('@kinvolk/headlamp-plugin/lib/lib/k8s/cluster', () => ({}));
+
+// The helpers barrel pulls in unrelated Headlamp modules, so only the one
+// function this component uses is stubbed here.
+vi.mock('../helpers', () => ({
+  parseDuration: (d: string) => {
+    const m = /^(\d+)([smh])$/.exec(d);
+    if (!m) return 0;
+    const n = Number(m[1]);
+    return m[2] === 'h' ? n * 3600000 : m[2] === 'm' ? n * 60000 : n * 1000;
+  },
+}));
 
 describe('formatRemainingTime', () => {
   const now = 1700000000000;
@@ -10,5 +33,43 @@ describe('formatRemainingTime', () => {
 
   it('formats a minute-scale future time', () => {
     expect(formatRemainingTime(now + 5 * 60 * 1000, now)).toBe('5m');
+  });
+});
+
+describe('RemainingTimeDisplay', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // An item whose last reconcile was just now, so the next attempt is one
+  // interval away and the component schedules a refresh timeout.
+  function itemDueIn(interval: string) {
+    return {
+      jsonData: {
+        spec: { interval },
+        status: {
+          conditions: [
+            {
+              type: 'Ready',
+              status: 'True',
+              lastTransitionTime: new Date().toISOString(),
+            },
+          ],
+        },
+      },
+    } as any;
+  }
+
+  it('clears its pending timeout when unmounted', () => {
+    const setSpy = vi.spyOn(window, 'setTimeout');
+    const clearSpy = vi.spyOn(window, 'clearTimeout');
+
+    const { unmount } = render(<RemainingTimeDisplay item={itemDueIn('5m')} />);
+    expect(setSpy).toHaveBeenCalled();
+
+    clearSpy.mockClear();
+    unmount();
+
+    expect(clearSpy).toHaveBeenCalled();
   });
 });

--- a/flux/src/common/RemainingTimeDisplay.tsx
+++ b/flux/src/common/RemainingTimeDisplay.tsx
@@ -138,7 +138,7 @@ export default function RemainingTimeDisplay(props: RemainingTimeDisplayProps) {
     }
 
     if (!!timeoutRef.current) {
-      window.clearInterval(timeoutRef.current);
+      window.clearTimeout(timeoutRef.current);
     }
 
     // The trigger projection is not perfect, so if our remaining time is getting negative,
@@ -154,10 +154,12 @@ export default function RemainingTimeDisplay(props: RemainingTimeDisplayProps) {
 
   React.useEffect(() => {
     // Just to clear out any remaining timeouts when the component is unmounted
-    if (!!timeoutRef.current) {
-      window.clearInterval(timeoutRef.current);
-      timeoutRef.current = undefined;
-    }
+    return () => {
+      if (!!timeoutRef.current) {
+        window.clearTimeout(timeoutRef.current);
+        timeoutRef.current = undefined;
+      }
+    };
   }, []);
 
   return (

--- a/flux/src/common/RemainingTimeDisplay.tsx
+++ b/flux/src/common/RemainingTimeDisplay.tsx
@@ -137,7 +137,7 @@ export default function RemainingTimeDisplay(props: RemainingTimeDisplayProps) {
       timeoutTrigger = remainingTimeSecs % 60;
     }
 
-    if (!!timeoutRef.current) {
+    if (timeoutRef.current !== undefined) {
       window.clearTimeout(timeoutRef.current);
     }
 
@@ -155,7 +155,7 @@ export default function RemainingTimeDisplay(props: RemainingTimeDisplayProps) {
   React.useEffect(() => {
     // Just to clear out any remaining timeouts when the component is unmounted
     return () => {
-      if (!!timeoutRef.current) {
+      if (timeoutRef.current !== undefined) {
         window.clearTimeout(timeoutRef.current);
         timeoutRef.current = undefined;
       }


### PR DESCRIPTION
`RemainingTimeDisplay` kept its cleanup in the effect body instead of returning it, so with `[]` deps it ran once on mount while the ref was still undefined and never again. The pending timeout outlived the component and fired `setTimeRemaining` after unmount, one per Flux list row showing a next reconciliation time.

Returns the cleanup now, and uses `clearTimeout` rather than `clearInterval` since the handle comes from `setTimeout`.

Added a test that renders the component, unmounts it and asserts the timeout is cleared. It fails without the change.

Fixes #1006