### PR TITLE
fix(prometheus): formatBytes breaks above 1TB

### DIFF
--- a/prometheus/src/util.test.ts
+++ b/prometheus/src/util.test.ts
@@ -205,6 +205,10 @@ describe('formatBytes', () => {
     // values above the largest unit used to come out as "1.00undefined"
     [1024 ** 5, '1024.00TB'],
     [1024 ** 6, '1048576.00TB'],
+    // same defect on the other side: log(bytes) < 0 for 0 < bytes < 1, which
+    // used to index units[-1] and print "undefined" too
+    [0.5, '0.50B'],
+    [-5, '-5.00B'],
   ])('formatBytes(%d) -> %s', (bytes, expected) => {
     expect(formatBytes(bytes)).toBe(expected);
   });

--- a/prometheus/src/util.test.ts
+++ b/prometheus/src/util.test.ts
@@ -1,4 +1,9 @@
-import { getTimeRangeAndStepSize, isArgoCDApplication, supportsPrometheusMetrics } from './util';
+import {
+  formatBytes,
+  getTimeRangeAndStepSize,
+  isArgoCDApplication,
+  supportsPrometheusMetrics,
+} from './util';
 
 beforeAll(async () => {
   global.TextEncoder = require('util').TextEncoder;
@@ -189,5 +194,18 @@ describe('isArgoCDApplication', () => {
     ['rejects an Application without an API version', { kind: 'Application' }, false],
   ])('%s', (_, resource, expected) => {
     expect(isArgoCDApplication(resource)).toBe(expected);
+  });
+});
+
+describe('formatBytes', () => {
+  test.each([
+    [0, '0.00B'],
+    [1024, '1.00KB'],
+    [1024 ** 4, '1.00TB'],
+    // values above the largest unit used to come out as "1.00undefined"
+    [1024 ** 5, '1024.00TB'],
+    [1024 ** 6, '1048576.00TB'],
+  ])('formatBytes(%d) -> %s', (bytes, expected) => {
+    expect(formatBytes(bytes)).toBe(expected);
   });
 });

--- a/prometheus/src/util.ts
+++ b/prometheus/src/util.ts
@@ -356,7 +356,10 @@ export function createDataProcessor(
  */
 export function formatBytes(bytes: number) {
   const units = ['B', 'KB', 'MB', 'GB', 'TB'];
-  const i = bytes === 0 ? 0 : Math.floor(Math.log(bytes) / Math.log(1024));
+  const i =
+    bytes === 0
+      ? 0
+      : Math.min(units.length - 1, Math.floor(Math.log(bytes) / Math.log(1024)));
   return (bytes / Math.pow(1024, i)).toFixed(2) + units[i];
 }
 

--- a/prometheus/src/util.ts
+++ b/prometheus/src/util.ts
@@ -356,10 +356,11 @@ export function createDataProcessor(
  */
 export function formatBytes(bytes: number) {
   const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  const exponent = Math.floor(Math.log(bytes) / Math.log(1024));
   const i =
-    bytes === 0
+    bytes === 0 || !Number.isFinite(exponent)
       ? 0
-      : Math.min(units.length - 1, Math.floor(Math.log(bytes) / Math.log(1024)));
+      : Math.min(units.length - 1, Math.max(0, exponent));
   return (bytes / Math.pow(1024, i)).toFixed(2) + units[i];
 }
 


### PR DESCRIPTION
formatBytes indexes into a fixed units array (B/KB/MB/GB/TB) using floor(log1024(bytes)), but never clamps it. Once bytes crosses 1024^5 the index goes past TB and units[i] is undefined, so the chart tooltip prints stuff like "1.00undefined" instead of a number.

This shows up in the Network/Disk/Filesystem charts, whose values are cumulative counters and can plausibly cross that line on a node that's been up a while.

Clamped the index to the last unit instead of adding PB/EB entries, same as it already does for the 0-byte case. Added a few cases to util.test.ts.