### PR TITLE
kueue: Add podSetUpdates to Workload admission checks table

### DIFF
--- a/kueue/src/components/workloads/Detail.tsx
+++ b/kueue/src/components/workloads/Detail.tsx
@@ -17,6 +17,7 @@ import {
 } from '../../resources/workload';
 import {
   renderPodSetRequests,
+  renderPodSetUpdates,
   renderResourceList,
   renderStringMap,
   renderText,
@@ -70,6 +71,7 @@ interface AdmissionCheckRow {
   requeueAfterSeconds: number | string;
   /** Retry count. */
   retryCount: number | string;
+  podSetUpdates: string;
 }
 
 /** Row rendered for status.reclaimablePods. */
@@ -164,6 +166,7 @@ function getAdmissionCheckRows(admissionChecks: AdmissionCheckState[] = []): Adm
     message: renderText(admissionCheck.message),
     requeueAfterSeconds: admissionCheck.requeueAfterSeconds ?? '-',
     retryCount: admissionCheck.retryCount ?? '-',
+    podSetUpdates: renderPodSetUpdates(admissionCheck.podSetUpdates),
   }));
 }
 
@@ -339,6 +342,10 @@ function getAdmissionChecksSection(workload: Workload) {
             {
               label: 'Retry Count',
               getter: (row: AdmissionCheckRow) => row.retryCount,
+            },
+            {
+              label: 'Pod Set Updates',
+              getter: (row: AdmissionCheckRow) => row.podSetUpdates,
             },
           ]}
         />

--- a/kueue/src/resources/workload.ts
+++ b/kueue/src/resources/workload.ts
@@ -415,6 +415,20 @@ export interface PodSetRequest {
 }
 
 /**
+ * Pod set modifications suggested by an AdmissionCheck for a Workload pod set.
+ *
+ * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#podsetupdate
+ */
+export interface PodSetUpdate {
+  name: string;
+  labels?: Record<string, string>;
+  annotations?: Record<string, string>;
+  nodeSelector?: Record<string, string>;
+  tolerations?: unknown[];
+  schedulingGates?: { name: string }[];
+}
+
+/**
  * Admission check state reported for a Workload.
  *
  * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#admissioncheckstate
@@ -456,6 +470,9 @@ export interface AdmissionCheckState {
    * @see https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#admissioncheckstate
    */
   retryCount?: number;
+
+  /** Pod set modifications suggested by this AdmissionCheck. */
+  podSetUpdates?: PodSetUpdate[];
 }
 
 /**

--- a/kueue/src/resources/workloadFormatters.test.ts
+++ b/kueue/src/resources/workloadFormatters.test.ts
@@ -16,6 +16,7 @@ import {
   renderOwnerReferences,
   renderPodSetRequests,
   renderPodSetsSummary,
+  renderPodSetUpdates,
   renderPriority,
   renderPriorityClassName,
   renderQueueName,
@@ -43,6 +44,13 @@ describe('Workload formatters', () => {
     expect(renderBoolean(false)).toBe('No');
     expect(renderBoolean(null)).toBe('-');
     expect(renderBoolean(undefined)).toBe('-');
+  });
+
+  it('formats admission check pod set updates', () => {
+    expect(renderPodSetUpdates()).toBe('-');
+    expect(
+      renderPodSetUpdates([{ name: 'main', labels: { role: 'worker' } }, { name: 'sidecar' }])
+    ).toBe('main: labels role=worker | sidecar: -');
   });
 
   it('formats common Workload list values', () => {

--- a/kueue/src/resources/workloadFormatters.ts
+++ b/kueue/src/resources/workloadFormatters.ts
@@ -2,6 +2,7 @@ import type { KubeOwnerReference } from '@kinvolk/headlamp-plugin/lib/k8s/cluste
 import type {
   Admission,
   PodSet,
+  PodSetUpdate,
   ReclaimablePod,
   RequeueState,
   ResourceList,
@@ -270,6 +271,29 @@ export function renderRequeueState(requeueState?: RequeueState) {
   ].filter(Boolean);
 
   return values.length > 0 ? values.join('; ') : '-';
+}
+
+/** Render the pod set modifications suggested by an AdmissionCheck. */
+export function renderPodSetUpdates(podSetUpdates: PodSetUpdate[] = []) {
+  if (podSetUpdates.length === 0) {
+    return '-';
+  }
+
+  return podSetUpdates
+    .map(update => {
+      const parts = [
+        renderStringMap(update.labels) !== '-' ? `labels ${renderStringMap(update.labels)}` : '',
+        renderStringMap(update.annotations) !== '-'
+          ? `annotations ${renderStringMap(update.annotations)}`
+          : '',
+        renderStringMap(update.nodeSelector) !== '-'
+          ? `nodeSelector ${renderStringMap(update.nodeSelector)}`
+          : '',
+      ].filter(Boolean);
+
+      return parts.length ? `${update.name}: ${parts.join('; ')}` : `${update.name}: -`;
+    })
+    .join(' | ');
 }
 
 /** Render owner references without dumping raw objects. */


### PR DESCRIPTION
Fixes #1233

## PR Summary

Adds `podSetUpdates` to the Workload Detail page's Admission Checks table.

## Problem

`status.admissionChecks[]` has a `podSetUpdates` field (labels, annotations, node selector suggested by an AdmissionCheck controller — e.g. a ProvisioningRequest-backed check), but the plugin's `AdmissionCheckState` type and the Admission Checks table only read the other six fields. This data was invisible in Headlamp; operators had to run `kubectl describe workload` or read raw YAML to see it.

## Fix

- Added a `PodSetUpdate` type to `workload.ts`, matching the v1beta2 API reference.
- Added `renderPodSetUpdates()` in `workloadFormatters.ts`.
- Added a "Pod Set Updates" column to the Admission Checks table in `Detail.tsx`.

## Testing

- Added a unit test for `renderPodSetUpdates()` covering labels, annotations, and node selector.
- `npm run tsc`, `npm run lint`, `npm run format --check`, and `npm run test` all pass.