### PR TITLE
tinkerbell: Read a condition's status before reporting its type

### DIFF
--- a/tinkerbell/src/components/bmc/jobs/List.tsx
+++ b/tinkerbell/src/components/bmc/jobs/List.tsx
@@ -4,6 +4,7 @@ import {
   type ResourceTableColumn,
 } from '@kinvolk/headlamp-plugin/lib/components/common';
 import { BmcJob } from '../../../resources/bmcJob';
+import { activeConditionType } from '../../../resources/common';
 import { countLabel, fallback, renderStatus } from '../../common/listHelpers';
 
 /**
@@ -27,8 +28,8 @@ export function BmcJobList() {
       id: 'status',
       label: 'Status',
       gridTemplate: 'max-content',
-      getValue: item => fallback(item.status?.conditions?.at(-1)?.type),
-      render: item => renderStatus(item.status?.conditions?.at(-1)?.type),
+      getValue: item => fallback(activeConditionType(item.status?.conditions)),
+      render: item => renderStatus(activeConditionType(item.status?.conditions)),
     },
     {
       id: 'started',

--- a/tinkerbell/src/components/bmc/tasks/List.tsx
+++ b/tinkerbell/src/components/bmc/tasks/List.tsx
@@ -4,6 +4,7 @@ import {
   type ResourceTableColumn,
 } from '@kinvolk/headlamp-plugin/lib/components/common';
 import { BmcTask } from '../../../resources/bmcTask';
+import { activeConditionType } from '../../../resources/common';
 import { fallback, renderStatus } from '../../common/listHelpers';
 
 /**
@@ -35,8 +36,8 @@ export function BmcTaskList() {
       id: 'status',
       label: 'Status',
       gridTemplate: 'max-content',
-      getValue: item => fallback(item.status?.conditions?.at(-1)?.type),
-      render: item => renderStatus(item.status?.conditions?.at(-1)?.type),
+      getValue: item => fallback(activeConditionType(item.status?.conditions)),
+      render: item => renderStatus(activeConditionType(item.status?.conditions)),
     },
     {
       id: 'started',

--- a/tinkerbell/src/resources/common.test.ts
+++ b/tinkerbell/src/resources/common.test.ts
@@ -1,4 +1,4 @@
-import { normalizeState } from './common';
+import { activeConditionType, normalizeState } from './common';
 
 describe('normalizeState', () => {
   it('returns Unknown when no state is available', () => {
@@ -16,5 +16,48 @@ describe('normalizeState', () => {
 
   it('humanizes plain underscore-separated states', () => {
     expect(normalizeState('PREPARING_WORKER')).toBe('Preparing Worker');
+  });
+});
+
+describe('activeConditionType', () => {
+  it('returns undefined when there are no conditions', () => {
+    expect(activeConditionType(undefined)).toBeUndefined();
+    expect(activeConditionType([])).toBeUndefined();
+  });
+
+  it('returns the type of a condition that is true', () => {
+    expect(activeConditionType([{ type: 'Completed', status: 'True' }])).toBe('Completed');
+  });
+
+  // The bug this guards against: reading the type alone reports a failure that the
+  // condition explicitly denies.
+  it('ignores a condition whose status is False', () => {
+    expect(activeConditionType([{ type: 'Failed', status: 'False' }])).toBeUndefined();
+  });
+
+  it('ignores a condition whose status is Unknown', () => {
+    expect(activeConditionType([{ type: 'Failed', status: 'Unknown' }])).toBeUndefined();
+  });
+
+  it('ignores a condition carrying no status at all', () => {
+    expect(activeConditionType([{ type: 'Failed' }])).toBeUndefined();
+  });
+
+  it('skips false conditions to find the true one, wherever it sits', () => {
+    expect(
+      activeConditionType([
+        { type: 'Completed', status: 'True' },
+        { type: 'Failed', status: 'False' },
+      ])
+    ).toBe('Completed');
+  });
+
+  it('takes the last true condition when several are asserted', () => {
+    expect(
+      activeConditionType([
+        { type: 'Running', status: 'True' },
+        { type: 'Completed', status: 'True' },
+      ])
+    ).toBe('Completed');
   });
 });

--- a/tinkerbell/src/resources/common.ts
+++ b/tinkerbell/src/resources/common.ts
@@ -52,6 +52,31 @@ export interface TinkerbellCondition {
 }
 
 /**
+ * Returns the type of the condition a resource is currently reporting.
+ *
+ * A condition carries a type and a status, and only the pair means anything:
+ * `{ type: "Failed", status: "False" }` says the job has not failed. Reading the
+ * type on its own inverts that, so this skips every condition whose status is not
+ * `True`.
+ *
+ * Where several conditions are true at once the last one wins, which matches the
+ * order a controller appends them.
+ *
+ * @param conditions - Conditions reported by a Tinkerbell or BMC resource.
+ * @returns The type of the last condition whose status is `True`, or undefined
+ *   when the resource is not asserting any condition.
+ */
+export function activeConditionType(conditions?: TinkerbellCondition[]): string | undefined {
+  if (!conditions?.length) {
+    return undefined;
+  }
+
+  const active = conditions.filter(condition => condition.status === 'True');
+
+  return active.length ? active[active.length - 1].type : undefined;
+}
+
+/**
  * Base interface for Tinkerbell custom resources.
  */
 export interface TinkerbellResource extends KubeObjectInterface {


### PR DESCRIPTION
## What Changed

The BMC Job and Task list views built their Status column like this:

```ts
render: item => renderStatus(item.status?.conditions?.at(-1)?.type),
```

A condition is a pair, and only the pair means anything. `{ type: 'Failed', status: 'False' }` says the job has **not** failed. Reading the type on its own inverts it, and `renderStatus` maps `Failed` to error, so that condition rendered as "Failed" in red.

`.at(-1)` is the second half of the problem. It takes whichever condition the controller appended most recently, which is not necessarily one the resource is currently asserting.

The plugin already models the field it was discarding:

```ts
export type ConditionStatus = 'True' | 'False' | 'Unknown';

export interface TinkerbellCondition {
  type?: string;
  status?: ConditionStatus | string;
  ...
}
```

This adds `activeConditionType()` in `src/resources/common.ts`, which skips every condition whose status is not `True` and returns the last of those, or `undefined` when the resource is asserting nothing. `undefined` reaches `fallback()` and renders as `-`, which is the honest answer when no condition is true.

Both list views now call it. No other behaviour changes.

## Tests

Seven cases added to `src/resources/common.test.ts`, covering a true condition, a false one, `Unknown`, a condition carrying no status at all, a true condition sitting behind a false one, and several true at once.

I checked they fail against the old behaviour instead of assuming it. Replacing the filter with the previous logic gives:

```
FAIL  src/resources/common.test.ts > activeConditionType > ignores a condition whose status is False
FAIL  src/resources/common.test.ts > activeConditionType > ignores a condition whose status is Unknown
FAIL  src/resources/common.test.ts > activeConditionType > ignores a condition carrying no status at all
FAIL  src/resources/common.test.ts > activeConditionType > skips false conditions to find the true one, wherever it sits
Tests  4 failed | 12 passed (16)
```

With the fix in place all 16 pass, `tsc --noEmit` is clean, `eslint --max-warnings 0` is clean, and Prettier reports no issues on the four files touched.

## Note for reviewers

Prettier flags 16 files in this plugin on a Windows checkout, including several this PR does not touch. That is CRLF in the working tree, not content: every file committed here has LF endings, and the four changed files pass `prettier --check` individually.
