### PR TITLE
feat(minikube): add action button to open minikube service URL

### DIFF
--- a/minikube/src/CommandCluster/CommandCluster.tsx
+++ b/minikube/src/CommandCluster/CommandCluster.tsx
@@ -9,6 +9,16 @@ const MAX_OUTPUT_LINES = 200;
 
 declare const pluginRunCommand: typeof runCommand;
 declare const pluginPath: string;
+
+function getPluginRunCommand() {
+  if (typeof pluginRunCommand === 'function') {
+    return pluginRunCommand;
+  }
+  if (typeof window !== 'undefined' && typeof (window as any).pluginRunCommand === 'function') {
+    return (window as any).pluginRunCommand;
+  }
+  return null;
+}
 const packagePath =
   typeof pluginPath !== 'undefined'
     ? pluginPath.startsWith('plugins/') || pluginPath.startsWith('plugins\\')
@@ -226,7 +236,12 @@ export default function CommandCluster(props: CommandClusterProps) {
       if (!openDialog) return;
 
       try {
-        const proc = runCommand('minikube', ['version', '--short'], {});
+        const runner = getPluginRunCommand();
+        if (!runner) {
+          setMinikubeAvailable(false);
+          return;
+        }
+        const proc = runner('minikube', ['version', '--short'], {});
         proc.on('exit', code => {
           setMinikubeAvailable(code === 0);
         });
@@ -280,6 +295,12 @@ export default function CommandCluster(props: CommandClusterProps) {
         console.log({ minikubeProfiles, isHyperV, isVfkit, driver, existingProfile });
       }
 
+      const runner = getPluginRunCommand();
+      if (!runner) {
+        console.error('pluginRunCommand is not available.');
+        return;
+      }
+
       if (isHyperV) {
         // If hyperv, we use the scriptjs to run the command because it needs to run with admin rights
         const commandHyperV = `${command}-minikube-hyperv`;
@@ -295,7 +316,7 @@ export default function CommandCluster(props: CommandClusterProps) {
         if (DEBUG) {
           console.log('runFunc 11.1, running commandHyperV:', commandHyperV, args);
         }
-        minikube = pluginRunCommand(
+        minikube = runner(
           // @ts-ignore
           'scriptjs',
           [`${packagePath}/manage-minikube.js`, ...args],
@@ -313,21 +334,21 @@ export default function CommandCluster(props: CommandClusterProps) {
           args.push('--container-runtime=containerd');
           args.push('--memory=3072');
           args.push('--addons=metallb,ingress-dns');
-          minikube = pluginRunCommand(
+          minikube = runner(
             // @ts-ignore
             'scriptjs',
             [`${packagePath}/manage-minikube.js`, ...args],
             {}
           );
         } else {
-          minikube = pluginRunCommand('minikube', args, {});
+          minikube = runner('minikube', args, {});
         }
       } else {
         if (driver) {
           args.push('--driver', driver);
         }
 
-        minikube = pluginRunCommand('minikube', args, {});
+        minikube = runner('minikube', args, {});
       }
       processRef.current = minikube;
 

--- a/minikube/src/CommandCluster/CommandCluster.tsx
+++ b/minikube/src/CommandCluster/CommandCluster.tsx
@@ -298,6 +298,7 @@ export default function CommandCluster(props: CommandClusterProps) {
       const runner = getPluginRunCommand();
       if (!runner) {
         console.error('pluginRunCommand is not available.');
+        setActing(false);
         return;
       }
 

--- a/minikube/src/CommandCluster/useInfo.ts
+++ b/minikube/src/CommandCluster/useInfo.ts
@@ -21,6 +21,17 @@ export interface DriverInfo {
 
 declare const pluginRunCommand: typeof runCommand;
 declare const pluginPath: string;
+
+function getPluginRunCommand() {
+  if (typeof pluginRunCommand === 'function') {
+    return pluginRunCommand;
+  }
+  if (typeof window !== 'undefined' && typeof (window as any).pluginRunCommand === 'function') {
+    return (window as any).pluginRunCommand;
+  }
+  return null;
+}
+
 const packagePath =
   typeof pluginPath !== 'undefined'
     ? pluginPath.startsWith('plugins/') || pluginPath.startsWith('plugins\\')
@@ -39,13 +50,22 @@ export function useInfo(): DriverInfo | null {
   const [info, setInfo] = React.useState<DriverInfo | null>(null);
 
   React.useEffect(() => {
+    const runner = getPluginRunCommand();
+    if (!runner) {
+      return;
+    }
+
     let stdoutData = '';
-    const scriptjs = pluginRunCommand(
-      //@ts-ignore
-      'scriptjs',
-      [`${packagePath}/manage-minikube.js`, '-headless', 'info'],
-      {}
-    );
+    try {
+      const scriptjs = runner(
+        //@ts-ignore
+        'scriptjs',
+        [`${packagePath}/manage-minikube.js`, '-headless', 'info'],
+        {}
+      );
+      if (!scriptjs || !scriptjs.stdout) {
+        return;
+      }
     scriptjs.stdout.on('data', data => {
       if (DEBUG) {
         console.log('useInfo on data:', data.toString());
@@ -73,6 +93,9 @@ export function useInfo(): DriverInfo | null {
         setInfo(null);
       }
     });
+    } catch (err) {
+      console.error('Failed to execute minikube info command:', err);
+    }
 
     return () => {
       // Cleanup if needed

--- a/minikube/src/CommandCluster/useInfo.ts
+++ b/minikube/src/CommandCluster/useInfo.ts
@@ -56,8 +56,9 @@ export function useInfo(): DriverInfo | null {
     }
 
     let stdoutData = '';
+    let scriptjs: any = null;
     try {
-      const scriptjs = runner(
+      scriptjs = runner(
         //@ts-ignore
         'scriptjs',
         [`${packagePath}/manage-minikube.js`, '-headless', 'info'],
@@ -98,7 +99,13 @@ export function useInfo(): DriverInfo | null {
     }
 
     return () => {
-      // Cleanup if needed
+      try {
+        if (scriptjs && typeof scriptjs.kill === 'function') {
+          scriptjs.kill();
+        }
+      } catch {
+        // ignore cleanup error
+      }
     };
   }, []);
 

--- a/minikube/src/MinikubeServiceAction.tsx
+++ b/minikube/src/MinikubeServiceAction.tsx
@@ -17,8 +17,11 @@ function getRunner() {
 
 function openUrl(url: string) {
   try {
-    const win = window.open(url, '_blank');
-    if (!win) {
+    if (typeof window !== 'undefined' && typeof window.open === 'function') {
+      const win = window.open(url, '_blank');
+      if (win) return;
+    }
+    if (typeof document !== 'undefined') {
       const link = document.createElement('a');
       link.href = url;
       link.target = '_blank';
@@ -127,10 +130,13 @@ export function MinikubeServiceAction({ item }: MinikubeServiceActionProps) {
       cmd.on?.('exit', (code: number) => {
         clearTimeout(timer);
         setLoading(false);
-        if (!opened && code !== 0) {
+        if (!opened) {
           setSnackbar({
             open: true,
-            message: `Minikube exited with code ${code}. Make sure Minikube is running.`,
+            message:
+              code !== 0
+                ? `Minikube exited with code ${code}. Make sure Minikube is running.`
+                : `No URL returned by Minikube for service "${name}". Does the service expose a port?`,
             severity: 'error',
           });
         }

--- a/minikube/src/MinikubeServiceAction.tsx
+++ b/minikube/src/MinikubeServiceAction.tsx
@@ -1,0 +1,185 @@
+import { ActionButton } from '@kinvolk/headlamp-plugin/lib/components/common';
+import type { KubeObject } from '@kinvolk/headlamp-plugin/lib/lib/k8s/KubeObject';
+import { Alert, Snackbar } from '@mui/material';
+import React from 'react';
+
+declare const pluginRunCommand: any;
+
+function getRunner() {
+  if (typeof pluginRunCommand === 'function') {
+    return pluginRunCommand;
+  }
+  if (typeof window !== 'undefined' && typeof (window as any)?.pluginRunCommand === 'function') {
+    return (window as any).pluginRunCommand;
+  }
+  return null;
+}
+
+function openUrl(url: string) {
+  try {
+    const win = window.open(url, '_blank');
+    if (!win) {
+      const link = document.createElement('a');
+      link.href = url;
+      link.target = '_blank';
+      link.rel = 'noopener noreferrer';
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+    }
+  } catch (e) {
+    console.error('[Minikube] Failed to open URL in browser:', e);
+  }
+}
+
+export interface MinikubeServiceActionProps {
+  item?: KubeObject;
+}
+
+export function MinikubeServiceAction({ item }: MinikubeServiceActionProps) {
+  const [loading, setLoading] = React.useState(false);
+  const [snackbar, setSnackbar] = React.useState<{
+    open: boolean;
+    message: string;
+    severity: 'info' | 'success' | 'error';
+  }>({
+    open: false,
+    message: '',
+    severity: 'info',
+  });
+
+  if (!item || item.kind !== 'Service') {
+    return null;
+  }
+
+  const name =
+    typeof item.getName === 'function'
+      ? item.getName()
+      : item.metadata?.name || (item as any)?.jsonData?.metadata?.name || '';
+  const namespace =
+    typeof item.getNamespace === 'function'
+      ? item.getNamespace()
+      : item.metadata?.namespace || (item as any)?.jsonData?.metadata?.namespace || 'default';
+
+  function handleOpenService() {
+    const runner = getRunner();
+
+    if (!runner) {
+      console.warn('[Minikube] Runner not available');
+      setSnackbar({
+        open: true,
+        message: 'Command runner is not available in this environment.',
+        severity: 'error',
+      });
+      return;
+    }
+
+    setLoading(true);
+    setSnackbar({
+      open: true,
+      message: `Fetching Minikube service URL for "${name}"...`,
+      severity: 'info',
+    });
+
+    try {
+      console.log(`[Minikube] Running service command for ${namespace}/${name}`);
+      const cmd = runner('minikube', ['service', name, '-n', namespace, '--url'], {});
+
+      let opened = false;
+
+      // Safety timeout after 30 seconds
+      const timer = setTimeout(() => {
+        if (!opened) {
+          setLoading(false);
+          setSnackbar({
+            open: true,
+            message: `Timed out waiting for Minikube URL for service "${name}".`,
+            severity: 'error',
+          });
+        }
+      }, 30000);
+
+      cmd.stdout?.on('data', (data: any) => {
+        if (opened) return;
+        const output = data.toString();
+        console.log('[Minikube] service output:', output);
+        const match = output.match(/https?:\/\/[^\s\r\n]+/);
+        if (match) {
+          opened = true;
+          clearTimeout(timer);
+          setLoading(false);
+          const url = match[0];
+          console.log('[Minikube] Opening URL:', url);
+          setSnackbar({
+            open: true,
+            message: `Opening ${url} in your browser...`,
+            severity: 'success',
+          });
+          openUrl(url);
+        }
+      });
+
+      cmd.stderr?.on('data', (data: any) => {
+        const errOutput = data.toString();
+        console.warn('[Minikube] service stderr:', errOutput);
+      });
+
+      cmd.on?.('exit', (code: number) => {
+        clearTimeout(timer);
+        setLoading(false);
+        if (!opened && code !== 0) {
+          setSnackbar({
+            open: true,
+            message: `Minikube exited with code ${code}. Make sure Minikube is running.`,
+            severity: 'error',
+          });
+        }
+      });
+
+      cmd.on?.('error', (err: any) => {
+        clearTimeout(timer);
+        setLoading(false);
+        console.error('[Minikube] process error:', err);
+        setSnackbar({
+          open: true,
+          message: `Failed to execute Minikube: ${err?.message || err}`,
+          severity: 'error',
+        });
+      });
+    } catch (err: any) {
+      setLoading(false);
+      console.error('[Minikube] Failed to run minikube service command:', err);
+      setSnackbar({
+        open: true,
+        message: `Error: ${err?.message || err}`,
+        severity: 'error',
+      });
+    }
+  }
+
+  return (
+    <>
+      <ActionButton
+        description={loading ? 'Fetching Minikube Service URL...' : 'Open Minikube Service URL'}
+        icon={loading ? 'mdi:loading' : 'mdi:open-in-new'}
+        onClick={handleOpenService}
+      />
+      <Snackbar
+        open={snackbar.open}
+        autoHideDuration={4000}
+        onClose={() => setSnackbar(prev => ({ ...prev, open: false }))}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert
+          onClose={() => setSnackbar(prev => ({ ...prev, open: false }))}
+          severity={snackbar.severity}
+          sx={{ width: '100%' }}
+        >
+          {snackbar.message}
+        </Alert>
+      </Snackbar>
+    </>
+  );
+}
+
+export default MinikubeServiceAction;

--- a/minikube/src/MinikubeServiceAction.tsx
+++ b/minikube/src/MinikubeServiceAction.tsx
@@ -102,10 +102,9 @@ export function MinikubeServiceAction({ item }: MinikubeServiceActionProps) {
         }
       }, 30000);
 
-      cmd.stdout?.on('data', (data: any) => {
+      function handleData(data: any) {
         if (opened) return;
         const output = data.toString();
-        console.log('[Minikube] service output:', output);
         const match = output.match(/https?:\/\/[^\s\r\n]+/);
         if (match) {
           opened = true;
@@ -120,11 +119,16 @@ export function MinikubeServiceAction({ item }: MinikubeServiceActionProps) {
           });
           openUrl(url);
         }
+      }
+
+      cmd.stdout?.on('data', (data: any) => {
+        console.log('[Minikube] service output:', data.toString());
+        handleData(data);
       });
 
       cmd.stderr?.on('data', (data: any) => {
-        const errOutput = data.toString();
-        console.warn('[Minikube] service stderr:', errOutput);
+        console.warn('[Minikube] service stderr:', data.toString());
+        handleData(data);
       });
 
       cmd.on?.('exit', (code: number) => {

--- a/minikube/src/__tests__/MinikubeServiceAction.test.tsx
+++ b/minikube/src/__tests__/MinikubeServiceAction.test.tsx
@@ -137,4 +137,36 @@ describe('MinikubeServiceAction Component', () => {
       )
     ).toBeTruthy();
   });
+
+  it('opens URL when emitted on stderr stream', () => {
+    const stderrListeners: Record<string, Function> = {};
+    const mockCmd = {
+      stdout: { on: vi.fn() },
+      stderr: {
+        on: vi.fn((event: string, cb: Function) => {
+          stderrListeners[event] = cb;
+        }),
+      },
+      on: vi.fn(),
+    };
+
+    const mockRunner = vi.fn().mockReturnValue(mockCmd);
+    (window as any).pluginRunCommand = mockRunner;
+
+    const serviceItem = {
+      kind: 'Service',
+      getName: () => 'web-stderr',
+      getNamespace: () => 'default',
+    } as any;
+
+    render(<MinikubeServiceAction item={serviceItem} />);
+
+    const button = screen.getByTestId('action-button');
+    fireEvent.click(button);
+
+    // Simulate stderr output containing the URL
+    stderrListeners['data']('Forwarding to http://127.0.0.1:45678\n');
+
+    expect(window.open).toHaveBeenCalledWith('http://127.0.0.1:45678', '_blank');
+  });
 });

--- a/minikube/src/__tests__/MinikubeServiceAction.test.tsx
+++ b/minikube/src/__tests__/MinikubeServiceAction.test.tsx
@@ -1,0 +1,35 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { MinikubeServiceAction } from '../MinikubeServiceAction';
+
+vi.mock('@kinvolk/headlamp-plugin/lib/components/common', () => ({
+  ActionButton: (props: any) => <button aria-label={props.description} onClick={props.onClick} data-testid="action-button" />,
+}));
+
+describe('MinikubeServiceAction Component', () => {
+  it('returns null if item is missing or not a Service', () => {
+    const { container: containerNull } = render(<MinikubeServiceAction item={undefined} />);
+    expect(containerNull.firstChild).toBeNull();
+
+    const nonServiceItem = {
+      kind: 'Pod',
+      getName: () => 'my-pod',
+      getNamespace: () => 'default',
+    } as any;
+
+    const { container: containerPod } = render(<MinikubeServiceAction item={nonServiceItem} />);
+    expect(containerPod.firstChild).toBeNull();
+  });
+
+  it('renders ActionButton for Service items', () => {
+    const serviceItem = {
+      kind: 'Service',
+      getName: () => 'my-service',
+      getNamespace: () => 'default',
+    } as any;
+
+    const { container } = render(<MinikubeServiceAction item={serviceItem} />);
+    expect(container.firstChild).not.toBeNull();
+  });
+});

--- a/minikube/src/__tests__/MinikubeServiceAction.test.tsx
+++ b/minikube/src/__tests__/MinikubeServiceAction.test.tsx
@@ -103,4 +103,38 @@ describe('MinikubeServiceAction Component', () => {
       screen.getByText('Command runner is not available in this environment.')
     ).toBeTruthy();
   });
+
+  it('shows error snackbar when minikube exits without emitting a URL', () => {
+    let exitHandler: Function | undefined;
+    const mockCmd = {
+      stdout: { on: vi.fn() },
+      stderr: { on: vi.fn() },
+      on: vi.fn((event: string, cb: Function) => {
+        if (event === 'exit') exitHandler = cb;
+      }),
+    };
+
+    const mockRunner = vi.fn().mockReturnValue(mockCmd);
+    (window as any).pluginRunCommand = mockRunner;
+
+    const serviceItem = {
+      kind: 'Service',
+      getName: () => 'backend-svc',
+      getNamespace: () => 'default',
+    } as any;
+
+    render(<MinikubeServiceAction item={serviceItem} />);
+
+    const button = screen.getByTestId('action-button');
+    fireEvent.click(button);
+
+    // Simulate process exiting with code 0 without any stdout URL
+    exitHandler?.(0);
+
+    expect(
+      screen.getByText(
+        'No URL returned by Minikube for service "backend-svc". Does the service expose a port?'
+      )
+    ).toBeTruthy();
+  });
 });

--- a/minikube/src/__tests__/MinikubeServiceAction.test.tsx
+++ b/minikube/src/__tests__/MinikubeServiceAction.test.tsx
@@ -1,13 +1,27 @@
-import { render } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { MinikubeServiceAction } from '../MinikubeServiceAction';
 
 vi.mock('@kinvolk/headlamp-plugin/lib/components/common', () => ({
-  ActionButton: (props: any) => <button aria-label={props.description} onClick={props.onClick} data-testid="action-button" />,
+  ActionButton: (props: any) => (
+    <button aria-label={props.description} onClick={props.onClick} data-testid="action-button" />
+  ),
 }));
 
 describe('MinikubeServiceAction Component', () => {
+  const originalOpen = window.open;
+
+  beforeEach(() => {
+    window.open = vi.fn();
+  });
+
+  afterEach(() => {
+    window.open = originalOpen;
+    delete (window as any).pluginRunCommand;
+    vi.restoreAllMocks();
+  });
+
   it('returns null if item is missing or not a Service', () => {
     const { container: containerNull } = render(<MinikubeServiceAction item={undefined} />);
     expect(containerNull.firstChild).toBeNull();
@@ -31,5 +45,62 @@ describe('MinikubeServiceAction Component', () => {
 
     const { container } = render(<MinikubeServiceAction item={serviceItem} />);
     expect(container.firstChild).not.toBeNull();
+  });
+
+  it('executes command and opens URL when action button is clicked', () => {
+    const stdoutListeners: Record<string, Function> = {};
+    const mockCmd = {
+      stdout: {
+        on: vi.fn((event: string, cb: Function) => {
+          stdoutListeners[event] = cb;
+        }),
+      },
+      stderr: {
+        on: vi.fn(),
+      },
+      on: vi.fn(),
+    };
+
+    const mockRunner = vi.fn().mockReturnValue(mockCmd);
+    (window as any).pluginRunCommand = mockRunner;
+
+    const serviceItem = {
+      kind: 'Service',
+      getName: () => 'web-demo',
+      getNamespace: () => 'kube-system',
+    } as any;
+
+    render(<MinikubeServiceAction item={serviceItem} />);
+
+    const button = screen.getByTestId('action-button');
+    fireEvent.click(button);
+
+    expect(mockRunner).toHaveBeenCalledWith(
+      'minikube',
+      ['service', 'web-demo', '-n', 'kube-system', '--url'],
+      {}
+    );
+
+    // Simulate stdout output with URL
+    stdoutListeners['data']('http://192.168.49.2:31000\n');
+
+    expect(window.open).toHaveBeenCalledWith('http://192.168.49.2:31000', '_blank');
+  });
+
+  it('shows error snackbar when runner is not available', () => {
+    const serviceItem = {
+      kind: 'Service',
+      getName: () => 'web-demo',
+      getNamespace: () => 'default',
+    } as any;
+
+    render(<MinikubeServiceAction item={serviceItem} />);
+
+    const button = screen.getByTestId('action-button');
+    fireEvent.click(button);
+
+    expect(
+      screen.getByText('Command runner is not available in this environment.')
+    ).toBeTruthy();
   });
 });

--- a/minikube/src/__tests__/utils.test.ts
+++ b/minikube/src/__tests__/utils.test.ts
@@ -1,6 +1,7 @@
+import { afterEach, describe, expect, it } from 'vitest';
 import { generateClusterName, isValidClusterName } from '../CommandCluster/CommandDialog';
 import { detectOS } from '../CommandCluster/DriverSelect';
-import { isElectron, isMinikube } from '../index';
+import { isElectron, isMinikube } from '../isElectron';
 
 describe('isElectron', () => {
   it('returns false in a standard browser environment', () => {

--- a/minikube/src/index.tsx
+++ b/minikube/src/index.tsx
@@ -162,5 +162,7 @@ if (registerClusterStatus) {
   });
 }
 
-registerDetailsViewHeaderAction(MinikubeServiceAction);
+if (registerDetailsViewHeaderAction) {
+  registerDetailsViewHeaderAction(MinikubeServiceAction);
+}
 

--- a/minikube/src/index.tsx
+++ b/minikube/src/index.tsx
@@ -162,7 +162,7 @@ if (registerClusterStatus) {
   });
 }
 
-if (registerDetailsViewHeaderAction) {
+if (registerDetailsViewHeaderAction && isElectron()) {
   registerDetailsViewHeaderAction(MinikubeServiceAction);
 }
 

--- a/minikube/src/index.tsx
+++ b/minikube/src/index.tsx
@@ -5,6 +5,7 @@ import {
   registerClusterProviderMenuItem,
   // @ts-ignore
   registerClusterStatus,
+  registerDetailsViewHeaderAction,
   registerRoute,
   runCommand,
 } from '@kinvolk/headlamp-plugin/lib';
@@ -14,39 +15,11 @@ import ClusterStatus from './ClusterStatus';
 import CommandCluster from './CommandCluster/CommandCluster';
 import CreateClusterPage from './CreateClusterPage';
 import MinikubeIcon from './minikube.svg?react';
+import MinikubeServiceAction from './MinikubeServiceAction';
 
 const DEBUG = false;
-
-export function isElectron(): boolean {
-  // Renderer process
-  if (
-    typeof window !== 'undefined' &&
-    typeof window.process === 'object' &&
-    (window.process as any).type === 'renderer'
-  ) {
-    return true;
-  }
-
-  // Main process
-  if (
-    typeof process !== 'undefined' &&
-    typeof process.versions === 'object' &&
-    !!(process.versions as any).electron
-  ) {
-    return true;
-  }
-
-  // Detect the user agent when the `nodeIntegration` option is set to true
-  if (
-    typeof navigator === 'object' &&
-    typeof navigator.userAgent === 'string' &&
-    navigator.userAgent.indexOf('Electron') >= 0
-  ) {
-    return true;
-  }
-
-  return false;
-}
+import { isElectron, isMinikube } from './isElectron';
+export { isElectron, isMinikube };
 
 registerRoute({
   path: '/create-cluster-minikube',
@@ -61,15 +34,6 @@ registerRoute({
   noAuthRequired: true,
   disabled: !isElectron(),
 });
-
-/**
- * @returns true if the cluster is a minikube cluster
- */
-export function isMinikube(cluster: {
-  meta_data?: { extensions?: { context_info?: { provider?: string } } };
-}): boolean {
-  return cluster.meta_data?.extensions?.context_info?.provider === 'minikube.sigs.k8s.io';
-}
 
 const minikubeCommands = [
   {
@@ -149,8 +113,20 @@ const packagePath =
 
 function Command() {
   function handleClick() {
+    const runner =
+      typeof pluginRunCommand === 'function'
+        ? pluginRunCommand
+        : typeof (window as any)?.pluginRunCommand === 'function'
+        ? (window as any).pluginRunCommand
+        : null;
+
+    if (!runner) {
+      console.warn('pluginRunCommand is not available');
+      return;
+    }
+
     console.log('Running manage-minikube.js script with package path:', packagePath);
-    const scriptjs = pluginRunCommand(
+    const scriptjs = runner(
       //@ts-ignore
       'scriptjs',
       [`${packagePath}/manage-minikube.js`, 'info'],
@@ -185,3 +161,6 @@ if (registerClusterStatus) {
     return <ClusterStatus cluster={cluster} error={error} />;
   });
 }
+
+registerDetailsViewHeaderAction(MinikubeServiceAction);
+

--- a/minikube/src/isElectron.ts
+++ b/minikube/src/isElectron.ts
@@ -1,0 +1,39 @@
+export function isElectron(): boolean {
+  // Renderer process
+  if (
+    typeof window !== 'undefined' &&
+    typeof window.process === 'object' &&
+    (window.process as any).type === 'renderer'
+  ) {
+    return true;
+  }
+
+  // Main process
+  if (
+    typeof process !== 'undefined' &&
+    typeof process.versions === 'object' &&
+    !!(process.versions as any).electron
+  ) {
+    return true;
+  }
+
+  // Detect the user agent when the `nodeIntegration` option is set to true
+  if (
+    typeof navigator === 'object' &&
+    typeof navigator.userAgent === 'string' &&
+    navigator.userAgent.indexOf('Electron') >= 0
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * @returns true if the cluster is a minikube cluster
+ */
+export function isMinikube(cluster: {
+  meta_data?: { extensions?: { context_info?: { provider?: string } } };
+}): boolean {
+  return cluster.meta_data?.extensions?.context_info?.provider === 'minikube.sigs.k8s.io';
+}


### PR DESCRIPTION
### Summary
This PR implements the feature suggested in #314 by @illume to add an action button in the Kubernetes Service details view that opens the service's exposed URL in the default browser using `minikube service <name> -n <namespace> --url`.

---

### Motivation & Background
When developing locally with Minikube, accessing services (especially `NodePort` or services exposed through Minikube tunnels) requires running `minikube service <name> --url`. This PR adds a one-click header action button on Kubernetes `Service` detail views within Minikube clusters to automatically retrieve the live URL and launch it in the browser.

---

### Key Changes
* **Header Action Button**: Added `MinikubeServiceAction` registered via `registerDetailsViewHeaderAction`.
* **Execution & Permissions**: Safely invokes `pluginRunCommand('minikube', ['service', name, '-n', namespace, '--url'])` in Headlamp Desktop.
* **Resilient Output Parsing**: Added regex extraction (`/https?:\/\/[^\s\r\n]+/`) to handle multi-line driver/tunnel notices from Minikube on Windows, macOS, and Linux.
* **User Feedback & Loading State**: Added interactive spinner feedback, 30-second safety timeout, and MUI `Snackbar` notifications for success/failure states.
* **Modularized Helpers & Crash Guards**: Separated pure `isElectron` / `isMinikube` helpers and added guards across Minikube components to prevent renderer crashes when global runner scopes are undefined.
* **Comprehensive Test Suite**: Added full unit tests in `src/__tests__/MinikubeServiceAction.test.tsx` and updated `src/__tests__/utils.test.ts` (24/24 tests passing).

---

### Screenshots

#### Before
*(No Minikube action button present on Service view)*


<img width="1366" height="768" alt="Screenshot (781)" src="https://github.com/user-attachments/assets/fb7ae123-723a-4493-843b-5b981bb08c3e" />


#### After
| 1. Action Button with Tooltip | 
| :---: |
<img width="1366" height="768" alt="Screenshot (796)" src="https://github.com/user-attachments/assets/5ba04484-a97f-4d8e-86cc-f0056bddb960" />
 

| 2. Loading State |
| :---: |
<img width="1366" height="768" alt="Screenshot (797)" src="https://github.com/user-attachments/assets/99c10664-d882-4ba4-a0ec-49bae9d73036" />
 

|  3. Success Toast & Browser Launch |
| :---: |
<img width="1366" height="768" alt="Screenshot (798)" src="https://github.com/user-attachments/assets/121fd470-b7e1-4f89-9093-634f17920abc" />
 

*(Live service opened in browser:)*
<img width="1366" height="721" alt="Screenshot (799)" src="https://github.com/user-attachments/assets/2a248ea3-dd07-461a-bd2f-9b17260fa31d" />

---

### Verification
- [x] Tested end-to-end on Minikube v1.38.1 with Headlamp Desktop.
- [x] Verified `minikube service` URL generation and browser launch on a live `NodePort` service (`nginx`).
- [x] All 24 unit tests passing (`npm run test`).
- [x] TypeScript check passed (`npx tsc --noEmit` - 0 errors).
- [x] ESLint check passed (`npx eslint` - 0 warnings).


