### PR TITLE
argocd: Add read-only ApplicationSets and Project GitOps views

### DIFF
--- a/argocd/README.md
+++ b/argocd/README.md
@@ -14,6 +14,8 @@ To learn more about Argo CD, see the [Argo CD Getting Started Guide](https://arg
 - **Refresh Action** — Requests a refresh by setting the `argocd.argoproj.io/refresh` annotation (supports `normal` and `hard` refresh types).
 - **Rollback Action** — Lets an authorized user deliberately select a complete earlier deployment from Sync History and trigger it as a one-time Argo CD operation without changing the Application's configured Git revision.
 - **Open in Argo CD** — Opens the current Application in the configured Argo CD web UI when `argocd-cm.data.url` is available.
+- **ApplicationSet Inventory** — Adds read-only ApplicationSet list and detail pages with safe generator summaries, template information, controller conditions, and live generated Application status.
+- **Headlamp Project GitOps Views** — Adds an Argo CD summary and Applications tab to Headlamp Projects for Applications that explicitly deploy into the Project's local namespaces.
 - **Argo CD Sidebar Icon** — Registers the official Argo CD octopus logo as an offline Iconify icon (CSP-safe, no external fetch).
 
 ### API availability scope
@@ -21,6 +23,18 @@ To learn more about Argo CD, see the [Argo CD Getting Started Guide](https://arg
 The Managed Resources table checks whether the selected Kubernetes cluster serves the exact API group, version, and kind reported by Argo CD. For example, it can show that a resource uses an API version that the cluster no longer serves.
 
 This is an **API availability check**, not a full controller compatibility test. A matching API does not prove that an installed controller implements every field or feature, and it does not prove that application traffic works. Remote or unverified Application destinations are not queried and are shown as `Not checked — remote`.
+
+### Read-only ApplicationSet behavior
+
+ApplicationSet pages intentionally have no create, edit, delete, sync, preview, or generator controls. Generated Applications are linked only when a live Application has an exact Kubernetes owner reference to the ApplicationSet UID in the same namespace and cluster. Names, labels, and naming conventions are not used as ownership evidence.
+
+Generator summaries show only safe identifiers such as generator type, repository URL, path count, provider organization, or plugin ConfigMap name. Secret references, tokens, credentials, and arbitrary plugin inputs are not rendered.
+
+The ApplicationSets sidebar entry is hidden when `applicationsets.argoproj.io` is not installed. Missing ApplicationSet support does not hide the existing Applications or Projects pages.
+
+### Headlamp Project matching
+
+An Argo CD Application appears in a Headlamp Project only when it was loaded from one of the Project's clusters, explicitly targets `in-cluster` or `https://kubernetes.default.svc`, and has an explicit destination namespace listed in the Project. Remote or unverified destinations and Applications without a destination namespace are excluded.
 
 ### Why the Kubernetes API instead of the Argo CD REST API?
 
@@ -78,6 +92,9 @@ rules:
   - apiGroups: ['argoproj.io']
     resources: ['applications']
     verbs: ['get', 'list', 'watch', 'patch']
+  - apiGroups: ['argoproj.io']
+    resources: ['applicationsets']
+    verbs: ['get', 'list', 'watch']
 ```
 
 If the user lacks `patch` permission, the Sync, Refresh, and Rollback buttons are hidden. Rollback
@@ -106,6 +123,8 @@ is not a valid HTTP(S) URL.
 Opening the link does not require an Argo CD API token and does not make an Argo CD API request.
 Argo CD handles authentication in the new browser tab. Advanced diagnostics, diffs, and resource
 actions remain available in the native Argo CD UI.
+
+ApplicationSet and Headlamp Project views are read-only. They require only `get`, `list`, and `watch` access to ApplicationSets and Applications. If Application listing is unavailable, the ApplicationSet controller's generated count remains visible when reported, but live generated Application status and links are not shown.
 
 ## Development
 

--- a/argocd/src/components/applicationsets/Detail.test.ts
+++ b/argocd/src/components/applicationsets/Detail.test.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { getGeneratedApplications } from './Detail';
+
+describe('ApplicationSetDetail generated Application resolution', () => {
+  it('only returns Applications with the matching owner UID', () => {
+    const applicationSet = {
+      cluster: 'cluster-a',
+      metadata: { namespace: 'argocd', uid: 'application-set-uid' },
+    } as any;
+    const matching = {
+      cluster: 'cluster-a',
+      metadata: {
+        namespace: 'argocd',
+        ownerReferences: [
+          {
+            apiVersion: 'argoproj.io/v1alpha1',
+            kind: 'ApplicationSet',
+            uid: 'application-set-uid',
+          },
+        ],
+      },
+    };
+    const namedButUnowned = {
+      cluster: 'cluster-a',
+      metadata: {
+        namespace: 'argocd',
+        labels: { 'app.kubernetes.io/instance': 'application-set' },
+      },
+    };
+
+    expect(
+      getGeneratedApplications([matching, matching, namedButUnowned] as any, applicationSet)
+    ).toEqual([matching]);
+  });
+});

--- a/argocd/src/components/applicationsets/Detail.tsx
+++ b/argocd/src/components/applicationsets/Detail.tsx
@@ -1,0 +1,296 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  DetailsGrid,
+  Link,
+  NameValueTable,
+  SectionBox,
+  SimpleTable,
+  StatusLabel,
+} from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { useParams } from 'react-router-dom';
+import { ArgoApplication } from '../../resources/application';
+import {
+  ApplicationSetCondition,
+  ArgoApplicationSet,
+  getGeneratedApplicationCount,
+  isGeneratedApplication,
+  safeRepositoryIdentifier,
+} from '../../resources/applicationset';
+import { getHealthStatus, getSyncStatus } from '../applications/statusHelpers';
+
+function getGeneratedApplications(
+  applications: ArgoApplication[],
+  applicationSet: ArgoApplicationSet
+): ArgoApplication[] {
+  const unique = new Map<string, ArgoApplication>();
+  applications.forEach(application => {
+    if (isGeneratedApplication(application, applicationSet)) {
+      unique.set(
+        `${application.cluster}/${application.metadata.namespace}/${application.metadata.name}`,
+        application
+      );
+    }
+  });
+  return [...unique.values()];
+}
+
+export default function ApplicationSetDetail(props: { namespace?: string; name?: string }) {
+  const params = useParams<{ namespace: string; name: string }>();
+  const { namespace = params.namespace, name = params.name } = props;
+  const [applications, applicationsError] = ArgoApplication.useList({ namespace });
+
+  return (
+    <DetailsGrid
+      resourceType={ArgoApplicationSet}
+      name={name}
+      namespace={namespace}
+      noDefaultActions
+      withEvents
+      extraInfo={(applicationSet: ArgoApplicationSet) =>
+        applicationSet
+          ? [
+              { name: 'Template Name', value: applicationSet.template?.metadata?.name ?? '-' },
+              { name: 'Template Project', value: applicationSet.templateProject },
+              {
+                name: 'Template Destination',
+                value:
+                  [
+                    applicationSet.templateDestination?.name ??
+                      applicationSet.templateDestination?.server,
+                    applicationSet.templateDestination?.namespace,
+                  ]
+                    .filter(Boolean)
+                    .join(' / ') || '-',
+              },
+              { name: 'Health', value: applicationSet.healthStatus },
+              {
+                name: 'Generated Applications',
+                value: getGeneratedCountLabel(applicationSet, applications),
+              },
+            ]
+          : []
+      }
+      extraSections={(applicationSet: ArgoApplicationSet) =>
+        applicationSet
+          ? [
+              getTemplateSection(applicationSet),
+              getGeneratorsSection(applicationSet),
+              getGeneratedApplicationsSection(applicationSet, applications, applicationsError),
+              getConditionsSection(applicationSet),
+            ].filter(Boolean)
+          : []
+      }
+    />
+  );
+}
+
+function getTemplateSection(applicationSet: ArgoApplicationSet) {
+  const sources = applicationSet.templateSources;
+  if (!sources.length) {
+    return {
+      id: 'template-sources',
+      section: <SectionBox title="Template Sources">No template source is configured.</SectionBox>,
+    };
+  }
+
+  return {
+    id: 'template-sources',
+    section: (
+      <SectionBox title="Template Sources">
+        <SimpleTable
+          data={sources}
+          columns={[
+            {
+              label: 'Repository',
+              getter: source => safeRepositoryIdentifier(source.repoURL) || '-',
+            },
+            { label: 'Revision', getter: source => source.targetRevision || 'HEAD' },
+            { label: 'Path / Chart', getter: source => source.path ?? source.chart ?? '-' },
+          ]}
+        />
+      </SectionBox>
+    ),
+  };
+}
+
+function getGeneratedCountLabel(
+  applicationSet: ArgoApplicationSet,
+  applications: ArgoApplication[] | null
+): string {
+  const liveCount = applications
+    ? getGeneratedApplications(applications, applicationSet).length
+    : undefined;
+  const count = getGeneratedApplicationCount(applicationSet.status, liveCount);
+  return count === undefined ? '—' : String(count);
+}
+
+function getGeneratorsSection(applicationSet: ArgoApplicationSet) {
+  return {
+    id: 'generators',
+    section: (
+      <SectionBox title="Generators">
+        {applicationSet.generatorSummaries.length ? (
+          <NameValueTable
+            rows={applicationSet.generatorSummaries.map((summary, index) => ({
+              name: `Generator ${index + 1}`,
+              value: summary,
+            }))}
+          />
+        ) : (
+          'No generators are configured.'
+        )}
+      </SectionBox>
+    ),
+  };
+}
+
+function getGeneratedApplicationsSection(
+  applicationSet: ArgoApplicationSet,
+  applications: ArgoApplication[] | null,
+  applicationsError: unknown
+) {
+  const verifiedLiveCount = applications
+    ? getGeneratedApplications(applications, applicationSet).length
+    : undefined;
+  const controllerCount = getGeneratedApplicationCount(applicationSet.status, verifiedLiveCount);
+  if (applicationsError) {
+    return {
+      id: 'generated-applications',
+      section: (
+        <SectionBox title="Generated Applications">
+          {controllerCount === undefined
+            ? 'Generated Application status could not be loaded.'
+            : `The controller reports ${controllerCount} generated Application${
+                controllerCount === 1 ? '' : 's'
+              }, but their status could not be loaded.`}
+        </SectionBox>
+      ),
+    };
+  }
+  if (!applications) {
+    return {
+      id: 'generated-applications',
+      section: (
+        <SectionBox title="Generated Applications">Loading generated Applications…</SectionBox>
+      ),
+    };
+  }
+
+  const generatedApplications = getGeneratedApplications(applications, applicationSet);
+  if (!generatedApplications.length) {
+    return {
+      id: 'generated-applications',
+      section: (
+        <SectionBox title="Generated Applications">
+          {controllerCount === undefined
+            ? 'No generated Applications have been observed yet.'
+            : `The controller reports ${controllerCount} generated Application${
+                controllerCount === 1 ? '' : 's'
+              }, but none are currently available to list.`}
+        </SectionBox>
+      ),
+    };
+  }
+
+  return {
+    id: 'generated-applications',
+    section: (
+      <SectionBox title="Generated Applications">
+        <SimpleTable
+          data={generatedApplications}
+          columns={[
+            {
+              label: 'Application',
+              getter: application => (
+                <Link
+                  routeName="argocd-application-detail"
+                  params={{
+                    namespace: application.metadata.namespace,
+                    name: application.metadata.name,
+                  }}
+                  activeCluster={application.cluster}
+                >
+                  {application.metadata.name}
+                </Link>
+              ),
+            },
+            {
+              label: 'Sync',
+              getter: application => (
+                <StatusLabel status={getSyncStatus(application.syncStatus)}>
+                  {application.syncStatus}
+                </StatusLabel>
+              ),
+            },
+            {
+              label: 'Health',
+              getter: application => (
+                <StatusLabel status={getHealthStatus(application.healthStatus)}>
+                  {application.healthStatus}
+                </StatusLabel>
+              ),
+            },
+          ]}
+        />
+      </SectionBox>
+    ),
+  };
+}
+
+function getConditionsSection(applicationSet: ArgoApplicationSet) {
+  const conditions = applicationSet.conditions;
+  if (!conditions.length) {
+    return {
+      id: 'conditions',
+      section: (
+        <SectionBox title="Conditions">No controller conditions have been reported.</SectionBox>
+      ),
+    };
+  }
+  return {
+    id: 'conditions',
+    section: (
+      <SectionBox title="Conditions">
+        <SimpleTable
+          data={conditions}
+          columns={[
+            { label: 'Type', getter: (condition: ApplicationSetCondition) => condition.type },
+            {
+              label: 'Status',
+              getter: (condition: ApplicationSetCondition) => condition.status ?? '-',
+            },
+            {
+              label: 'Reason',
+              getter: (condition: ApplicationSetCondition) => condition.reason ?? '-',
+            },
+            {
+              label: 'Message',
+              getter: (condition: ApplicationSetCondition) => condition.message ?? '-',
+            },
+            {
+              label: 'Last Transition',
+              getter: (condition: ApplicationSetCondition) => condition.lastTransitionTime ?? '-',
+            },
+          ]}
+        />
+      </SectionBox>
+    ),
+  };
+}
+
+export { getGeneratedApplications };

--- a/argocd/src/components/applicationsets/List.test.tsx
+++ b/argocd/src/components/applicationsets/List.test.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import ApplicationSetList from './List';
+
+vi.mock('@kinvolk/headlamp-plugin/lib/CommonComponents', () => ({
+  ResourceListView: () => null,
+}));
+
+describe('ApplicationSetList', () => {
+  it('is explicitly read-only', () => {
+    const element = ApplicationSetList();
+    expect(element.props.headerProps.titleSideActions).toEqual([]);
+    expect(element.props.enableRowActions).toBe(false);
+    expect(element.props.enableRowSelection).toBe(false);
+    expect(
+      element.props.columns.map((column: string | { id: string }) =>
+        typeof column === 'string' ? column : column.id
+      )
+    ).toContain('generated-applications');
+  });
+});

--- a/argocd/src/components/applicationsets/List.tsx
+++ b/argocd/src/components/applicationsets/List.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ResourceListView } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { ArgoApplicationSet } from '../../resources/applicationset';
+
+function destinationLabel(applicationSet: ArgoApplicationSet): string {
+  const destination = applicationSet.templateDestination;
+  if (!destination) return '-';
+  return (
+    [destination.name ?? destination.server, destination.namespace].filter(Boolean).join(' · ') ||
+    '-'
+  );
+}
+
+/** Inventory only: ApplicationSets intentionally expose no mutation controls. */
+export default function ApplicationSetList() {
+  return (
+    <ResourceListView
+      title="Argo CD ApplicationSets"
+      resourceClass={ArgoApplicationSet}
+      headerProps={{ titleSideActions: [] }}
+      enableRowActions={false}
+      enableRowSelection={false}
+      columns={[
+        'name',
+        'namespace',
+        {
+          id: 'generators',
+          label: 'Generators',
+          getValue: (applicationSet: ArgoApplicationSet) =>
+            applicationSet.generatorSummaries.join(', ') || '-',
+        },
+        {
+          id: 'template-project',
+          label: 'Template Project',
+          getValue: (applicationSet: ArgoApplicationSet) => applicationSet.templateProject,
+        },
+        {
+          id: 'template-destination',
+          label: 'Template Destination',
+          getValue: destinationLabel,
+        },
+        {
+          id: 'generated-applications',
+          label: 'Generated Applications',
+          getValue: (applicationSet: ArgoApplicationSet) =>
+            applicationSet.generatedApplicationCount === undefined
+              ? '—'
+              : String(applicationSet.generatedApplicationCount),
+        },
+        'age',
+      ]}
+    />
+  );
+}

--- a/argocd/src/components/projects/GitOps.test.ts
+++ b/argocd/src/components/projects/GitOps.test.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  getFailedProjectClusters,
+  getProjectApplicationCounts,
+  getProjectApplications,
+} from './GitOps';
+
+function application(overrides: Record<string, unknown> = {}) {
+  const value = {
+    cluster: 'cluster-a',
+    metadata: { namespace: 'argocd', name: 'guestbook' },
+    spec: { destination: { name: 'in-cluster', namespace: 'team-a' } },
+    syncStatus: 'Synced',
+    healthStatus: 'Healthy',
+    ...overrides,
+  };
+  return value as any;
+}
+
+const project = { id: 'project', clusters: ['cluster-a', 'cluster-b'], namespaces: ['team-a'] };
+
+describe('Headlamp Project Argo CD matching', () => {
+  it('includes only exact local cluster and explicit destination namespace matches', () => {
+    const local = application();
+    const remote = application({
+      spec: { destination: { server: 'https://remote', namespace: 'team-a' } },
+    });
+    const missingNamespace = application({ spec: { destination: { name: 'in-cluster' } } });
+    const wrongCluster = application({ cluster: 'cluster-c' });
+    const storedOnly = application({
+      spec: { destination: { name: 'in-cluster', namespace: 'other' } },
+    });
+
+    expect(
+      getProjectApplications([local, remote, missingNamespace, wrongCluster, storedOnly], project)
+    ).toEqual([local]);
+  });
+
+  it('rejects destinations that mix a local identifier with a remote identifier', () => {
+    const local = application();
+    const localNameWithRemoteServer = application({
+      metadata: { namespace: 'argocd', name: 'remote-server' },
+      spec: { destination: { name: 'in-cluster', server: 'https://remote', namespace: 'team-a' } },
+    });
+    const localServerWithRemoteName = application({
+      metadata: { namespace: 'argocd', name: 'remote-name' },
+      spec: {
+        destination: {
+          server: 'https://kubernetes.default.svc',
+          name: 'remote-cluster',
+          namespace: 'team-a',
+        },
+      },
+    });
+
+    expect(
+      getProjectApplications([local, localNameWithRemoteServer, localServerWithRemoteName], project)
+    ).toEqual([local]);
+  });
+
+  it('keeps identical names on different Project clusters separate', () => {
+    const first = application();
+    const second = application({ cluster: 'cluster-b' });
+    expect(getProjectApplications([first, second], project)).toHaveLength(2);
+  });
+
+  it('counts missing or unknown status as needing attention', () => {
+    expect(
+      getProjectApplicationCounts([
+        application(),
+        application({ metadata: { namespace: 'argocd', name: 'warning' }, syncStatus: 'Unknown' }),
+      ])
+    ).toEqual({ total: 2, synced: 1, healthy: 2, needsAttention: 1 });
+  });
+
+  it('detects partial and total cluster failures from missing result entries', () => {
+    expect(
+      getFailedProjectClusters(project.clusters, { 'cluster-a': { items: [application()] } }, [{}])
+    ).toEqual(['cluster-b']);
+    expect(getFailedProjectClusters(project.clusters, {}, [{}])).toEqual([
+      'cluster-a',
+      'cluster-b',
+    ]);
+  });
+
+  it('detects explicit cluster errors and the legacy all-failed response', () => {
+    expect(
+      getFailedProjectClusters(
+        project.clusters,
+        {
+          'cluster-a': { items: [] },
+          'cluster-b': { errors: [new Error('forbidden')] },
+        },
+        null
+      )
+    ).toEqual(['cluster-b']);
+    expect(getFailedProjectClusters(project.clusters, undefined, [new Error('forbidden')])).toEqual(
+      project.clusters
+    );
+  });
+});

--- a/argocd/src/components/projects/GitOps.tsx
+++ b/argocd/src/components/projects/GitOps.tsx
@@ -1,0 +1,286 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Link,
+  SectionBox,
+  SimpleTable,
+  StatusLabel,
+} from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { Box, Tooltip, Typography } from '@mui/material';
+import { ArgoApplication } from '../../resources/application';
+import { safeRepositoryIdentifier } from '../../resources/applicationset';
+import { getHealthStatus, getSyncStatus } from '../applications/statusHelpers';
+
+export interface HeadlampProjectDefinition {
+  id: string;
+  namespaces: string[];
+  clusters: string[];
+}
+
+interface ApplicationListQuery {
+  0?: ArgoApplication[] | null;
+  1?: unknown;
+  items?: ArgoApplication[] | null;
+  errors?: unknown[] | null;
+  isLoading?: boolean;
+  clusterResults?: Record<
+    string,
+    { items?: ArgoApplication[] | null; errors?: unknown[] | null; isLoading?: boolean }
+  >;
+}
+
+function isExplicitlyLocal(application: ArgoApplication): boolean {
+  const destination = application.spec.destination;
+  const hasLocalServer = destination?.server === 'https://kubernetes.default.svc';
+  const hasLocalName = destination?.name === 'in-cluster';
+
+  return (
+    (hasLocalServer || hasLocalName) &&
+    (!destination?.server || hasLocalServer) &&
+    (!destination?.name || hasLocalName)
+  );
+}
+
+/** Strictly matches Applications to a Headlamp Project's cluster and destination namespace. */
+export function getProjectApplications(
+  applications: ArgoApplication[],
+  project: HeadlampProjectDefinition
+): ArgoApplication[] {
+  const projectClusters = new Set(project.clusters);
+  const projectNamespaces = new Set(project.namespaces);
+  const matches = new Map<string, ArgoApplication>();
+
+  applications.forEach(application => {
+    const destinationNamespace = application.spec.destination?.namespace;
+    if (
+      !projectClusters.has(application.cluster) ||
+      !isExplicitlyLocal(application) ||
+      !destinationNamespace ||
+      !projectNamespaces.has(destinationNamespace)
+    ) {
+      return;
+    }
+
+    matches.set(
+      `${application.cluster}/${application.metadata.namespace}/${application.metadata.name}`,
+      application
+    );
+  });
+
+  return [...matches.values()].sort((left, right) => {
+    const clusterOrder = left.cluster.localeCompare(right.cluster);
+    return clusterOrder || left.metadata.name.localeCompare(right.metadata.name);
+  });
+}
+
+export function getProjectApplicationCounts(applications: ArgoApplication[]) {
+  return {
+    total: applications.length,
+    synced: applications.filter(application => application.syncStatus === 'Synced').length,
+    healthy: applications.filter(application => application.healthStatus === 'Healthy').length,
+    needsAttention: applications.filter(
+      application => application.syncStatus !== 'Synced' || application.healthStatus !== 'Healthy'
+    ).length,
+  };
+}
+
+function normalizeQuery(result: unknown): ApplicationListQuery {
+  return result as ApplicationListQuery;
+}
+
+/** Identifies Project clusters whose Application list did not return usable results. */
+export function getFailedProjectClusters(
+  projectClusters: string[],
+  clusterResults: ApplicationListQuery['clusterResults'],
+  errors: unknown[] | null
+): string[] {
+  if (clusterResults) {
+    return projectClusters.filter(
+      cluster => !clusterResults[cluster] || Boolean(clusterResults[cluster].errors?.length)
+    );
+  }
+  return errors?.length ? projectClusters : [];
+}
+
+function useProjectApplicationData(project: HeadlampProjectDefinition) {
+  const query = normalizeQuery(ArgoApplication.useList({ clusters: project.clusters }));
+  const applications = query.items ?? query[0] ?? null;
+  const errors = query.errors ?? (query[1] ? [query[1]] : null);
+  const clusterResults = query.clusterResults;
+  const failedClusters = getFailedProjectClusters(project.clusters, clusterResults, errors);
+  const loading = query.isLoading ?? applications === null;
+
+  return {
+    applications: getProjectApplications(applications ?? [], project),
+    failedClusters,
+    loading,
+    allFailed: failedClusters.length === project.clusters.length && project.clusters.length > 0,
+  };
+}
+
+function EmptyState(props: { children: string }) {
+  return <Box sx={{ color: 'text.secondary', p: 2, textAlign: 'center' }}>{props.children}</Box>;
+}
+
+function SummaryCard(props: { label: string; value: number }) {
+  return (
+    <Box sx={theme => ({ border: `1px solid ${theme.palette.divider}`, borderRadius: 1, p: 1.5 })}>
+      <Typography variant="h5">{props.value}</Typography>
+      <Typography color="text.secondary" variant="body2">
+        {props.label}
+      </Typography>
+    </Box>
+  );
+}
+
+export function ArgoCDProjectOverview(props: { project: HeadlampProjectDefinition }) {
+  const state = useProjectApplicationData(props.project);
+  const counts = getProjectApplicationCounts(state.applications);
+
+  return (
+    <SectionBox title="Argo CD">
+      {state.loading ? (
+        <EmptyState>Loading Argo CD Applications…</EmptyState>
+      ) : state.allFailed ? (
+        <EmptyState>Argo CD Application data is unavailable for this Project.</EmptyState>
+      ) : (
+        <>
+          {state.failedClusters.length > 0 && (
+            <Typography color="warning.main" sx={{ mb: 1 }}>
+              Showing partial results. Some Project clusters could not be read.
+            </Typography>
+          )}
+          <Box
+            sx={{
+              display: 'grid',
+              gridTemplateColumns: { xs: 'repeat(2, 1fr)', md: 'repeat(4, minmax(0, 1fr))' },
+              gap: 1.5,
+            }}
+          >
+            <SummaryCard label="Total Applications" value={counts.total} />
+            <SummaryCard label="Synced" value={counts.synced} />
+            <SummaryCard label="Healthy" value={counts.healthy} />
+            <SummaryCard label="Needs Attention" value={counts.needsAttention} />
+          </Box>
+        </>
+      )}
+    </SectionBox>
+  );
+}
+
+function sourceSummary(application: ArgoApplication): { concise: string; complete: string } {
+  const values = application.sources.map(source => {
+    const location = source.path ?? source.chart ?? safeRepositoryIdentifier(source.repoURL);
+    return `${location || '-'} @ ${source.targetRevision ?? 'HEAD'}`;
+  });
+  return {
+    concise: values.length > 1 ? `${values.length} sources` : values[0] ?? '-',
+    complete: values.join('\n') || '-',
+  };
+}
+
+export function ArgoCDProjectApplicationsTab(props: { project: HeadlampProjectDefinition }) {
+  const state = useProjectApplicationData(props.project);
+  const showCluster = props.project.clusters.length > 1;
+
+  if (state.loading) return <EmptyState>Loading Argo CD Applications…</EmptyState>;
+  if (state.allFailed)
+    return <EmptyState>Argo CD Application data is unavailable for this Project.</EmptyState>;
+  if (!state.applications.length) {
+    return (
+      <SectionBox title="Argo CD Applications">
+        {state.failedClusters.length > 0 && (
+          <Typography color="warning.main" sx={{ mb: 1 }}>
+            Showing partial results. Some Project clusters could not be read.
+          </Typography>
+        )}
+        <EmptyState>
+          {state.failedClusters.length > 0
+            ? 'No Argo CD Applications deploy into this Project’s namespaces in the Project clusters that could be read.'
+            : 'No Argo CD Applications deploy into this Project’s namespaces.'}
+        </EmptyState>
+      </SectionBox>
+    );
+  }
+
+  return (
+    <SectionBox title="Argo CD Applications">
+      {state.failedClusters.length > 0 && (
+        <Typography color="warning.main" sx={{ mb: 1 }}>
+          Showing partial results. Some Project clusters could not be read.
+        </Typography>
+      )}
+      <SimpleTable
+        data={state.applications}
+        columns={[
+          {
+            label: 'Application',
+            getter: application => (
+              <Link
+                routeName="argocd-application-detail"
+                params={{
+                  namespace: application.metadata.namespace,
+                  name: application.metadata.name,
+                }}
+                activeCluster={application.cluster}
+              >
+                {application.metadata.name}
+              </Link>
+            ),
+          },
+          { label: 'Argo CD Namespace', getter: application => application.metadata.namespace },
+          {
+            label: 'Target Namespace',
+            getter: application => application.spec.destination.namespace,
+          },
+          ...(showCluster
+            ? [{ label: 'Cluster', getter: (application: ArgoApplication) => application.cluster }]
+            : []),
+          {
+            label: 'Source / Revision',
+            getter: application => {
+              const summary = sourceSummary(application);
+              return (
+                <Tooltip title={<span style={{ whiteSpace: 'pre-line' }}>{summary.complete}</span>}>
+                  <Box component="span" tabIndex={0} aria-label={summary.complete}>
+                    {summary.concise}
+                  </Box>
+                </Tooltip>
+              );
+            },
+          },
+          {
+            label: 'Sync',
+            getter: application => (
+              <StatusLabel status={getSyncStatus(application.syncStatus)}>
+                {application.syncStatus}
+              </StatusLabel>
+            ),
+          },
+          {
+            label: 'Health',
+            getter: application => (
+              <StatusLabel status={getHealthStatus(application.healthStatus)}>
+                {application.healthStatus}
+              </StatusLabel>
+            ),
+          },
+        ]}
+      />
+    </SectionBox>
+  );
+}

--- a/argocd/src/index.test.tsx
+++ b/argocd/src/index.test.tsx
@@ -19,19 +19,25 @@ import { describe, expect, it, vi } from 'vitest';
 import ArgoNamespaceInsights from './components/namespaces/ArgoNamespaceInsights';
 
 const {
+  mockApiList,
   mockRegisterDetailsViewSectionsProcessor,
+  mockRegisterKindIcon,
+  mockRegisterMapSource,
+  mockRegisterProjectDetailsTab,
+  mockRegisterProjectOverviewSection,
   mockRegisterRoute,
   mockRegisterSidebarEntry,
   mockRegisterSidebarEntryFilter,
-  mockRegisterMapSource,
-  mockRegisterKindIcon,
 } = vi.hoisted(() => ({
+  mockApiList: vi.fn(() => vi.fn()),
   mockRegisterDetailsViewSectionsProcessor: vi.fn(),
+  mockRegisterKindIcon: vi.fn(),
+  mockRegisterMapSource: vi.fn(),
+  mockRegisterProjectDetailsTab: vi.fn(),
+  mockRegisterProjectOverviewSection: vi.fn(),
   mockRegisterRoute: vi.fn(),
   mockRegisterSidebarEntry: vi.fn(),
   mockRegisterSidebarEntryFilter: vi.fn(),
-  mockRegisterMapSource: vi.fn(),
-  mockRegisterKindIcon: vi.fn(),
 }));
 
 vi.mock('@kinvolk/headlamp-plugin/lib', () => ({
@@ -44,6 +50,8 @@ vi.mock('@kinvolk/headlamp-plugin/lib', () => ({
   registerSidebarEntryFilter: mockRegisterSidebarEntryFilter,
   registerMapSource: mockRegisterMapSource,
   registerKindIcon: mockRegisterKindIcon,
+  registerProjectDetailsTab: mockRegisterProjectDetailsTab,
+  registerProjectOverviewSection: mockRegisterProjectOverviewSection,
   ApiProxy: { request: vi.fn() },
   K8s: {
     cluster: {
@@ -56,7 +64,7 @@ vi.mock('@kinvolk/headlamp-plugin/lib', () => ({
     },
     ResourceClasses: {
       CustomResourceDefinition: {
-        apiList: vi.fn(() => vi.fn()),
+        apiList: mockApiList,
       },
     },
   },
@@ -139,6 +147,25 @@ describe('argocd plugin', () => {
     );
   });
 
+  it('should register the ApplicationSet list and detail routes', () => {
+    expect(mockRegisterRoute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/argocd/applicationsets',
+        name: 'argocd-applicationsets-list',
+        sidebar: 'argocd-applicationsets',
+        exact: true,
+      })
+    );
+    expect(mockRegisterRoute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/argocd/applicationsets/:namespace/:name',
+        name: 'argocd-applicationset-detail',
+        sidebar: 'argocd-applicationsets',
+        exact: true,
+      })
+    );
+  });
+
   it('should register sidebar entries with the Argo CD icon', () => {
     expect(mockRegisterSidebarEntry).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -165,6 +192,16 @@ describe('argocd plugin', () => {
         label: 'Projects',
         url: '/argocd/projects',
         parent: 'argocd',
+      })
+    );
+
+    expect(mockRegisterSidebarEntry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'argocd-applicationsets',
+        label: 'ApplicationSets',
+        url: '/argocd/applicationsets',
+        parent: 'argocd',
+        icon: 'simple-icons:argo',
       })
     );
   });
@@ -208,6 +245,62 @@ describe('argocd plugin', () => {
     );
   });
 
+  it('hides only entries whose exact CRD is missing', () => {
+    const filter = mockRegisterSidebarEntryFilter.mock.calls[0][0];
+    const applications = { name: 'argocd-applications', parent: 'argocd' };
+    const applicationSets = { name: 'argocd-applicationsets', parent: 'argocd' };
+
+    expect(filter(applications)).toBe(applications);
+    const success = (mockApiList.mock.calls as any)[0][0] as (crds: unknown[]) => void;
+    success([{ jsonData: { metadata: { name: 'applications.argoproj.io' } } }]);
+
+    expect(filter(applications)).toBe(applications);
+    expect(filter(applicationSets)).toBeNull();
+  });
+
+  it('keeps an ApplicationSet-only installation usable', () => {
+    const filter = mockRegisterSidebarEntryFilter.mock.calls[0][0];
+    const success = (mockApiList.mock.calls as any)[0][0] as (crds: unknown[]) => void;
+    success([{ jsonData: { metadata: { name: 'applicationsets.argoproj.io' } } }]);
+
+    expect(filter({ name: 'argocd', parent: null, url: '/argocd/applications' })).toEqual(
+      expect.objectContaining({ url: '/argocd/applicationsets' })
+    );
+    expect(filter({ name: 'argocd-applications', parent: 'argocd' })).toBeNull();
+    expect(filter({ name: 'argocd-applicationsets', parent: 'argocd' })).not.toBeNull();
+  });
+
+  it('keeps Argo CD navigation visible when CRD discovery is forbidden', () => {
+    const filter = mockRegisterSidebarEntryFilter.mock.calls[0][0];
+    const failure = (mockApiList.mock.calls as any)[0][1] as () => void;
+    failure();
+
+    const parent = { name: 'argocd', parent: null, url: '/argocd/applications' };
+    const applications = { name: 'argocd-applications', parent: 'argocd' };
+    const projects = { name: 'argocd-projects', parent: 'argocd' };
+    const applicationSets = { name: 'argocd-applicationsets', parent: 'argocd' };
+
+    expect(filter(parent)).toBe(parent);
+    expect(filter(applications)).toBe(applications);
+    expect(filter(projects)).toBe(projects);
+    expect(filter(applicationSets)).toBe(applicationSets);
+  });
+
+  it('registers the Project integrations exactly once', () => {
+    expect(mockRegisterProjectOverviewSection).toHaveBeenCalledTimes(1);
+    expect(mockRegisterProjectOverviewSection).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'argocd.project-overview' })
+    );
+    expect(mockRegisterProjectDetailsTab).toHaveBeenCalledTimes(1);
+    expect(mockRegisterProjectDetailsTab).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'argocd.project-applications',
+        label: 'Argo CD Applications',
+        icon: 'simple-icons:argo',
+      })
+    );
+  });
+
   it('should register the Application and AppProject kind icons', () => {
     expect(mockRegisterKindIcon).toHaveBeenCalledWith(
       'Application',
@@ -221,5 +314,17 @@ describe('argocd plugin', () => {
       'argoproj.io'
     );
     expect(mockRegisterKindIcon).toHaveBeenCalledWith('AppProject', expect.anything());
+  });
+
+  it('registers group-specific and fallback ApplicationSet icons', () => {
+    expect(mockRegisterKindIcon).toHaveBeenCalledWith(
+      'ApplicationSet',
+      expect.objectContaining({ color: '#EF7B4D' }),
+      'argoproj.io'
+    );
+    expect(mockRegisterKindIcon).toHaveBeenCalledWith(
+      'ApplicationSet',
+      expect.objectContaining({ color: '#EF7B4D' })
+    );
   });
 });

--- a/argocd/src/index.tsx
+++ b/argocd/src/index.tsx
@@ -21,6 +21,8 @@ import {
   registerDetailsViewSectionsProcessor,
   registerKindIcon,
   registerMapSource,
+  registerProjectDetailsTab,
+  registerProjectOverviewSection,
   registerRoute,
   registerSidebarEntry,
   registerSidebarEntryFilter,
@@ -30,21 +32,24 @@ import type { ReactNode } from 'react';
 import { ARGO_ICON_COLOR, ARGO_ICON_NAME, argoIcon } from './argoIcon';
 import ApplicationDetail from './components/applications/Detail';
 import ApplicationList from './components/applications/List';
+import ApplicationSetDetail from './components/applicationsets/Detail';
+import ApplicationSetList from './components/applicationsets/List';
 import AppProjectDetail from './components/appprojects/Detail';
 import AppProjectList from './components/appprojects/List';
 import ArgoNamespaceInsights from './components/namespaces/ArgoNamespaceInsights';
+import { ArgoCDProjectApplicationsTab, ArgoCDProjectOverview } from './components/projects/GitOps';
 import { argoCDSource } from './mapView';
 
 // ---------------------------------------------------------------------------
 // CRD Detection Guard — hide Argo CD sidebar entries on clusters without
 // the argoproj.io CRDs installed. Follows the Flux plugin pattern.
 // ---------------------------------------------------------------------------
-const argoInstalledByCluster: Record<string, boolean> = {};
+const argoCRDsByCluster: Record<string, Set<string> | undefined> = {};
 const lastCheckedAt: Record<string, number> = {};
 const inFlight: Record<string, boolean> = {};
 const CHECK_TTL_MS = 30 * 1000;
 
-function checkArgoInstalled(cluster: string) {
+function checkArgoCRDs(cluster: string) {
   const now = Date.now();
   const fresh = now - (lastCheckedAt[cluster] ?? 0) < CHECK_TTL_MS;
   if (inFlight[cluster] || fresh) {
@@ -54,18 +59,24 @@ function checkArgoInstalled(cluster: string) {
 
   const listFn = K8s.ResourceClasses.CustomResourceDefinition.apiList(
     (crds: { jsonData: { metadata: { name: string } } }[]) => {
-      argoInstalledByCluster[cluster] = crds.some(crd =>
-        [
-          'applications.argoproj.io',
-          'appprojects.argoproj.io',
-          'applicationsets.argoproj.io',
-        ].includes(crd.jsonData?.metadata?.name)
+      argoCRDsByCluster[cluster] = new Set(
+        crds
+          .map(crd => crd.jsonData?.metadata?.name)
+          .filter(
+            (name): name is string =>
+              typeof name === 'string' &&
+              [
+                'applications.argoproj.io',
+                'appprojects.argoproj.io',
+                'applicationsets.argoproj.io',
+              ].includes(name)
+          )
       );
       lastCheckedAt[cluster] = Date.now();
       inFlight[cluster] = false;
     },
     () => {
-      argoInstalledByCluster[cluster] = false;
+      delete argoCRDsByCluster[cluster];
       lastCheckedAt[cluster] = Date.now();
       inFlight[cluster] = false;
     },
@@ -80,12 +91,25 @@ registerSidebarEntryFilter(entry => {
   }
 
   const cluster = Utils.getCluster() ?? '';
-  checkArgoInstalled(cluster);
+  checkArgoCRDs(cluster);
 
-  if (argoInstalledByCluster[cluster] === false) {
-    return null;
+  const installed = argoCRDsByCluster[cluster];
+  if (!installed) return entry;
+
+  if (entry.name === 'argocd') {
+    if (installed.size === 0) return null;
+    if (installed.has('applications.argoproj.io')) return entry;
+    if (installed.has('appprojects.argoproj.io')) return { ...entry, url: '/argocd/projects' };
+    return { ...entry, url: '/argocd/applicationsets' };
   }
-  return entry;
+
+  const requiredCRD: Record<string, string> = {
+    'argocd-applications': 'applications.argoproj.io',
+    'argocd-projects': 'appprojects.argoproj.io',
+    'argocd-applicationsets': 'applicationsets.argoproj.io',
+  };
+  const requirement = requiredCRD[entry.name];
+  return !requirement || installed.has(requirement) ? entry : null;
 });
 
 const NAMESPACE_GITOPS_INSIGHTS_SECTION_ID = 'argocd.namespace-gitops-insights';
@@ -199,3 +223,42 @@ registerKindIcon('Application', { icon: argoIcon, color: ARGO_ICON_COLOR }, 'arg
 registerKindIcon('Application', { icon: argoIcon, color: ARGO_ICON_COLOR });
 registerKindIcon('AppProject', { icon: argoIcon, color: ARGO_ICON_COLOR }, 'argoproj.io');
 registerKindIcon('AppProject', { icon: argoIcon, color: ARGO_ICON_COLOR });
+
+registerRoute({
+  path: '/argocd/applicationsets',
+  sidebar: 'argocd-applicationsets',
+  name: 'argocd-applicationsets-list',
+  exact: true,
+  component: () => <ApplicationSetList />,
+});
+
+registerRoute({
+  path: '/argocd/applicationsets/:namespace/:name',
+  sidebar: 'argocd-applicationsets',
+  name: 'argocd-applicationset-detail',
+  exact: true,
+  component: () => <ApplicationSetDetail />,
+});
+
+registerSidebarEntry({
+  parent: 'argocd',
+  name: 'argocd-applicationsets',
+  label: 'ApplicationSets',
+  url: '/argocd/applicationsets',
+  icon: ARGO_ICON_NAME,
+});
+
+registerProjectOverviewSection({
+  id: 'argocd.project-overview',
+  component: ArgoCDProjectOverview,
+});
+
+registerProjectDetailsTab({
+  id: 'argocd.project-applications',
+  label: 'Argo CD Applications',
+  icon: ARGO_ICON_NAME,
+  component: ArgoCDProjectApplicationsTab,
+});
+
+registerKindIcon('ApplicationSet', { icon: argoIcon, color: ARGO_ICON_COLOR }, 'argoproj.io');
+registerKindIcon('ApplicationSet', { icon: argoIcon, color: ARGO_ICON_COLOR });

--- a/argocd/src/resources/applicationset.test.ts
+++ b/argocd/src/resources/applicationset.test.ts
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  ArgoApplicationSet,
+  getApplicationSetHealthStatus,
+  getGeneratedApplicationCount,
+  getGeneratorSummary,
+  isGeneratedApplication,
+  safeRepositoryIdentifier,
+} from './applicationset';
+
+describe('ApplicationSet helpers', () => {
+  it.each([
+    [{ list: { elements: [{ cluster: 'prod' }] } }, 'List'],
+    [{ clusters: {} }, 'Clusters'],
+    [{ scmProvider: { gitlab: { tokenRef: { secretName: 'hidden' } } } }, 'SCM Provider'],
+    [{ pullRequest: { github: { tokenRef: { secretName: 'hidden' } } } }, 'Pull Request'],
+    [{ clusterDecisionResource: { configMapRef: 'placement' } }, 'Cluster Decision Resource'],
+  ])('summarises supported generator %j safely', (generator, expected) => {
+    expect(getGeneratorSummary(generator)).toBe(expected);
+    expect(getGeneratorSummary(generator)).not.toContain('hidden');
+  });
+
+  it('summarises nested generators without exposing credentials or plugin input', () => {
+    expect(
+      getGeneratorSummary({
+        matrix: {
+          generators: [
+            { git: { repoURL: 'https://example.test/repo', directories: [{}] } },
+            { clusters: {} },
+          ],
+        },
+      })
+    ).toBe('Matrix (Git · https://example.test/repo · 1 path + Clusters)');
+    expect(
+      getGeneratorSummary({
+        plugin: {
+          configMapRef: { name: 'generator-plugin', tokenRef: { secretName: 'hidden' } },
+          input: { token: 'secret' },
+        },
+      })
+    ).toBe('Plugin · generator-plugin');
+    expect(
+      getGeneratorSummary({ merge: { generators: [{ list: {} }, { pullRequest: {} }] } })
+    ).toBe('Merge (List + Pull Request)');
+    expect(getGeneratorSummary({ future: { password: 'secret' } })).toBe('Unknown generator');
+  });
+
+  it('redacts credentials, query parameters, and fragments from Git repository URLs', () => {
+    const summary = getGeneratorSummary({
+      git: {
+        repoURL: 'https://user:token@example.test/org/repo?access_token=hidden#private',
+        files: [{}],
+      },
+    });
+
+    expect(summary).toBe('Git · https://example.test/org/repo · 1 path');
+    expect(summary).not.toMatch(/user|token|hidden|private/);
+  });
+
+  it('redacts credentials from malformed and SCP-style repository URLs', () => {
+    expect(safeRepositoryIdentifier('https://user:token@bad host/repo?secret=hidden')).toBe(
+      'https://bad host/repo'
+    );
+    expect(safeRepositoryIdentifier('git@github.example:team/repo.git#private')).toBe(
+      'github.example:team/repo.git'
+    );
+  });
+
+  it('normalizes single-source, multi-source, and templated destination data', () => {
+    const single = new ArgoApplicationSet({
+      apiVersion: 'argoproj.io/v1alpha1',
+      kind: 'ApplicationSet',
+      metadata: { name: 'single', namespace: 'argocd' },
+      spec: {
+        template: {
+          spec: {
+            project: '{{project}}',
+            source: { repoURL: 'https://example.test/repo', targetRevision: '{{revision}}' },
+            destination: { name: '{{cluster}}', namespace: '{{namespace}}' },
+          },
+        },
+      },
+    } as any);
+    const multiple = new ArgoApplicationSet({
+      apiVersion: 'argoproj.io/v1alpha1',
+      kind: 'ApplicationSet',
+      metadata: { name: 'multiple', namespace: 'argocd' },
+      spec: {
+        template: {
+          spec: {
+            sources: [
+              { repoURL: 'https://example.test/one' },
+              { repoURL: 'https://example.test/two' },
+            ],
+          },
+        },
+      },
+    } as any);
+
+    expect(single.templateSources).toHaveLength(1);
+    expect(single.templateProject).toBe('{{project}}');
+    expect(single.templateDestination).toEqual({ name: '{{cluster}}', namespace: '{{namespace}}' });
+    expect(multiple.templateSources).toHaveLength(2);
+  });
+
+  it('uses the documented ApplicationSet health priority', () => {
+    expect(getApplicationSetHealthStatus({ health: { status: 'Healthy' } })).toBe('Healthy');
+    expect(
+      getApplicationSetHealthStatus({
+        conditions: [
+          { type: 'ResourcesUpToDate', status: 'True' },
+          { type: 'ErrorOccurred', status: 'True' },
+        ],
+      })
+    ).toBe('Degraded');
+    expect(
+      getApplicationSetHealthStatus({
+        conditions: [{ type: 'RolloutProgressing', status: 'True' }],
+      })
+    ).toBe('Progressing');
+    expect(getApplicationSetHealthStatus()).toBe('Unknown');
+  });
+
+  it('uses count precedence and keeps an unknown count unknown', () => {
+    expect(getGeneratedApplicationCount({ resourcesCount: 5, resources: [{}, {}] }, 1)).toBe(5);
+    expect(getGeneratedApplicationCount({ resources: [{}, {}] }, 1)).toBe(2);
+    expect(getGeneratedApplicationCount(undefined, 1)).toBe(1);
+    expect(getGeneratedApplicationCount()).toBeUndefined();
+  });
+
+  it('matches generated Applications only by same-cluster namespace and owner UID', () => {
+    const applicationSet = {
+      cluster: 'cluster-a',
+      metadata: { namespace: 'argocd', uid: 'set-uid' },
+    };
+    const app = {
+      cluster: 'cluster-a',
+      metadata: {
+        namespace: 'argocd',
+        ownerReferences: [
+          { apiVersion: 'argoproj.io/v1alpha1', kind: 'ApplicationSet', uid: 'set-uid' },
+        ],
+      },
+    };
+    expect(isGeneratedApplication(app, applicationSet)).toBe(true);
+    expect(
+      isGeneratedApplication(
+        {
+          ...app,
+          metadata: {
+            ...app.metadata,
+            ownerReferences: [
+              { apiVersion: 'argoproj.io/v1beta1', kind: 'ApplicationSet', uid: 'set-uid' },
+            ],
+          },
+        },
+        applicationSet
+      )
+    ).toBe(true);
+    expect(isGeneratedApplication({ ...app, cluster: 'cluster-b' }, applicationSet)).toBe(false);
+    expect(
+      isGeneratedApplication(
+        { ...app, metadata: { ...app.metadata, namespace: 'other' } },
+        applicationSet
+      )
+    ).toBe(false);
+    expect(
+      isGeneratedApplication(
+        {
+          ...app,
+          metadata: {
+            ...app.metadata,
+            ownerReferences: [
+              { apiVersion: 'argoproj.io/v1alpha1', kind: 'ApplicationSet', uid: 'other' },
+            ],
+          },
+        },
+        applicationSet
+      )
+    ).toBe(false);
+    expect(
+      isGeneratedApplication(
+        {
+          ...app,
+          metadata: {
+            ...app.metadata,
+            ownerReferences: [
+              { apiVersion: 'other.io/v1alpha1', kind: 'ApplicationSet', uid: 'set-uid' },
+              { apiVersion: 'argoproj.io/v1alpha1', kind: 'Application', uid: 'set-uid' },
+            ],
+          },
+        },
+        applicationSet
+      )
+    ).toBe(false);
+  });
+});

--- a/argocd/src/resources/applicationset.ts
+++ b/argocd/src/resources/applicationset.ts
@@ -1,0 +1,287 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { K8s } from '@kinvolk/headlamp-plugin/lib';
+import { ArgoApplicationSpec, argocdApiGroup, argocdApiVersion, SourceSpec } from './application';
+
+const { KubeObject } = K8s.cluster;
+type KubeObjectInterface = K8s.cluster.KubeObjectInterface;
+
+export interface ApplicationSetCondition {
+  type: string;
+  status?: string;
+  reason?: string;
+  message?: string;
+  lastTransitionTime?: string;
+}
+
+export interface ApplicationSetResource {
+  group?: string;
+  version?: string;
+  kind?: string;
+  namespace?: string;
+  name?: string;
+}
+
+export interface ApplicationSetTemplate {
+  metadata?: { name?: string };
+  spec?: Partial<ArgoApplicationSpec>;
+}
+
+export interface ApplicationSetStatus {
+  health?: { status?: string };
+  conditions?: ApplicationSetCondition[];
+  resources?: ApplicationSetResource[];
+  resourcesCount?: number;
+  applicationStatus?: ApplicationSetProgressiveSyncStatus[];
+}
+
+export interface ApplicationSetProgressiveSyncStatus {
+  application: string;
+  status?: string;
+  step?: string;
+  message?: string;
+  lastTransitionTime?: string;
+}
+
+export interface ArgoApplicationSetSpec {
+  generators?: Record<string, unknown>[];
+  template?: ApplicationSetTemplate;
+}
+
+export interface KubeArgoApplicationSet extends KubeObjectInterface {
+  spec: ArgoApplicationSetSpec;
+  status?: ApplicationSetStatus;
+}
+
+type GeneratorValue = Record<string, unknown>;
+
+function asRecord(value: unknown): GeneratorValue | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as GeneratorValue)
+    : undefined;
+}
+
+function generatorChildren(value: unknown): GeneratorValue[] {
+  const record = asRecord(value);
+  const generators = record?.generators;
+  return Array.isArray(generators)
+    ? generators
+        .map(asRecord)
+        .filter((generator): generator is GeneratorValue => Boolean(generator))
+    : [];
+}
+
+/** Returns a repository identifier without credentials, query parameters, or fragments. */
+export function safeRepositoryIdentifier(value: unknown): string {
+  if (typeof value !== 'string') return '';
+  const repository = value.trim();
+  if (!repository) return '';
+
+  try {
+    const url = new URL(repository);
+    url.username = '';
+    url.password = '';
+    url.search = '';
+    url.hash = '';
+    return url.toString();
+  } catch {
+    const withoutQueryOrFragment = repository.split(/[?#]/, 1)[0];
+    const withoutUrlUserInfo = withoutQueryOrFragment.replace(
+      /^([a-z][a-z\d+.-]*:\/\/)[^/@\s]*@/i,
+      '$1'
+    );
+    return withoutUrlUserInfo.replace(/^[^@\s]+@(?=[^/\s]+[:/])/, '');
+  }
+}
+
+function namedGeneratorSummary(name: string, value: unknown): string {
+  const record = asRecord(value);
+  if (!record) return name;
+
+  if (name === 'Git') {
+    const directories = Array.isArray(record.directories) ? record.directories.length : 0;
+    const files = Array.isArray(record.files) ? record.files.length : 0;
+    const repo = safeRepositoryIdentifier(record.repoURL);
+    const count = directories + files;
+    return [name, repo, count ? `${count} path${count === 1 ? '' : 's'}` : '']
+      .filter(Boolean)
+      .join(' · ');
+  }
+
+  if (name === 'Plugin') {
+    const configMapRef = asRecord(record.configMapRef);
+    const configMapName =
+      typeof record.configMapRef === 'string'
+        ? record.configMapRef
+        : typeof configMapRef?.name === 'string'
+        ? configMapRef.name
+        : '';
+    return configMapName ? `${name} · ${configMapName}` : name;
+  }
+
+  if (name === 'SCM Provider') {
+    const github = asRecord(record.github);
+    return typeof github?.organization === 'string' ? `${name} · ${github.organization}` : name;
+  }
+
+  return name;
+}
+
+/** Returns a short, credential-safe description of an ApplicationSet generator. */
+export function getGeneratorSummary(generator: GeneratorValue): string {
+  const knownGenerators: [string, string][] = [
+    ['list', 'List'],
+    ['clusters', 'Clusters'],
+    ['git', 'Git'],
+    ['scmProvider', 'SCM Provider'],
+    ['pullRequest', 'Pull Request'],
+    ['clusterDecisionResource', 'Cluster Decision Resource'],
+    ['plugin', 'Plugin'],
+  ];
+
+  for (const [key, label] of knownGenerators) {
+    if (key in generator) return namedGeneratorSummary(label, generator[key]);
+  }
+
+  for (const [key, label] of [
+    ['matrix', 'Matrix'],
+    ['merge', 'Merge'],
+  ] as [string, string][]) {
+    if (key in generator) {
+      const children = generatorChildren(generator[key]).map(getGeneratorSummary);
+      return children.length ? `${label} (${children.join(' + ')})` : label;
+    }
+  }
+
+  return 'Unknown generator';
+}
+
+export function getApplicationSetHealthStatus(status?: ApplicationSetStatus): string {
+  if (status?.health?.status) return status.health.status;
+  const trueConditions = new Set(
+    (status?.conditions ?? [])
+      .filter(condition => condition.status === 'True')
+      .map(condition => condition.type)
+  );
+  if (trueConditions.has('ErrorOccurred')) return 'Degraded';
+  if (trueConditions.has('RolloutProgressing')) return 'Progressing';
+  if (trueConditions.has('ResourcesUpToDate')) return 'Healthy';
+  return 'Unknown';
+}
+
+/** Applies the controller, status-resource, then verified-live count precedence. */
+export function getGeneratedApplicationCount(
+  status?: ApplicationSetStatus,
+  verifiedLiveCount?: number
+): number | undefined {
+  if (typeof status?.resourcesCount === 'number') return status.resourcesCount;
+  if (status?.resources) return status.resources.length;
+  return verifiedLiveCount;
+}
+
+/**
+ * Determines whether an Application is generated by this ApplicationSet.
+ * The controller-created owner reference UID is the only accepted identity.
+ */
+export function isGeneratedApplication(
+  application: {
+    cluster?: string;
+    metadata: {
+      namespace?: string;
+      ownerReferences?: Array<{ apiVersion?: string; kind?: string; uid?: string }>;
+    };
+  },
+  applicationSet: { cluster?: string; metadata: { namespace?: string; uid?: string } }
+): boolean {
+  if (
+    !applicationSet.metadata.uid ||
+    application.cluster !== applicationSet.cluster ||
+    application.metadata.namespace !== applicationSet.metadata.namespace
+  ) {
+    return false;
+  }
+
+  return (application.metadata.ownerReferences ?? []).some(
+    owner =>
+      owner.apiVersion?.split('/')[0] === argocdApiGroup &&
+      owner.kind === 'ApplicationSet' &&
+      owner.uid === applicationSet.metadata.uid
+  );
+}
+
+/** Headlamp KubeObject wrapper for the read-only Argo CD ApplicationSet CRD. */
+export class ArgoApplicationSet extends KubeObject<KubeArgoApplicationSet> {
+  static kind = 'ApplicationSet';
+  static apiName = 'applicationsets';
+  static apiVersion = argocdApiVersion;
+  static isNamespaced = true;
+
+  static get detailsRoute() {
+    return '/argocd/applicationsets/:namespace/:name';
+  }
+
+  get spec(): ArgoApplicationSetSpec {
+    return this.jsonData.spec;
+  }
+
+  get status(): ApplicationSetStatus | undefined {
+    return this.jsonData.status;
+  }
+
+  get generators(): GeneratorValue[] {
+    return this.spec.generators ?? [];
+  }
+
+  get generatorSummaries(): string[] {
+    return this.generators.map(getGeneratorSummary);
+  }
+
+  get template(): ApplicationSetTemplate | undefined {
+    return this.spec.template;
+  }
+
+  get templateSources(): SourceSpec[] {
+    const spec = this.template?.spec;
+    return spec?.sources ?? (spec?.source ? [spec.source] : []);
+  }
+
+  get templateProject(): string {
+    return this.template?.spec?.project ?? '-';
+  }
+
+  get templateDestination(): ArgoApplicationSpec['destination'] | undefined {
+    return this.template?.spec?.destination;
+  }
+
+  get conditions(): ApplicationSetCondition[] {
+    return this.status?.conditions ?? [];
+  }
+
+  get progressiveSyncStatus(): ApplicationSetProgressiveSyncStatus[] {
+    return this.status?.applicationStatus ?? [];
+  }
+
+  get healthStatus(): string {
+    return getApplicationSetHealthStatus(this.status);
+  }
+
+  get generatedApplicationCount(): number | undefined {
+    return getGeneratedApplicationCount(this.status);
+  }
+}
+
+export { argocdApiGroup };


### PR DESCRIPTION
## Summary

This PR adds read-only Argo CD ApplicationSet visibility and Argo CD GitOps information to Headlamp Projects.

ApplicationSets receive CRD-aware list and detail pages with safe generator summaries, template information, controller conditions, generated Application counts, and live generated Application status. Headlamp Project pages receive an Argo CD overview and an Applications tab for Applications that explicitly deploy into the Project's local namespaces.

No ApplicationSet mutation or new Argo CD action is introduced.

## Why read-only first?

ApplicationSets can generate and manage many Applications. Inventory, ownership, and status visibility provide immediate operational value without exposing risky create, edit, delete, preview, sync, or generator mutation controls.

Project integration answers a separate operational question: which Argo CD Applications deploy into the namespaces owned by this Headlamp Project? Membership is based on destination cluster and namespace, not where the Application custom resource is stored.

## Changes

### ApplicationSets

- Add an ArgoApplicationSet KubeObject model with typed template, generator, condition, health, resource-count, and progressive-sync accessors.
- Add concise summaries for List, Clusters, Git, SCM Provider, Pull Request, Cluster Decision Resource, Plugin, Matrix, and Merge generators.
- Avoid rendering secret references, credentials, tokens, or arbitrary plugin inputs.
- Add a read-only ApplicationSet list with generator, template project, destination, generated count, and age columns.
- Add a read-only detail page with template sources and destination, generator summaries, generated Applications, controller conditions, and Events.
- Resolve generated Applications only through exact same-cluster, same-namespace owner references matching the ApplicationSet UID.
- Preserve controller counts when live Application listing is forbidden or unavailable.

### Headlamp Projects

- Register an Argo CD summary on Project overview pages.
- Register an Argo CD Applications Project detail tab.
- Include only Applications loaded from a Project cluster that explicitly target in-cluster or https://kubernetes.default.svc and deploy into one of the Project namespaces.
- Exclude remote or unverified destinations and Applications without an explicit destination namespace.
- Preserve cluster context in Application links and deduplicate by cluster, Application namespace, and name.
- Show Total, Synced, Healthy, and Needs Attention counts.
- Preserve successful results and show a partial-results warning when only some Project clusters fail.

### Registration and CRD handling

- Refine the cached CRD guard to track exact Argo CD CRD names per cluster.
- Hide only the sidebar entry whose CRD is unavailable.
- Keep the Argo CD parent visible when any supported Argo CD CRD exists.
- Add ApplicationSet routes, sidebar navigation, Project integrations, and offline Argo icon registrations.
- Keep existing Applications, AppProjects, Resource Tree Map, namespace insights, API availability, and Open in Argo CD behavior intact.

## Safety

- No ApplicationSet create, edit, delete, sync, preview, or generator controls.
- No Kubernetes mutation requests.
- Generated Applications are never inferred from names, labels, or templates.
- Remote Applications never become Project members based only on a matching namespace name.
- Missing destination namespaces are excluded instead of being assumed to be default.
- No network-loaded icons or Argo CD API tokens are introduced.

## Validation

- Prettier formatting check passed.
- ESLint passed with zero warnings.
- TypeScript passed with no emit.
- All 15 test files and 112 tests passed.
- Production build passed.
- All six commits include Signed-off-by lines.

## Steps to test

1. Install an ApplicationSet CRD and create a List-generator ApplicationSet producing at least two Applications.
2. Open Argo CD > ApplicationSets and verify the read-only inventory columns.
3. Open an ApplicationSet and verify template information, generator summaries, generated Applications, conditions, and Events.
4. Select a generated Application and confirm its existing cluster-aware Argo CD Application detail page opens.
5. Confirm no create, edit, delete, sync, preview, or generator actions are present.
6. Remove or deny ApplicationSet list access and verify the page handles the unavailable state without mutation controls.
7. Open a Headlamp Project containing the generated destination namespace.
8. Verify the overview counts and Argo CD Applications tab include the local generated Applications.
9. Create or inspect a remote Application targeting the same namespace name and verify it is excluded.
10. If using a multi-cluster Project, verify cluster identity is shown and partial cluster failures retain successful results.
11. On a cluster without the ApplicationSet CRD, verify only the ApplicationSets sidebar entry is hidden.

## Required access

This feature uses Kubernetes read access only: get, list, and watch for ApplicationSets and Applications.