### PR TITLE
fix(kompose): handle non-ASCII characters in compose files

### DIFF
--- a/kompose/src/kompose.test.ts
+++ b/kompose/src/kompose.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { komposePod } from './kompose';
+
+describe('komposePod', () => {
+  it('does not throw on a compose file with non-ASCII characters', () => {
+    const compose = 'services:\n  web:\n    # café ☕\n    image: nginx';
+    expect(() => komposePod(compose)).not.toThrow();
+  });
+
+  it('embeds a script that decodes back to the original content', () => {
+    const compose = 'services:\n  café:\n    image: nginx “latest”';
+    const job = komposePod(compose) as any;
+    const script: string = job.spec.template.spec.containers[0].args[0];
+    const encoded = script.match(/^echo "([^"]+)"/)?.[1];
+    expect(encoded).toBeTruthy();
+    const decoded = decodeURIComponent(escape(atob(encoded as string)));
+    expect(decoded).toBe(compose);
+  });
+});

--- a/kompose/src/kompose.tsx
+++ b/kompose/src/kompose.tsx
@@ -4,6 +4,11 @@ const generateName = () => {
   return 'kompose-' + Math.random().toString(36).substring(7);
 };
 
+// btoa only accepts Latin1 code points, so a compose file with any non-ASCII
+// character (accented names, emoji in a comment, curly quotes) throws
+// "Invalid character" instead of encoding. Route through UTF-8 bytes first.
+const toBase64 = (value: string) => btoa(unescape(encodeURIComponent(value)));
+
 /**
  * Create a Kompose pod to convert a Docker Compose file to Kubernetes resources.
  * @param composeBase64 The base64 encoded Docker Compose file.
@@ -34,7 +39,7 @@ export const komposePod = (composeBase64: string, komposeImage: string = '') => 
               image: komposeImage || 'femtopixel/kompose',
               command: ['sh', '-c'],
               args: [
-                `echo "${btoa(
+                `echo "${toBase64(
                   composeBase64
                 )}" | base64 -d | kompose convert -o /k8s-kompose.yml -f - 2> /k8s-kompose-error.yml && echo KOMPOSE_OUTPUT=$(base64 /k8s-kompose.yml)__ENDOUTPUT__ || echo KOMPOSE_ERROR=$(cat /k8s-kompose-error.yml)__ENDERROR__`,
               ],


### PR DESCRIPTION
converting a compose file with any non-ASCII character (accented service names, an emoji left in a comment, smart quotes pasted in from somewhere) throws `InvalidCharacterError` instead of running, because `komposePod` base64-encodes the file with plain `btoa`, which only accepts Latin1 code points.

worse, `runKompose` in ui.tsx calls `komposePod` before its try/catch starts, so the failure isn't caught anywhere — the conversion just hangs on the spinner with no error shown.

fixed by routing the string through `encodeURIComponent`/`unescape` before `btoa`, so it only ever sees single-byte characters. added a test that reproduces the throw pre-fix and one that checks the encode/decode round-trips back to the original content.