### PR TITLE
argocd: Add safe Application rollback from Sync History

### DIFF
--- a/argocd/README.md
+++ b/argocd/README.md
@@ -12,6 +12,7 @@ To learn more about Argo CD, see the [Argo CD Getting Started Guide](https://arg
 - **Application Detail View** — Displays detailed metadata for a single Application: project, source, destination, sync status, health status, and Kubernetes events.
 - **Sync Action** — Triggers a sync by patching the Application's `.operation` field via the Kubernetes API. The Argo CD application-controller picks this up exactly as it would from the Argo CD UI.
 - **Refresh Action** — Requests a refresh by setting the `argocd.argoproj.io/refresh` annotation (supports `normal` and `hard` refresh types).
+- **Rollback Action** — Lets an authorized user deliberately select a complete earlier deployment from Sync History and trigger it as a one-time Argo CD operation without changing the Application's configured Git revision.
 - **Open in Argo CD** — Opens the current Application in the configured Argo CD web UI when `argocd-cm.data.url` is available.
 - **Argo CD Sidebar Icon** — Registers the official Argo CD octopus logo as an offline Iconify icon (CSP-safe, no external fetch).
 
@@ -29,13 +30,33 @@ Instead, this plugin drives Argo CD the **Kubernetes-native way** — by writing
 
 ### Behavioral differences from the Argo CD UI
 
-| Behavior | Argo CD UI | This plugin |
-|---|---|---|
-| **Auth** | Argo CD session token (JWT or cookie) | Kubernetes RBAC (same kubeconfig as Headlamp) |
-| **Sync** | REST API `POST /api/v1/applications/{name}/sync` | K8s PATCH on `.operation.sync` field |
-| **Refresh** | REST API `GET` with `?refresh=normal` | K8s PATCH setting `argocd.argoproj.io/refresh` annotation |
-| **Refresh annotation cleanup** | Controller removes the annotation after reconciliation | Same — the controller handles cleanup |
-| **`.operation` field cleanup** | Controller clears `.operation` and writes `.status.operationState` | Same — this is controller-managed |
+| Behavior                       | Argo CD UI                                                         | This plugin                                                                  |
+| ------------------------------ | ------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
+| **Auth**                       | Argo CD session token (JWT or cookie)                              | Kubernetes RBAC (same kubeconfig as Headlamp)                                |
+| **Sync**                       | REST API `POST /api/v1/applications/{name}/sync`                   | K8s PATCH on `.operation.sync` field                                         |
+| **Rollback**                   | REST API rollback request                                          | K8s PATCH on `.operation.sync` using the selected historical source snapshot |
+| **Refresh**                    | REST API `GET` with `?refresh=normal`                              | K8s PATCH setting `argocd.argoproj.io/refresh` annotation                    |
+| **Refresh annotation cleanup** | Controller removes the annotation after reconciliation             | Same — the controller handles cleanup                                        |
+| **`.operation` field cleanup** | Controller clears `.operation` and writes `.status.operationState` | Same — this is controller-managed                                            |
+
+### Rollback behavior and safeguards
+
+Rollback is available on an Application detail page only when all of these conditions are met:
+
+- the user has Kubernetes `patch` permission for the Application;
+- automated sync is disabled;
+- Argo CD is not already processing another operation; and
+- Sync History contains at least one earlier deployment with a complete source snapshot.
+
+The dialog starts with no deployment selected. It shows the full historical revision, source, and
+deployment time for review before confirmation. Single-source and multi-source Applications are
+supported when Argo CD recorded complete, aligned history data.
+
+After confirmation, Headlamp patches only the Application's top-level `.operation` field. It does
+not patch `spec.source.targetRevision`, `spec.sources`, or the Git repository, and it does not enable
+pruning. The success message says that rollback was **triggered** because the Argo CD controller
+performs the deployment asynchronously. Sync windows and other controller policies can still reject
+or delay the operation.
 
 ## Prerequisites
 
@@ -54,12 +75,15 @@ kind: ClusterRole
 metadata:
   name: argocd-headlamp-plugin
 rules:
-  - apiGroups: ["argoproj.io"]
-    resources: ["applications"]
-    verbs: ["get", "list", "watch", "patch"]
+  - apiGroups: ['argoproj.io']
+    resources: ['applications']
+    verbs: ['get', 'list', 'watch', 'patch']
 ```
 
-If the user lacks `patch` permission, the Sync/Refresh buttons are hidden. If a patch request is still attempted and returns 403, the plugin shows a clear error message explaining which RBAC permission is missing.
+If the user lacks `patch` permission, the Sync, Refresh, and Rollback buttons are hidden. Rollback
+requires no permission beyond the existing Application `patch` permission. If a patch request is
+still attempted and returns 403, the plugin shows a clear error message explaining which Kubernetes
+RBAC permission is missing.
 
 ### Optional Argo CD UI link permission
 
@@ -68,10 +92,10 @@ ConfigMap. Grant this permission in the namespace where the Argo CD application 
 runs if you want the action to appear:
 
 ```yaml
-- apiGroups: [""]
-  resources: ["configmaps"]
-  resourceNames: ["argocd-cm"]
-  verbs: ["get"]
+- apiGroups: ['']
+  resources: ['configmaps']
+  resourceNames: ['argocd-cm']
+  verbs: ['get']
 ```
 
 The plugin first uses `Application.status.controllerNamespace` to find the ConfigMap and falls
@@ -129,6 +153,7 @@ If you don't have a full Argo CD installation, you can use the provided test man
    ```
 
 6. Copy the contents of the `dist/` folder to your Headlamp plugins directory:
+
    - **Linux/macOS**: `~/.config/Headlamp/plugins/argocd/`
    - **Windows**: `%APPDATA%\Headlamp\Config\plugins\argocd\`
 

--- a/argocd/src/api/argoClient.test.ts
+++ b/argocd/src/api/argoClient.test.ts
@@ -34,11 +34,11 @@ vi.mock('@kinvolk/headlamp-plugin/lib', () => ({
   },
 }));
 
-import { refreshApplication, syncApplication } from './argoClient';
+import { refreshApplication, rollbackApplication, syncApplication } from './argoClient';
 
 describe('argoClient', () => {
   beforeEach(() => {
-    mockRequest.mockReset().mockResolvedValue({});
+    mockRequest.mockReset().mockResolvedValue({ metadata: { resourceVersion: '42' } });
   });
 
   it('syncApplication sends a merge-patch with .operation.sync', async () => {
@@ -73,6 +73,148 @@ describe('argoClient', () => {
         }),
       })
     );
+  });
+
+  it('rollbackApplication sends a complete single-source history snapshot', async () => {
+    await rollbackApplication(
+      'guestbook',
+      'argocd',
+      {
+        id: 4,
+        revision: 'abc123def456',
+        deployedAt: '2025-01-01T00:00:00Z',
+        source: {
+          repoURL: 'https://github.com/example/apps.git',
+          targetRevision: 'main',
+          path: 'guestbook',
+          helm: { valueFiles: ['values-production.yaml'] },
+        },
+      },
+      ['CreateNamespace=true']
+    );
+
+    expect(mockRequest).toHaveBeenLastCalledWith(
+      '/apis/argoproj.io/v1alpha1/namespaces/argocd/applications/guestbook',
+      expect.objectContaining({
+        headers: { 'Content-Type': 'application/json-patch+json' },
+        body: JSON.stringify([
+          { op: 'test', path: '/metadata/resourceVersion', value: '42' },
+          {
+            op: 'add',
+            path: '/operation',
+            value: {
+              initiatedBy: { username: 'headlamp' },
+              sync: {
+                revision: 'abc123def456',
+                source: {
+                  repoURL: 'https://github.com/example/apps.git',
+                  targetRevision: 'main',
+                  path: 'guestbook',
+                  helm: { valueFiles: ['values-production.yaml'] },
+                },
+                dryRun: false,
+                prune: false,
+                syncOptions: ['CreateNamespace=true'],
+                syncStrategy: { apply: {} },
+              },
+            },
+          },
+        ]),
+      })
+    );
+
+    const requestOptions = mockRequest.mock.calls[1][1];
+    expect(JSON.stringify(requestOptions.body)).not.toContain('spec');
+  });
+
+  it('rollbackApplication sends aligned multi-source revisions and snapshots', async () => {
+    const sources = [
+      { repoURL: 'https://github.com/example/apps.git', path: 'guestbook' },
+      { repoURL: 'https://github.com/example/values.git', ref: 'values' },
+    ];
+
+    await rollbackApplication('guestbook', 'argocd', {
+      id: 3,
+      revisions: ['app-revision', 'values-revision'],
+      sources,
+      deployedAt: '2025-01-01T00:00:00Z',
+    });
+
+    const requestOptions = mockRequest.mock.calls[1][1];
+    const patch = JSON.parse(requestOptions.body);
+    expect(patch[1].value.sync).toEqual({
+      revisions: ['app-revision', 'values-revision'],
+      sources,
+      dryRun: false,
+      prune: false,
+      syncOptions: [],
+      syncStrategy: { apply: {} },
+    });
+    expect(JSON.stringify(patch)).not.toContain('spec');
+  });
+
+  it('rejects incomplete rollback history before sending a patch', async () => {
+    await expect(
+      rollbackApplication('guestbook', 'argocd', {
+        id: 2,
+        revisions: ['only-one-revision'],
+        sources: [
+          { repoURL: 'https://github.com/example/apps.git' },
+          { repoURL: 'https://github.com/example/values.git' },
+        ],
+        deployedAt: '2025-01-01T00:00:00Z',
+      })
+    ).rejects.toThrow(/multi-source history entry is incomplete/);
+
+    expect(mockRequest).not.toHaveBeenCalled();
+  });
+
+  it('uses the existing RBAC error handling for rollback', async () => {
+    mockRequest
+      .mockResolvedValueOnce({ metadata: { resourceVersion: '42' } })
+      .mockRejectedValueOnce({ status: 403, message: 'Forbidden' });
+
+    await expect(
+      rollbackApplication('guestbook', 'argocd', {
+        id: 1,
+        revision: 'abc123',
+        source: { repoURL: 'https://github.com/example/apps.git' },
+        deployedAt: '2025-01-01T00:00:00Z',
+      })
+    ).rejects.toThrow(/Permission denied.*RBAC.*"argocd" namespace/);
+  });
+
+  it('refuses rollback when an operation is already in progress', async () => {
+    mockRequest.mockResolvedValueOnce({
+      metadata: { resourceVersion: '42' },
+      operation: { sync: {} },
+    });
+
+    await expect(
+      rollbackApplication('guestbook', 'argocd', {
+        id: 1,
+        revision: 'abc123',
+        source: { repoURL: 'https://github.com/example/apps.git' },
+        deployedAt: '2025-01-01T00:00:00Z',
+      })
+    ).rejects.toThrow(/operation is already in progress/);
+
+    expect(mockRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports a stale Application conflict during rollback', async () => {
+    mockRequest
+      .mockResolvedValueOnce({ metadata: { resourceVersion: '42' } })
+      .mockRejectedValueOnce({ status: 409, message: 'Conflict' });
+
+    await expect(
+      rollbackApplication('guestbook', 'argocd', {
+        id: 1,
+        revision: 'abc123',
+        source: { repoURL: 'https://github.com/example/apps.git' },
+        deployedAt: '2025-01-01T00:00:00Z',
+      })
+    ).rejects.toThrow(/Application changed/);
   });
 
   it('refreshApplication sends a merge-patch with the refresh annotation', async () => {

--- a/argocd/src/api/argoClient.ts
+++ b/argocd/src/api/argoClient.ts
@@ -15,7 +15,7 @@
  */
 
 import { ApiProxy } from '@kinvolk/headlamp-plugin/lib';
-import { argocdApiVersion } from '../resources/application';
+import { argocdApiVersion, type RevisionHistory, type SourceSpec } from '../resources/application';
 
 const request = ApiProxy.request;
 
@@ -36,6 +36,27 @@ function applicationPath(name: string, namespace: string): string {
   return `${APPLICATIONS_API_ROOT}/namespaces/${namespace}/applications/${name}`;
 }
 
+function applicationApiError(err: unknown, namespace: string): Error {
+  const errObj = typeof err === 'object' && err !== null ? (err as Record<string, unknown>) : {};
+  const status = errObj.status ?? errObj.statusCode;
+  const message =
+    err instanceof Error ? err.message : errObj.message ? String(errObj.message) : String(err);
+
+  // Prefer the structured status code; only fall back to message matching
+  // when the error has no status property, to avoid false positives.
+  const isForbidden = status === 403 || (status === undefined && message.includes('403'));
+
+  if (isForbidden) {
+    return new Error(
+      `Permission denied: your Kubernetes RBAC role does not allow patching Application ` +
+        `resources in the "${namespace}" namespace. ` +
+        'Ask your cluster admin to grant you patch access to applications.argoproj.io.'
+    );
+  }
+
+  return err instanceof Error ? err : new Error(message);
+}
+
 /**
  * Sends a JSON merge-patch to an Application custom resource via the Kubernetes API.
  *
@@ -54,24 +75,69 @@ async function mergePatchApplication(name: string, namespace: string, patch: obj
       body: JSON.stringify(patch),
     });
   } catch (err: unknown) {
+    throw applicationApiError(err, namespace);
+  }
+}
+
+/** Writes a sync operation without changing the Application's desired-state spec. */
+function triggerSyncOperation(name: string, namespace: string, sync: Record<string, unknown>) {
+  return mergePatchApplication(name, namespace, {
+    operation: {
+      initiatedBy: { username: 'headlamp' },
+      sync,
+    },
+  });
+}
+
+type ApplicationOperationState = {
+  metadata?: { resourceVersion?: string };
+  operation?: unknown;
+};
+
+/**
+ * Replaces the Application operation only when the version read was still current.
+ *
+ * A JSON Patch `test` makes the check and write one Kubernetes API operation. This prevents a
+ * rollback from combining with an operation started by another actor between the detail view
+ * rendering and this request.
+ */
+async function replaceOperationIfIdle(
+  name: string,
+  namespace: string,
+  operation: Record<string, unknown>
+) {
+  const path = applicationPath(name, namespace);
+  let application: ApplicationOperationState;
+  try {
+    application = (await request(path)) as ApplicationOperationState;
+  } catch (err: unknown) {
+    throw applicationApiError(err, namespace);
+  }
+  const resourceVersion = application?.metadata?.resourceVersion;
+
+  if (!resourceVersion) {
+    throw new Error('Cannot rollback: the Application did not provide a resource version.');
+  }
+  if (application.operation !== undefined && application.operation !== null) {
+    throw new Error('Cannot rollback: an Argo CD operation is already in progress.');
+  }
+
+  try {
+    return await request(path, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json-patch+json' },
+      body: JSON.stringify([
+        { op: 'test', path: '/metadata/resourceVersion', value: resourceVersion },
+        { op: 'add', path: '/operation', value: operation },
+      ]),
+    });
+  } catch (err: unknown) {
     const errObj = typeof err === 'object' && err !== null ? (err as Record<string, unknown>) : {};
     const status = errObj.status ?? errObj.statusCode;
-    const message =
-      err instanceof Error ? err.message : errObj.message ? String(errObj.message) : String(err);
-
-    // Prefer the structured status code; only fall back to message matching
-    // when the error has no status property, to avoid false positives.
-    const isForbidden = status === 403 || (status === undefined && message.includes('403'));
-
-    if (isForbidden) {
-      throw new Error(
-        `Permission denied: your Kubernetes RBAC role does not allow patching Application ` +
-          `resources in the "${namespace}" namespace. ` +
-          'Ask your cluster admin to grant you patch access to applications.argoproj.io.'
-      );
+    if (status === 409) {
+      throw new Error('Cannot rollback: the Application changed. Refresh it and try again.');
     }
-
-    throw err instanceof Error ? err : new Error(message);
+    throw applicationApiError(err, namespace);
   }
 }
 
@@ -91,14 +157,63 @@ async function mergePatchApplication(name: string, namespace: string, patch: obj
  *   controller resolves the app's configured `targetRevision`.
  */
 export function syncApplication(name: string, namespace: string, revision?: string) {
-  const sync: Record<string, string> = {};
+  const sync: Record<string, unknown> = {};
   if (revision !== undefined) {
     sync.revision = revision;
   }
-  return mergePatchApplication(name, namespace, {
-    operation: {
-      initiatedBy: { username: 'headlamp' },
-      sync,
+  return triggerSyncOperation(name, namespace, sync);
+}
+
+function getRollbackSources(entry: RevisionHistory): {
+  revision?: string;
+  revisions?: string[];
+  source?: SourceSpec;
+  sources?: SourceSpec[];
+} {
+  if (entry.revisions?.length || entry.sources?.length) {
+    if (
+      !entry.revisions?.length ||
+      !entry.sources?.length ||
+      entry.revisions.length !== entry.sources.length
+    ) {
+      throw new Error('Cannot rollback: the selected multi-source history entry is incomplete.');
+    }
+
+    return { revisions: entry.revisions, sources: entry.sources };
+  }
+
+  if (!entry.revision || !entry.source) {
+    throw new Error('Cannot rollback: the selected history entry is incomplete.');
+  }
+
+  return { revision: entry.revision, source: entry.source };
+}
+
+/**
+ * Triggers a rollback using the revision and source snapshot stored in Application history.
+ *
+ * Argo CD implements rollback as a sync operation with historical source overrides. These
+ * overrides are scoped to the operation and never change `spec.source` or `spec.sources`.
+ *
+ * @param name - The Application resource name.
+ * @param namespace - The namespace where the Application lives.
+ * @param entry - A complete earlier deployment from `status.history`.
+ * @param syncOptions - The Application's configured per-sync options.
+ */
+export async function rollbackApplication(
+  name: string,
+  namespace: string,
+  entry: RevisionHistory,
+  syncOptions: string[] = []
+) {
+  return await replaceOperationIfIdle(name, namespace, {
+    initiatedBy: { username: 'headlamp' },
+    sync: {
+      ...getRollbackSources(entry),
+      dryRun: false,
+      prune: false,
+      syncOptions,
+      syncStrategy: { apply: {} },
     },
   });
 }

--- a/argocd/src/components/applications/Detail.test.tsx
+++ b/argocd/src/components/applications/Detail.test.tsx
@@ -16,17 +16,28 @@
 
 import { cleanup, render, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { application } = vi.hoisted(() => ({
+  application: {
+    metadata: { name: 'guestbook', namespace: 'argocd' },
+    isAutomatedSyncEnabled: false,
+    rollbackHistory: [{ id: 1 }],
+    hasActiveOperation: false,
+  },
+}));
 
 vi.mock('@kinvolk/headlamp-plugin/lib/CommonComponents', () => ({
   ActionButton: ({ description }: { description: string }) => <button>{description}</button>,
-  AuthVisible: ({ children }: { children: ReactNode }) => children,
+  AuthVisible: ({ children, authVerb }: { children: ReactNode; authVerb: string }) => (
+    <div data-auth-verb={authVerb}>{children}</div>
+  ),
   DateLabel: () => null,
   DetailsGrid: (props: {
     actions: (application: unknown) => Array<{ id: string; action: ReactNode }>;
   }) => (
     <div>
-      {props.actions({ metadata: { name: 'guestbook', namespace: 'argocd' } }).map(entry => (
+      {props.actions(application).map(entry => (
         <div data-testid={entry.id} key={entry.id}>
           {entry.action}
         </div>
@@ -45,6 +56,7 @@ vi.mock('@kinvolk/headlamp-plugin/lib/components/common', () => ({
 
 vi.mock('../../api/argoClient', () => ({
   refreshApplication: vi.fn(),
+  rollbackApplication: vi.fn(),
   syncApplication: vi.fn(),
 }));
 
@@ -56,12 +68,25 @@ vi.mock('../../resources/application', () => ({
   ArgoApplication: class ArgoApplication {},
 }));
 
+vi.mock('./apiAvailability', () => ({
+  canOpenManagedResourcesInCurrentCluster: () => true,
+  getApiAvailabilityPresentation: () => ({ label: 'Available', status: 'success', tooltip: '' }),
+  managedResourceApiKey: () => 'resource',
+  useManagedResourceApiAvailability: () => ({ availability: new Map(), loading: false }),
+}));
+
 vi.mock('./managedResourceLinks', () => ({
   getManagedResourceLink: vi.fn(),
 }));
 
 vi.mock('./openInArgoCD', () => ({
   OpenInArgoCDAction: () => <button>Open in Argo CD</button>,
+}));
+
+vi.mock('./rollback', () => ({
+  RollbackAction: ({ disabled }: { disabled: boolean }) => (
+    <button disabled={disabled}>Rollback</button>
+  ),
 }));
 
 vi.mock('./statusHelpers', () => ({
@@ -79,15 +104,49 @@ import ApplicationDetail from './Detail';
 
 afterEach(cleanup);
 
+beforeEach(() => {
+  application.isAutomatedSyncEnabled = false;
+  application.rollbackHistory = [{ id: 1 }];
+  application.hasActiveOperation = false;
+});
+
 describe('ApplicationDetail actions', () => {
-  it('keeps Sync and Refresh alongside the Open in Argo CD action', () => {
+  it('keeps Sync, Refresh, and Open in Argo CD alongside the RBAC-protected Rollback action', () => {
     render(<ApplicationDetail />);
 
     expect(screen.getByTestId('argocd-sync')).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Sync' })).toBeTruthy();
     expect(screen.getByTestId('argocd-refresh')).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Refresh' })).toBeTruthy();
+    expect(screen.getByTestId('argocd-rollback')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Rollback' })).toBeTruthy();
+    expect(
+      screen.getByRole('button', { name: 'Rollback' }).parentElement?.getAttribute('data-auth-verb')
+    ).toBe('patch');
     expect(screen.getByTestId('argocd-open-external')).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Open in Argo CD' })).toBeTruthy();
+  });
+
+  it('hides Rollback when history has no usable earlier deployment', () => {
+    application.rollbackHistory = [];
+    render(<ApplicationDetail />);
+
+    expect(screen.queryByTestId('argocd-rollback')).toBeNull();
+  });
+
+  it('hides Rollback while automated sync is enabled', () => {
+    application.isAutomatedSyncEnabled = true;
+    render(<ApplicationDetail />);
+
+    expect(screen.queryByTestId('argocd-rollback')).toBeNull();
+  });
+
+  it('disables Rollback when Argo CD already has an active operation', () => {
+    application.hasActiveOperation = true;
+    render(<ApplicationDetail />);
+
+    expect((screen.getByRole('button', { name: 'Rollback' }) as HTMLButtonElement).disabled).toBe(
+      true
+    );
   });
 });

--- a/argocd/src/components/applications/Detail.tsx
+++ b/argocd/src/components/applications/Detail.tsx
@@ -30,9 +30,14 @@ import { Alert, Box, Link as MuiLink, Tooltip, Typography } from '@mui/material'
 import type { Theme } from '@mui/material/styles';
 import type { ComponentProps, ReactNode } from 'react';
 import { useParams } from 'react-router-dom';
-import { refreshApplication, syncApplication } from '../../api/argoClient';
+import { refreshApplication, rollbackApplication, syncApplication } from '../../api/argoClient';
 import { useArgoOperation } from '../../hooks/useArgoOperation';
-import { ArgoApplication, ManagedResource, RevisionHistory } from '../../resources/application';
+import {
+  ArgoApplication,
+  compareRevisionHistory,
+  ManagedResource,
+  RevisionHistory,
+} from '../../resources/application';
 import {
   ApiAvailability,
   canOpenManagedResourcesInCurrentCluster,
@@ -42,6 +47,7 @@ import {
 } from './apiAvailability';
 import { getManagedResourceLink } from './managedResourceLinks';
 import { OpenInArgoCDAction } from './openInArgoCD';
+import { RollbackAction } from './rollback';
 import { getHealthIcon, getHealthStatus, getSyncIcon, getSyncStatus } from './statusHelpers';
 
 type HeadlampStatus = ComponentProps<typeof StatusLabel>['status'];
@@ -65,7 +71,8 @@ export default function ApplicationDetail(props: { namespace?: string; name?: st
   const { namespace = params.namespace, name = params.name } = props;
   const sync = useArgoOperation(syncApplication, 'Sync');
   const refresh = useArgoOperation(refreshApplication, 'Refresh');
-  const anyLoading = sync.isLoading || refresh.isLoading;
+  const rollback = useArgoOperation(rollbackApplication, 'Rollback');
+  const anyLoading = sync.isLoading || refresh.isLoading || rollback.isLoading;
 
   return (
     <DetailsGrid
@@ -102,6 +109,22 @@ export default function ApplicationDetail(props: { namespace?: string; name?: st
                   </AuthVisible>
                 ),
               },
+              ...(!app.isAutomatedSyncEnabled && app.rollbackHistory.length
+                ? [
+                    {
+                      id: 'argocd-rollback',
+                      action: (
+                        <AuthVisible item={app} authVerb="patch">
+                          <RollbackAction
+                            application={app}
+                            operation={rollback}
+                            disabled={anyLoading || app.hasActiveOperation}
+                          />
+                        </AuthVisible>
+                      ),
+                    },
+                  ]
+                : []),
               {
                 id: 'argocd-open-external',
                 action: <OpenInArgoCDAction application={app} />,
@@ -570,7 +593,7 @@ function getManagedResourceKindIcon(kind: string) {
 }
 
 function getSyncHistorySection(app: ArgoApplication) {
-  const history = [...app.syncHistory].sort(compareHistoryEntries);
+  const history = [...app.syncHistory].sort(compareRevisionHistory);
 
   return {
     id: 'sync-history',
@@ -630,17 +653,6 @@ function getSyncHistorySection(app: ArgoApplication) {
       </SectionBox>
     ),
   };
-}
-
-function compareHistoryEntries(first: RevisionHistory, second: RevisionHistory) {
-  const firstTime = Date.parse(first.deployedAt || first.deployStartedAt || '') || 0;
-  const secondTime = Date.parse(second.deployedAt || second.deployStartedAt || '') || 0;
-
-  if (firstTime !== secondTime) {
-    return secondTime - firstTime;
-  }
-
-  return (second.id ?? 0) - (first.id ?? 0);
 }
 
 function RevisionLabel(props: { entry: RevisionHistory }) {

--- a/argocd/src/components/applications/rollback.test.tsx
+++ b/argocd/src/components/applications/rollback.test.tsx
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@kinvolk/headlamp-plugin/lib/CommonComponents', () => ({
+  ActionButton: (props: {
+    description: string;
+    longDescription?: string;
+    icon: string;
+    onClick: () => void;
+    iconButtonProps?: { disabled?: boolean };
+  }) => (
+    <button
+      aria-label={props.description}
+      data-icon={props.icon}
+      data-long-description={props.longDescription}
+      disabled={props.iconButtonProps?.disabled}
+      onClick={props.onClick}
+    />
+  ),
+  Dialog: (props: { open: boolean; title: string; children: ReactNode }) =>
+    props.open ? (
+      <div role="dialog" aria-label={props.title}>
+        {props.children}
+      </div>
+    ) : null,
+}));
+
+import type { ArgoApplication, RevisionHistory } from '../../resources/application';
+import { RollbackAction, type RollbackOperationController } from './rollback';
+
+const source = { repoURL: 'https://github.com/example/apps.git', path: 'guestbook' };
+const previous: RevisionHistory = {
+  id: 4,
+  revision: '0123456789abcdef0123456789abcdef01234567',
+  source,
+  deployedAt: '2025-01-02T03:04:05Z',
+};
+
+function application(entries: RevisionHistory[] = [previous]) {
+  return {
+    metadata: { name: 'guestbook', namespace: 'argocd' },
+    rollbackHistory: entries,
+    syncPolicy: { syncOptions: ['CreateNamespace=true'] },
+  } as ArgoApplication;
+}
+
+function controller(options?: { succeeds?: boolean; isLoading?: boolean }) {
+  return {
+    execute: vi.fn().mockResolvedValue(options?.succeeds ?? true),
+    isLoading: options?.isLoading ?? false,
+  } satisfies RollbackOperationController;
+}
+
+afterEach(cleanup);
+
+describe('RollbackAction', () => {
+  it('opens with no preselected deployment and shows the full revision and deployment time', () => {
+    const operation = controller();
+    render(<RollbackAction application={application()} operation={operation} />);
+
+    const action = screen.getByRole('button', { name: 'Rollback' });
+    expect(action.getAttribute('data-icon')).toBe('mdi:backup-restore');
+    expect(action.getAttribute('data-long-description')).toMatch(/without changing/i);
+    fireEvent.click(action);
+
+    expect(screen.getByRole('dialog', { name: 'Rollback Application' })).toBeTruthy();
+    expect(screen.getByText(previous.revision as string)).toBeTruthy();
+    expect(screen.getByText(/Source: guestbook/)).toBeTruthy();
+    expect(screen.getAllByTitle(previous.deployedAt as string).length).toBeGreaterThan(0);
+    expect((screen.getByRole('radio') as HTMLInputElement).checked).toBe(false);
+    expect(
+      (screen.getAllByRole('button', { name: 'Rollback' })[1] as HTMLButtonElement).disabled
+    ).toBe(true);
+  });
+
+  it('cancels without sending a rollback request', () => {
+    const operation = controller();
+    render(<RollbackAction application={application()} operation={operation} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Rollback' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(operation.execute).not.toHaveBeenCalled();
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('confirms the selected single-source history entry and closes on success', async () => {
+    const operation = controller();
+    render(<RollbackAction application={application()} operation={operation} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Rollback' }));
+    fireEvent.click(screen.getByRole('radio'));
+    expect(screen.getByLabelText('Selected deployment').textContent).toContain('History ID 4');
+    fireEvent.click(screen.getAllByRole('button', { name: 'Rollback' })[1]);
+
+    await waitFor(() =>
+      expect(operation.execute).toHaveBeenCalledWith('guestbook', 'argocd', previous, [
+        'CreateNamespace=true',
+      ])
+    );
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull());
+  });
+
+  it('keeps the dialog open when the request fails', async () => {
+    const operation = controller({ succeeds: false });
+    render(<RollbackAction application={application()} operation={operation} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Rollback' }));
+    fireEvent.click(screen.getByRole('radio'));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Rollback' })[1]);
+
+    await waitFor(() => expect(operation.execute).toHaveBeenCalledOnce());
+    expect(screen.getByRole('dialog')).toBeTruthy();
+  });
+
+  it('shows every aligned revision for a multi-source deployment', () => {
+    const multiSource: RevisionHistory = {
+      id: 2,
+      revisions: ['app-revision', 'values-revision'],
+      sources: [source, { repoURL: 'https://github.com/example/values.git', ref: 'values' }],
+      deployedAt: '2025-01-01T00:00:00Z',
+    };
+    render(<RollbackAction application={application([multiSource])} operation={controller()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Rollback' }));
+    expect(screen.getByText('app-revision')).toBeTruthy();
+    expect(screen.getByText('values-revision')).toBeTruthy();
+    expect(screen.getByText(/Source 2.*values\.git/)).toBeTruthy();
+  });
+
+  it('disables the action and submission while another operation is active', () => {
+    const operation = controller({ isLoading: true });
+    const { rerender } = render(
+      <RollbackAction application={application()} operation={operation} disabled />
+    );
+
+    expect(
+      (screen.getByRole('button', { name: 'Rolling back...' }) as HTMLButtonElement).disabled
+    ).toBe(true);
+
+    rerender(<RollbackAction application={application()} operation={controller()} disabled />);
+    expect((screen.getByRole('button', { name: 'Rollback' }) as HTMLButtonElement).disabled).toBe(
+      true
+    );
+  });
+});

--- a/argocd/src/components/applications/rollback.tsx
+++ b/argocd/src/components/applications/rollback.tsx
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ActionButton, Dialog } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import {
+  Alert,
+  Box,
+  Button,
+  DialogActions,
+  DialogContent,
+  FormControlLabel,
+  Radio,
+  RadioGroup,
+  Typography,
+} from '@mui/material';
+import { useState } from 'react';
+import type { ArgoApplication, RevisionHistory, SourceSpec } from '../../resources/application';
+
+export interface RollbackOperationController {
+  execute: (
+    name: string,
+    namespace: string,
+    entry: RevisionHistory,
+    syncOptions?: string[]
+  ) => Promise<boolean>;
+  isLoading: boolean;
+}
+
+function sourceLabel(source: SourceSpec | undefined): string {
+  if (!source) return 'Unknown source';
+  return source.path || source.chart || source.repoURL;
+}
+
+function RevisionDetails(props: { entry: RevisionHistory }) {
+  const { entry } = props;
+  const revisions = entry.revisions ?? (entry.revision ? [entry.revision] : []);
+  const sources = entry.sources ?? (entry.source ? [entry.source] : []);
+
+  return (
+    <Box sx={{ display: 'grid', gap: 0.5, minWidth: 0 }}>
+      {revisions.map((revision, index) => (
+        <Box key={`${entry.id}-${index}`} sx={{ minWidth: 0 }}>
+          <Typography variant="caption" color="text.secondary" display="block">
+            {revisions.length > 1 ? `Source ${index + 1}` : 'Source'}: {sourceLabel(sources[index])}
+          </Typography>
+          <Typography
+            component="div"
+            variant="body2"
+            sx={{ fontFamily: 'monospace', overflowWrap: 'anywhere' }}
+          >
+            {revision}
+          </Typography>
+        </Box>
+      ))}
+    </Box>
+  );
+}
+
+function DeploymentTime(props: { value: string }) {
+  const formatted = new Date(props.value).toLocaleString();
+
+  return (
+    <time dateTime={props.value} title={props.value}>
+      {formatted}
+    </time>
+  );
+}
+
+/** Renders a deliberate rollback selector for complete earlier Application deployments. */
+export function RollbackAction(props: {
+  application: ArgoApplication;
+  operation: RollbackOperationController;
+  disabled?: boolean;
+}) {
+  const { application, operation, disabled = false } = props;
+  const [open, setOpen] = useState(false);
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+  const candidates = application.rollbackHistory;
+  const selectedEntry = candidates.find(entry => entry.id === selectedId);
+  const isBlocked = disabled || operation.isLoading;
+
+  const closeDialog = () => {
+    if (operation.isLoading) return;
+    setOpen(false);
+    setSelectedId(null);
+  };
+
+  const confirmRollback = async () => {
+    if (!selectedEntry || isBlocked) return;
+
+    const succeeded = await operation.execute(
+      application.metadata.name,
+      application.metadata.namespace,
+      selectedEntry,
+      application.syncPolicy?.syncOptions ?? []
+    );
+    if (succeeded) {
+      setOpen(false);
+      setSelectedId(null);
+    }
+  };
+
+  return (
+    <>
+      <ActionButton
+        description={operation.isLoading ? 'Rolling back...' : 'Rollback'}
+        longDescription="Deploy an earlier revision from Argo CD Sync History without changing the Application's configured Git revision."
+        icon={operation.isLoading ? 'mdi:loading' : 'mdi:backup-restore'}
+        onClick={() => setOpen(true)}
+        iconButtonProps={{ disabled: isBlocked }}
+      />
+      <Dialog open={open} onClose={closeDialog} title="Rollback Application">
+        <DialogContent dividers>
+          <Typography sx={{ mb: 2 }}>
+            Select an earlier successful deployment for {application.metadata.name}. No option is
+            selected automatically.
+          </Typography>
+          <RadioGroup
+            aria-label="Rollback revision"
+            value={selectedId === null ? '' : String(selectedId)}
+            onChange={event => setSelectedId(Number(event.target.value))}
+          >
+            {candidates.map(entry => (
+              <Box
+                key={entry.id}
+                sx={{
+                  border: theme => `1px solid ${theme.palette.divider}`,
+                  borderRadius: 1,
+                  mb: 1,
+                }}
+              >
+                <FormControlLabel
+                  value={String(entry.id)}
+                  control={<Radio />}
+                  disabled={operation.isLoading}
+                  sx={{ alignItems: 'flex-start', m: 0, p: 1.25, width: '100%' }}
+                  label={
+                    <Box sx={{ display: 'grid', gap: 0.5, pt: 0.25 }}>
+                      <Typography variant="subtitle2">History ID {entry.id}</Typography>
+                      <RevisionDetails entry={entry} />
+                      <Typography variant="caption" color="text.secondary">
+                        Deployed <DeploymentTime value={entry.deployedAt as string} />
+                      </Typography>
+                    </Box>
+                  }
+                />
+              </Box>
+            ))}
+          </RadioGroup>
+
+          {selectedEntry && (
+            <Box
+              aria-label="Selected deployment"
+              sx={{
+                border: theme => `1px solid ${theme.palette.divider}`,
+                borderRadius: 1,
+                p: 1.5,
+                mt: 2,
+              }}
+            >
+              <Typography variant="subtitle2" sx={{ mb: 0.75 }}>
+                Selected deployment · History ID {selectedEntry.id}
+              </Typography>
+              <RevisionDetails entry={selectedEntry} />
+              <Typography variant="body2" color="text.secondary" sx={{ mt: 0.75 }}>
+                Deployed <DeploymentTime value={selectedEntry.deployedAt as string} />
+              </Typography>
+            </Box>
+          )}
+
+          <Alert
+            severity="warning"
+            sx={theme => ({
+              mt: 2,
+              color: theme.palette.text.primary,
+              '& .MuiAlert-icon': { color: theme.palette.warning.main },
+              '& .MuiAlert-message': { color: theme.palette.text.primary },
+            })}
+          >
+            This deploys the selected historical content as a one-time operation. It does not change
+            spec.source.targetRevision or spec.sources, so Git remains the source of truth.
+          </Alert>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={closeDialog} disabled={operation.isLoading}>
+            Cancel
+          </Button>
+          <Button
+            color="warning"
+            variant="contained"
+            onClick={confirmRollback}
+            disabled={!selectedEntry || isBlocked}
+          >
+            {operation.isLoading ? 'Rolling back...' : 'Rollback'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+}

--- a/argocd/src/hooks/useArgoOperation.test.tsx
+++ b/argocd/src/hooks/useArgoOperation.test.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { enqueueSnackbar } = vi.hoisted(() => ({ enqueueSnackbar: vi.fn() }));
+
+vi.mock('notistack', () => ({
+  useSnackbar: () => ({ enqueueSnackbar }),
+}));
+
+import { useArgoOperation } from './useArgoOperation';
+
+beforeEach(() => enqueueSnackbar.mockReset());
+
+describe('useArgoOperation', () => {
+  it('returns true and forwards operation-specific arguments after success', async () => {
+    const operation = vi.fn().mockResolvedValue({});
+    const { result } = renderHook(() => useArgoOperation(operation, 'Rollback'));
+
+    let succeeded = false;
+    await act(async () => {
+      succeeded = await result.current.execute('guestbook', 'argocd', 'revision-1');
+    });
+
+    expect(succeeded).toBe(true);
+    expect(operation).toHaveBeenCalledWith('guestbook', 'argocd', 'revision-1');
+    expect(enqueueSnackbar).toHaveBeenCalledWith('Rollback triggered for guestbook', {
+      variant: 'success',
+    });
+  });
+
+  it('returns false and keeps existing error feedback after failure', async () => {
+    const operation = vi.fn().mockRejectedValue(new Error('controller rejected operation'));
+    const { result } = renderHook(() => useArgoOperation(operation, 'Rollback'));
+
+    let succeeded = true;
+    await act(async () => {
+      succeeded = await result.current.execute('guestbook', 'argocd');
+    });
+
+    expect(succeeded).toBe(false);
+    expect(enqueueSnackbar).toHaveBeenCalledWith(
+      'Failed to rollback guestbook: controller rejected operation',
+      { variant: 'error' }
+    );
+  });
+});

--- a/argocd/src/hooks/useArgoOperation.ts
+++ b/argocd/src/hooks/useArgoOperation.ts
@@ -17,7 +17,11 @@
 import { useSnackbar } from 'notistack';
 import { useCallback, useRef, useState } from 'react';
 
-type OperationFn = (name: string, namespace: string) => Promise<unknown>;
+type OperationFn<Args extends unknown[] = []> = (
+  name: string,
+  namespace: string,
+  ...args: Args
+) => Promise<unknown>;
 
 function getErrorMessage(error: unknown): string {
   if (error instanceof Error) return error.message;
@@ -32,25 +36,30 @@ function getErrorMessage(error: unknown): string {
  * Hook for a single Argo CD operation with loading state and snackbar feedback.
  * Used by the Application detail view where one operation runs at a time.
  */
-export function useArgoOperation(operationFn: OperationFn, operationLabel: string) {
+export function useArgoOperation<Args extends unknown[]>(
+  operationFn: OperationFn<Args>,
+  operationLabel: string
+) {
   const { enqueueSnackbar } = useSnackbar();
   const [isLoading, setIsLoading] = useState(false);
   const inFlightRef = useRef(false);
 
   const execute = useCallback(
-    async (name: string, namespace: string) => {
-      if (isLoading) return;
-      if (inFlightRef.current) return;
+    async (name: string, namespace: string, ...args: Args): Promise<boolean> => {
+      if (isLoading) return false;
+      if (inFlightRef.current) return false;
       inFlightRef.current = true;
       setIsLoading(true);
       try {
-        await operationFn(name, namespace);
+        await operationFn(name, namespace, ...args);
         enqueueSnackbar(`${operationLabel} triggered for ${name}`, { variant: 'success' });
+        return true;
       } catch (error) {
         enqueueSnackbar(
           `Failed to ${operationLabel.toLowerCase()} ${name}: ${getErrorMessage(error)}`,
           { variant: 'error' }
         );
+        return false;
       } finally {
         inFlightRef.current = false;
         setIsLoading(false);

--- a/argocd/src/resources/application.test.ts
+++ b/argocd/src/resources/application.test.ts
@@ -32,7 +32,13 @@ vi.mock('@kinvolk/headlamp-plugin/lib', () => ({
   },
 }));
 
-import { ArgoApplication, type KubeArgoApplication } from './application';
+import {
+  ArgoApplication,
+  getRollbackHistoryEntries,
+  isAutomatedSyncEnabled,
+  type KubeArgoApplication,
+  type RevisionHistory,
+} from './application';
 
 function createApplication(controllerNamespace?: string) {
   return new ArgoApplication({
@@ -59,5 +65,181 @@ describe('ArgoApplication controllerNamespace', () => {
 
   it('returns undefined when Argo CD has not reported a controller namespace', () => {
     expect(createApplication().controllerNamespace).toBeUndefined();
+  });
+});
+
+const source = {
+  repoURL: 'https://github.com/example/apps.git',
+  targetRevision: 'main',
+  path: 'guestbook',
+};
+
+function historyEntry(
+  id: number,
+  deployedAt: string,
+  revision: string,
+  overrides: Partial<RevisionHistory> = {}
+): RevisionHistory {
+  return { id, deployedAt, revision, source, ...overrides };
+}
+
+describe('isAutomatedSyncEnabled', () => {
+  const spec = (automated?: { enabled?: boolean | null }) => ({
+    project: 'default',
+    destination: {},
+    syncPolicy: automated === undefined ? undefined : { automated },
+  });
+
+  it.each([
+    [{}, true],
+    [{ enabled: true }, true],
+    [{ enabled: null }, true],
+    [{ enabled: false }, false],
+  ])('maps automated policy %j to %s', (automated, expected) => {
+    expect(isAutomatedSyncEnabled(spec(automated))).toBe(expected);
+  });
+
+  it('treats a missing automated policy as manual sync', () => {
+    expect(isAutomatedSyncEnabled(spec())).toBe(false);
+  });
+});
+
+describe('getRollbackHistoryEntries', () => {
+  it('sorts newest first and excludes the current deployment', () => {
+    const entries = [
+      historyEntry(1, '2025-01-01T00:00:00Z', 'oldest'),
+      historyEntry(3, '2025-03-01T00:00:00Z', 'current'),
+      historyEntry(2, '2025-02-01T00:00:00Z', 'previous'),
+    ];
+
+    expect(getRollbackHistoryEntries(entries).map(entry => entry.id)).toEqual([2, 1]);
+  });
+
+  it('rejects incomplete and legacy single-source entries', () => {
+    const current = historyEntry(5, '2025-05-01T00:00:00Z', 'current');
+    const entries = [
+      current,
+      historyEntry(4, '2025-04-01T00:00:00Z', '', {}),
+      historyEntry(3, '2025-03-01T00:00:00Z', 'missing-source', { source: undefined }),
+      historyEntry(2, '', 'missing-time'),
+      historyEntry(1, 'not-a-date', 'invalid-time'),
+    ];
+
+    expect(getRollbackHistoryEntries(entries)).toEqual([]);
+  });
+
+  it('keeps complete multi-source snapshots with aligned revisions', () => {
+    const sources = [source, { ...source, repoURL: 'https://github.com/example/values.git' }];
+    const current = historyEntry(3, '2025-03-01T00:00:00Z', '', {
+      revision: undefined,
+      revisions: ['current-app', 'current-values'],
+      source: undefined,
+      sources,
+    });
+    const previous = historyEntry(2, '2025-02-01T00:00:00Z', '', {
+      revision: undefined,
+      revisions: ['previous-app', 'previous-values'],
+      source: undefined,
+      sources,
+    });
+
+    expect(getRollbackHistoryEntries([previous, current])).toEqual([previous]);
+  });
+
+  it('accepts a complete one-item sources snapshot', () => {
+    const pluralSource = [{ ...source }];
+    const current = historyEntry(3, '2025-03-01T00:00:00Z', '', {
+      revision: undefined,
+      revisions: ['current'],
+      source: undefined,
+      sources: pluralSource,
+    });
+    const previous = historyEntry(2, '2025-02-01T00:00:00Z', '', {
+      revision: undefined,
+      revisions: ['previous'],
+      source: undefined,
+      sources: pluralSource,
+    });
+
+    expect(getRollbackHistoryEntries([previous, current])).toEqual([previous]);
+  });
+
+  it('uses each historical source shape instead of the current Application source count', () => {
+    const currentSources = [
+      source,
+      { ...source, repoURL: 'https://github.com/example/values.git' },
+    ];
+    const current = historyEntry(3, '2025-03-01T00:00:00Z', '', {
+      revision: undefined,
+      revisions: ['current-app', 'current-values'],
+      source: undefined,
+      sources: currentSources,
+    });
+    const previous = historyEntry(2, '2025-02-01T00:00:00Z', 'previous', {
+      source,
+    });
+
+    expect(getRollbackHistoryEntries([previous, current])).toEqual([previous]);
+  });
+
+  it('rejects multi-source entries with missing or mismatched data', () => {
+    const sources = [source, { ...source, repoURL: 'https://github.com/example/values.git' }];
+    const current = historyEntry(4, '2025-04-01T00:00:00Z', '', {
+      revision: undefined,
+      revisions: ['current-app', 'current-values'],
+      source: undefined,
+      sources,
+    });
+    const mismatched = historyEntry(3, '2025-03-01T00:00:00Z', '', {
+      revision: undefined,
+      revisions: ['only-one'],
+      source: undefined,
+      sources,
+    });
+    const missingSource = historyEntry(2, '2025-02-01T00:00:00Z', '', {
+      revision: undefined,
+      revisions: ['app', 'values'],
+      source: undefined,
+      sources: [source],
+    });
+
+    expect(getRollbackHistoryEntries([current, mismatched, missingSource])).toEqual([]);
+  });
+
+  it('deduplicates history IDs while preserving the newest record', () => {
+    const current = historyEntry(3, '2025-03-01T00:00:00Z', 'current');
+    const newestDuplicate = historyEntry(2, '2025-02-02T00:00:00Z', 'newer-duplicate');
+    const olderDuplicate = historyEntry(2, '2025-02-01T00:00:00Z', 'older-duplicate');
+
+    expect(
+      getRollbackHistoryEntries([olderDuplicate, current, newestDuplicate]).map(
+        entry => entry.revision
+      )
+    ).toEqual(['newer-duplicate']);
+  });
+
+  it('exposes rollback and operation state through ArgoApplication getters', () => {
+    const app = new ArgoApplication({
+      apiVersion: 'argoproj.io/v1alpha1',
+      kind: 'Application',
+      metadata: { name: 'guestbook', namespace: 'argocd', uid: 'guestbook-uid' },
+      spec: {
+        project: 'default',
+        source,
+        destination: {},
+        syncPolicy: { automated: { enabled: false } },
+      },
+      operation: { sync: {} },
+      status: {
+        history: [
+          historyEntry(2, '2025-02-01T00:00:00Z', 'current'),
+          historyEntry(1, '2025-01-01T00:00:00Z', 'previous'),
+        ],
+      },
+    } as KubeArgoApplication);
+
+    expect(app.isAutomatedSyncEnabled).toBe(false);
+    expect(app.hasActiveOperation).toBe(true);
+    expect(app.rollbackHistory.map(entry => entry.revision)).toEqual(['previous']);
   });
 });

--- a/argocd/src/resources/application.ts
+++ b/argocd/src/resources/application.ts
@@ -36,6 +36,8 @@ export interface SourceSpec {
   targetRevision?: string;
   path?: string;
   chart?: string;
+  /** Preserve source-specific Helm, Kustomize, directory, and plugin settings from history. */
+  [key: string]: unknown;
 }
 
 /**
@@ -133,6 +135,10 @@ export interface ArgoApplicationStatus {
   sync?: {
     /** The sync status string (e.g., "Synced", "OutOfSync"). */
     status: string;
+    /** Resolved revision for a single-source Application. */
+    revision?: string;
+    /** Resolved revisions, ordered to match spec.sources, for a multi-source Application. */
+    revisions?: string[];
   };
   /** Kubernetes resources managed by this Application. */
   resources?: ManagedResource[];
@@ -150,8 +156,80 @@ export interface ArgoApplicationStatus {
 export interface KubeArgoApplication extends KubeObjectInterface {
   /** The desired state of the Argo CD Application. */
   spec: ArgoApplicationSpec;
+  /** A pending or running operation. Argo CD removes this after it is processed. */
+  operation?: {
+    sync?: Record<string, unknown>;
+    [key: string]: unknown;
+  };
   /** The observed runtime state of the Argo CD Application, populated by the controller. */
   status?: ArgoApplicationStatus;
+}
+
+/** Sorts deployment history from newest to oldest, using the history ID as a stable fallback. */
+export function compareRevisionHistory(first: RevisionHistory, second: RevisionHistory): number {
+  const firstTime = Date.parse(first.deployedAt || first.deployStartedAt || '') || 0;
+  const secondTime = Date.parse(second.deployedAt || second.deployStartedAt || '') || 0;
+
+  if (firstTime !== secondTime) {
+    return secondTime - firstTime;
+  }
+
+  return (second.id ?? -1) - (first.id ?? -1);
+}
+
+/**
+ * Returns whether Argo CD automated sync is effectively enabled.
+ *
+ * Argo CD treats an `automated` object as enabled unless `enabled` is explicitly false.
+ */
+export function isAutomatedSyncEnabled(spec: ArgoApplicationSpec): boolean {
+  const automated = spec.syncPolicy?.automated;
+  return automated !== undefined && automated.enabled !== false;
+}
+
+function isCompleteSource(source: SourceSpec | undefined): source is SourceSpec {
+  return typeof source?.repoURL === 'string' && source.repoURL.trim().length > 0;
+}
+
+function isUsableHistoryEntry(entry: RevisionHistory): boolean {
+  if (!Number.isInteger(entry.id) || (entry.id ?? -1) < 0 || !entry.deployedAt) {
+    return false;
+  }
+
+  if (Number.isNaN(Date.parse(entry.deployedAt))) {
+    return false;
+  }
+
+  const hasPluralSnapshot = entry.revisions !== undefined || entry.sources !== undefined;
+  if (hasPluralSnapshot) {
+    return (
+      (entry.sources?.length ?? 0) > 0 &&
+      entry.revisions?.length === entry.sources?.length &&
+      entry.revisions.every(revision => revision.trim().length > 0) &&
+      entry.sources.every(isCompleteSource)
+    );
+  }
+
+  return !!entry.revision?.trim() && isCompleteSource(entry.source);
+}
+
+/**
+ * Returns safe rollback choices from Application status history.
+ *
+ * The newest unique history record represents the current deployment and is excluded. Older
+ * malformed, legacy, or source-incomplete records are not offered as rollback targets.
+ */
+export function getRollbackHistoryEntries(history: RevisionHistory[]): RevisionHistory[] {
+  const seenIds = new Set<number>();
+  const uniqueHistory = [...history].sort(compareRevisionHistory).filter(entry => {
+    if (!Number.isInteger(entry.id) || seenIds.has(entry.id as number)) {
+      return false;
+    }
+    seenIds.add(entry.id as number);
+    return true;
+  });
+
+  return uniqueHistory.slice(1).filter(isUsableHistoryEntry);
 }
 
 /**
@@ -248,6 +326,16 @@ export class ArgoApplication extends KubeObject<KubeArgoApplication> {
     return this.spec.syncPolicy;
   }
 
+  /** Whether Argo CD automated sync is currently effective for this Application. */
+  get isAutomatedSyncEnabled(): boolean {
+    return isAutomatedSyncEnabled(this.spec);
+  }
+
+  /** Whether Argo CD has a pending or running operation on this Application. */
+  get hasActiveOperation(): boolean {
+    return this.jsonData.operation !== undefined && this.jsonData.operation !== null;
+  }
+
   /** Returns the list of managed Kubernetes resources. */
   get managedResources(): ManagedResource[] {
     return this.status?.resources ?? [];
@@ -256,6 +344,11 @@ export class ArgoApplication extends KubeObject<KubeArgoApplication> {
   /** Returns the sync history entries recorded by Argo CD. */
   get syncHistory(): RevisionHistory[] {
     return this.status?.history ?? [];
+  }
+
+  /** Returns complete earlier deployments that can be used for a safe rollback operation. */
+  get rollbackHistory(): RevisionHistory[] {
+    return getRollbackHistoryEntries(this.syncHistory);
   }
 
   /** Returns the list of conditions set by the controller. */


### PR DESCRIPTION
## Summary

This PR adds a deliberate, Kubernetes-native rollback action to the existing Argo CD Application detail page. Operators can select an earlier usable deployment from Sync History, review its full revision and deployment time, and confirm before Headlamp submits the rollback operation.

Rollback is hidden when automated sync is enabled or no earlier complete deployment is available. It uses the existing Kubernetes patch permission and never modifies the Application spec or its configured Git target revision.

## Why Kubernetes-native rollback?

The plugin already performs Sync and Refresh through the Kubernetes API. Rollback follows the same model by patching only the Application operation field. Argo CD executes the operation asynchronously, while Git remains the source of truth.

## Changes

- Model complete single-source and multi-source rollback history snapshots.
- Sort history newest-first and exclude the current deployment.
- Reject malformed, incomplete, or duplicate history records.
- Add a rollback API operation that preserves historical sources, revisions, sync options, and the apply strategy.
- Add an RBAC-protected Rollback header action and confirmation dialog.
- Require an explicit history selection; no revision is preselected.
- Prevent duplicate submissions and conflicting Sync, Refresh, or Rollback actions while loading.
- Keep the dialog open after failure and close it after a successful request.
- Improve warning readability in Headlamp's dark theme.
- Document behavior, limitations, and required permissions.

## Safety

- Patches only the top-level operation field.
- Never patches spec.source.targetRevision or spec.sources.
- Uses prune: false and dryRun: false.
- Hides rollback while automated sync is enabled.
- Hides rollback when no complete earlier history snapshot exists.
- Uses the existing Kubernetes patch RBAC check and error handling.
- Reports that rollback was triggered, not completed, because Argo CD performs it asynchronously.

## Validation

- Prettier formatting check passed.
- ESLint passed with zero warnings.
- TypeScript passed with no emit.
- All 13 test files and 118 tests passed.
- Production build passed.
- All four commits include Signed-off-by lines.

## Steps to test

1. Open a manually synced Argo CD Application containing at least two successful history entries.
2. Confirm the Rollback action appears in the Application detail header.
3. Open Rollback and confirm no deployment is selected automatically.
4. Select an earlier deployment and verify its complete revision and deployment time are shown.
5. Cancel and confirm no Kubernetes request is sent.
6. Reopen the dialog, select a deployment, and confirm rollback.
7. Verify Argo CD creates a sync operation for the historical source snapshot.
8. Verify spec.source.targetRevision or spec.sources remains unchanged.
9. Enable automated sync and confirm the Rollback action disappears.
10. Verify a user without Application patch permission cannot see the action.

## Scope

This PR does not call the Argo CD REST API, change Git, enable pruning, or claim that a triggered rollback has finished.