### PR TITLE
fix(knative): clean up blob URL and DOM node after log download

### DIFF
--- a/knative/src/components/kservices/detail/header/KServiceLogsHeaderButton.tsx
+++ b/knative/src/components/kservices/detail/header/KServiceLogsHeaderButton.tsx
@@ -396,11 +396,17 @@ function KServiceLogsActivityContent({ kservice }: { kservice: KService }) {
 
     const element = document.createElement('a');
     const file = new Blob([downloadLogs.join('')], { type: 'text/plain' });
-    element.href = URL.createObjectURL(file);
+    const url = URL.createObjectURL(file);
+    element.href = url;
     element.download = `${downloadName}_${time}.txt`;
-    // Required for FireFox
-    document.body.appendChild(element);
-    element.click();
+    try {
+      // Required for FireFox
+      document.body.appendChild(element);
+      element.click();
+    } finally {
+      element.remove();
+      URL.revokeObjectURL(url);
+    }
   }
 
   React.useEffect(() => {


### PR DESCRIPTION
Downloading logs from the KService log viewer creates a Blob URL and an anchor element for every click, but never revokes the URL or removes the element afterward. Each download leaves a detached `<a>` in the DOM permanently and pins the log Blob in memory for the rest of the session — noticeable on a page where someone re-downloads logs repeatedly while debugging.

Both `kompose`'s download button and `ai-assistant`'s `LogsDialog` already do this correctly in this same repo (the latter uses a try/finally so cleanup happens even if `click()` throws), so I matched that pattern here instead of inventing a new one.

Verified the before/after behavior with a standalone script simulating both code paths — the old one never calls `remove()`/`revokeObjectURL`, the new one calls both every time regardless of whether `click()` succeeds. Didn't add a full component-render test since exercising this function means standing up the whole KService pods/activity/permissions mocking chain for a five-line cleanup fix, which felt disproportionate — happy to add one if a maintainer wants it.