### PR TITLE
karpenter: NodePool: Parse CPU quantities as cores

### DIFF
--- a/karpenter/src/NodePool/Details.tsx
+++ b/karpenter/src/NodePool/Details.tsx
@@ -16,6 +16,7 @@ import { DiffEditorDialog } from '../common/resourceEditor';
 import { handleShowDiff } from '../helpers/handleDiff';
 import { getHandleSaveHelper } from '../helpers/handleSave';
 import { renderInstanceRequirements } from '../helpers/instanceRequirements';
+import { parseCpu } from '../helpers/parseCpu';
 import { parseRam } from '../helpers/parseRam';
 import { renderDisruptionBudgets } from '../helpers/renderBudgets';
 import { nodePoolClass } from './List';
@@ -91,8 +92,8 @@ export function NodePoolDetailView(props: { name?: string }) {
         withEvents
         actions={actions()}
         extraInfo={item => {
-          const usedCPU = parseInt(item.jsonData.status?.resources?.cpu || '0');
-          const CPUlimit = parseInt(item.jsonData.spec?.limits?.cpu || '0');
+          const usedCPU = parseCpu(item.jsonData.status?.resources?.cpu || '0');
+          const CPUlimit = parseCpu(item.jsonData.spec?.limits?.cpu || '0');
 
           const usedMemory = parseRam(item.jsonData.status?.resources?.memory || '0');
           const memoryLimit = parseRam(item.jsonData.spec?.limits?.memory || '0');

--- a/karpenter/src/NodePool/List.tsx
+++ b/karpenter/src/NodePool/List.tsx
@@ -3,6 +3,7 @@ import { Link, ResourceListView } from '@kinvolk/headlamp-plugin/lib/CommonCompo
 import { PercentageBar } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 import { makeCustomResourceClass } from '@kinvolk/headlamp-plugin/lib/lib/k8s/crd';
 import { getResourceStr } from '@kinvolk/headlamp-plugin/lib/Utils';
+import { parseCpu } from '../helpers/parseCpu';
 import { parseRam } from '../helpers/parseRam';
 import { CPUtooltip, Memorytooltip } from '../helpers/tooltip';
 
@@ -73,14 +74,14 @@ function NodePoolsList() {
           id: 'nodepool-cpu',
           label: t('CPU'),
           getValue: nodePool => {
-            const used = parseInt(nodePool.jsonData.status?.resources?.cpu || '0');
-            const limit = parseInt(nodePool.jsonData.spec?.limits?.cpu || '0');
+            const used = parseCpu(nodePool.jsonData.status?.resources?.cpu || '0');
+            const limit = parseCpu(nodePool.jsonData.spec?.limits?.cpu || '0');
 
             return limit > 0 ? `${used}/${limit}` : t('{{used}} (No limit)', { used });
           },
           render: nodePool => {
-            const used = parseInt(nodePool.jsonData.status?.resources?.cpu || 0);
-            const limit = parseInt(nodePool.jsonData.spec?.limits?.cpu || 0);
+            const used = parseCpu(nodePool.jsonData.status?.resources?.cpu || '0');
+            const limit = parseCpu(nodePool.jsonData.spec?.limits?.cpu || '0');
             const data: ChartDataPoint[] = [
               {
                 name: 'CPU',

--- a/karpenter/src/helpers/parseCpu.test.ts
+++ b/karpenter/src/helpers/parseCpu.test.ts
@@ -1,0 +1,23 @@
+import { parseCpu } from './parseCpu';
+
+describe('parseCpu', () => {
+  it('returns 0 for missing or unparseable values', () => {
+    expect(parseCpu('')).toBe(0);
+    expect(parseCpu('abc')).toBe(0);
+  });
+
+  it('converts milli-cores to cores', () => {
+    expect(parseCpu('1750m')).toBe(1.75);
+    expect(parseCpu('500m')).toBe(0.5);
+  });
+
+  it('converts micro-cores and nano-cores to cores', () => {
+    expect(parseCpu('500000u')).toBe(0.5);
+    expect(parseCpu('500000000n')).toBe(0.5);
+  });
+
+  it('keeps unsuffixed quantities as cores', () => {
+    expect(parseCpu('8')).toBe(8);
+    expect(parseCpu('1.5')).toBe(1.5);
+  });
+});

--- a/karpenter/src/helpers/parseCpu.tsx
+++ b/karpenter/src/helpers/parseCpu.tsx
@@ -1,0 +1,18 @@
+export function parseCpu(cpuStr: string): number {
+  if (!cpuStr) return 0;
+
+  const quantity = `${cpuStr}`.trim();
+  const match = quantity.match(/^(\d+(?:\.\d+)?)(n|u|m)?$/);
+  if (!match) return 0;
+
+  const num = parseFloat(match[1]);
+  const unit = match[2];
+
+  const perCore: Record<string, number> = {
+    n: 1e9,
+    u: 1e6,
+    m: 1e3,
+  };
+
+  return unit ? num / perCore[unit] : num;
+}


### PR DESCRIPTION
## Summary

`status.resources.cpu` and `spec.limits.cpu` on a Karpenter NodePool are Kubernetes resource quantities, so they can carry a suffix. Both NodePool views read them with `parseInt`, which stops at the first non-digit: `parseInt('1750m')` is `1750`, so 1.75 cores is displayed and charted as 1750 cores. `parseInt` also truncates a plain decimal, turning `1.5` cores into `1`.

Karpenter reports these values in milli-cores whenever the amount is not a whole number of cores, which is the normal case for a NodePool that has scaled up partially. With `spec.limits.cpu: 8` and `status.resources.cpu: 1750m`, the list column read `1750/8` and the percentage bar pinned at full.

Memory in the same two files was already correct — it goes through `parseRam()`. Only CPU used `parseInt`.

## Related Issue

Fixes #1243

## Changes

- Added `karpenter/src/helpers/parseCpu.tsx`, converting `n`, `u` and `m` quantities to cores and returning 0 for anything unparseable. It mirrors the shape of the existing `parseRam` helper next to it, and the conversion matches `parseCpuQuantity` in the kubeflow plugin.

  On why this is a local helper rather than the SDK's `parseCpu` from `@kinvolk/headlamp-plugin/lib/lib/units`: in the pinned `headlamp-plugin` 0.14.0 that function parses with `parseInt`, so `parseCpu('1.5') / TO_ONE_CPU` is `1` rather than `1.5`, and an unparseable value yields `NaN` instead of `0`, which would feed `NaN` straight into `PercentageBar`. Using it here would trade this bug for a smaller one. Happy to switch to the SDK function instead once a release carries the `parseFloat` version, if maintainers would rather wait for that.
- Added `karpenter/src/helpers/parseCpu.test.ts` covering milli-cores, micro-cores, nano-cores, unsuffixed and decimal quantities, and the unparseable case.
- `NodePool/List.tsx` and `NodePool/Details.tsx` now read CPU through `parseCpu` instead of `parseInt`.

## Steps to Test

1. `cd karpenter && npm install && npm run test` — the four new `parseCpu` cases pass.
2. `npm run lint && npm run tsc` — both clean.
3. Against a cluster running Karpenter, open Karpenter → NodePools with a NodePool whose `status.resources.cpu` is reported in milli-cores, for example `1750m`, and `spec.limits.cpu` set to `8`.
4. The CPU column reads `1.75/8` and the bar sits near 22%, instead of `1750/8` at full.
5. Open that NodePool's details page: CPU reads `1.75 of 8` instead of `1750 of 8`.
