### PR TITLE
fix(keda): sort Jobs list by completions, not parallelism

### DIFF
--- a/keda/src/components/common/CommonComponents.test.ts
+++ b/keda/src/components/common/CommonComponents.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { sortByCompletions } from './CommonComponents';
+import { getCompletions, sortByCompletions } from './CommonComponents';
 
 function job(completions?: number, parallelism?: number) {
   return { spec: { completions, parallelism } } as any;
@@ -21,5 +21,15 @@ describe('sortByCompletions', () => {
     expect(
       Number.isNaN(sortByCompletions(job(undefined, undefined), job(undefined, undefined)))
     ).toBe(false);
+  });
+});
+
+describe('getCompletions', () => {
+  it('renders both fields when set', () => {
+    expect(getCompletions(job(1, 5))).toBe('1/5');
+  });
+
+  it('renders 0 instead of undefined for unset fields, matching how they sort', () => {
+    expect(getCompletions(job(undefined, undefined))).toBe('0/0');
   });
 });

--- a/keda/src/components/common/CommonComponents.test.ts
+++ b/keda/src/components/common/CommonComponents.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { sortByCompletions } from './CommonComponents';
+
+function job(completions?: number, parallelism?: number) {
+  return { spec: { completions, parallelism } } as any;
+}
+
+describe('sortByCompletions', () => {
+  it('sorts by completions, not parallelism, when they disagree', () => {
+    // job1 has fewer completions but more parallelism than job2 — a completions-first
+    // sort must put job1 before job2, the opposite of what a parallelism-first sort would do.
+    expect(sortByCompletions(job(1, 5), job(5, 1))).toBeLessThan(0);
+  });
+
+  it('falls back to parallelism when completions are equal', () => {
+    expect(sortByCompletions(job(2, 1), job(2, 4))).toBeLessThan(0);
+  });
+
+  it('treats missing completions/parallelism as 0 instead of NaN', () => {
+    expect(sortByCompletions(job(undefined, undefined), job(1, 1))).toBeLessThan(0);
+    expect(
+      Number.isNaN(sortByCompletions(job(undefined, undefined), job(undefined, undefined)))
+    ).toBe(false);
+  });
+});

--- a/keda/src/components/common/CommonComponents.tsx
+++ b/keda/src/components/common/CommonComponents.tsx
@@ -572,13 +572,13 @@ export function sortByCompletions(job1: Job, job2: Job) {
   return completionsSorted;
 }
 
+export function getCompletions(job: Job) {
+  return `${job.spec.completions ?? 0}/${job.spec.parallelism ?? 0}`;
+}
+
 export function JobsListRenderer(props: JobsListRendererProps) {
   const { jobs, errors, hideColumns = [], reflectTableInURL = 'jobs', noNamespaceFilter } = props;
   const { t } = useTranslation();
-
-  function getCompletions(job: Job) {
-    return `${job.spec.completions}/${job.spec.parallelism}`;
-  }
 
   return (
     <ResourceListView

--- a/keda/src/components/common/CommonComponents.tsx
+++ b/keda/src/components/common/CommonComponents.tsx
@@ -564,20 +564,20 @@ export interface JobsListRendererProps {
   noNamespaceFilter?: boolean;
 }
 
+export function sortByCompletions(job1: Job, job2: Job) {
+  const completionsSorted = (job1.spec.completions ?? 0) - (job2.spec.completions ?? 0);
+  if (completionsSorted === 0) {
+    return (job1.spec.parallelism ?? 0) - (job2.spec.parallelism ?? 0);
+  }
+  return completionsSorted;
+}
+
 export function JobsListRenderer(props: JobsListRendererProps) {
   const { jobs, errors, hideColumns = [], reflectTableInURL = 'jobs', noNamespaceFilter } = props;
   const { t } = useTranslation();
 
   function getCompletions(job: Job) {
     return `${job.spec.completions}/${job.spec.parallelism}`;
-  }
-
-  function sortByCompletions(job1: Job, job2: Job) {
-    const parallelismSorted = job1.spec.parallelism - job2.spec.parallelism;
-    if (parallelismSorted === 0) {
-      return job1.spec.completions - job2.spec.completions;
-    }
-    return parallelismSorted;
   }
 
   return (


### PR DESCRIPTION
sortByCompletions in the keda Jobs list sorted by `parallelism` first and only fell back to `completions` on a tie, which is backwards from what the name says it does. Two jobs with the same parallelism but very different completion counts would land in the right order by luck, but anything where the two disagreed sorted wrong.

Also switched to nullish coalescing on both fields — a job missing `completions` or `parallelism` (both are optional on the Job spec) turned the comparison into `NaN`, which `Array.sort` treats unpredictably.

Exported the function out of `JobsListRenderer` so it can actually be unit tested instead of only exercised through the rendered table.