### PR TITLE
ai-assistant: appbar: Register events after render

### DIFF
--- a/ai-assistant/src/components/appbar/HeadlampEventHandler.test.tsx
+++ b/ai-assistant/src/components/appbar/HeadlampEventHandler.test.tsx
@@ -14,35 +14,44 @@
  * limitations under the License.
  */
 
+import { render, waitFor } from '@testing-library/react';
 import React from 'react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const registerHeadlampEventCallback = vi.fn();
 const setEvent = vi.fn();
+const useGlobalState = vi.fn(() => ({ event: null, setEvent }));
 
 vi.mock('@kinvolk/headlamp-plugin/lib', () => ({
   registerHeadlampEventCallback: (callback: unknown) => registerHeadlampEventCallback(callback),
 }));
 
 vi.mock('../../pluginState', () => ({
-  useGlobalState: () => ({ event: null, setEvent }),
+  useGlobalState,
 }));
 
 /** Renders the handler and returns the callback it registered. */
 async function getEventCallback() {
   const { default: HeadlampEventHandler } = await import('./HeadlampEventHandler');
-  HeadlampEventHandler();
+  render(<HeadlampEventHandler />);
+  await waitFor(() => expect(registerHeadlampEventCallback).toHaveBeenCalledTimes(1));
   return registerHeadlampEventCallback.mock.calls.at(-1)![0] as (event: {
     type: string;
     data?: unknown;
-  }) => null;
+  }) => void;
 }
 
 const project = { id: 'my-project', namespaces: ['dev'], clusters: ['minikube'] };
 
 describe('HeadlampEventHandler', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
+    useGlobalState.mockImplementation(() => ({ event: null, setEvent }));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it('stores the project list from the project list view event', async () => {
@@ -55,6 +64,83 @@ describe('HeadlampEventHandler', () => {
       title: 'Projects',
       projects: [project],
     });
+  });
+
+  it('keeps one active callback through StrictMode rerenders and removes it on unmount', async () => {
+    const { default: HeadlampEventHandler } = await import('./HeadlampEventHandler');
+    const { rerender, unmount } = render(
+      <React.StrictMode>
+        <HeadlampEventHandler />
+      </React.StrictMode>
+    );
+    await waitFor(() => expect(registerHeadlampEventCallback).toHaveBeenCalledTimes(1));
+    const callback = registerHeadlampEventCallback.mock.calls[0][0] as (event: {
+      type: string;
+      data?: unknown;
+    }) => void;
+
+    rerender(
+      <React.StrictMode>
+        <HeadlampEventHandler />
+      </React.StrictMode>
+    );
+    callback({ type: 'headlamp.project-list-view', data: { projects: [project] } });
+
+    expect(registerHeadlampEventCallback).toHaveBeenCalledTimes(1);
+    expect(setEvent).toHaveBeenCalledTimes(1);
+
+    unmount();
+    setEvent.mockClear();
+    callback({ type: 'headlamp.project-list-view', data: { projects: [project] } });
+
+    expect(setEvent).not.toHaveBeenCalled();
+  });
+
+  it('dispatches to a snapshot when a subscriber unmounts another subscriber', async () => {
+    const firstSetEvent = vi.fn();
+    const secondSetEvent = vi.fn();
+    useGlobalState
+      .mockReturnValueOnce({ event: null, setEvent: firstSetEvent })
+      .mockReturnValueOnce({ event: null, setEvent: secondSetEvent });
+    const { default: HeadlampEventHandler } = await import('./HeadlampEventHandler');
+    render(<HeadlampEventHandler />);
+    const secondHandler = render(<HeadlampEventHandler />);
+    await waitFor(() => expect(registerHeadlampEventCallback).toHaveBeenCalledTimes(1));
+    firstSetEvent.mockImplementation(() => secondHandler.unmount());
+    const callback = registerHeadlampEventCallback.mock.calls[0][0] as (event: {
+      type: string;
+      data?: unknown;
+    }) => void;
+
+    callback({ type: 'headlamp.project-list-view', data: { projects: [project] } });
+
+    expect(firstSetEvent).toHaveBeenCalledTimes(1);
+    expect(secondSetEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('continues dispatching when a subscriber throws', async () => {
+    const error = new Error('subscriber failed');
+    const firstSetEvent = vi.fn(() => {
+      throw error;
+    });
+    const secondSetEvent = vi.fn();
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    useGlobalState
+      .mockReturnValueOnce({ event: null, setEvent: firstSetEvent })
+      .mockReturnValueOnce({ event: null, setEvent: secondSetEvent });
+    const { default: HeadlampEventHandler } = await import('./HeadlampEventHandler');
+    render(<HeadlampEventHandler />);
+    render(<HeadlampEventHandler />);
+    await waitFor(() => expect(registerHeadlampEventCallback).toHaveBeenCalledTimes(1));
+    const callback = registerHeadlampEventCallback.mock.calls[0][0] as (event: {
+      type: string;
+      data?: unknown;
+    }) => void;
+
+    callback({ type: 'headlamp.project-list-view', data: { projects: [project] } });
+
+    expect(secondSetEvent).toHaveBeenCalledTimes(1);
+    expect(consoleError).toHaveBeenCalledWith('Failed to handle Headlamp event:', error);
   });
 
   it('defaults to an empty project list when none are provided', async () => {

--- a/ai-assistant/src/components/appbar/HeadlampEventHandler.tsx
+++ b/ai-assistant/src/components/appbar/HeadlampEventHandler.tsx
@@ -1,4 +1,5 @@
 import { registerHeadlampEventCallback } from '@kinvolk/headlamp-plugin/lib';
+import { useEffect, useRef } from 'react';
 import type { HeadlampEventPayload, ProjectSummary } from '../../pluginState';
 import { useGlobalState } from '../../pluginState';
 
@@ -12,6 +13,32 @@ const HEADLAMP_EVENT_TYPE = {
   CREATE_PROJECT: 'headlamp.create-project',
   DELETE_PROJECT: 'headlamp.delete-project',
 } as const;
+
+type HeadlampEventCallback = Parameters<typeof registerHeadlampEventCallback>[0];
+
+const headlampEventSubscribers = new Set<HeadlampEventCallback>();
+let isHeadlampEventDispatcherRegistered = false;
+
+function subscribeToHeadlampEvents(callback: HeadlampEventCallback): () => void {
+  headlampEventSubscribers.add(callback);
+
+  if (!isHeadlampEventDispatcherRegistered) {
+    registerHeadlampEventCallback(event => {
+      for (const subscriber of [...headlampEventSubscribers]) {
+        try {
+          subscriber(event);
+        } catch (error) {
+          console.error('Failed to handle Headlamp event:', error);
+        }
+      }
+    });
+    isHeadlampEventDispatcherRegistered = true;
+  }
+
+  return () => {
+    headlampEventSubscribers.delete(callback);
+  };
+}
 
 /** Tab labels can be React nodes, so fall back to the serializable tab id. */
 function projectTabName(tab: unknown): string | undefined {
@@ -36,95 +63,100 @@ function projectTitle(project: ProjectSummary | undefined): string {
  */
 export default function HeadlampEventHandler() {
   const _pluginState = useGlobalState();
+  const pluginStateRef = useRef(_pluginState);
+  pluginStateRef.current = _pluginState;
 
-  registerHeadlampEventCallback(event => {
-    // Headlamp's event.data type does not expose all fields present at runtime.
-    // Cast once here rather than scattering per-field `as any` assertions.
-    const data = (event.data ?? {}) as Record<string, unknown>;
-    const prev = (_pluginState?.event ?? {}) as Record<string, unknown>;
+  useEffect(() => {
+    return subscribeToHeadlampEvents(event => {
+      const pluginState = pluginStateRef.current;
+      // Headlamp's event.data type does not expose all fields present at runtime.
+      // Cast once here rather than scattering per-field `as any` assertions.
+      const data = (event.data ?? {}) as Record<string, unknown>;
+      const prev = (pluginState?.event ?? {}) as Record<string, unknown>;
 
-    if (event.type === 'headlamp.home-page-loaded') {
-      _pluginState.setEvent({
-        ..._pluginState.event,
-        type: 'headlamp.home-page-loaded',
-        clusters: data.clusters,
-        errors: data.errors,
-      } as HeadlampEventPayload);
-    }
-    if (event.type === HEADLAMP_EVENT_TYPE.OBJECT_EVENTS) {
-      _pluginState.setEvent({
-        ..._pluginState.event,
-        type: HEADLAMP_EVENT_TYPE.OBJECT_EVENTS,
-        objectEvent: prev.objectEvent,
-        resources: data.resources,
-        resourceKind: data.resourceKind,
-      } as HeadlampEventPayload);
-    }
-    if (event.type === HEADLAMP_EVENT_TYPE.DETAILS_VIEW) {
-      _pluginState.setEvent({
-        type: HEADLAMP_EVENT_TYPE.DETAILS_VIEW,
-        title: data.title,
-        resource: data.resource,
-        objectEvent: prev.objectEvent,
-        resources: data.resources,
-        resourceKind: data.resourceKind,
-      } as HeadlampEventPayload);
-    }
-    if (event.type === HEADLAMP_EVENT_TYPE.LIST_VIEW) {
-      _pluginState.setEvent({
-        type: HEADLAMP_EVENT_TYPE.LIST_VIEW,
-        title: data.title,
-        resources: data.resources,
-        resourceKind: data.resourceKind,
-        resource: data.resource,
-        objectEvent: prev.objectEvent,
-      } as HeadlampEventPayload);
-    }
-    if (event.type === HEADLAMP_EVENT_TYPE.PROJECT_LIST_VIEW) {
-      _pluginState.setEvent({
-        type: HEADLAMP_EVENT_TYPE.PROJECT_LIST_VIEW,
-        title: 'Projects',
-        projects: (data.projects ?? []) as ProjectSummary[],
-      } as HeadlampEventPayload);
-    }
-    if (event.type === HEADLAMP_EVENT_TYPE.PROJECT_DETAILS_VIEW) {
-      const project = data.project as ProjectSummary | undefined;
-      _pluginState.setEvent({
-        type: HEADLAMP_EVENT_TYPE.PROJECT_DETAILS_VIEW,
-        title: projectTitle(project),
-        project,
-        resources: data.resources,
-      } as HeadlampEventPayload);
-    }
-    if (event.type === HEADLAMP_EVENT_TYPE.PROJECT_DETAILS_TAB_CHANGE) {
-      const project = data.project as ProjectSummary | undefined;
-      _pluginState.setEvent({
-        type: HEADLAMP_EVENT_TYPE.PROJECT_DETAILS_TAB_CHANGE,
-        title: projectTitle(project),
-        project,
-        projectTab: projectTabName(data.tab),
-        previousProjectTab: projectTabName(data.previousTab),
-        resources: data.resources,
-      } as HeadlampEventPayload);
-    }
-    if (event.type === HEADLAMP_EVENT_TYPE.CREATE_PROJECT) {
-      const project = data.project as ProjectSummary | undefined;
-      _pluginState.setEvent({
-        type: HEADLAMP_EVENT_TYPE.CREATE_PROJECT,
-        title: projectTitle(project),
-        project,
-      } as HeadlampEventPayload);
-    }
-    if (event.type === HEADLAMP_EVENT_TYPE.DELETE_PROJECT) {
-      const project = data.project as ProjectSummary | undefined;
-      _pluginState.setEvent({
-        type: HEADLAMP_EVENT_TYPE.DELETE_PROJECT,
-        title: projectTitle(project),
-        project,
-        deleteNamespaces: data.deleteNamespaces as boolean | undefined,
-      } as HeadlampEventPayload);
-    }
-    return null;
-  });
+      if (event.type === 'headlamp.home-page-loaded') {
+        pluginState.setEvent({
+          ...pluginState.event,
+          type: 'headlamp.home-page-loaded',
+          clusters: data.clusters,
+          errors: data.errors,
+        } as HeadlampEventPayload);
+      }
+      if (event.type === HEADLAMP_EVENT_TYPE.OBJECT_EVENTS) {
+        pluginState.setEvent({
+          ...pluginState.event,
+          type: HEADLAMP_EVENT_TYPE.OBJECT_EVENTS,
+          objectEvent: prev.objectEvent,
+          resources: data.resources,
+          resourceKind: data.resourceKind,
+        } as HeadlampEventPayload);
+      }
+      if (event.type === HEADLAMP_EVENT_TYPE.DETAILS_VIEW) {
+        pluginState.setEvent({
+          type: HEADLAMP_EVENT_TYPE.DETAILS_VIEW,
+          title: data.title,
+          resource: data.resource,
+          objectEvent: prev.objectEvent,
+          resources: data.resources,
+          resourceKind: data.resourceKind,
+        } as HeadlampEventPayload);
+      }
+      if (event.type === HEADLAMP_EVENT_TYPE.LIST_VIEW) {
+        pluginState.setEvent({
+          type: HEADLAMP_EVENT_TYPE.LIST_VIEW,
+          title: data.title,
+          resources: data.resources,
+          resourceKind: data.resourceKind,
+          resource: data.resource,
+          objectEvent: prev.objectEvent,
+        } as HeadlampEventPayload);
+      }
+      if (event.type === HEADLAMP_EVENT_TYPE.PROJECT_LIST_VIEW) {
+        pluginState.setEvent({
+          type: HEADLAMP_EVENT_TYPE.PROJECT_LIST_VIEW,
+          title: 'Projects',
+          projects: (data.projects ?? []) as ProjectSummary[],
+        } as HeadlampEventPayload);
+      }
+      if (event.type === HEADLAMP_EVENT_TYPE.PROJECT_DETAILS_VIEW) {
+        const project = data.project as ProjectSummary | undefined;
+        pluginState.setEvent({
+          type: HEADLAMP_EVENT_TYPE.PROJECT_DETAILS_VIEW,
+          title: projectTitle(project),
+          project,
+          resources: data.resources,
+        } as HeadlampEventPayload);
+      }
+      if (event.type === HEADLAMP_EVENT_TYPE.PROJECT_DETAILS_TAB_CHANGE) {
+        const project = data.project as ProjectSummary | undefined;
+        pluginState.setEvent({
+          type: HEADLAMP_EVENT_TYPE.PROJECT_DETAILS_TAB_CHANGE,
+          title: projectTitle(project),
+          project,
+          projectTab: projectTabName(data.tab),
+          previousProjectTab: projectTabName(data.previousTab),
+          resources: data.resources,
+        } as HeadlampEventPayload);
+      }
+      if (event.type === HEADLAMP_EVENT_TYPE.CREATE_PROJECT) {
+        const project = data.project as ProjectSummary | undefined;
+        pluginState.setEvent({
+          type: HEADLAMP_EVENT_TYPE.CREATE_PROJECT,
+          title: projectTitle(project),
+          project,
+        } as HeadlampEventPayload);
+      }
+      if (event.type === HEADLAMP_EVENT_TYPE.DELETE_PROJECT) {
+        const project = data.project as ProjectSummary | undefined;
+        pluginState.setEvent({
+          type: HEADLAMP_EVENT_TYPE.DELETE_PROJECT,
+          title: projectTitle(project),
+          project,
+          deleteNamespaces: data.deleteNamespaces as boolean | undefined,
+        } as HeadlampEventPayload);
+      }
+    });
+  }, []);
+
   return null;
 }


### PR DESCRIPTION
## Summary

- register the Headlamp event callback after React commits instead of during render
- keep callbacks connected to the latest shared plugin state without registering on rerender
- render the handler in tests and cover single callback registration


Was seeing this 

```
Warning: Cannot update a component (`Plugins`) while rendering a different component (`qG`). To locate the bad setState() call inside `qG`, follow the stack trace as described in https://reactjs.org/link/setstate-in-render Error Component Stack
    at qG (../src/components/appbar/HeadlampEventHandler.tsx:38:24)
    at ErrorBoundary (ErrorBoundary.tsx:55:1)
    at AppBarActions (TopBar.tsx:248:3)
    at div (<anonymous>)
    at chunk-F3CYMQTH.js:2916:38
    at Toolbar2 (chunk-XAIC7LRB.js:126:17)
    at nav (<anonymous>)
    at chunk-F3CYMQTH.js:2916:38
    at Paper2 (chunk-FWZRMJK5.js:148:17)
    at chunk-F3CYMQTH.js:2916:38
    at AppBar2 (chunk-76NB2BJB.js:186:17)
    at TopBar.tsx:277:5
    at TopBar (TopBar.tsx:102:32)
    at div (<anonymous>)
    at chunk-F3CYMQTH.js:2916:38
    at Box3 (chunk-F2ZA2UMM.js:87:19)
    at div (<anonymous>)
    at chunk-F3CYMQTH.js:2916:38
    at Box3 (chunk-F2ZA2UMM.js:87:19)
    at Layout (Layout.tsx:201:32)
    at MonacoEditorLoaderInitializer (MonacoEditorLoaderInitializer.tsx:29:49)
    at PreviousRouteProvider (RouteSwitcher.tsx:244:41)
    at Router2 (chunk-4MSBMKCL.js:1598:30)
    at BrowserRouter2 (react-router-dom.js:71:35)
    at Router (AppContainer.tsx:160:19)
    at SnackbarProvider2 (notistack.js:1251:24)
    at AppContainer (AppContainer.tsx:168:59)
    at DefaultPropsProvider (chunk-FO5STQHE.js:31:3)
    at RtlProvider (chunk-CCQBJLQB.js:194:5)
    at ThemeProvider (chunk-CCQBJLQB.js:141:5)
    at ThemeProvider2 (chunk-CCQBJLQB.js:356:5)
    at ThemeProvider (chunk-QUXTRDVZ.js:343:12)
    at StyledEngineProvider (chunk-F3CYMQTH.js:3602:5)
    at ThemeProviderNexti18n (ThemeProviderNexti18n.tsx:126:40)
    at I18nextProvider (I18nextProvider.js:4:3)
    at AppWithRedux (App.tsx:39:3)
    at QueryClientProvider (chunk-D4U4PBCO.js:3312:3)
    at Provider (react-redux.js:1013:11)
    at ErrorBoundary (ErrorBoundary.tsx:55:1)
    at App (<anonymous>)

```



## Testing

- `CI=true npm run check`
- look at dev console, and don't see above error.