### PR TITLE
karpenter: parseRam: Accept decimal and Pi/Ei quantities

### DIFF
--- a/karpenter/src/helpers/parseRam.test.ts
+++ b/karpenter/src/helpers/parseRam.test.ts
@@ -1,0 +1,30 @@
+import { parseRam } from './parseRam';
+
+describe('parseRam', () => {
+  it('returns 0 for missing or unparseable values', () => {
+    expect(parseRam('')).toBe(0);
+    expect(parseRam('abc')).toBe(0);
+    expect(parseRam('1Xi')).toBe(0);
+  });
+
+  it('parses decimal quantities', () => {
+    expect(parseRam('1.5Gi')).toBe(1.5 * 1024 ** 3);
+    expect(parseRam('1.5G')).toBe(1.5e9);
+  });
+
+  it('parses Pi and Ei', () => {
+    expect(parseRam('2Pi')).toBe(2 * 1024 ** 5);
+    expect(parseRam('2Ei')).toBe(2 * 1024 ** 6);
+  });
+
+  it('treats suffixes without i as decimal multiples', () => {
+    expect(parseRam('1G')).toBe(1e9);
+    expect(parseRam('1Gi')).toBe(1024 ** 3);
+  });
+
+  it('parses plain byte counts and existing binary units', () => {
+    expect(parseRam('1000')).toBe(1000);
+    expect(parseRam('64Gi')).toBe(68719476736);
+    expect(parseRam('700Mi')).toBe(734003200);
+  });
+});

--- a/karpenter/src/helpers/parseRam.tsx
+++ b/karpenter/src/helpers/parseRam.tsx
@@ -1,21 +1,13 @@
+const DECIMAL_UNITS = ['', 'K', 'M', 'G', 'T', 'P', 'E'];
+
 export function parseRam(ramStr: string): number {
   if (!ramStr) return 0;
-  const match = ramStr.match(/^(\d+)([KMGT]i?)?$/i);
+
+  const match = `${ramStr}`.trim().match(/^(\d+(?:\.\d+)?)(?:([KMGTPE])(i)?)?$/i);
   if (!match) return 0;
 
-  const num = parseInt(match[1]);
-  const unit = match[2]?.toUpperCase();
+  const num = parseFloat(match[1]);
+  const exponent = DECIMAL_UNITS.indexOf(match[2]?.toUpperCase() ?? '');
 
-  const units: Record<string, number> = {
-    K: 1024,
-    KI: 1024,
-    M: 1024 * 1024,
-    MI: 1024 * 1024,
-    G: 1024 * 1024 * 1024,
-    GI: 1024 * 1024 * 1024,
-    T: 1024 * 1024 * 1024 * 1024,
-    TI: 1024 * 1024 * 1024 * 1024,
-  };
-
-  return num * (units[unit] || 1);
+  return num * (match[3] ? 1024 : 1000) ** exponent;
 }


### PR DESCRIPTION
## Summary

`parseRam` matched memory quantities against `/^(\d+)([KMGT]i?)?$/i`, which rejects two valid forms and returns `0` for both:

- **Decimals.** `1.5Gi` has no digit-only mantissa, so a NodePool with `spec.limits.memory: 1.5Gi` showed its limit as `0`. Because the callers treat `limit > 0` as "a limit exists", the view then reported "No limit" for a NodePool that has one, and the percentage bar was scaled against a total of 1 byte.
- **Pi and Ei.** The unit group stopped at `T`, so `2Pi` returned `0`.

The suffixes that did parse were also scaled with the wrong base. Kubernetes reads a suffix without `i` as a decimal multiple and one with `i` as binary, so `1G` is 10^9 bytes while `1Gi` is 2^30. The old map sent both to 1024^3, making unsuffixed limits read about 7% high.

## Related Issue

Fixes #1245

## Changes

- `parseRam` now accepts an optional fractional part, covers `P` and `E`, and picks base 1000 or 1024 from the presence of the `i` suffix. Unparseable input and an unknown unit still return 0, and `i` is only accepted when it follows a unit.
- Added `karpenter/src/helpers/parseRam.test.ts` covering decimals, `Pi`/`Ei`, the decimal-versus-binary distinction, plain byte counts, and the unparseable cases. Three of the five fail against the previous implementation.

I did not switch to the SDK's `parseRam` from `@kinvolk/headlamp-plugin/lib/lib/units`: it handles `Pi`/`Ei` and the base correctly, but in the pinned 0.14.0 it takes the mantissa from a leading-digits match, so `1.5Gi` comes back as `1` instead of `1610612736`. That is better than the current `0` but still wrong, so fixing the local helper avoids trading one bug for another.

## Steps to Test

1. `cd karpenter && npm install && npm run test` — the five `parseRam` cases pass.
2. `npm run lint && npm run tsc` — both clean.
3. Check out `main` for `karpenter/src/helpers/parseRam.tsx` only, keeping the test file, and re-run: the decimal, `Pi`/`Ei`, and decimal-multiple cases fail.
4. Against a cluster running Karpenter, apply a NodePool with `spec.limits.memory: 1.5Gi` and open Karpenter → NodePools. The Memory column reads `1.5Gi` with a scaled bar instead of `0 (No limit)`.
