### PR TITLE
fix(karpenter): fix Age column sort in event lists

### DIFF
--- a/karpenter/src/common/EventList.test.ts
+++ b/karpenter/src/common/EventList.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { sortEventsByAge } from './EventList';
+
+function fakeEvent(lastOccurrence: string) {
+  return { lastOccurrence } as any;
+}
+
+describe('sortEventsByAge', () => {
+  it('sorts newer events before older ones', () => {
+    const newer = fakeEvent('2024-06-01T00:00:00Z');
+    const older = fakeEvent('2024-01-01T00:00:00Z');
+    expect(sortEventsByAge(newer, older)).toBeLessThan(0);
+    expect(sortEventsByAge(older, newer)).toBeGreaterThan(0);
+  });
+
+  it('treats equal timestamps as equal', () => {
+    const a = fakeEvent('2024-01-01T00:00:00Z');
+    const b = fakeEvent('2024-01-01T00:00:00Z');
+    expect(sortEventsByAge(a, b)).toBe(0);
+  });
+});

--- a/karpenter/src/common/EventList.tsx
+++ b/karpenter/src/common/EventList.tsx
@@ -34,6 +34,14 @@ export interface ObjectEventListProps {
   title: string;
 }
 
+// Event only exposes lastTimestamp through getValue() internally, not as a public
+// property, so reading n1.lastTimestamp directly is always undefined -- this sorted
+// nothing. lastOccurrence is the getter that actually resolves to a real value,
+// including for EventSeries-based repeated events where lastTimestamp is empty.
+export function sortEventsByAge(n1: Event, n2: Event): number {
+  return new Date(n2.lastOccurrence).getTime() - new Date(n1.lastOccurrence).getTime();
+}
+
 export default function CustomObjectEventList(props: ObjectEventListProps) {
   const { t } = useTranslation();
   let fieldSelector = `source=${props.source},involvedObject.kind=${props.kind}`;
@@ -98,8 +106,7 @@ export default function CustomObjectEventList(props: ObjectEventListProps) {
                 />
               );
             },
-            sort: (n1: KubeEvent, n2: KubeEvent) =>
-              new Date(n2.lastTimestamp).getTime() - new Date(n1.lastTimestamp).getTime(),
+            sort: sortEventsByAge,
           },
         ]}
         data={eventList}


### PR DESCRIPTION
The Age column's sort comparator reads `n1.lastTimestamp` / `n2.lastTimestamp` straight off the event objects. `Event` doesn't expose that as a public property though, only internally via `getValue('lastTimestamp')`, so both sides come back `undefined` and `new Date(undefined).getTime()` is `NaN` every time. The comparator always returns `NaN`, so clicking the Age header never actually reorders anything.

Switched to `lastOccurrence`, which is the getter the same column already uses to render what it shows the user. It also handles EventSeries correctly (falls back to `series.lastObservedTime`), which `lastTimestamp` doesn't — that's the normal shape for karpenter's own repeated scaling/consolidation events, so this wasn't just an edge case.

Pulled the comparator out into its own exported function so it's testable without needing a live Event instance.