### PR TITLE
metal3: Prepare 0.1.0-alpha release

### DIFF
--- a/metal3/0.1.0-alpha/README.md
+++ b/metal3/0.1.0-alpha/README.md
@@ -1,0 +1,94 @@
+# Metal3 Headlamp Plugin
+
+A [Headlamp](https://headlamp.dev) plugin that adds a Metal3 section to the UI for viewing
+bare-metal infrastructure through Kubernetes.
+
+[Metal3](https://metal3.io) manages bare-metal hosts as Kubernetes resources. This plugin surfaces
+those resources in Headlamp with list and detail views, so operators can inspect their bare-metal
+estate without dropping to `kubectl`.
+
+> Status: alpha. See [Current scope](#current-scope) and [Limitations](#limitations).
+
+## Screenshots
+
+The BareMetalHost list, with the composite Status column showing operational status, provisioning
+state, and error type together:
+
+![BareMetalHost list view](https://raw.githubusercontent.com/headlamp-k8s/plugins/main/metal3/screenshots/baremetalhost-list.png)
+
+The BareMetalHost detail view, showing the four status axes, the consumer, power state, and BMC
+address:
+
+![BareMetalHost detail view](https://raw.githubusercontent.com/headlamp-k8s/plugins/main/metal3/screenshots/baremetalhost-detail.png)
+
+## Current scope
+
+- **BareMetalHost**
+  - List view with a composite **Status** column that combines the host's operational status
+    (the headline signal), its provisioning state, and any error type into a single cell. A host
+    that is provisioned but in error is therefore shown as both at once, which a single-value
+    column cannot do.
+  - Detail view with configuration, status, hardware inventory, consumer, power state, and BMC
+    fields.
+  - Power on/off, soft or hard reboot, attach/detach, and reprovision/deprovision actions, each
+    with a confirmation step.
+- List and detail views for Metal3Machine, Metal3MachineTemplate, Metal3Cluster,
+  Metal3ClusterTemplate, Metal3Data, Metal3DataClaim, Metal3DataTemplate, Metal3Remediation, and
+  Metal3RemediationTemplate resources.
+- A relationship map connecting Cluster API Machine, Metal3Machine, and BareMetalHost resources.
+- A fleet overview that groups hosts by a selected label and summarizes availability, claims,
+  power state, hosts in progress, and hosts needing attention.
+- Graceful handling when the Metal3 CRDs are not installed in the connected cluster: the views
+  show an explanatory message instead of an empty or erroring screen.
+
+## Prerequisites
+
+- [Headlamp](https://headlamp.dev) (desktop app or in-cluster).
+- A Kubernetes cluster whose API has the Metal3 `baremetal-operator` CRDs installed, in
+  particular `baremetalhosts.metal3.io`. If those CRDs are absent, the plugin indicates that the
+  operator is not installed rather than showing an empty view. To stand up Metal3 and provision a
+  host, see the Metal3 [Try it](https://book.metal3.io/developer_environment/tryit) getting-started
+  guide.
+
+## Limitations
+
+- This is an alpha release, so views and behavior may change before v1.0.
+- Mutating actions are limited to individual BareMetalHost resources; bulk host actions are not
+  yet available.
+- The fleet overview does not yet include a recent-activity view.
+- BMC credentials remain in the linked Kubernetes Secret and are never displayed by the plugin.
+
+## Development
+
+Install dependencies and start a watch build:
+
+```bash
+npm install
+npm start
+```
+
+Then run Headlamp (the desktop app or a build from source) pointed at a cluster that has the
+Metal3 CRDs; the plugin's "Metal3" entry appears in the sidebar.
+
+A sample BareMetalHost manifest for local testing is in
+[`test-files/baremetalhost.yaml`](https://github.com/headlamp-k8s/plugins/blob/main/metal3/test-files/baremetalhost.yaml):
+
+```bash
+kubectl apply -f test-files/baremetalhost.yaml
+```
+
+Other useful commands:
+
+```bash
+npm run build   # production build to dist/
+npm run tsc     # type-check
+npm test        # unit tests (vitest)
+npm run lint    # lint
+```
+
+For general Headlamp plugin development, see the
+[plugin documentation](https://headlamp.dev/docs/latest/development/plugins/).
+
+## License
+
+Apache License 2.0.

--- a/metal3/0.1.0-alpha/artifacthub-pkg.yml
+++ b/metal3/0.1.0-alpha/artifacthub-pkg.yml
@@ -1,0 +1,33 @@
+version: 0.1.0-alpha
+name: headlamp_metal3
+displayName: Metal3
+createdAt: "2026-08-26T00:00:00Z"
+description: A Headlamp plugin for viewing Metal3 bare-metal hosts and infrastructure
+logoURL: https://avatars.githubusercontent.com/u/49879880?s=200&v=4
+license: Apache-2.0
+homeURL: https://github.com/headlamp-k8s/plugins/tree/main/metal3
+keywords:
+  - headlamp
+  - headlamp-plugin
+  - kubernetes
+  - metal3
+  - bare-metal
+  - infrastructure
+maintainers:
+  - name: mastermaxx03
+    email: srivastavaanimesh22@gmail.com
+changes:
+  - kind: added
+    description: "Add BareMetalHost list and detail views"
+  - kind: added
+    description: "Show operational, provisioning, and error status together"
+  - kind: added
+    description: "Link BareMetalHost consumers and Kubernetes resources"
+  - kind: added
+    description: "Handle clusters without the Metal3 CRDs"
+annotations:
+  headlamp/plugin/archive-url: >-
+    https://github.com/headlamp-k8s/plugins/releases/download/metal3-0.1.0-alpha/headlamp-k8s-metal3-0.1.0-alpha.tar.gz
+  headlamp/plugin/archive-checksum: sha256:eda7b6ab8fae3734564805ab3b220969ce8c2e809a63469ca95199f80e292678
+  headlamp/plugin/version-compat: ">=0.22"
+  headlamp/plugin/distro-compat: in-cluster,web,docker-desktop,desktop

--- a/metal3/package-lock.json
+++ b/metal3/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@headlamp-k8s/metal3",
-  "version": "0.1.0",
+  "version": "0.1.0-alpha",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@headlamp-k8s/metal3",
-      "version": "0.1.0",
+      "version": "0.1.0-alpha",
       "devDependencies": {
         "@kinvolk/headlamp-plugin": "^0.14.0"
       }

--- a/metal3/package.json
+++ b/metal3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@headlamp-k8s/metal3",
-  "version": "0.1.0",
+  "version": "0.1.0-alpha",
   "description": "A Headlamp plugin for viewing Metal3 bare-metal hosts and infrastructure.",
   "scripts": {
     "start": "headlamp-plugin start",


### PR DESCRIPTION
## Summary

- set the Metal3 plugin package version to `0.1.0-alpha`
- add the versioned release README and Artifact Hub metadata
- point Artifact Hub at the tagged release archive and its SHA-256 checksum

Release notes: #1118

## Validation

- `npm run build`
- `npm run tsc`
- `npm run lint`
- `npm run format -- --check`
- `npm run test` (59 passed, 1 skipped)
- `npm run package` and SHA-256 checksum verification