### PR TITLE
fix(minikube): macOS version check compared minor versions as floats

### DIFF
--- a/minikube/src/CommandCluster/DriverSelect.tsx
+++ b/minikube/src/CommandCluster/DriverSelect.tsx
@@ -65,6 +65,16 @@ export function detectOS(): 'macos' | 'windows' | 'linux' | 'unknown' {
 }
 
 /**
+ * Compares a "major.minor" macOS version string against a minimum major/minor,
+ * component-wise (not as a float — "10.9" vs "10.13" is major=10,minor=9 vs 10,13,
+ * not 10.9 vs 10.13 as numbers).
+ */
+export function isMacOSAtLeast(version: string, minMajor: number, minMinor: number): boolean {
+  const [major, minor] = version.split('.').map(Number);
+  return major > minMajor || (major === minMajor && minor >= minMinor);
+}
+
+/**
  * @returns the MacOS version as a string, e.g., "13.4"
  */
 function getMacOSVersion() {
@@ -114,7 +124,7 @@ function useDrivers(info: DriverInfo | null): { value: string; label: string }[]
 
   if (os === 'macos') {
     const macOSVersion = getMacOSVersion();
-    if (macOSVersion && parseFloat(macOSVersion) >= 10.13) {
+    if (macOSVersion && isMacOSAtLeast(macOSVersion, 10, 13)) {
       // remove vfkit if it exists
       const vfkitIndex = drivers.findIndex(driver => driver.value === 'vfkit');
       if (vfkitIndex !== -1) {

--- a/minikube/src/__tests__/utils.test.ts
+++ b/minikube/src/__tests__/utils.test.ts
@@ -1,5 +1,5 @@
 import { generateClusterName, isValidClusterName } from '../CommandCluster/CommandDialog';
-import { detectOS } from '../CommandCluster/DriverSelect';
+import { detectOS, isMacOSAtLeast } from '../CommandCluster/DriverSelect';
 import { isElectron, isMinikube } from '../index';
 
 describe('isElectron', () => {
@@ -95,6 +95,28 @@ describe('detectOS', () => {
       configurable: true,
     });
     expect(detectOS()).toBe('unknown');
+  });
+});
+
+describe('isMacOSAtLeast', () => {
+  it('rejects old single-digit minor versions', () => {
+    // this used to be compared with parseFloat, where "10.9" > 10.13 numerically
+    expect(isMacOSAtLeast('10.9', 10, 13)).toBe(false);
+    expect(isMacOSAtLeast('10.2', 10, 13)).toBe(false);
+  });
+
+  it('accepts versions past the minor threshold', () => {
+    expect(isMacOSAtLeast('10.13', 10, 13)).toBe(true);
+    expect(isMacOSAtLeast('10.15', 10, 13)).toBe(true);
+  });
+
+  it('accepts any higher major version', () => {
+    expect(isMacOSAtLeast('11.0', 10, 13)).toBe(true);
+    expect(isMacOSAtLeast('14.4', 10, 13)).toBe(true);
+  });
+
+  it('rejects lower major versions regardless of minor', () => {
+    expect(isMacOSAtLeast('9.9', 10, 13)).toBe(false);
   });
 });
 


### PR DESCRIPTION
The driver picker moves vfkit to the top of the list for macOS >= 10.13, but the check does `parseFloat(macOSVersion) >= 10.13`. Version strings don't work that way — `parseFloat('10.9') >= 10.13` is `true` because 10.9 is numerically bigger than 10.13, even though Mavericks (10.9) shipped years before High Sierra (10.13). Any macOS 10.x with a single-digit minor version hits this.

Replaced it with a small helper that splits on `.` and compares major/minor as integers, and exported it so it's testable alongside the existing `detectOS` tests in `__tests__/utils.test.ts`.

Ran the full test/lint/tsc for the plugin locally, all green.