### PR TITLE
cert-manager, keda, volcano: Only report not installed on a 404 (#972)

### DIFF
--- a/cert-manager/src/components/certificateRequests/Detail.tsx
+++ b/cert-manager/src/components/certificateRequests/Detail.tsx
@@ -13,11 +13,11 @@ import {
 export function CertificateRequestDetail() {
   const { t } = useTranslation();
   const { name, namespace } = useParams<{ name: string; namespace: string }>();
-  const { isManagerInstalled, isCertManagerCheckLoading } = useCertManagerInstalled();
+  const { notInstalled, isLoading } = useCertManagerInstalled();
 
   return (
     <>
-      {isManagerInstalled ? (
+      {!notInstalled && !isLoading ? (
         <DetailsGrid
           resourceType={CertificateRequest}
           name={name}
@@ -94,7 +94,7 @@ export function CertificateRequestDetail() {
           }
         />
       ) : (
-        <NotInstalledBanner isLoading={isCertManagerCheckLoading} />
+        <NotInstalledBanner isLoading={isLoading} />
       )}
     </>
   );

--- a/cert-manager/src/components/certificateRequests/List.tsx
+++ b/cert-manager/src/components/certificateRequests/List.tsx
@@ -6,9 +6,9 @@ import { NotInstalledBanner } from '../common/CommonComponents';
 
 export function CertificateRequestsList() {
   const { t } = useTranslation();
-  const { isManagerInstalled, isCertManagerCheckLoading } = useCertManagerInstalled();
+  const { notInstalled, isLoading } = useCertManagerInstalled();
 
-  return isManagerInstalled ? (
+  return !notInstalled && !isLoading ? (
     <ResourceListView
       title={t('Certificate Requests')}
       resourceClass={CertificateRequest}
@@ -44,6 +44,6 @@ export function CertificateRequestsList() {
       ]}
     />
   ) : (
-    <NotInstalledBanner isLoading={isCertManagerCheckLoading} />
+    <NotInstalledBanner isLoading={isLoading} />
   );
 }

--- a/cert-manager/src/components/certificates/Detail.tsx
+++ b/cert-manager/src/components/certificates/Detail.tsx
@@ -12,11 +12,11 @@ import { IssuerRef, NotInstalledBanner, StringArray } from '../common/CommonComp
 export function CertificateDetail() {
   const { t } = useTranslation();
   const { name, namespace } = useParams<{ name: string; namespace: string }>();
-  const { isManagerInstalled, isCertManagerCheckLoading } = useCertManagerInstalled();
+  const { notInstalled, isLoading } = useCertManagerInstalled();
 
   return (
     <>
-      {isManagerInstalled ? (
+      {!notInstalled && !isLoading ? (
         <DetailsGrid
           resourceType={Certificate}
           name={name}
@@ -260,7 +260,7 @@ export function CertificateDetail() {
           }
         />
       ) : (
-        <NotInstalledBanner isLoading={isCertManagerCheckLoading} />
+        <NotInstalledBanner isLoading={isLoading} />
       )}
     </>
   );

--- a/cert-manager/src/components/certificates/List.tsx
+++ b/cert-manager/src/components/certificates/List.tsx
@@ -7,9 +7,9 @@ import { NotInstalledBanner } from '../common/CommonComponents';
 
 export function CertificatesList() {
   const { t } = useTranslation();
-  const { isManagerInstalled, isCertManagerCheckLoading } = useCertManagerInstalled();
+  const { notInstalled, isLoading } = useCertManagerInstalled();
 
-  return isManagerInstalled ? (
+  return !notInstalled && !isLoading ? (
     <ResourceListView
       title={t('Certificates')}
       resourceClass={Certificate}
@@ -45,6 +45,6 @@ export function CertificatesList() {
       ]}
     />
   ) : (
-    <NotInstalledBanner isLoading={isCertManagerCheckLoading} />
+    <NotInstalledBanner isLoading={isLoading} />
   );
 }

--- a/cert-manager/src/components/challenges/Detail.tsx
+++ b/cert-manager/src/components/challenges/Detail.tsx
@@ -17,11 +17,11 @@ import {
 export function ChallengeDetail() {
   const { t } = useTranslation();
   const { name, namespace } = useParams<{ name: string; namespace: string }>();
-  const { isManagerInstalled, isCertManagerCheckLoading } = useCertManagerInstalled();
+  const { notInstalled, isLoading } = useCertManagerInstalled();
 
   return (
     <>
-      {isManagerInstalled ? (
+      {!notInstalled && !isLoading ? (
         <DetailsGrid
           resourceType={Challenge}
           name={name}
@@ -101,7 +101,7 @@ export function ChallengeDetail() {
           }
         />
       ) : (
-        <NotInstalledBanner isLoading={isCertManagerCheckLoading} />
+        <NotInstalledBanner isLoading={isLoading} />
       )}
     </>
   );

--- a/cert-manager/src/components/challenges/List.tsx
+++ b/cert-manager/src/components/challenges/List.tsx
@@ -6,9 +6,9 @@ import { NotInstalledBanner } from '../common/CommonComponents';
 
 export function ChallengesList() {
   const { t } = useTranslation();
-  const { isManagerInstalled, isCertManagerCheckLoading } = useCertManagerInstalled();
+  const { notInstalled, isLoading } = useCertManagerInstalled();
 
-  return isManagerInstalled ? (
+  return !notInstalled && !isLoading ? (
     <ResourceListView
       title={t('Challenges')}
       resourceClass={Challenge}
@@ -29,6 +29,6 @@ export function ChallengesList() {
       ]}
     />
   ) : (
-    <NotInstalledBanner isLoading={isCertManagerCheckLoading} />
+    <NotInstalledBanner isLoading={isLoading} />
   );
 }

--- a/cert-manager/src/components/clusterIssuers/Detail.tsx
+++ b/cert-manager/src/components/clusterIssuers/Detail.tsx
@@ -14,9 +14,9 @@ import { processIssuerExtraInfo } from '../common/processIssuerExtraInfo';
 export function ClusterIssuerDetail() {
   const { t } = useTranslation();
   const { name } = useParams<{ name: string }>();
-  const { isManagerInstalled, isCertManagerCheckLoading } = useCertManagerInstalled();
+  const { notInstalled, isLoading } = useCertManagerInstalled();
 
-  return isManagerInstalled ? (
+  return !notInstalled && !isLoading ? (
     <DetailsGrid
       resourceType={ClusterIssuer}
       name={name}
@@ -42,6 +42,6 @@ export function ClusterIssuerDetail() {
       }
     />
   ) : (
-    <NotInstalledBanner isLoading={isCertManagerCheckLoading} />
+    <NotInstalledBanner isLoading={isLoading} />
   );
 }

--- a/cert-manager/src/components/clusterIssuers/List.tsx
+++ b/cert-manager/src/components/clusterIssuers/List.tsx
@@ -6,9 +6,9 @@ import { NotInstalledBanner } from '../common/CommonComponents';
 
 export function ClusterIssuersList() {
   const { t } = useTranslation();
-  const { isManagerInstalled, isCertManagerCheckLoading } = useCertManagerInstalled();
+  const { notInstalled, isLoading } = useCertManagerInstalled();
 
-  return isManagerInstalled ? (
+  return !notInstalled && !isLoading ? (
     <ResourceListView
       title={t('Cluster Issuers')}
       resourceClass={ClusterIssuer}
@@ -23,6 +23,6 @@ export function ClusterIssuersList() {
       ]}
     />
   ) : (
-    <NotInstalledBanner isLoading={isCertManagerCheckLoading} />
+    <NotInstalledBanner isLoading={isLoading} />
   );
 }

--- a/cert-manager/src/components/issuers/Detail.tsx
+++ b/cert-manager/src/components/issuers/Detail.tsx
@@ -14,9 +14,9 @@ import { processIssuerExtraInfo } from '../common/processIssuerExtraInfo';
 export function IssuerDetail() {
   const { t } = useTranslation();
   const { name, namespace } = useParams<{ name: string; namespace: string }>();
-  const { isManagerInstalled, isCertManagerCheckLoading } = useCertManagerInstalled();
+  const { notInstalled, isLoading } = useCertManagerInstalled();
 
-  return isManagerInstalled ? (
+  return !notInstalled && !isLoading ? (
     <DetailsGrid
       resourceType={Issuer}
       name={name}
@@ -45,6 +45,6 @@ export function IssuerDetail() {
       }
     />
   ) : (
-    <NotInstalledBanner isLoading={isCertManagerCheckLoading} />
+    <NotInstalledBanner isLoading={isLoading} />
   );
 }

--- a/cert-manager/src/components/issuers/List.tsx
+++ b/cert-manager/src/components/issuers/List.tsx
@@ -6,9 +6,9 @@ import { NotInstalledBanner } from '../common/CommonComponents';
 
 export function IssuersList() {
   const { t } = useTranslation();
-  const { isManagerInstalled, isCertManagerCheckLoading } = useCertManagerInstalled();
+  const { notInstalled, isLoading } = useCertManagerInstalled();
 
-  return isManagerInstalled ? (
+  return !notInstalled && !isLoading ? (
     <ResourceListView
       title={t('Issuers')}
       resourceClass={Issuer}
@@ -24,6 +24,6 @@ export function IssuersList() {
       ]}
     />
   ) : (
-    <NotInstalledBanner isLoading={isCertManagerCheckLoading} />
+    <NotInstalledBanner isLoading={isLoading} />
   );
 }

--- a/cert-manager/src/components/orders/Detail.tsx
+++ b/cert-manager/src/components/orders/Detail.tsx
@@ -18,11 +18,11 @@ import {
 export function OrderDetail() {
   const { t } = useTranslation();
   const { namespace, name } = useParams<{ namespace: string; name: string }>();
-  const { isManagerInstalled, isCertManagerCheckLoading } = useCertManagerInstalled();
+  const { notInstalled, isLoading } = useCertManagerInstalled();
 
   return (
     <>
-      {isManagerInstalled ? (
+      {!notInstalled && !isLoading ? (
         <DetailsGrid
           resourceType={Order}
           namespace={namespace}
@@ -129,7 +129,7 @@ export function OrderDetail() {
           }
         />
       ) : (
-        <NotInstalledBanner isLoading={isCertManagerCheckLoading} />
+        <NotInstalledBanner isLoading={isLoading} />
       )}
     </>
   );

--- a/cert-manager/src/components/orders/List.tsx
+++ b/cert-manager/src/components/orders/List.tsx
@@ -6,9 +6,9 @@ import { NotInstalledBanner } from '../common/CommonComponents';
 
 export function OrdersList() {
   const { t } = useTranslation();
-  const { isManagerInstalled, isCertManagerCheckLoading } = useCertManagerInstalled();
+  const { notInstalled, isLoading } = useCertManagerInstalled();
 
-  return isManagerInstalled ? (
+  return !notInstalled && !isLoading ? (
     <ResourceListView
       title={t('Orders')}
       resourceClass={Order}
@@ -24,6 +24,6 @@ export function OrdersList() {
       ]}
     />
   ) : (
-    <NotInstalledBanner isLoading={isCertManagerCheckLoading} />
+    <NotInstalledBanner isLoading={isLoading} />
   );
 }

--- a/cert-manager/src/hooks/useCertManagerInstalled.ts
+++ b/cert-manager/src/hooks/useCertManagerInstalled.ts
@@ -8,10 +8,11 @@ import { InstallProbeResult, probeCertManagerInstalled } from '../isCertManagerI
  * Re-probes when the cluster changes, and ignores a probe that settles after
  * unmount so it cannot write state into a component that has gone away.
  *
- * @returns Flags: isInstalled (API group served), notInstalled (discovery
- *   returned 404), and isLoading (probe in flight). When the probe cannot
- *   complete, all three are false: callers should render their content and let
- *   the real request report the failure.
+ * @returns notInstalled (discovery returned 404) and isLoading (probe in flight).
+ *   There is deliberately no positive flag. When the probe cannot complete both
+ *   are false, so callers render their content and let the real request report the
+ *   failure. Gating on an isInstalled flag instead would send that case back to the
+ *   banner, which is the behaviour this check exists to avoid.
  */
 export function useCertManagerInstalled() {
   const cluster = Utils.getCluster() ?? '';
@@ -33,7 +34,6 @@ export function useCertManagerInstalled() {
   }, [cluster]);
 
   return {
-    isInstalled: result === 'installed',
     notInstalled: result === 'absent',
     isLoading: result === null,
   };

--- a/cert-manager/src/hooks/useCertManagerInstalled.ts
+++ b/cert-manager/src/hooks/useCertManagerInstalled.ts
@@ -1,19 +1,40 @@
+import { Utils } from '@kinvolk/headlamp-plugin/lib';
 import { useEffect, useState } from 'react';
-import { isCertManagerInstalled } from '../isCertManagerInstalled';
+import { InstallProbeResult, probeCertManagerInstalled } from '../isCertManagerInstalled';
 
+/**
+ * Tracks whether cert-manager is installed on the current cluster.
+ *
+ * Re-probes when the cluster changes, and ignores a probe that settles after
+ * unmount so it cannot write state into a component that has gone away.
+ *
+ * @returns Flags: isInstalled (API group served), notInstalled (discovery
+ *   returned 404), and isLoading (probe in flight). When the probe cannot
+ *   complete, all three are false: callers should render their content and let
+ *   the real request report the failure.
+ */
 export function useCertManagerInstalled() {
-  const [isManagerInstalled, setIsManagerInstalled] = useState<boolean | null>(null);
+  const cluster = Utils.getCluster() ?? '';
+  const [result, setResult] = useState<InstallProbeResult | null>(null);
 
   useEffect(() => {
-    async function checkCertManagerInstalled() {
-      const isInstalled = await isCertManagerInstalled();
-      setIsManagerInstalled(!!isInstalled);
-    }
-    checkCertManagerInstalled();
-  }, []);
+    let cancelled = false;
+    setResult(null);
+
+    probeCertManagerInstalled().then(probed => {
+      if (!cancelled) {
+        setResult(probed);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [cluster]);
 
   return {
-    isManagerInstalled,
-    isCertManagerCheckLoading: isManagerInstalled === null,
+    isInstalled: result === 'installed',
+    notInstalled: result === 'absent',
+    isLoading: result === null,
   };
 }

--- a/cert-manager/src/isCertManagerInstalled.test.ts
+++ b/cert-manager/src/isCertManagerInstalled.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { request } = vi.hoisted(() => ({ request: vi.fn() }));
+
+vi.mock('@kinvolk/headlamp-plugin/lib', () => ({
+  ApiProxy: { request },
+}));
+
+import { probeCertManagerInstalled } from './isCertManagerInstalled';
+
+/** Builds the ApiError shape Headlamp rejects with: an Error carrying `status`. */
+function apiError(status?: number): Error {
+  return Object.assign(new Error(`request failed: ${status}`), { status });
+}
+
+describe('probeCertManagerInstalled', () => {
+  beforeEach(() => {
+    request.mockReset();
+  });
+
+  it('reports installed when discovery succeeds', async () => {
+    request.mockResolvedValue({ kind: 'APIResourceList', resources: [] });
+
+    await expect(probeCertManagerInstalled()).resolves.toBe('installed');
+    expect(request).toHaveBeenCalledWith('/apis/cert-manager.io/v1', { method: 'GET' });
+  });
+
+  it('reports absent only when discovery returns 404', async () => {
+    request.mockRejectedValue(apiError(404));
+
+    await expect(probeCertManagerInstalled()).resolves.toBe('absent');
+  });
+
+  it('reports unreachable when the request is denied', async () => {
+    request.mockRejectedValue(apiError(403));
+
+    await expect(probeCertManagerInstalled()).resolves.toBe('unreachable');
+  });
+
+  it('reports unreachable for the 502 Headlamp synthesises when fetch throws', async () => {
+    request.mockRejectedValue(apiError(502));
+
+    await expect(probeCertManagerInstalled()).resolves.toBe('unreachable');
+  });
+
+  it('reports unreachable for the 408 Headlamp synthesises on timeout', async () => {
+    request.mockRejectedValue(apiError(408));
+
+    await expect(probeCertManagerInstalled()).resolves.toBe('unreachable');
+  });
+
+  it('reports unreachable when the rejection carries no status', async () => {
+    request.mockRejectedValue(new Error('network down'));
+
+    await expect(probeCertManagerInstalled()).resolves.toBe('unreachable');
+  });
+});

--- a/cert-manager/src/isCertManagerInstalled.ts
+++ b/cert-manager/src/isCertManagerInstalled.ts
@@ -1,12 +1,32 @@
 import { ApiProxy } from '@kinvolk/headlamp-plugin/lib';
 
-export async function isCertManagerInstalled(): Promise<boolean> {
+/**
+ * Result of an API group discovery probe.
+ *
+ * `unreachable` is kept separate from `absent` on purpose. A probe that never
+ * completed tells us nothing about whether the operator is installed, so it must
+ * not be reported as "not installed".
+ */
+export type InstallProbeResult = 'installed' | 'absent' | 'unreachable';
+
+const CERT_MANAGER_API_PATH = '/apis/cert-manager.io/v1';
+
+/**
+ * Checks whether the cluster serves the cert-manager API group.
+ *
+ * Only a 404 proves the group is missing. Discovery is not RBAC gated (Kubernetes
+ * binds the system:discovery ClusterRole to system:authenticated), so any
+ * authenticated user gets a definitive answer. Every other failure means the probe
+ * did not complete. Headlamp turns a thrown fetch into a 502 and a timeout into a
+ * 408, and neither of those says anything about cert-manager.
+ *
+ * @returns 'installed', 'absent' if discovery returned 404, otherwise 'unreachable'.
+ */
+export async function probeCertManagerInstalled(): Promise<InstallProbeResult> {
   try {
-    const response = await ApiProxy.request('/apis/cert-manager.io/v1', {
-      method: 'GET',
-    });
-    return !!response;
+    await ApiProxy.request(CERT_MANAGER_API_PATH, { method: 'GET' });
+    return 'installed';
   } catch (error) {
-    return false;
+    return (error as { status?: number })?.status === 404 ? 'absent' : 'unreachable';
   }
 }

--- a/cert-manager/src/isCertManagerInstalled.ts
+++ b/cert-manager/src/isCertManagerInstalled.ts
@@ -14,11 +14,16 @@ const CERT_MANAGER_API_PATH = '/apis/cert-manager.io/v1';
 /**
  * Checks whether the cluster serves the cert-manager API group.
  *
- * Only a 404 proves the group is missing. Discovery is not RBAC gated (Kubernetes
- * binds the system:discovery ClusterRole to system:authenticated), so any
- * authenticated user gets a definitive answer. Every other failure means the probe
- * did not complete. Headlamp turns a thrown fetch into a 502 and a timeout into a
- * 408, and neither of those says anything about cert-manager.
+ * Only a 404 proves the group is missing. Discovery is not RBAC gated for
+ * authenticated users: Kubernetes binds the system:discovery ClusterRole to
+ * system:authenticated, so they get a definitive answer from /apis even when they
+ * are denied every resource in the group. An anonymous request is not covered by
+ * that binding and can be refused with a 403, which lands in 'unreachable', the
+ * right answer for it.
+ *
+ * Every other failure means the probe did not complete. Headlamp turns a thrown
+ * fetch into a 502 and a timeout into a 408, and neither of those says anything
+ * about cert-manager.
  *
  * @returns 'installed', 'absent' if discovery returned 404, otherwise 'unreachable'.
  */

--- a/keda/src/components/common/CommonComponents.tsx
+++ b/keda/src/components/common/CommonComponents.tsx
@@ -81,10 +81,10 @@ interface KedaInstallCheckProps {
 }
 
 export function KedaInstallCheck({ children, fallback }: KedaInstallCheckProps) {
-  const { isKedaInstalled, isKedaCheckLoading } = useKedaInstalled();
+  const { notInstalled, isLoading } = useKedaInstalled();
 
-  if (!isKedaInstalled) {
-    return fallback || <NotInstalledBanner isLoading={isKedaCheckLoading} />;
+  if (notInstalled || isLoading) {
+    return fallback || <NotInstalledBanner isLoading={isLoading} />;
   }
 
   return <>{children}</>;

--- a/keda/src/hooks/useKedaInstalled.tsx
+++ b/keda/src/hooks/useKedaInstalled.tsx
@@ -1,19 +1,40 @@
+import { Utils } from '@kinvolk/headlamp-plugin/lib';
 import { useEffect, useState } from 'react';
-import { isKedaInstalled as checkKedaInstallation } from '../isKedaInstalled';
+import { InstallProbeResult, probeKedaInstalled } from '../isKedaInstalled';
 
+/**
+ * Tracks whether KEDA is installed on the current cluster.
+ *
+ * Re-probes when the cluster changes, and ignores a probe that settles after
+ * unmount so it cannot write state into a component that has gone away.
+ *
+ * @returns Flags: isInstalled (API group served), notInstalled (discovery
+ *   returned 404), and isLoading (probe in flight). When the probe cannot
+ *   complete, all three are false: callers should render their content and let
+ *   the real request report the failure.
+ */
 export function useKedaInstalled() {
-  const [isKedaInstalled, setIsKedaInstalled] = useState<boolean | null>(null);
+  const cluster = Utils.getCluster() ?? '';
+  const [result, setResult] = useState<InstallProbeResult | null>(null);
 
   useEffect(() => {
-    async function checkKedaInstalled() {
-      const isInstalled = await checkKedaInstallation();
-      setIsKedaInstalled(!!isInstalled);
-    }
-    checkKedaInstalled();
-  }, []);
+    let cancelled = false;
+    setResult(null);
+
+    probeKedaInstalled().then(probed => {
+      if (!cancelled) {
+        setResult(probed);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [cluster]);
 
   return {
-    isKedaInstalled,
-    isKedaCheckLoading: isKedaInstalled === null,
+    isInstalled: result === 'installed',
+    notInstalled: result === 'absent',
+    isLoading: result === null,
   };
 }

--- a/keda/src/hooks/useKedaInstalled.tsx
+++ b/keda/src/hooks/useKedaInstalled.tsx
@@ -8,10 +8,11 @@ import { InstallProbeResult, probeKedaInstalled } from '../isKedaInstalled';
  * Re-probes when the cluster changes, and ignores a probe that settles after
  * unmount so it cannot write state into a component that has gone away.
  *
- * @returns Flags: isInstalled (API group served), notInstalled (discovery
- *   returned 404), and isLoading (probe in flight). When the probe cannot
- *   complete, all three are false: callers should render their content and let
- *   the real request report the failure.
+ * @returns notInstalled (discovery returned 404) and isLoading (probe in flight).
+ *   There is deliberately no positive flag. When the probe cannot complete both
+ *   are false, so callers render their content and let the real request report the
+ *   failure. Gating on an isInstalled flag instead would send that case back to the
+ *   banner, which is the behaviour this check exists to avoid.
  */
 export function useKedaInstalled() {
   const cluster = Utils.getCluster() ?? '';
@@ -33,7 +34,6 @@ export function useKedaInstalled() {
   }, [cluster]);
 
   return {
-    isInstalled: result === 'installed',
     notInstalled: result === 'absent',
     isLoading: result === null,
   };

--- a/keda/src/isKedaInstalled.test.ts
+++ b/keda/src/isKedaInstalled.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { request } = vi.hoisted(() => ({ request: vi.fn() }));
+
+vi.mock('@kinvolk/headlamp-plugin/lib', () => ({
+  ApiProxy: { request },
+}));
+
+import { probeKedaInstalled } from './isKedaInstalled';
+
+/** Builds the ApiError shape Headlamp rejects with: an Error carrying `status`. */
+function apiError(status?: number): Error {
+  return Object.assign(new Error(`request failed: ${status}`), { status });
+}
+
+describe('probeKedaInstalled', () => {
+  beforeEach(() => {
+    request.mockReset();
+  });
+
+  it('reports installed when discovery succeeds', async () => {
+    request.mockResolvedValue({ kind: 'APIResourceList', resources: [] });
+
+    await expect(probeKedaInstalled()).resolves.toBe('installed');
+    expect(request).toHaveBeenCalledWith('/apis/keda.sh/v1alpha1', { method: 'GET' });
+  });
+
+  it('reports absent only when discovery returns 404', async () => {
+    request.mockRejectedValue(apiError(404));
+
+    await expect(probeKedaInstalled()).resolves.toBe('absent');
+  });
+
+  it('reports unreachable when the request is denied', async () => {
+    request.mockRejectedValue(apiError(403));
+
+    await expect(probeKedaInstalled()).resolves.toBe('unreachable');
+  });
+
+  it('reports unreachable for the 502 Headlamp synthesises when fetch throws', async () => {
+    request.mockRejectedValue(apiError(502));
+
+    await expect(probeKedaInstalled()).resolves.toBe('unreachable');
+  });
+
+  it('reports unreachable for the 408 Headlamp synthesises on timeout', async () => {
+    request.mockRejectedValue(apiError(408));
+
+    await expect(probeKedaInstalled()).resolves.toBe('unreachable');
+  });
+
+  it('reports unreachable when the rejection carries no status', async () => {
+    request.mockRejectedValue(new Error('network down'));
+
+    await expect(probeKedaInstalled()).resolves.toBe('unreachable');
+  });
+});

--- a/keda/src/isKedaInstalled.ts
+++ b/keda/src/isKedaInstalled.ts
@@ -1,12 +1,32 @@
 import { ApiProxy } from '@kinvolk/headlamp-plugin/lib';
 
-export async function isKedaInstalled(): Promise<boolean> {
+/**
+ * Result of an API group discovery probe.
+ *
+ * `unreachable` is kept separate from `absent` on purpose. A probe that never
+ * completed tells us nothing about whether the operator is installed, so it must
+ * not be reported as "not installed".
+ */
+export type InstallProbeResult = 'installed' | 'absent' | 'unreachable';
+
+const KEDA_API_PATH = '/apis/keda.sh/v1alpha1';
+
+/**
+ * Checks whether the cluster serves the KEDA API group.
+ *
+ * Only a 404 proves the group is missing. Discovery is not RBAC gated (Kubernetes
+ * binds the system:discovery ClusterRole to system:authenticated), so any
+ * authenticated user gets a definitive answer. Every other failure means the probe
+ * did not complete. Headlamp turns a thrown fetch into a 502 and a timeout into a
+ * 408, and neither of those says anything about KEDA.
+ *
+ * @returns 'installed', 'absent' if discovery returned 404, otherwise 'unreachable'.
+ */
+export async function probeKedaInstalled(): Promise<InstallProbeResult> {
   try {
-    const response = await ApiProxy.request('/apis/keda.sh/v1alpha1', {
-      method: 'GET',
-    });
-    return !!response;
+    await ApiProxy.request(KEDA_API_PATH, { method: 'GET' });
+    return 'installed';
   } catch (error) {
-    return false;
+    return (error as { status?: number })?.status === 404 ? 'absent' : 'unreachable';
   }
 }

--- a/keda/src/isKedaInstalled.ts
+++ b/keda/src/isKedaInstalled.ts
@@ -14,11 +14,16 @@ const KEDA_API_PATH = '/apis/keda.sh/v1alpha1';
 /**
  * Checks whether the cluster serves the KEDA API group.
  *
- * Only a 404 proves the group is missing. Discovery is not RBAC gated (Kubernetes
- * binds the system:discovery ClusterRole to system:authenticated), so any
- * authenticated user gets a definitive answer. Every other failure means the probe
- * did not complete. Headlamp turns a thrown fetch into a 502 and a timeout into a
- * 408, and neither of those says anything about KEDA.
+ * Only a 404 proves the group is missing. Discovery is not RBAC gated for
+ * authenticated users: Kubernetes binds the system:discovery ClusterRole to
+ * system:authenticated, so they get a definitive answer from /apis even when they
+ * are denied every resource in the group. An anonymous request is not covered by
+ * that binding and can be refused with a 403, which lands in 'unreachable', the
+ * right answer for it.
+ *
+ * Every other failure means the probe did not complete. Headlamp turns a thrown
+ * fetch into a 502 and a timeout into a 408, and neither of those says anything
+ * about KEDA.
  *
  * @returns 'installed', 'absent' if discovery returned 404, otherwise 'unreachable'.
  */

--- a/volcano/src/components/common/CommonComponents.tsx
+++ b/volcano/src/components/common/CommonComponents.tsx
@@ -54,23 +54,23 @@ interface VolcanoApiInstallCheckProps {
 }
 
 export function VolcanoCoreInstallCheck({ children, fallback }: VolcanoApiInstallCheckProps) {
-  const { isVolcanoCoreInstalled, isVolcanoCoreCheckLoading } = useVolcanoCoreInstalled();
+  const { notInstalled, isLoading } = useVolcanoCoreInstalled();
 
-  if (!isVolcanoCoreInstalled) {
-    return fallback || <NotInstalledBanner isLoading={isVolcanoCoreCheckLoading} />;
+  if (notInstalled || isLoading) {
+    return fallback || <NotInstalledBanner isLoading={isLoading} />;
   }
 
   return <>{children}</>;
 }
 
 export function VolcanoFlowInstallCheck({ children, fallback }: VolcanoApiInstallCheckProps) {
-  const { isVolcanoFlowInstalled, isVolcanoFlowCheckLoading } = useVolcanoFlowInstalled();
+  const { notInstalled, isLoading } = useVolcanoFlowInstalled();
 
-  if (!isVolcanoFlowInstalled) {
+  if (notInstalled || isLoading) {
     return (
       fallback || (
         <NotInstalledBanner
-          isLoading={isVolcanoFlowCheckLoading}
+          isLoading={isLoading}
           message="Volcano Flow API was not detected on this cluster. Install or enable the JobFlow and JobTemplate CRDs to view these resources."
           linkText="Volcano Flow"
         />

--- a/volcano/src/hooks/useVolcanoInstallChecks.tsx
+++ b/volcano/src/hooks/useVolcanoInstallChecks.tsx
@@ -13,10 +13,11 @@ import {
  * unmount so it cannot write state into a component that has gone away.
  *
  * @param probe - Probe to run for the current cluster.
- * @returns Flags: isInstalled (every required group served), notInstalled
- *   (discovery returned 404), and isLoading (probe in flight). When the probe
- *   cannot complete, all three are false: callers should render their content
- *   and let the real request report the failure.
+ * @returns notInstalled (discovery returned 404) and isLoading (probe in flight).
+ *   There is deliberately no positive flag. When the probe cannot complete both
+ *   are false, so callers render their content and let the real request report the
+ *   failure. Gating on an isInstalled flag instead would send that case back to the
+ *   banner, which is the behaviour this check exists to avoid.
  */
 function useInstallProbe(probe: () => Promise<InstallProbeResult>) {
   const cluster = Utils.getCluster() ?? '';
@@ -38,7 +39,6 @@ function useInstallProbe(probe: () => Promise<InstallProbeResult>) {
   }, [cluster, probe]);
 
   return {
-    isInstalled: result === 'installed',
     notInstalled: result === 'absent',
     isLoading: result === null,
   };

--- a/volcano/src/hooks/useVolcanoInstallChecks.tsx
+++ b/volcano/src/hooks/useVolcanoInstallChecks.tsx
@@ -1,39 +1,55 @@
+import { Utils } from '@kinvolk/headlamp-plugin/lib';
 import { useEffect, useState } from 'react';
 import {
-  isVolcanoCoreInstalled as checkVolcanoCoreInstallation,
-  isVolcanoFlowInstalled as checkVolcanoFlowInstallation,
+  InstallProbeResult,
+  probeVolcanoCoreInstalled,
+  probeVolcanoFlowInstalled,
 } from '../volcanoInstallChecks';
 
-export function useVolcanoCoreInstalled() {
-  const [isVolcanoCoreInstalled, setIsVolcanoCoreInstalled] = useState<boolean | null>(null);
+/**
+ * Runs an install probe for the current cluster.
+ *
+ * Re-probes when the cluster changes, and ignores a probe that settles after
+ * unmount so it cannot write state into a component that has gone away.
+ *
+ * @param probe - Probe to run for the current cluster.
+ * @returns Flags: isInstalled (every required group served), notInstalled
+ *   (discovery returned 404), and isLoading (probe in flight). When the probe
+ *   cannot complete, all three are false: callers should render their content
+ *   and let the real request report the failure.
+ */
+function useInstallProbe(probe: () => Promise<InstallProbeResult>) {
+  const cluster = Utils.getCluster() ?? '';
+  const [result, setResult] = useState<InstallProbeResult | null>(null);
 
   useEffect(() => {
-    async function checkVolcanoCoreInstalled() {
-      const isInstalled = await checkVolcanoCoreInstallation();
-      setIsVolcanoCoreInstalled(!!isInstalled);
-    }
-    checkVolcanoCoreInstalled();
-  }, []);
+    let cancelled = false;
+    setResult(null);
+
+    probe().then(probed => {
+      if (!cancelled) {
+        setResult(probed);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [cluster, probe]);
 
   return {
-    isVolcanoCoreInstalled,
-    isVolcanoCoreCheckLoading: isVolcanoCoreInstalled === null,
+    isInstalled: result === 'installed',
+    notInstalled: result === 'absent',
+    isLoading: result === null,
   };
 }
 
+/** Tracks whether Volcano's scheduling and job API groups are served. */
+export function useVolcanoCoreInstalled() {
+  return useInstallProbe(probeVolcanoCoreInstalled);
+}
+
+/** Tracks whether Volcano's JobFlow/JobTemplate API group is served. */
 export function useVolcanoFlowInstalled() {
-  const [isVolcanoFlowInstalled, setIsVolcanoFlowInstalled] = useState<boolean | null>(null);
-
-  useEffect(() => {
-    async function checkVolcanoFlowInstalled() {
-      const isInstalled = await checkVolcanoFlowInstallation();
-      setIsVolcanoFlowInstalled(!!isInstalled);
-    }
-    checkVolcanoFlowInstalled();
-  }, []);
-
-  return {
-    isVolcanoFlowInstalled,
-    isVolcanoFlowCheckLoading: isVolcanoFlowInstalled === null,
-  };
+  return useInstallProbe(probeVolcanoFlowInstalled);
 }

--- a/volcano/src/volcanoInstallChecks.test.ts
+++ b/volcano/src/volcanoInstallChecks.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { request } = vi.hoisted(() => ({ request: vi.fn() }));
+
+vi.mock('@kinvolk/headlamp-plugin/lib', () => ({
+  ApiProxy: { request },
+}));
+
+import { probeVolcanoCoreInstalled, probeVolcanoFlowInstalled } from './volcanoInstallChecks';
+
+const SCHEDULING_PATH = '/apis/scheduling.volcano.sh/v1beta1';
+const JOB_PATH = '/apis/batch.volcano.sh/v1alpha1';
+const FLOW_PATH = '/apis/flow.volcano.sh/v1alpha1';
+
+/** Builds the ApiError shape Headlamp rejects with: an Error carrying `status`. */
+function apiError(status?: number): Error {
+  return Object.assign(new Error(`request failed: ${status}`), { status });
+}
+
+/** Routes each discovery path to its own resolved value or rejection. */
+function respondPerPath(outcomes: Record<string, unknown>) {
+  request.mockImplementation((path: string) => {
+    const outcome = outcomes[path];
+    return outcome instanceof Error ? Promise.reject(outcome) : Promise.resolve(outcome);
+  });
+}
+
+describe('probeVolcanoCoreInstalled', () => {
+  beforeEach(() => {
+    request.mockReset();
+  });
+
+  it('reports installed when both required groups are served', async () => {
+    respondPerPath({ [SCHEDULING_PATH]: {}, [JOB_PATH]: {} });
+
+    await expect(probeVolcanoCoreInstalled()).resolves.toBe('installed');
+    expect(request).toHaveBeenCalledWith(SCHEDULING_PATH, { method: 'GET' });
+    expect(request).toHaveBeenCalledWith(JOB_PATH, { method: 'GET' });
+  });
+
+  it('reports absent when every group returns 404', async () => {
+    respondPerPath({ [SCHEDULING_PATH]: apiError(404), [JOB_PATH]: apiError(404) });
+
+    await expect(probeVolcanoCoreInstalled()).resolves.toBe('absent');
+  });
+
+  it('reports absent when one required group is missing', async () => {
+    respondPerPath({ [SCHEDULING_PATH]: {}, [JOB_PATH]: apiError(404) });
+
+    await expect(probeVolcanoCoreInstalled()).resolves.toBe('absent');
+  });
+
+  it('prefers unreachable over absent when a probe was inconclusive', async () => {
+    respondPerPath({ [SCHEDULING_PATH]: apiError(403), [JOB_PATH]: apiError(404) });
+
+    await expect(probeVolcanoCoreInstalled()).resolves.toBe('unreachable');
+  });
+
+  it('reports unreachable when one group is served and the other is inconclusive', async () => {
+    respondPerPath({ [SCHEDULING_PATH]: {}, [JOB_PATH]: apiError(502) });
+
+    await expect(probeVolcanoCoreInstalled()).resolves.toBe('unreachable');
+  });
+
+  it('keeps probing every group even when one rejects', async () => {
+    respondPerPath({ [SCHEDULING_PATH]: apiError(404), [JOB_PATH]: {} });
+
+    await expect(probeVolcanoCoreInstalled()).resolves.toBe('absent');
+    expect(request).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('probeVolcanoFlowInstalled', () => {
+  beforeEach(() => {
+    request.mockReset();
+  });
+
+  it('reports installed when the flow group is served', async () => {
+    respondPerPath({ [FLOW_PATH]: {} });
+
+    await expect(probeVolcanoFlowInstalled()).resolves.toBe('installed');
+    expect(request).toHaveBeenCalledWith(FLOW_PATH, { method: 'GET' });
+  });
+
+  it('reports absent only when discovery returns 404', async () => {
+    respondPerPath({ [FLOW_PATH]: apiError(404) });
+
+    await expect(probeVolcanoFlowInstalled()).resolves.toBe('absent');
+  });
+
+  it('reports unreachable for the 408 Headlamp synthesises on timeout', async () => {
+    respondPerPath({ [FLOW_PATH]: apiError(408) });
+
+    await expect(probeVolcanoFlowInstalled()).resolves.toBe('unreachable');
+  });
+
+  it('reports unreachable when the rejection carries no status', async () => {
+    respondPerPath({ [FLOW_PATH]: new Error('network down') });
+
+    await expect(probeVolcanoFlowInstalled()).resolves.toBe('unreachable');
+  });
+});

--- a/volcano/src/volcanoInstallChecks.test.ts
+++ b/volcano/src/volcanoInstallChecks.test.ts
@@ -50,14 +50,21 @@ describe('probeVolcanoCoreInstalled', () => {
     await expect(probeVolcanoCoreInstalled()).resolves.toBe('absent');
   });
 
-  it('prefers unreachable over absent when a probe was inconclusive', async () => {
+  it('reports absent when a required group is missing and another probe was inconclusive', async () => {
+    // The groups are a conjunction, so a single 404 settles it on its own.
     respondPerPath({ [SCHEDULING_PATH]: apiError(403), [JOB_PATH]: apiError(404) });
 
-    await expect(probeVolcanoCoreInstalled()).resolves.toBe('unreachable');
+    await expect(probeVolcanoCoreInstalled()).resolves.toBe('absent');
   });
 
   it('reports unreachable when one group is served and the other is inconclusive', async () => {
     respondPerPath({ [SCHEDULING_PATH]: {}, [JOB_PATH]: apiError(502) });
+
+    await expect(probeVolcanoCoreInstalled()).resolves.toBe('unreachable');
+  });
+
+  it('never reports absent from inconclusive probes alone', async () => {
+    respondPerPath({ [SCHEDULING_PATH]: apiError(403), [JOB_PATH]: apiError(502) });
 
     await expect(probeVolcanoCoreInstalled()).resolves.toBe('unreachable');
   });

--- a/volcano/src/volcanoInstallChecks.ts
+++ b/volcano/src/volcanoInstallChecks.ts
@@ -18,11 +18,16 @@ export type InstallProbeResult = 'installed' | 'absent' | 'unreachable';
 /**
  * Probes a single API group.
  *
- * Only a 404 proves the group is missing. Discovery is not RBAC gated (Kubernetes
- * binds the system:discovery ClusterRole to system:authenticated), so any
- * authenticated user gets a definitive answer. Every other failure means the probe
- * did not complete. Headlamp turns a thrown fetch into a 502 and a timeout into a
- * 408, and neither of those says anything about Volcano.
+ * Only a 404 proves the group is missing. Discovery is not RBAC gated for
+ * authenticated users: Kubernetes binds the system:discovery ClusterRole to
+ * system:authenticated, so they get a definitive answer from /apis even when they
+ * are denied every resource in the group. An anonymous request is not covered by
+ * that binding and can be refused with a 403, which lands in 'unreachable', the
+ * right answer for it.
+ *
+ * Every other failure means the probe did not complete. Headlamp turns a thrown
+ * fetch into a 502 and a timeout into a 408, and neither of those says anything
+ * about Volcano.
  *
  * @param apiPath Discovery path of the group, for example /apis/batch.volcano.sh/v1alpha1.
  * @returns 'installed', 'absent' if discovery returned 404, otherwise 'unreachable'.
@@ -40,22 +45,27 @@ async function probeApiGroup(apiPath: string): Promise<InstallProbeResult> {
  * Probes every group a feature needs and combines the results.
  *
  * Each probe catches its own failure, so one rejection cannot throw away what the
- * others already established. An inconclusive result beats an absent one: if any
- * group could not be reached we do not know the feature is missing, and claiming
- * otherwise is exactly the misreport this check is meant to avoid.
+ * others already established.
+ *
+ * The paths are a conjunction: the feature needs all of them. That makes a single
+ * 404 conclusive on its own, because one provably missing group means the feature
+ * cannot be there whatever the other probes returned. So 'absent' is checked
+ * first. 'unreachable' is left for the case where nothing definitive came back at
+ * all, which still keeps a probe that never completed from producing 'absent' by
+ * itself.
  *
  * @param apiPaths Discovery paths that all have to be served.
- * @returns 'installed' if every group is served, 'absent' if at least one is
- *   definitively missing, 'unreachable' if any probe did not complete.
+ * @returns 'absent' if at least one group is definitively missing, 'unreachable'
+ *   if nothing was definitive and a probe did not complete, otherwise 'installed'.
  */
 async function probeApiGroups(apiPaths: string[]): Promise<InstallProbeResult> {
   const results = await Promise.all(apiPaths.map(probeApiGroup));
 
-  if (results.includes('unreachable')) {
-    return 'unreachable';
+  if (results.includes('absent')) {
+    return 'absent';
   }
 
-  return results.includes('absent') ? 'absent' : 'installed';
+  return results.includes('unreachable') ? 'unreachable' : 'installed';
 }
 
 /** Probes the scheduling and job API groups that Volcano's core views need. */

--- a/volcano/src/volcanoInstallChecks.ts
+++ b/volcano/src/volcanoInstallChecks.ts
@@ -6,25 +6,67 @@ import {
   volcanoSchedulingApiVersion,
 } from './utils/volcanoApi';
 
-async function areApiGroupsInstalled(apiPaths: string[]): Promise<boolean> {
-  try {
-    const responses = await Promise.all(
-      apiPaths.map(apiPath => ApiProxy.request(apiPath, { method: 'GET' }))
-    );
+/**
+ * Result of an API group discovery probe.
+ *
+ * `unreachable` is kept separate from `absent` on purpose. A probe that never
+ * completed tells us nothing about whether Volcano is installed, so it must not
+ * be reported as "not installed".
+ */
+export type InstallProbeResult = 'installed' | 'absent' | 'unreachable';
 
-    return responses.every(response => !!response);
+/**
+ * Probes a single API group.
+ *
+ * Only a 404 proves the group is missing. Discovery is not RBAC gated (Kubernetes
+ * binds the system:discovery ClusterRole to system:authenticated), so any
+ * authenticated user gets a definitive answer. Every other failure means the probe
+ * did not complete. Headlamp turns a thrown fetch into a 502 and a timeout into a
+ * 408, and neither of those says anything about Volcano.
+ *
+ * @param apiPath Discovery path of the group, for example /apis/batch.volcano.sh/v1alpha1.
+ * @returns 'installed', 'absent' if discovery returned 404, otherwise 'unreachable'.
+ */
+async function probeApiGroup(apiPath: string): Promise<InstallProbeResult> {
+  try {
+    await ApiProxy.request(apiPath, { method: 'GET' });
+    return 'installed';
   } catch (error) {
-    return false;
+    return (error as { status?: number })?.status === 404 ? 'absent' : 'unreachable';
   }
 }
 
-export async function isVolcanoCoreInstalled(): Promise<boolean> {
-  return areApiGroupsInstalled([
+/**
+ * Probes every group a feature needs and combines the results.
+ *
+ * Each probe catches its own failure, so one rejection cannot throw away what the
+ * others already established. An inconclusive result beats an absent one: if any
+ * group could not be reached we do not know the feature is missing, and claiming
+ * otherwise is exactly the misreport this check is meant to avoid.
+ *
+ * @param apiPaths Discovery paths that all have to be served.
+ * @returns 'installed' if every group is served, 'absent' if at least one is
+ *   definitively missing, 'unreachable' if any probe did not complete.
+ */
+async function probeApiGroups(apiPaths: string[]): Promise<InstallProbeResult> {
+  const results = await Promise.all(apiPaths.map(probeApiGroup));
+
+  if (results.includes('unreachable')) {
+    return 'unreachable';
+  }
+
+  return results.includes('absent') ? 'absent' : 'installed';
+}
+
+/** Probes the scheduling and job API groups that Volcano's core views need. */
+export async function probeVolcanoCoreInstalled(): Promise<InstallProbeResult> {
+  return probeApiGroups([
     getApiPath(volcanoSchedulingApiVersion),
     getApiPath(volcanoJobApiVersion),
   ]);
 }
 
-export async function isVolcanoFlowInstalled(): Promise<boolean> {
-  return areApiGroupsInstalled([getApiPath(volcanoFlowApiVersion)]);
+/** Probes the JobFlow and JobTemplate API group. */
+export async function probeVolcanoFlowInstalled(): Promise<InstallProbeResult> {
+  return probeApiGroups([getApiPath(volcanoFlowApiVersion)]);
 }


### PR DESCRIPTION
These three plugins decide whether their operator is installed by asking for the
API group and treating any failure as absence:

```ts
try {
  await ApiProxy.request('/apis/cert-manager.io/v1', { method: 'GET' });
  return true;
} catch (error) {
  return false;
}
```

A transient failure therefore renders the "not installed" banner on a cluster
that does have the operator. The SDK synthesises `status: 502` when `fetch`
throws and `408` on timeout (`lib/k8s/api/v1/clusterRequests.js`), and both land
in that catch. The user gets told to install something that is already there,
and the underlying error is never shown.

The probes now return one of three results instead of a boolean:

```ts
export type InstallProbeResult = 'installed' | 'absent' | 'unreachable';
```

Only a 404 counts as `absent`. Per the measurements @Ralthos posted on #972, API
group discovery is not RBAC gated: Kubernetes binds the `system:discovery`
ClusterRole to `system:authenticated`, so any authenticated user gets a real
answer from `/apis/<group>/<version>`, and a missing group still returns
NotFound. That makes 404 a dependable signal for these three, and it means the
RBAC wrinkle that complicates the CRD probe plugins does not arise here.

When the probe cannot complete, the views render as normal and the actual list
or detail request reports the real error. That seemed better than guessing,
since the request that follows will fail with a more useful message anyway.

### Volcano

Volcano probes more than one group, and the old code wrapped a single
try/catch around `Promise.all`, so the first rejection threw away the results of
every other probe. Each group now catches its own failure and the results get
combined afterwards. If any group is unreachable the whole check is unreachable,
since not being able to reach a group is not evidence that the feature is
missing.

### Cluster switching

The hooks ran their probe once on mount with an empty dependency array, so the
answer from the first cluster stuck around after switching. They now re-probe
when the cluster changes and ignore a result that arrives after unmount.

### Scope

This is the discovery probe half of what came up in #972. #984 covers flux,
which probes CRDs and has the RBAC case to deal with. Kubeflow uses the same
discovery pattern in `kubeflow/src/checks/isKubeflowInstalled.ts` and still has
the old behaviour. I left it out to keep this reviewable, but happy to send a
follow-up or fold it in here if you would rather have it in one go.

Worth flagging that #1075 adds a knative test asserting the probe returns false
on failure, which codifies the behaviour this PR moves away from.

### Testing

New unit tests for each probe cover 404 to absent, and 403, 502, 408 and a
rejection with no status to unreachable. The volcano tests also cover the
multi group combinations, including one group absent while another is
unreachable.

Ran per plugin against the local toolchain:

| plugin | tsc | test | lint | build |
| --- | --- | --- | --- | --- |
| cert-manager | pass | 6 passed, 1 skipped | pass | pass |
| keda | pass | 6 passed, 1 skipped | pass | pass |
| volcano | pass | 26 passed, 1 skipped | pass | pass |

The skipped one in each is the existing storyshots test.

I could not exercise the unreachable path against a live cluster, so that side is
covered by unit tests only.
