### PR TITLE
ci: fix plugin workflow diff target for push events

### DIFF
--- a/.github/workflows/headlamp-plugin-github-workflow.yaml
+++ b/.github/workflows/headlamp-plugin-github-workflow.yaml
@@ -29,9 +29,20 @@ jobs:
 
       - name: Find changed Headlamp plugin directories
         id: dirs
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
         run: |
+          # Determine the correct base ref depending on the event type.
+          # On push, github.event.before is the commit SHA before the push.
+          # On pull_request, origin/main is the correct base.
+          if [ "$GITHUB_EVENT_NAME" = "push" ]; then
+            BASE_REF="$BEFORE_SHA"
+          else
+            BASE_REF="origin/main"
+          fi
+
           # Get all top-level directories that had changes
-          changed_dirs=$(git diff --name-only origin/main...HEAD | awk -F/ '{print $1}' | sort -u)
+          changed_dirs=$(git diff --name-only "$BASE_REF"...HEAD | awk -F/ '{print $1}' | sort -u)
           echo "Changed directories: $changed_dirs"
 
           # If .github/ changed, run all plugins

--- a/.github/workflows/headlamp-plugin-github-workflow.yaml
+++ b/.github/workflows/headlamp-plugin-github-workflow.yaml
@@ -37,6 +37,10 @@ jobs:
           # On pull_request, origin/main is the correct base.
           if [ "$GITHUB_EVENT_NAME" = "push" ]; then
             BASE_REF="$BEFORE_SHA"
+            # Fallback for new branches where before SHA is all zeros
+            if [ "$BASE_REF" = "0000000000000000000000000000000000000000" ]; then
+              BASE_REF="HEAD~1"
+            fi
           else
             BASE_REF="origin/main"
           fi


### PR DESCRIPTION
## Problem
The plugin workflow runs after pushes to `main`, but it compares `HEAD` with `origin/main`. On a push event, both refs point to the same commit, so the diff is always empty and every plugin job is skipped. 

Fixes #1133.

## Fix
* Uses `github.event.before` (the SHA immediately before the push) as the base ref when the event is a `push`.
* Keeps using `origin/main` for `pull_request` events (unchanged behavior).
* Adds a fallback to `HEAD~1` to handle edge cases where the `before` SHA is all zeros (e.g., force-pushes or new branches).