### PR TITLE
tinkerbell: Add resource map integration

### DIFF
--- a/tinkerbell/src/components/bmc/jobs/Detail.tsx
+++ b/tinkerbell/src/components/bmc/jobs/Detail.tsx
@@ -8,20 +8,24 @@ import {
 import { useParams } from 'react-router-dom';
 import { BmcJob } from '../../../resources/bmcJob';
 import { fallback, renderUnknownValue } from '../../common/detailHelpers';
+import type { TinkerbellDetailProps } from '../../common/detailTypes';
 
 /**
  * Renders the Tinkerbell BMC Job detail view.
  *
  * @returns BMC Job detail page with machine reference, tasks, and timing.
  */
-export function BmcJobDetail() {
-  const { namespace, name } = useParams<{ namespace: string; name: string }>();
+export function BmcJobDetail(props: TinkerbellDetailProps = {}) {
+  const params = useParams<{ namespace: string; name: string }>();
+  const namespace = props.namespace ?? params.namespace;
+  const name = props.name ?? params.name;
 
   return (
     <DetailsGrid
       resourceType={BmcJob}
       name={name}
       namespace={namespace}
+      cluster={props.cluster}
       extraInfo={item =>
         item
           ? [

--- a/tinkerbell/src/components/bmc/machines/Detail.tsx
+++ b/tinkerbell/src/components/bmc/machines/Detail.tsx
@@ -2,20 +2,24 @@ import { ConditionsSection, DetailsGrid } from '@kinvolk/headlamp-plugin/lib/com
 import { useParams } from 'react-router-dom';
 import { BmcMachine } from '../../../resources/bmcMachine';
 import { statusValue } from '../../common/detailHelpers';
+import type { TinkerbellDetailProps } from '../../common/detailTypes';
 
 /**
  * Renders the Tinkerbell BMC Machine detail view.
  *
  * @returns BMC Machine detail page with power, connection, and conditions.
  */
-export function BmcMachineDetail() {
-  const { namespace, name } = useParams<{ namespace: string; name: string }>();
+export function BmcMachineDetail(props: TinkerbellDetailProps = {}) {
+  const params = useParams<{ namespace: string; name: string }>();
+  const namespace = props.namespace ?? params.namespace;
+  const name = props.name ?? params.name;
 
   return (
     <DetailsGrid
       resourceType={BmcMachine}
       name={name}
       namespace={namespace}
+      cluster={props.cluster}
       extraInfo={item =>
         item ? [{ name: 'Power State', value: statusValue(item.status?.powerState) }] : []
       }

--- a/tinkerbell/src/components/bmc/tasks/Detail.tsx
+++ b/tinkerbell/src/components/bmc/tasks/Detail.tsx
@@ -7,6 +7,7 @@ import {
 import { useParams } from 'react-router-dom';
 import { BmcTask } from '../../../resources/bmcTask';
 import { fallback, renderUnknownValue } from '../../common/detailHelpers';
+import type { TinkerbellDetailProps } from '../../common/detailTypes';
 
 /**
  * Gets the BMC operation name from the task data key.
@@ -26,14 +27,17 @@ function getTaskOperation(item: BmcTask): string {
  *
  * @returns BMC Task detail page with operation, connection, and timing.
  */
-export function BmcTaskDetail() {
-  const { namespace, name } = useParams<{ namespace: string; name: string }>();
+export function BmcTaskDetail(props: TinkerbellDetailProps = {}) {
+  const params = useParams<{ namespace: string; name: string }>();
+  const namespace = props.namespace ?? params.namespace;
+  const name = props.name ?? params.name;
 
   return (
     <DetailsGrid
       resourceType={BmcTask}
       name={name}
       namespace={namespace}
+      cluster={props.cluster}
       extraInfo={item =>
         item
           ? [

--- a/tinkerbell/src/components/common/detailTypes.ts
+++ b/tinkerbell/src/components/common/detailTypes.ts
@@ -1,0 +1,9 @@
+/** Props shared by Tinkerbell detail pages and map node detail panels. */
+export interface TinkerbellDetailProps {
+  /** Resource name to render when the detail view is opened outside a route. */
+  name?: string;
+  /** Resource namespace to render when the detail view is opened outside a route. */
+  namespace?: string;
+  /** Cluster name used by Headlamp when rendering a map node detail panel. */
+  cluster?: string;
+}

--- a/tinkerbell/src/components/hardware/Detail.tsx
+++ b/tinkerbell/src/components/hardware/Detail.tsx
@@ -14,6 +14,7 @@ import {
   renderTextSection,
   renderUnknownValue,
 } from '../common/detailHelpers';
+import type { TinkerbellDetailProps } from '../common/detailTypes';
 import { getHardwareAgentID } from './helpers';
 
 /** Controller-reported block device details from the agent attributes annotation. */
@@ -104,14 +105,17 @@ function hasRecord(value: Record<string, unknown> | undefined): boolean {
  *
  * @returns Hardware detail page with interfaces, disks, references, and data sections.
  */
-export function HardwareDetail() {
-  const { namespace, name } = useParams<{ namespace: string; name: string }>();
+export function HardwareDetail(props: TinkerbellDetailProps = {}) {
+  const params = useParams<{ namespace: string; name: string }>();
+  const namespace = props.namespace ?? params.namespace;
+  const name = props.name ?? params.name;
 
   return (
     <DetailsGrid
       resourceType={Hardware}
       name={name}
       namespace={namespace}
+      cluster={props.cluster}
       extraInfo={item =>
         item
           ? (() => {

--- a/tinkerbell/src/components/templates/Detail.tsx
+++ b/tinkerbell/src/components/templates/Detail.tsx
@@ -6,6 +6,7 @@ import {
 import { useParams } from 'react-router-dom';
 import { Template } from '../../resources/template';
 import { fallback, renderTextSection } from '../common/detailHelpers';
+import type { TinkerbellDetailProps } from '../common/detailTypes';
 
 /** Parsed summary for one task in a Tinkerbell template. */
 interface ParsedTemplateTask {
@@ -312,14 +313,17 @@ function parseTemplateData(data: string | undefined): ParsedTemplate {
  *
  * @returns Template detail page with summary, parsed tasks, actions, and raw data.
  */
-export function TemplateDetail() {
-  const { namespace, name } = useParams<{ namespace: string; name: string }>();
+export function TemplateDetail(props: TinkerbellDetailProps = {}) {
+  const params = useParams<{ namespace: string; name: string }>();
+  const namespace = props.namespace ?? params.namespace;
+  const name = props.name ?? params.name;
 
   return (
     <DetailsGrid
       resourceType={Template}
       name={name}
       namespace={namespace}
+      cluster={props.cluster}
       extraInfo={item => {
         const parsedTemplate = parseTemplateData(item?.data);
 

--- a/tinkerbell/src/components/workflowrulesets/Detail.tsx
+++ b/tinkerbell/src/components/workflowrulesets/Detail.tsx
@@ -7,6 +7,7 @@ import {
 import { useParams } from 'react-router-dom';
 import { WorkflowRuleSet } from '../../resources/workflowRuleSet';
 import { fallback, renderUnknownValue } from '../common/detailHelpers';
+import type { TinkerbellDetailProps } from '../common/detailTypes';
 
 /**
  * Gets the template reference from WorkflowRuleSet workflow config.
@@ -30,14 +31,17 @@ function getTemplateRef(item: WorkflowRuleSet): string {
  *
  * @returns WorkflowRuleSet detail page with rules and workflow config.
  */
-export function WorkflowRuleSetDetail() {
-  const { namespace, name } = useParams<{ namespace: string; name: string }>();
+export function WorkflowRuleSetDetail(props: TinkerbellDetailProps = {}) {
+  const params = useParams<{ namespace: string; name: string }>();
+  const namespace = props.namespace ?? params.namespace;
+  const name = props.name ?? params.name;
 
   return (
     <DetailsGrid
       resourceType={WorkflowRuleSet}
       name={name}
       namespace={namespace}
+      cluster={props.cluster}
       extraInfo={item =>
         item
           ? [

--- a/tinkerbell/src/components/workflows/Detail.tsx
+++ b/tinkerbell/src/components/workflows/Detail.tsx
@@ -9,6 +9,7 @@ import { useParams } from 'react-router-dom';
 import { normalizeState } from '../../resources/common';
 import { Workflow, WorkflowActionStatus } from '../../resources/workflow';
 import { booleanValue, fallback, renderRecordSection, statusValue } from '../common/detailHelpers';
+import type { TinkerbellDetailProps } from '../common/detailTypes';
 import { getCurrentAction, getCurrentTask, getTaskState, getWorkflowState } from './helpers';
 
 /** Workflow action row enriched with its parent task name. */
@@ -114,14 +115,17 @@ function renderTemplateRendering(value: string | Record<string, any> | undefined
  *
  * @returns Workflow detail page with references, status, tasks, and actions.
  */
-export function WorkflowDetail() {
-  const { namespace, name } = useParams<{ namespace: string; name: string }>();
+export function WorkflowDetail(props: TinkerbellDetailProps = {}) {
+  const params = useParams<{ namespace: string; name: string }>();
+  const namespace = props.namespace ?? params.namespace;
+  const name = props.name ?? params.name;
 
   return (
     <DetailsGrid
       resourceType={Workflow}
       name={name}
       namespace={namespace}
+      cluster={props.cluster}
       extraInfo={item =>
         item
           ? [

--- a/tinkerbell/src/index.tsx
+++ b/tinkerbell/src/index.tsx
@@ -16,6 +16,7 @@
 import { addIcon, Icon } from '@iconify/react';
 import {
   registerKindIcon,
+  registerMapSource,
   registerRoute,
   registerSidebarEntry,
 } from '@kinvolk/headlamp-plugin/lib';
@@ -35,6 +36,7 @@ import { WorkflowRuleSetDetail } from './components/workflowrulesets/Detail';
 import { WorkflowRuleSetList } from './components/workflowrulesets/List';
 import { WorkflowDetail } from './components/workflows/Detail';
 import { WorkflowList } from './components/workflows/List';
+import { tinkerbellSource } from './mapView';
 import { BmcJob } from './resources/bmcJob';
 import { BmcMachine } from './resources/bmcMachine';
 import { BmcTask } from './resources/bmcTask';
@@ -49,6 +51,8 @@ addIcon('simple-icons:tinkerbell', {
   width: 24,
   height: 24,
 });
+
+registerMapSource(tinkerbellSource);
 
 registerSidebarEntry({
   parent: null,

--- a/tinkerbell/src/mapRelationships.test.ts
+++ b/tinkerbell/src/mapRelationships.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getBmcJobRelationshipEdges,
+  getBmcTaskRelationshipEdges,
+  getHardwareBmcRelationshipEdges,
+  getWorkflowRelationshipEdges,
+  getWorkflowRuleSetRelationshipEdges,
+  getWorkflowRuleSetTemplateRef,
+} from './mapRelationships';
+import type { BmcJob } from './resources/bmcJob';
+import type { BmcMachine } from './resources/bmcMachine';
+import type { BmcTask } from './resources/bmcTask';
+import type { Hardware } from './resources/hardware';
+import type { Template } from './resources/template';
+import type { Workflow } from './resources/workflow';
+import type { WorkflowRuleSet } from './resources/workflowRuleSet';
+
+function objectWithSpec<T>(uid: string, name: string, namespace: string, spec?: any): T {
+  return {
+    metadata: {
+      uid,
+      name,
+      namespace,
+    },
+    spec,
+  } as T;
+}
+
+describe('Tinkerbell map relationships', () => {
+  it('connects workflows to referenced hardware and templates', () => {
+    const hardware = [objectWithSpec<Hardware>('hardware-uid', 'machine1', 'tinkerbell')];
+    const templates = [objectWithSpec<Template>('template-uid', 'ubuntu', 'tinkerbell')];
+    const workflows = [
+      objectWithSpec<Workflow>('workflow-uid', 'install', 'tinkerbell', {
+        hardwareRef: 'machine1',
+        templateRef: 'ubuntu',
+      }),
+    ];
+
+    expect(getWorkflowRelationshipEdges(workflows, hardware, templates)).toEqual([
+      {
+        id: 'hardware-uid-workflow-uid',
+        source: 'hardware-uid',
+        target: 'workflow-uid',
+        label: 'runs workflow',
+      },
+      {
+        id: 'workflow-uid-template-uid',
+        source: 'workflow-uid',
+        target: 'template-uid',
+        label: 'uses template',
+      },
+    ]);
+  });
+
+  it('connects hardware to its referenced BMC machine', () => {
+    const hardware = [
+      objectWithSpec<Hardware>('hardware-uid', 'machine1', 'tinkerbell', {
+        bmcRef: {
+          name: 'machine1-bmc',
+          namespace: 'tinkerbell',
+        },
+      }),
+    ];
+    const machines = [objectWithSpec<BmcMachine>('machine-uid', 'machine1-bmc', 'tinkerbell')];
+
+    expect(getHardwareBmcRelationshipEdges(hardware, machines)).toEqual([
+      {
+        id: 'hardware-uid-machine-uid',
+        source: 'hardware-uid',
+        target: 'machine-uid',
+        label: 'uses BMC',
+      },
+    ]);
+  });
+
+  it('connects BMC jobs to referenced BMC machines', () => {
+    const machines = [objectWithSpec<BmcMachine>('machine-uid', 'machine1-bmc', 'tinkerbell')];
+    const jobs = [
+      objectWithSpec<BmcJob>('job-uid', 'power-cycle', 'tinkerbell', {
+        machineRef: {
+          name: 'machine1-bmc',
+          namespace: 'tinkerbell',
+        },
+      }),
+    ];
+
+    expect(getBmcJobRelationshipEdges(jobs, machines)).toEqual([
+      {
+        id: 'machine-uid-job-uid',
+        source: 'machine-uid',
+        target: 'job-uid',
+        label: 'runs BMC job',
+      },
+    ]);
+  });
+
+  it('connects BMC tasks to owning BMC jobs', () => {
+    const jobs = [objectWithSpec<BmcJob>('job-uid', 'power-cycle', 'tinkerbell')];
+    const tasks = [
+      {
+        metadata: {
+          uid: 'task-uid',
+          name: 'power-cycle-task',
+          namespace: 'tinkerbell',
+          ownerReferences: [
+            {
+              kind: 'Job',
+              name: 'power-cycle',
+              uid: 'job-uid',
+            },
+          ],
+        },
+      } as BmcTask,
+    ];
+
+    expect(getBmcTaskRelationshipEdges(tasks, jobs)).toEqual([
+      {
+        id: 'job-uid-task-uid',
+        source: 'job-uid',
+        target: 'task-uid',
+        label: 'creates task',
+      },
+    ]);
+  });
+
+  it('does not connect BMC tasks to recreated jobs with the same name', () => {
+    const jobs = [objectWithSpec<BmcJob>('new-job-uid', 'power-cycle', 'tinkerbell')];
+    const tasks = [
+      {
+        metadata: {
+          uid: 'task-uid',
+          name: 'power-cycle-task',
+          namespace: 'tinkerbell',
+          ownerReferences: [
+            {
+              kind: 'Job',
+              name: 'power-cycle',
+              uid: 'old-job-uid',
+            },
+          ],
+        },
+      } as BmcTask,
+    ];
+
+    expect(getBmcTaskRelationshipEdges(tasks, jobs)).toEqual([]);
+  });
+
+  it('connects WorkflowRuleSets to referenced templates', () => {
+    const templates = [objectWithSpec<Template>('template-uid', 'ubuntu', 'tinkerbell')];
+    const ruleSets = [
+      objectWithSpec<WorkflowRuleSet>('ruleset-uid', 'rules', 'tinkerbell', {
+        workflow: {
+          template: {
+            ref: 'ubuntu',
+          },
+        },
+      }),
+    ];
+
+    expect(getWorkflowRuleSetTemplateRef(ruleSets[0])).toBe('ubuntu');
+    expect(getWorkflowRuleSetRelationshipEdges(ruleSets, templates)).toEqual([
+      {
+        id: 'ruleset-uid-template-uid',
+        source: 'ruleset-uid',
+        target: 'template-uid',
+        label: 'uses template',
+      },
+    ]);
+  });
+
+  it('connects WorkflowRuleSets to templates in the configured workflow namespace', () => {
+    const templates = [objectWithSpec<Template>('template-uid', 'ubuntu', 'workflows')];
+    const ruleSets = [
+      objectWithSpec<WorkflowRuleSet>('ruleset-uid', 'rules', 'tinkerbell', {
+        workflow: {
+          namespace: 'workflows',
+          templateRef: 'ubuntu',
+        },
+      }),
+    ];
+
+    expect(getWorkflowRuleSetRelationshipEdges(ruleSets, templates)).toEqual([
+      {
+        id: 'ruleset-uid-template-uid',
+        source: 'ruleset-uid',
+        target: 'template-uid',
+        label: 'uses template',
+      },
+    ]);
+  });
+
+  it('skips missing references instead of creating guessed edges', () => {
+    const workflows = [
+      objectWithSpec<Workflow>('workflow-uid', 'install', 'tinkerbell', {
+        hardwareRef: 'missing-hardware',
+        templateRef: 'missing-template',
+      }),
+    ];
+
+    expect(getWorkflowRelationshipEdges(workflows, [], [])).toEqual([]);
+  });
+});

--- a/tinkerbell/src/mapRelationships.ts
+++ b/tinkerbell/src/mapRelationships.ts
@@ -1,0 +1,224 @@
+import type { GraphEdge } from '@kinvolk/headlamp-plugin/lib/components/resourceMap/graph/graphModel';
+import type { BmcJob } from './resources/bmcJob';
+import type { BmcMachine } from './resources/bmcMachine';
+import type { BmcTask } from './resources/bmcTask';
+import type { Hardware } from './resources/hardware';
+import type { Template } from './resources/template';
+import type { Workflow } from './resources/workflow';
+import type { WorkflowRuleSet } from './resources/workflowRuleSet';
+
+type TinkerbellMapObject = {
+  metadata: {
+    uid: string;
+    name: string;
+    namespace?: string;
+    ownerReferences?: {
+      apiVersion?: string;
+      kind?: string;
+      name?: string;
+      uid?: string;
+    }[];
+  };
+};
+
+/**
+ * Builds a graph edge between two Kubernetes objects.
+ *
+ * @param from - Source object for the relationship.
+ * @param to - Target object for the relationship.
+ * @param label - Optional relationship label shown by the map.
+ * @returns Graph edge connecting the two objects.
+ */
+export function makeTinkerbellEdge(
+  from: TinkerbellMapObject,
+  to: TinkerbellMapObject,
+  label?: string
+): GraphEdge {
+  return {
+    id: `${from.metadata.uid}-${to.metadata.uid}`,
+    source: from.metadata.uid,
+    target: to.metadata.uid,
+    label,
+  };
+}
+
+function findByNameAndNamespace<T extends TinkerbellMapObject>(
+  items: T[] | null | undefined,
+  name: string | undefined,
+  namespace: string | undefined
+): T | undefined {
+  if (!name || !items) {
+    return undefined;
+  }
+
+  return items.find(
+    item =>
+      item.metadata.name === name &&
+      (!namespace || !item.metadata.namespace || item.metadata.namespace === namespace)
+  );
+}
+
+/**
+ * Gets the template reference from a WorkflowRuleSet workflow config.
+ *
+ * @param item - WorkflowRuleSet resource to inspect.
+ * @returns Template reference/name when present.
+ */
+export function getWorkflowRuleSetTemplateRef(item: WorkflowRuleSet): string | undefined {
+  const workflow = item.spec?.workflow;
+  const template = workflow?.template ?? workflow?.templateRef ?? workflow?.ref;
+
+  if (typeof template === 'string') {
+    return template;
+  }
+
+  return template?.ref ?? template?.name ?? workflow?.templateName;
+}
+
+/**
+ * Builds Hardware -> Workflow and Workflow -> Template edges.
+ *
+ * @param workflows - Tinkerbell Workflow resources.
+ * @param hardware - Tinkerbell Hardware resources.
+ * @param templates - Tinkerbell Template resources.
+ * @returns Relationship edges for workflows.
+ */
+export function getWorkflowRelationshipEdges(
+  workflows: Workflow[] | null | undefined,
+  hardware: Hardware[] | null | undefined,
+  templates: Template[] | null | undefined
+): GraphEdge[] {
+  const edges: GraphEdge[] = [];
+
+  workflows?.forEach(workflow => {
+    const namespace = workflow.metadata.namespace;
+    const relatedHardware = findByNameAndNamespace(hardware, workflow.spec?.hardwareRef, namespace);
+    const relatedTemplate = findByNameAndNamespace(
+      templates,
+      workflow.spec?.templateRef,
+      namespace
+    );
+
+    if (relatedHardware) {
+      edges.push(makeTinkerbellEdge(relatedHardware, workflow, 'runs workflow'));
+    }
+
+    if (relatedTemplate) {
+      edges.push(makeTinkerbellEdge(workflow, relatedTemplate, 'uses template'));
+    }
+  });
+
+  return edges;
+}
+
+/**
+ * Builds Hardware -> BMC Machine edges from Hardware bmcRef values.
+ *
+ * @param hardware - Tinkerbell Hardware resources.
+ * @param machines - Tinkerbell BMC Machine resources.
+ * @returns Relationship edges for BMC-backed hardware.
+ */
+export function getHardwareBmcRelationshipEdges(
+  hardware: Hardware[] | null | undefined,
+  machines: BmcMachine[] | null | undefined
+): GraphEdge[] {
+  const edges: GraphEdge[] = [];
+
+  hardware?.forEach(item => {
+    const bmcRef = item.spec?.bmcRef;
+    const machine = findByNameAndNamespace(
+      machines,
+      bmcRef?.name,
+      bmcRef?.namespace ?? item.metadata.namespace
+    );
+
+    if (machine) {
+      edges.push(makeTinkerbellEdge(item, machine, 'uses BMC'));
+    }
+  });
+
+  return edges;
+}
+
+/**
+ * Builds BMC Machine -> BMC Job edges from Job machineRef values.
+ *
+ * @param jobs - Tinkerbell BMC Job resources.
+ * @param machines - Tinkerbell BMC Machine resources.
+ * @returns Relationship edges for BMC jobs.
+ */
+export function getBmcJobRelationshipEdges(
+  jobs: BmcJob[] | null | undefined,
+  machines: BmcMachine[] | null | undefined
+): GraphEdge[] {
+  const edges: GraphEdge[] = [];
+
+  jobs?.forEach(job => {
+    const machine = findByNameAndNamespace(
+      machines,
+      job.spec?.machineRef?.name,
+      job.spec?.machineRef?.namespace ?? job.metadata.namespace
+    );
+
+    if (machine) {
+      edges.push(makeTinkerbellEdge(machine, job, 'runs BMC job'));
+    }
+  });
+
+  return edges;
+}
+
+/**
+ * Builds BMC Job -> BMC Task edges from Task ownerReferences.
+ *
+ * @param tasks - Tinkerbell BMC Task resources.
+ * @param jobs - Tinkerbell BMC Job resources.
+ * @returns Relationship edges for BMC task ownership.
+ */
+export function getBmcTaskRelationshipEdges(
+  tasks: BmcTask[] | null | undefined,
+  jobs: BmcJob[] | null | undefined
+): GraphEdge[] {
+  const edges: GraphEdge[] = [];
+
+  tasks?.forEach(task => {
+    const ownerRefs = task.metadata.ownerReferences ?? [];
+    const job = jobs?.find(candidate =>
+      ownerRefs.some(owner => owner.kind === 'Job' && owner.uid === candidate.metadata.uid)
+    );
+
+    if (job) {
+      edges.push(makeTinkerbellEdge(job, task, 'creates task'));
+    }
+  });
+
+  return edges;
+}
+
+/**
+ * Builds WorkflowRuleSet -> Template edges from workflow template references.
+ *
+ * @param ruleSets - Tinkerbell WorkflowRuleSet resources.
+ * @param templates - Tinkerbell Template resources.
+ * @returns Relationship edges for workflow rule sets.
+ */
+export function getWorkflowRuleSetRelationshipEdges(
+  ruleSets: WorkflowRuleSet[] | null | undefined,
+  templates: Template[] | null | undefined
+): GraphEdge[] {
+  const edges: GraphEdge[] = [];
+
+  ruleSets?.forEach(ruleSet => {
+    const template = findByNameAndNamespace(
+      templates,
+      getWorkflowRuleSetTemplateRef(ruleSet),
+      ruleSet.spec?.workflow?.namespace ?? ruleSet.metadata.namespace
+    );
+
+    if (template) {
+      edges.push(makeTinkerbellEdge(ruleSet, template, 'uses template'));
+    }
+  });
+
+  return edges;
+}

--- a/tinkerbell/src/mapView.tsx
+++ b/tinkerbell/src/mapView.tsx
@@ -1,0 +1,374 @@
+import { Icon } from '@iconify/react';
+import type {
+  GraphNode,
+  GraphNodeStatus,
+} from '@kinvolk/headlamp-plugin/lib/components/resourceMap/graph/graphModel';
+import type { ComponentType } from 'react';
+import { useMemo } from 'react';
+import { BmcJobDetail } from './components/bmc/jobs/Detail';
+import { BmcMachineDetail } from './components/bmc/machines/Detail';
+import { BmcTaskDetail } from './components/bmc/tasks/Detail';
+import type { TinkerbellDetailProps } from './components/common/detailTypes';
+import { HardwareDetail } from './components/hardware/Detail';
+import { TemplateDetail } from './components/templates/Detail';
+import { WorkflowRuleSetDetail } from './components/workflowrulesets/Detail';
+import { WorkflowDetail } from './components/workflows/Detail';
+import { getWorkflowState } from './components/workflows/helpers';
+import {
+  getBmcJobRelationshipEdges,
+  getBmcTaskRelationshipEdges,
+  getHardwareBmcRelationshipEdges,
+  getWorkflowRelationshipEdges,
+  getWorkflowRuleSetRelationshipEdges,
+} from './mapRelationships';
+import { BmcJob } from './resources/bmcJob';
+import { BmcMachine } from './resources/bmcMachine';
+import { BmcTask } from './resources/bmcTask';
+import { normalizeState } from './resources/common';
+import { Hardware } from './resources/hardware';
+import { Template } from './resources/template';
+import { Workflow } from './resources/workflow';
+import { WorkflowRuleSet } from './resources/workflowRuleSet';
+
+const tinkerbellMapIcon = (
+  <Icon icon="simple-icons:tinkerbell" width="100%" height="100%" color="rgb(50, 108, 229)" />
+);
+
+type TinkerbellMapKubeObject = {
+  metadata: {
+    uid: string;
+    name?: string;
+    namespace?: string;
+  };
+  cluster?: string;
+  jsonData?: {
+    metadata?: {
+      name?: string;
+      namespace?: string;
+    };
+  };
+};
+
+function makeMapDetailsComponent(Detail: ComponentType<TinkerbellDetailProps>) {
+  return function TinkerbellMapDetails({ node }: { node: GraphNode }) {
+    const kubeObject = node.kubeObject as TinkerbellMapKubeObject | undefined;
+    const metadata = kubeObject?.metadata ?? kubeObject?.jsonData?.metadata ?? node.data;
+
+    return (
+      <Detail name={metadata?.name} namespace={metadata?.namespace} cluster={kubeObject?.cluster} />
+    );
+  };
+}
+
+const HardwareMapDetails = makeMapDetailsComponent(HardwareDetail);
+const WorkflowMapDetails = makeMapDetailsComponent(WorkflowDetail);
+const TemplateMapDetails = makeMapDetailsComponent(TemplateDetail);
+const WorkflowRuleSetMapDetails = makeMapDetailsComponent(WorkflowRuleSetDetail);
+const BmcMachineMapDetails = makeMapDetailsComponent(BmcMachineDetail);
+const BmcJobMapDetails = makeMapDetailsComponent(BmcJobDetail);
+const BmcTaskMapDetails = makeMapDetailsComponent(BmcTaskDetail);
+
+function makeTinkerbellNode(
+  kubeObject: TinkerbellMapKubeObject,
+  subtitle: string,
+  weight: number,
+  detailsComponent: GraphNode['detailsComponent'],
+  status?: GraphNodeStatus
+): GraphNode {
+  return {
+    id: kubeObject.metadata.uid,
+    kubeObject: kubeObject as GraphNode['kubeObject'],
+    subtitle,
+    weight,
+    detailsComponent,
+    status,
+  };
+}
+
+function getConditionStatus(
+  conditions: { type?: string; reason?: string; status?: string }[] | undefined
+): GraphNodeStatus | undefined {
+  const condition = conditions?.at(-1);
+  const type = normalizeState(condition?.type);
+  const status = normalizeState(condition?.status);
+
+  if (type === 'Contactable') {
+    if (status === 'True') {
+      return 'success';
+    }
+
+    if (status === 'False') {
+      return 'error';
+    }
+
+    return 'warning';
+  }
+
+  const state = normalizeState(condition?.type ?? condition?.reason ?? condition?.status);
+
+  if (['Failed', 'Error', 'Timeout'].includes(state)) {
+    return 'error';
+  }
+
+  if (['Completed', 'Success', 'Ready'].includes(state)) {
+    return 'success';
+  }
+
+  if (['Running', 'Pending', 'Unknown'].includes(state)) {
+    return 'warning';
+  }
+
+  return undefined;
+}
+
+function getWorkflowMapStatus(workflow: Workflow): GraphNodeStatus | undefined {
+  const state = getWorkflowState(workflow);
+
+  if (['Failed', 'Timeout'].includes(state)) {
+    return 'error';
+  }
+
+  if (state === 'Success') {
+    return 'success';
+  }
+
+  return undefined;
+}
+
+const hardwareSource = {
+  id: 'tinkerbell-hardware',
+  label: 'Hardware',
+  icon: <Icon icon="mdi:server" width="100%" height="100%" color="rgb(50, 108, 229)" />,
+  useData() {
+    const [hardware, hardwareError] = Hardware.useList();
+    const [machines] = BmcMachine.useList();
+
+    return useMemo(() => {
+      if (hardwareError) {
+        return { nodes: [] };
+      }
+
+      if (!hardware) {
+        return null;
+      }
+
+      return {
+        nodes: hardware.map(item =>
+          makeTinkerbellNode(item, 'Tinkerbell Hardware', 5000, HardwareMapDetails)
+        ),
+        edges: getHardwareBmcRelationshipEdges(hardware, machines),
+      };
+    }, [hardware, hardwareError, machines]);
+  },
+};
+
+const workflowSource = {
+  id: 'tinkerbell-workflows',
+  label: 'Workflows',
+  icon: (
+    <Icon
+      icon="mdi:transit-connection-variant"
+      width="100%"
+      height="100%"
+      color="rgb(50, 108, 229)"
+    />
+  ),
+  useData() {
+    const [workflows, workflowsError] = Workflow.useList();
+    const [hardware] = Hardware.useList();
+    const [templates] = Template.useList();
+
+    return useMemo(() => {
+      if (workflowsError) {
+        return { nodes: [] };
+      }
+
+      if (!workflows) {
+        return null;
+      }
+
+      return {
+        nodes: workflows.map(item =>
+          makeTinkerbellNode(
+            item,
+            'Tinkerbell Workflow',
+            4000,
+            WorkflowMapDetails,
+            getWorkflowMapStatus(item)
+          )
+        ),
+        edges: getWorkflowRelationshipEdges(workflows, hardware, templates),
+      };
+    }, [workflows, workflowsError, hardware, templates]);
+  },
+};
+
+const templateSource = {
+  id: 'tinkerbell-templates',
+  label: 'Templates',
+  icon: (
+    <Icon icon="mdi:file-document-outline" width="100%" height="100%" color="rgb(50, 108, 229)" />
+  ),
+  useData() {
+    const [templates, templatesError] = Template.useList();
+
+    return useMemo(() => {
+      if (templatesError) {
+        return { nodes: [] };
+      }
+
+      if (!templates) {
+        return null;
+      }
+
+      return {
+        nodes: templates.map(item =>
+          makeTinkerbellNode(item, 'Tinkerbell Template', 3000, TemplateMapDetails)
+        ),
+      };
+    }, [templates, templatesError]);
+  },
+};
+
+const workflowRuleSetSource = {
+  id: 'tinkerbell-workflow-rulesets',
+  label: 'WorkflowRuleSets',
+  icon: <Icon icon="mdi:file-tree-outline" width="100%" height="100%" color="rgb(50, 108, 229)" />,
+  useData() {
+    const [ruleSets, ruleSetsError] = WorkflowRuleSet.useList();
+    const [templates] = Template.useList();
+
+    return useMemo(() => {
+      if (ruleSetsError) {
+        return { nodes: [] };
+      }
+
+      if (!ruleSets) {
+        return null;
+      }
+
+      return {
+        nodes: ruleSets.map(item =>
+          makeTinkerbellNode(item, 'Tinkerbell WorkflowRuleSet', 2500, WorkflowRuleSetMapDetails)
+        ),
+        edges: getWorkflowRuleSetRelationshipEdges(ruleSets, templates),
+      };
+    }, [ruleSets, ruleSetsError, templates]);
+  },
+};
+
+const bmcMachineSource = {
+  id: 'tinkerbell-bmc-machines',
+  label: 'BMC Machines',
+  icon: <Icon icon="mdi:server-network" width="100%" height="100%" color="rgb(50, 108, 229)" />,
+  useData() {
+    const [machines, machinesError] = BmcMachine.useList();
+
+    return useMemo(() => {
+      if (machinesError) {
+        return { nodes: [] };
+      }
+
+      if (!machines) {
+        return null;
+      }
+
+      return {
+        nodes: machines.map(item =>
+          makeTinkerbellNode(
+            item,
+            'Tinkerbell BMC Machine',
+            3500,
+            BmcMachineMapDetails,
+            getConditionStatus(item.status?.conditions)
+          )
+        ),
+      };
+    }, [machines, machinesError]);
+  },
+};
+
+const bmcJobSource = {
+  id: 'tinkerbell-bmc-jobs',
+  label: 'BMC Jobs',
+  icon: (
+    <Icon icon="mdi:clipboard-play-outline" width="100%" height="100%" color="rgb(50, 108, 229)" />
+  ),
+  useData() {
+    const [jobs, jobsError] = BmcJob.useList();
+    const [machines] = BmcMachine.useList();
+
+    return useMemo(() => {
+      if (jobsError) {
+        return { nodes: [] };
+      }
+
+      if (!jobs) {
+        return null;
+      }
+
+      return {
+        nodes: jobs.map(item =>
+          makeTinkerbellNode(
+            item,
+            'Tinkerbell BMC Job',
+            3000,
+            BmcJobMapDetails,
+            getConditionStatus(item.status?.conditions)
+          )
+        ),
+        edges: getBmcJobRelationshipEdges(jobs, machines),
+      };
+    }, [jobs, jobsError, machines]);
+  },
+};
+
+const bmcTaskSource = {
+  id: 'tinkerbell-bmc-tasks',
+  label: 'BMC Tasks',
+  icon: (
+    <Icon icon="mdi:clipboard-check-outline" width="100%" height="100%" color="rgb(50, 108, 229)" />
+  ),
+  useData() {
+    const [tasks, tasksError] = BmcTask.useList();
+    const [jobs] = BmcJob.useList();
+
+    return useMemo(() => {
+      if (tasksError) {
+        return { nodes: [] };
+      }
+
+      if (!tasks) {
+        return null;
+      }
+
+      return {
+        nodes: tasks.map(item =>
+          makeTinkerbellNode(
+            item,
+            'Tinkerbell BMC Task',
+            2000,
+            BmcTaskMapDetails,
+            getConditionStatus(item.status?.conditions)
+          )
+        ),
+        edges: getBmcTaskRelationshipEdges(tasks, jobs),
+      };
+    }, [tasks, tasksError, jobs]);
+  },
+};
+
+export const tinkerbellSource = {
+  id: 'tinkerbell',
+  label: 'Tinkerbell',
+  icon: tinkerbellMapIcon,
+  sources: [
+    hardwareSource,
+    workflowSource,
+    templateSource,
+    workflowRuleSetSource,
+    bmcMachineSource,
+    bmcJobSource,
+    bmcTaskSource,
+  ],
+};


### PR DESCRIPTION
## Summary

Add resource map integration for the Tinkerbell plugin.

## Changes Made

- Registered Tinkerbell resources in Headlamp's Map view.
- Added map nodes for Hardware, Workflow, Template, WorkflowRuleSet,
  BMC Machine, BMC Job, and BMC Task.
- Added relationship edges between related Tinkerbell resources:
  - Hardware -> Workflow
  - Workflow -> Template
  - Hardware -> BMC Machine
  - BMC Machine -> BMC Job
  - BMC Job -> BMC Task
  - WorkflowRuleSet -> Template
- Enabled Tinkerbell detail views to open from Map nodes.
- Added tests for Tinkerbell map relationship helpers.



## Testing

- Built the plugin successfully.
- Ran the Tinkerbell test suite successfully.
- Manually tested the Map view with the Tinkerbell Vagrant lab.
- Verified Hardware, Workflow, Template, WorkflowRuleSet, and BMC
  resources appear in the Map view.
- Verified map nodes open their detail views.