### PR TITLE
feat(kueue): add i18n support to Workload list component

### DIFF
--- a/kueue/src/components/workloads/List.tsx
+++ b/kueue/src/components/workloads/List.tsx
@@ -1,54 +1,57 @@
 import { ResourceListView } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { useTranslation } from 'react-i18next';
 import { Workload } from '../../resources/workload';
 import KueueAdminResourceAccess from '../common/KueueAdminResourceAccess';
 
 export default function WorkloadList() {
+  const { t } = useTranslation();
+
   return (
     <KueueAdminResourceAccess
       resourceClass={Workload}
-      resourceLabel="Workloads"
+      resourceLabel={t('Workloads')}
       verb="list"
-      accessDescription="Kueue Workloads are namespaced user workload resources."
+      accessDescription={t('Kueue Workloads are namespaced user workload resources.')}
     >
       <ResourceListView
-        title="Kueue Workloads"
+        title={t('Kueue Workloads')}
         resourceClass={Workload}
         columns={[
           'name',
           'namespace',
           {
             id: 'queue',
-            label: 'Queue',
+            label: t('Queue'),
             getValue: (workload: Workload) => workload.queueNameDisplay,
           },
           {
             id: 'priority',
-            label: 'Priority',
+            label: t('Priority'),
             getValue: (workload: Workload) => workload.priorityDisplay,
           },
           {
             id: 'priorityClass',
-            label: 'Priority Class',
+            label: t('Priority Class'),
             getValue: (workload: Workload) => workload.priorityClassDisplay,
           },
           {
             id: 'active',
-            label: 'Active',
+            label: t('Active'),
             getValue: (workload: Workload) => workload.activeDisplay,
           },
           {
             id: 'admitted',
-            label: 'Admitted',
+            label: t('Admitted'),
             getValue: (workload: Workload) => workload.admittedDisplay,
           },
           {
             id: 'finished',
-            label: 'Finished',
+            label: t('Finished'),
             getValue: (workload: Workload) => workload.finishedDisplay,
           },
           {
             id: 'status',
-            label: 'Status',
+            label: t('Status'),
             getValue: (workload: Workload) => workload.statusDisplay,
           },
           'age',


### PR DESCRIPTION
## Summary

This PR adds internationalization support to the Kueue `WorkloadList` component by wrapping user-facing strings with Headlamp's `useTranslation` hook.

## Changes

- Added `useTranslation` from `react-i18next`.
- Internationalized the Workload list title, access description, and column labels.
- Kept Headlamp's built-in `name` and `namespace` column identifiers unchanged.

## Testing

- `npm run format`
- `npm run lint`
- `npm run tsc`
- `npm run build`
- `npm run test`

All checks pass successfully.