### PR TITLE
fix(app-catalog): guard against catalog Services with no annotations

### DIFF
--- a/app-catalog/src/helpers/catalog.test.ts
+++ b/app-catalog/src/helpers/catalog.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest';
+import { CatalogLists } from './catalog';
+
+const { mockFetchCatalogs } = vi.hoisted(() => ({
+  mockFetchCatalogs: vi.fn(),
+}));
+
+vi.mock('../api/catalogs', () => ({
+  fetchCatalogs: mockFetchCatalogs,
+}));
+
+describe('CatalogLists', () => {
+  it('does not throw for a catalog Service with no annotations', async () => {
+    mockFetchCatalogs.mockResolvedValue({
+      items: [
+        {
+          metadata: { name: 'my-catalog', namespace: 'default' },
+          spec: { ports: [{ name: 'http', port: 8080 }] },
+        },
+      ],
+    });
+
+    const catalogs = await CatalogLists();
+
+    expect(catalogs).toHaveLength(1);
+    expect(catalogs[0].uri).toBe('http://my-catalog.default:8080');
+  });
+
+  it('still reads annotation values when present', async () => {
+    mockFetchCatalogs.mockResolvedValue({
+      items: [
+        {
+          metadata: {
+            name: 'my-catalog',
+            namespace: 'default',
+            annotations: { 'catalog.headlamp.dev/uri': 'https://charts.example.com' },
+          },
+          spec: { ports: [{ name: 'http', port: 8080 }] },
+        },
+      ],
+    });
+
+    const catalogs = await CatalogLists();
+
+    expect(catalogs[0].uri).toBe('https://charts.example.com');
+  });
+});

--- a/app-catalog/src/helpers/catalog.ts
+++ b/app-catalog/src/helpers/catalog.ts
@@ -37,8 +37,9 @@ export function CatalogLists() {
     for (let i = 0; i < response.items.length; i++) {
       let serviceUri = '';
       const metadata = response.items[i].metadata;
-      if (ANNOTATION_URI in metadata.annotations) {
-        serviceUri = metadata.annotations[ANNOTATION_URI];
+      const annotations = metadata.annotations ?? {};
+      if (ANNOTATION_URI in annotations) {
+        serviceUri = annotations[ANNOTATION_URI];
       }
 
       // Using the first port
@@ -48,14 +49,10 @@ export function CatalogLists() {
       }
 
       let catalogDisplayName = '';
-      if (
-        ANNOTATION_DISPLAY_NAME in metadata.annotations &&
-        metadata.annotations[ANNOTATION_DISPLAY_NAME] !== ''
-      ) {
-        catalogDisplayName = metadata.annotations[ANNOTATION_DISPLAY_NAME];
+      if (ANNOTATION_DISPLAY_NAME in annotations && annotations[ANNOTATION_DISPLAY_NAME] !== '') {
+        catalogDisplayName = annotations[ANNOTATION_DISPLAY_NAME];
       } else {
-        catalogDisplayName =
-          ANNOTATION_NAME in metadata.annotations ? metadata.annotations[ANNOTATION_NAME] : '';
+        catalogDisplayName = ANNOTATION_NAME in annotations ? annotations[ANNOTATION_NAME] : '';
       }
 
       // Represents a catalog with its metadata and URI.
@@ -66,7 +63,7 @@ export function CatalogLists() {
         displayName: catalogDisplayName,
         metadataName: metadata.name,
         namespace: metadata.namespace,
-        protocol: metadata.annotations[ANNOTATION_PROTOCOL],
+        protocol: annotations[ANNOTATION_PROTOCOL],
         uri: serviceUri,
       };
 


### PR DESCRIPTION
`CatalogLists` used the `in` operator straight on `metadata.annotations`, which K8s omits entirely when a resource has no annotations set. All a catalog Service actually needs is the `catalog.headlamp.dev/is-catalog` label — nothing requires it to also carry an annotation — so a bare-minimum catalog Service throws before the sidebar entry can even render.

Defaulted `annotations` to `{}` once and used that everywhere instead of reading `metadata.annotations` directly at each call site. Added a test for the no-annotations case plus one confirming annotation values still get picked up when present.