### PR TITLE
fix(kyverno): distinguish unavailable CRDs from absence

### DIFF
--- a/kyverno/src/components/CRDGuard.tsx
+++ b/kyverno/src/components/CRDGuard.tsx
@@ -51,7 +51,7 @@ export function CRDGuard({ requires, children, message }: CRDGuardProps) {
     return <NotInstalledBanner loading />;
   }
 
-  if (!status[requires]) {
+  if (status[requires] === false) {
     return <NotInstalledBanner message={message || defaultMessages[requires]} />;
   }
 

--- a/kyverno/src/hooks/useKyvernoCRDs.ts
+++ b/kyverno/src/hooks/useKyvernoCRDs.ts
@@ -17,34 +17,36 @@
 import { ApiProxy, K8s } from '@kinvolk/headlamp-plugin/lib';
 import { useEffect, useState } from 'react';
 
+export type CRDAvailability = boolean | undefined;
+
 export interface KyvernoCRDStatus {
-  legacy: boolean; // kyverno.io/v1 (ClusterPolicy, Policy)
-  cel: boolean; // policies.kyverno.io/v1 (ValidatingPolicy, MutatingPolicy, etc.)
-  cleanup: boolean; // kyverno.io/v2 (CleanupPolicy, ClusterCleanupPolicy)
-  reports: boolean; // wgpolicyk8s.io/v1alpha2 (PolicyReport, ClusterPolicyReport)
-  exceptions: boolean; // kyverno.io/v2 (PolicyException)
-  kyvernoV2Reports: boolean; // kyverno.io/v2 (Admission/BackgroundScan reports)
-  ephemeralReports: boolean; // reports.kyverno.io/v1 (EphemeralReport, ClusterEphemeralReport)
+  legacy: CRDAvailability; // kyverno.io/v1 (ClusterPolicy, Policy)
+  cel: CRDAvailability; // policies.kyverno.io/v1 (ValidatingPolicy, MutatingPolicy, etc.)
+  cleanup: CRDAvailability; // kyverno.io/v2 (CleanupPolicy, ClusterCleanupPolicy)
+  reports: CRDAvailability; // wgpolicyk8s.io/v1alpha2 (PolicyReport, ClusterPolicyReport)
+  exceptions: CRDAvailability; // kyverno.io/v2 (PolicyException)
+  kyvernoV2Reports: CRDAvailability; // kyverno.io/v2 (Admission/BackgroundScan reports)
+  ephemeralReports: CRDAvailability; // reports.kyverno.io/v1 (EphemeralReport, ClusterEphemeralReport)
   loading: boolean;
 }
 
 const initialStatus: KyvernoCRDStatus = {
-  legacy: false,
-  cel: false,
-  cleanup: false,
-  reports: false,
-  exceptions: false,
-  kyvernoV2Reports: false,
-  ephemeralReports: false,
+  legacy: undefined,
+  cel: undefined,
+  cleanup: undefined,
+  reports: undefined,
+  exceptions: undefined,
+  kyvernoV2Reports: undefined,
+  ephemeralReports: undefined,
   loading: true,
 };
 
-async function checkAPIGroup(path: string): Promise<boolean> {
+async function checkAPIGroup(path: string): Promise<CRDAvailability> {
   try {
     await ApiProxy.request(path, { method: 'GET' });
     return true;
-  } catch {
-    return false;
+  } catch (error) {
+    return (error as { status?: number }).status === 404 ? false : undefined;
   }
 }
 


### PR DESCRIPTION
## Summary

Fix Kyverno install detection so API-group probe failures are not incorrectly treated as "not installed".

Currently, `checkAPIGroup()` catches every request failure and returns `false`. This makes a missing API group indistinguishable from transient failures such as timeouts, unavailable API servers, or other request errors.

As a result, `CRDGuard` can show a misleading "Kyverno was not detected on this cluster" message when the plugin simply cannot determine the API group's availability.

## What this changes

- Distinguishes a confirmed missing API group from an unavailable/undetermined probe result.
- Only treats an actual `404` response as evidence that the API group is absent.
- Keeps other request failures from being presented as "not installed".
- Preserves the existing per-cluster cache and in-flight request deduplication.
- Keeps failures isolated between Kyverno API groups.

## Why

A failed discovery request does not necessarily mean Kyverno is not installed. Treating every error as `false` can hide otherwise valid Kyverno functionality and produce an incorrect installation status.

This follows the discussion in #1083 around distinguishing `installed`, `absent`, and `unreachable` states.

Fixes #1083

## Validation

Validated the behavior for:

- successful API-group discovery
- `404` / API group absent
- `403` / access denied
- `408` / timeout
- `502` / unavailable API server
- network/request failures
- partial failures where one Kyverno API group is unavailable while others remain available
- per-cluster cache isolation
- concurrent consumers sharing an in-flight probe