### PR TITLE
fix(volcano): getRelatedPodGroup name fallback ignored namespace

### DIFF
--- a/volcano/src/utils/volcanoRelationships.test.ts
+++ b/volcano/src/utils/volcanoRelationships.test.ts
@@ -1,0 +1,40 @@
+import { VolcanoJob } from '../resources/job';
+import { VolcanoPodGroup } from '../resources/podgroup';
+import { getRelatedPodGroup } from './volcanoRelationships';
+
+function makeJob(name: string, namespace: string, uid = 'job-uid'): VolcanoJob {
+  return { metadata: { name, namespace, uid } } as VolcanoJob;
+}
+
+function makePodGroup(name: string, namespace: string): VolcanoPodGroup {
+  return { metadata: { name, namespace } } as VolcanoPodGroup;
+}
+
+describe('getRelatedPodGroup', () => {
+  it('does not match a same-named PodGroup from a different namespace', () => {
+    const job = makeJob('training-job', 'team-a');
+    const podGroups = [makePodGroup('training-job', 'team-b')];
+
+    expect(getRelatedPodGroup(job, podGroups)).toBeNull();
+  });
+
+  it('matches the PodGroup in the same namespace when names collide across namespaces', () => {
+    const job = makeJob('training-job', 'team-a');
+    const ownJobPodGroup = makePodGroup('training-job', 'team-a');
+    const podGroups = [makePodGroup('training-job', 'team-b'), ownJobPodGroup];
+
+    expect(getRelatedPodGroup(job, podGroups)).toBe(ownJobPodGroup);
+  });
+
+  it('matches by canonical name within the same namespace', () => {
+    const job = makeJob('training-job', 'team-a', 'abc-123');
+    const podGroup = makePodGroup('training-job-abc-123', 'team-a');
+
+    expect(getRelatedPodGroup(job, [podGroup])).toBe(podGroup);
+  });
+
+  it('returns null when there are no podGroups', () => {
+    expect(getRelatedPodGroup(makeJob('j', 'ns'), [])).toBeNull();
+    expect(getRelatedPodGroup(makeJob('j', 'ns'), null)).toBeNull();
+  });
+});

--- a/volcano/src/utils/volcanoRelationships.ts
+++ b/volcano/src/utils/volcanoRelationships.ts
@@ -148,12 +148,18 @@ export function getRelatedPodGroup(
   }
 
   // Owner refs are authoritative; name fallback keeps older objects connected when refs are absent.
+  // podGroups can span every namespace (e.g. the cluster-wide map view), so the name match has to
+  // stay within the Job's own namespace or same-named Jobs in different namespaces will cross-link.
   const jobName = job.metadata.name;
   const jobUid = job.metadata.uid;
+  const jobNamespace = job.metadata.namespace;
 
   if (jobName && jobUid) {
     const canonicalName = `${jobName}-${jobUid}`;
-    const byCanonicalName = podGroups.find(podGroup => podGroup.metadata.name === canonicalName);
+    const byCanonicalName = podGroups.find(
+      podGroup =>
+        podGroup.metadata.name === canonicalName && podGroup.metadata.namespace === jobNamespace
+    );
 
     if (byCanonicalName) {
       return byCanonicalName;
@@ -161,7 +167,12 @@ export function getRelatedPodGroup(
   }
 
   if (jobName) {
-    return podGroups.find(podGroup => podGroup.metadata.name === jobName) || null;
+    return (
+      podGroups.find(
+        podGroup =>
+          podGroup.metadata.name === jobName && podGroup.metadata.namespace === jobNamespace
+      ) || null
+    );
   }
 
   return null;


### PR DESCRIPTION
Noticed this while looking at the map view code. getRelatedPodGroup falls back to matching PodGroups by name when owner references aren't set (older objects, or a race between the Job and PodGroup getting created). Both the canonical-name fallback and the plain-name fallback only compared metadata.name, not namespace.

That's fine for the Job detail page since podGroups there is already namespace-scoped, but the map view (mapView.tsx) lists Jobs and PodGroups with useList() across the whole cluster. If two namespaces happen to have a Job with the same name and neither PodGroup has an owner reference set, you'd get linked to the wrong namespace's PodGroup in the graph.

Added a namespace check to both fallback branches, plus a test file for the function since it didn't have one yet.