### PR TITLE
 fix(kueue): resolve namespace-scoped RBAC blocks for Workloads and L…

### DIFF
--- a/kueue/src/components/common/KueueAdminResourceAccess.tsx
+++ b/kueue/src/components/common/KueueAdminResourceAccess.tsx
@@ -31,11 +31,21 @@ export default function KueueAdminResourceAccess({
   children,
 }: KueueAdminResourceAccessProps) {
   const [allowed, setAllowed] = useState<boolean | null>(null);
+  const [error, setError] = useState<Error | null>(null);
 
   return (
     <>
-      {allowed === null && <Loader title={`Checking access to Kueue ${resourceLabel}`} />}
-      {allowed === false && (
+      {allowed === null && error === null && (
+        <Loader title={`Checking access to Kueue ${resourceLabel}`} />
+      )}
+      {error !== null && (
+        <SectionBox title={`Kueue ${resourceLabel}`}>
+          <EmptyContent color="error.main">
+            {`Failed to check access: ${error.message}`}
+          </EmptyContent>
+        </SectionBox>
+      )}
+      {allowed === false && error === null && (
         <SectionBox title={`Kueue ${resourceLabel}`}>
           <EmptyContent color="text.secondary">
             {`${accessDescription} Your current Kubernetes credentials are not authorized to ${
@@ -49,7 +59,7 @@ export default function KueueAdminResourceAccess({
         authVerb={verb}
         namespace={namespace}
         onAuthResult={result => setAllowed(result.allowed)}
-        onError={() => setAllowed(false)}
+        onError={err => setError(err)}
       >
         {children}
       </AuthVisible>

--- a/kueue/src/components/common/KueueAdminResourceAccess.tsx
+++ b/kueue/src/components/common/KueueAdminResourceAccess.tsx
@@ -14,6 +14,8 @@ interface KueueAdminResourceAccessProps {
   resourceLabel: string;
   /** Kubernetes verb to verify before rendering the page. */
   verb: 'get' | 'list';
+  /** Optional namespace for namespace-scoped resources. */
+  namespace?: string;
   /** Optional sentence describing the resource scope in denied messages. */
   accessDescription?: string;
   /** Page content to render after the user is authorized. */
@@ -24,6 +26,7 @@ export default function KueueAdminResourceAccess({
   resourceClass,
   resourceLabel,
   verb,
+  namespace,
   accessDescription = `Kueue ${resourceLabel} are cluster-scoped admin resources.`,
   children,
 }: KueueAdminResourceAccessProps) {
@@ -44,6 +47,7 @@ export default function KueueAdminResourceAccess({
       <AuthVisible
         item={resourceClass}
         authVerb={verb}
+        namespace={namespace}
         onAuthResult={result => setAllowed(result.allowed)}
         onError={() => setAllowed(false)}
       >

--- a/kueue/src/components/localqueues/Detail.tsx
+++ b/kueue/src/components/localqueues/Detail.tsx
@@ -43,6 +43,7 @@ export default function LocalQueueDetail() {
       resourceClass={LocalQueue}
       resourceLabel="LocalQueues"
       verb="get"
+      namespace={namespace}
       accessDescription="Kueue LocalQueues are namespaced user queue resources."
     >
       <DetailsGrid

--- a/kueue/src/components/localqueues/List.tsx
+++ b/kueue/src/components/localqueues/List.tsx
@@ -1,11 +1,25 @@
 import { ResourceListView } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import type { FilterState } from '@kinvolk/headlamp-plugin/lib/redux/filterSlice';
+import { useSelector } from 'react-redux';
 import { ClusterQueue } from '../../resources/clusterQueue';
 import { LocalQueue } from '../../resources/localQueue';
+import KueueAdminResourceAccess from '../common/KueueAdminResourceAccess';
 
 export default function LocalQueueList() {
+  const namespacesSet = useSelector((state: { filter: FilterState }) => state.filter.namespaces);
+  const namespaces = [...namespacesSet];
+  const namespace = namespaces.length === 1 ? namespaces[0] : undefined;
+
   return (
-    <ResourceListView
-      title="Kueue LocalQueues"
+    <KueueAdminResourceAccess
+      resourceClass={LocalQueue}
+      resourceLabel="LocalQueues"
+      verb="list"
+      namespace={namespace}
+      accessDescription="Kueue LocalQueues are namespaced user queue resources."
+    >
+      <ResourceListView
+        title="Kueue LocalQueues"
         resourceClass={LocalQueue}
         columns={[
           'name',
@@ -43,5 +57,6 @@ export default function LocalQueueList() {
           'age',
         ]}
       />
+    </KueueAdminResourceAccess>
   );
 }

--- a/kueue/src/components/localqueues/List.tsx
+++ b/kueue/src/components/localqueues/List.tsx
@@ -1,18 +1,11 @@
 import { ResourceListView } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 import { ClusterQueue } from '../../resources/clusterQueue';
 import { LocalQueue } from '../../resources/localQueue';
-import KueueAdminResourceAccess from '../common/KueueAdminResourceAccess';
 
 export default function LocalQueueList() {
   return (
-    <KueueAdminResourceAccess
-      resourceClass={LocalQueue}
-      resourceLabel="LocalQueues"
-      verb="list"
-      accessDescription="Kueue LocalQueues are namespaced user queue resources."
-    >
-      <ResourceListView
-        title="Kueue LocalQueues"
+    <ResourceListView
+      title="Kueue LocalQueues"
         resourceClass={LocalQueue}
         columns={[
           'name',
@@ -50,6 +43,5 @@ export default function LocalQueueList() {
           'age',
         ]}
       />
-    </KueueAdminResourceAccess>
   );
 }

--- a/kueue/src/components/workloads/Detail.tsx
+++ b/kueue/src/components/workloads/Detail.tsx
@@ -461,6 +461,7 @@ export default function WorkloadDetail() {
       resourceClass={Workload}
       resourceLabel="Workloads"
       verb="get"
+      namespace={namespace}
       accessDescription="Kueue Workloads are namespaced user workload resources."
     >
       <DetailsGrid

--- a/kueue/src/components/workloads/List.tsx
+++ b/kueue/src/components/workloads/List.tsx
@@ -1,10 +1,25 @@
 import { ResourceListView } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import type { FilterState } from '@kinvolk/headlamp-plugin/lib/redux/filterSlice';
+import { useSelector } from 'react-redux';
 import { Workload } from '../../resources/workload';
+import KueueAdminResourceAccess from '../common/KueueAdminResourceAccess';
 
 export default function WorkloadList() {
+  // Use 'type' import so it doesn't crash at runtime, and avoid 'any'
+  const namespacesSet = useSelector((state: { filter: FilterState }) => state.filter.namespaces);
+  const namespaces = [...namespacesSet];
+  const namespace = namespaces.length === 1 ? namespaces[0] : undefined;
+
   return (
-    <ResourceListView
-      title="Kueue Workloads"
+    <KueueAdminResourceAccess
+      resourceClass={Workload}
+      resourceLabel="Workloads"
+      verb="list"
+      namespace={namespace}
+      accessDescription="Kueue Workloads are namespaced user workload resources."
+    >
+      <ResourceListView
+        title="Kueue Workloads"
         resourceClass={Workload}
         columns={[
           'name',
@@ -47,5 +62,6 @@ export default function WorkloadList() {
           'age',
         ]}
       />
+    </KueueAdminResourceAccess>
   );
 }

--- a/kueue/src/components/workloads/List.tsx
+++ b/kueue/src/components/workloads/List.tsx
@@ -1,17 +1,10 @@
 import { ResourceListView } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 import { Workload } from '../../resources/workload';
-import KueueAdminResourceAccess from '../common/KueueAdminResourceAccess';
 
 export default function WorkloadList() {
   return (
-    <KueueAdminResourceAccess
-      resourceClass={Workload}
-      resourceLabel="Workloads"
-      verb="list"
-      accessDescription="Kueue Workloads are namespaced user workload resources."
-    >
-      <ResourceListView
-        title="Kueue Workloads"
+    <ResourceListView
+      title="Kueue Workloads"
         resourceClass={Workload}
         columns={[
           'name',
@@ -54,6 +47,5 @@ export default function WorkloadList() {
           'age',
         ]}
       />
-    </KueueAdminResourceAccess>
   );
 }


### PR DESCRIPTION
## Summary

This PR fixes namespace-scoped RBAC blocks for Kueue Workloads and LocalQueues by ensuring localized access checks are used instead of strictly enforcing cluster-scoped admin access.

## Related Issue

Fixes #1199 

## Changes

- **Updated** `KueueAdminResourceAccess` to accept and pass an optional `namespace` prop.
- **Fixed** RBAC checks on LocalQueue and Workload `Detail` views by passing the `namespace` to `KueueAdminResourceAccess`.
- **Refactored** LocalQueue and Workload `List` views by removing the cluster-scoped `KueueAdminResourceAccess` wrapper, allowing Headlamp's native `ResourceListView` to natively handle localized RBAC.

## Steps to Test

1. Configure a user or ServiceAccount with namespace-scoped permissions (no cluster-wide access) for Kueue Workloads and LocalQueues.
2. Log into Headlamp with that user/ServiceAccount.
3. Navigate to the Kueue Workloads and LocalQueues list views and verify they load successfully without cluster-wide RBAC block errors.
4. Navigate to the detail view of a Workload and LocalQueue within the permitted namespace and verify access is correctly granted.

## Screenshots

<img width="1899" height="1114" alt="image" src="https://github.com/user-attachments/assets/e23359f1-0c1b-4252-b20b-85fa34a76fcf" />
<img width="1903" height="1116" alt="image" src="https://github.com/user-attachments/assets/4e7ff3bd-28e8-44f0-886a-2d860bb07bf0" />
