### PR TITLE
ai-assistant: Release 0.4.0-alpha

### DIFF
--- a/ai-assistant/0.4.0-alpha/README.md
+++ b/ai-assistant/0.4.0-alpha/README.md
@@ -1,0 +1,137 @@
+# Headlamp AI Assistant
+
+The Headlamp AI Assistant is a plugin that integrates AI capabilities directly into Headlamp. It provides a conversational interface to interact with your Kubernetes clusters, helping you manage resources, troubleshoot issues, and understand complex configurations through natural language.
+
+The assistant is context-aware, meaning it uses information about your cluster to provide more relevant and accurate responses.
+
+**IMPORTANT:** This plugin is in alpha state!
+
+## End-to-end tests
+
+`npm run e2e` runs the complete cross-platform harness in `e2e/run-ai-assistant-e2e.ts`. It builds the plugin and Headlamp image, creates a KWOK cluster and the test fixtures, and runs the Playwright scenarios.
+
+`npm run e2e:playwright` runs only the Playwright scenarios against an already running Headlamp instance. It does not build Headlamp or create the KWOK cluster. See [e2e/README.md](e2e/README.md) for setup and configuration.
+
+## Key Features
+
+- **Conversational Kubernetes Management**: Interact with your cluster using natural language. Ask questions, get explanations, and issue commands.
+- **Context-Aware Assistance**: The AI has access to cluster information, making its responses relevant to your current setup.
+- **Multi-Provider Support**: Choose from a wide range of AI providers.
+- **Configurable Tools**: Fine-tune the AI's capabilities by enabling or disabling specific tools, like direct Kubernetes API access.
+- **Resource Generation**: Ask the AI to generate Kubernetes YAML manifests for deployments, services, and more.
+- **In-depth Analysis**: Get help diagnosing issues, understanding resource configurations, and interpreting logs.
+
+## Supported Providers
+
+The plugin supports multiple AI providers, allowing you to choose the one that best fits your needs:
+
+- **OpenAI** (GPT models)
+- **Azure OpenAI Service**
+- **Anthropic** (Claude models)
+- **Mistral AI**
+- **Google** (Gemini models)
+- **DeepSeek** (deepseek-v4-flash, deepseek-v4-pro)
+- **OpenAI-Compatible** (vLLM, llama.cpp, and other OpenAI-compatible servers)
+- **Local Models** (via Ollama)
+
+You will need to provide your own API keys and endpoint information for the provider you choose to use. Please note that using AI providers may incur costs, so check the pricing details of your chosen provider.
+
+## Adding Holmes Agent to Your Cluster
+
+The AI Assistant can connect to a [HolmesGPT](https://holmesgpt.dev) agent running in your cluster for enhanced Kubernetes diagnostics and troubleshooting. Follow the steps below to deploy Holmes.
+
+### 1. Add the Robusta Helm Repository
+
+```bash
+helm repo add robusta https://robusta-charts.storage.googleapis.com
+helm repo update
+```
+
+### 2. Create a `values.yaml`
+
+Below is an example using Azure OpenAI. For other providers (OpenAI, AWS Bedrock, etc.), see the [HolmesGPT installation docs](https://holmesgpt.dev/latest/installation/kubernetes-installation/#installation).
+
+```yaml
+# values.yaml
+image: robustadev/holmes:0.19.1
+
+additionalEnvVars:
+  - name: AZURE_API_KEY
+    value: ''
+  - name: AZURE_API_BASE
+    value: 'https://<your-azure-endpoint>.openai.azure.com'
+  - name: AZURE_API_VERSION
+    value: '2024-02-15-preview'
+# Or load from secret:
+# - name: AZURE_API_KEY
+#   valueFrom:
+#     secretKeyRef:
+#       name: holmes-secrets
+#       key: azure-api-key
+# - name: AZURE_API_BASE
+#   valueFrom:
+#     secretKeyRef:
+#       name: holmes-secrets
+#       key: azure-api-base
+
+modelList:
+  azure-gpt4:
+    api_key: '{{ env.AZURE_API_KEY }}'
+    model: azure/gpt-5
+    api_base: '{{ env.AZURE_API_BASE }}'
+    api_version: '{{ env.AZURE_API_VERSION }}'
+```
+
+### 3. Render and Patch the Helm Template
+
+Holmes requires enabling the AG-UI server for the AI Assistant to communicate with it. Render the template and update the container command:
+
+```bash
+helm template holmesgpt robusta/holmes -f values.yaml > rendered.yaml
+```
+
+In `rendered.yaml`, find the container command and change it to:
+
+```yaml
+command: ['python3', '-u', '/app/experimental/ag-ui/server-agui.py']
+```
+
+### 4. Deploy to Your Cluster
+
+```bash
+kubectl apply -f rendered.yaml
+```
+
+## MCP (Model Context Protocol) Server Support
+
+The AI Assistant supports [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) servers, allowing you to extend the assistant's capabilities by connecting it to external tools and data sources.
+
+> **Note:** MCP server support is currently available only in the **Headlamp desktop application**.
+
+### What is MCP?
+
+MCP is an open protocol that enables AI assistants to interact with external tools and services. By configuring MCP servers, you can give the AI Assistant access to specialized tools — for example, connecting it to [Flux](https://fluxcd.io/) for GitOps management or any other MCP-compatible tool.
+
+### Configuring MCP Servers
+
+Navigate to the AI Assistant settings to add and manage MCP servers. Each server is configured with:
+
+- **Name** — A unique identifier for the server.
+- **Command** — The executable to run (e.g., `flux-operator-mcp`).
+- **Args** — Command-line arguments (e.g., `serve --kube-context HEADLAMP_CURRENT_CLUSTER`).
+- **Environment Variables** — Optional env vars required by the server (e.g., `KUBECONFIG`).
+
+You can configure servers using the form-based UI or by editing the JSON configuration directly.
+
+![MCP Servers List](mcp-servers-list.png)
+
+![MCP Config Editor](mcp-config.png)
+
+### Managing MCP Tools
+
+Once servers are configured, the assistant automatically discovers the tools they expose. You can:
+
+- Enable or disable individual tools per server.
+- View tool descriptions and input schemas.
+- Track tool usage statistics.
+- Use bulk operations to enable or disable all tools at once.

--- a/ai-assistant/0.4.0-alpha/artifacthub-pkg.yml
+++ b/ai-assistant/0.4.0-alpha/artifacthub-pkg.yml
@@ -1,0 +1,28 @@
+version: 0.4.0-alpha
+name: headlamp_ai_assistant
+displayName: AI Assistant
+createdAt: '2026-08-25T00:00:00Z'
+logoURL: 'https://raw.githubusercontent.com/headlamp-k8s/plugins/main/ai-assistant/logo.png'
+description: 'The AI Assistant plugin for Headlamp provides an AI-powered assistant to help users interact with their Kubernetes clusters more efficiently.'
+changes:
+  - kind: added
+    description: 'Discover and verify Azure OpenAI and Azure AI Services chat deployments across all enabled Azure subscriptions.'
+  - kind: added
+    description: 'Preconfigure the read-only aks-mcp server and AKS skills on AKS Desktop, bind discovered MCP tools, and add project context.'
+  - kind: added
+    description: 'Localize the AI Assistant UI in 18 languages while keeping translated prompt labels separate from model input.'
+  - kind: changed
+    description: 'Update DeepSeek presets to deepseek-v4-pro and deepseek-v4-flash.'
+  - kind: changed
+    description: 'Reuse downloaded skills, queue diagnosis until ready, preserve explicit Chat mode selection, and improve sidebar scrolling.'
+  - kind: changed
+    description: 'Use the correct GitHub Copilot icon, improve theme-aware logos, and hide Holmes controls on AKS Desktop.'
+  - kind: fixed
+    description: 'Improve Azure provider detection, verification feedback, cancellation, legacy configuration recovery, and authorization errors.'
+  - kind: fixed
+    description: 'Keep model selection valid, avoid repeated event requests to unreachable clusters, and reject disabled queued diagnoses.'
+annotations:
+  headlamp/plugin/archive-url: https://github.com/headlamp-k8s/plugins/releases/download/ai-assistant-0.4.0-alpha/headlamp-k8s-ai-assistant-0.4.0-alpha.tar.gz
+  headlamp/plugin/archive-checksum: 'SHA256:3c969569432e7374975b6993ed7865087669dddaa54777106e0af32d8209068f'
+  headlamp/plugin/version-compat: '>=0.22'
+  headlamp/plugin/distro-compat: in-cluster,web,docker-desktop,desktop

--- a/ai-assistant/package-lock.json
+++ b/ai-assistant/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@headlamp-k8s/ai-assistant",
-  "version": "0.3.0-alpha",
+  "version": "0.4.0-alpha",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@headlamp-k8s/ai-assistant",
-      "version": "0.3.0-alpha",
+      "version": "0.4.0-alpha",
       "dependencies": {
         "@ag-ui/client": "^0.0.45",
         "@headlamp-k8s/ai-common": "file:./packages/ai-common",

--- a/ai-assistant/package.json
+++ b/ai-assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@headlamp-k8s/ai-assistant",
-  "version": "0.3.0-alpha",
+  "version": "0.4.0-alpha",
   "description": "Headlamp's AI Assistant",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- bump the AI Assistant package and lockfile to `0.4.0-alpha`
- add Artifact Hub metadata with user-facing release changes and the packaged archive checksum
- snapshot the current AI Assistant README for the release

## Testing

- `npm run package`
- verified the packaged `package.json` version is `0.4.0-alpha`
- verified the archive SHA-256 matches the Artifact Hub metadata
- verified the release README is byte-identical to the plugin README
- `git diff --check`

Relates to #1248
