### PR TITLE
fix(ai-assistant): allow query parameters in kubernetes_api_request URL validation

### DIFF
--- a/ai-assistant/packages/ai-cli/src/kubectl.test.ts
+++ b/ai-assistant/packages/ai-cli/src/kubectl.test.ts
@@ -49,6 +49,24 @@ describe('buildKubectlArgs', () => {
     expect(result.args).toEqual(['get', '--raw', '/api/v1/pods']);
   });
 
+  it('allows query parameters for label selectors and field selectors', () => {
+    const url = '/api/v1/namespaces/default/pods?labelSelector=app=nginx&fieldSelector=status.phase=Running';
+    const result = buildKubectlArgs(url, 'GET');
+    expect(result.args).toEqual(['get', '--raw', url]);
+  });
+
+  it('allows pagination and limit query parameters', () => {
+    const url = '/api/v1/pods?limit=100&continue=eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9';
+    const result = buildKubectlArgs(url, 'GET');
+    expect(result.args).toEqual(['get', '--raw', url]);
+  });
+
+  it('allows URL-encoded query parameters and set-based selectors', () => {
+    const url = '/api/v1/pods?labelSelector=tier+in+(frontend,backend),!deprecated';
+    const result = buildKubectlArgs(url, 'GET');
+    expect(result.args).toEqual(['get', '--raw', url]);
+  });
+
   it('POST produces kubectl create --raw with stdin', () => {
     const body = '{"apiVersion":"v1","kind":"Pod"}';
     const result = buildKubectlArgs('/api/v1/namespaces/default/pods', 'POST', body);
@@ -114,6 +132,18 @@ describe('buildKubectlArgs', () => {
 
   it('rejects paths with shell metacharacters', () => {
     expect(() => buildKubectlArgs('/api/v1/pods;echo hacked', 'GET')).toThrow(
+      'contains disallowed characters'
+    );
+  });
+
+  it('rejects query strings containing dangerous shell characters', () => {
+    expect(() => buildKubectlArgs('/api/v1/pods?filter=x;rm -rf /', 'GET')).toThrow(
+      'contains disallowed characters'
+    );
+    expect(() => buildKubectlArgs('/api/v1/pods?filter=`whoami`', 'GET')).toThrow(
+      'contains disallowed characters'
+    );
+    expect(() => buildKubectlArgs('/api/v1/pods?filter=$PATH', 'GET')).toThrow(
       'contains disallowed characters'
     );
   });

--- a/ai-assistant/packages/ai-cli/src/kubectl.ts
+++ b/ai-assistant/packages/ai-cli/src/kubectl.ts
@@ -48,9 +48,11 @@ export function createKubectlTool(options: KubectlToolOptions = {}) {
   const description = readOnly
     ? `Make read-only GET requests to the Kubernetes API server to inspect resources.
 Use standard Kubernetes API URL paths like /api/v1/pods or /api/v1/namespaces/default/pods/my-pod.
+Query parameters such as ?labelSelector=app=nginx or ?limit=100 are supported.
 Only GET is supported. Mutating operations are not permitted.`
     : `Make requests to the Kubernetes API server to fetch, create, update or delete resources.
 Use standard Kubernetes API URL paths like /api/v1/pods or /api/v1/namespaces/default/pods/my-pod.
+Query parameters such as ?labelSelector=app=nginx or ?limit=100 are supported.
 Supported methods: ${methodList}.`;
 
   return tool(
@@ -82,7 +84,7 @@ Supported methods: ${methodList}.`;
         url: z
           .string()
           .describe(
-            'Kubernetes API URL path, e.g. /api/v1/pods or /api/v1/namespaces/default/pods/my-pod'
+            'Kubernetes API URL path, e.g. /api/v1/pods or /api/v1/namespaces/default/pods?labelSelector=app=nginx'
           ),
         method: z.string().describe(`HTTP method: ${methodList}`),
         body: z.string().optional().describe('Optional JSON request body for POST/PUT/PATCH'),
@@ -108,9 +110,10 @@ export function buildKubectlArgs(
     throw new Error(`Invalid API path: must start with "/", got "${url}"`);
   }
   // Reject paths with characters that could be used for injection or path traversal.
-  if (!/^\/[a-zA-Z0-9\/_.:@%~-]+$/.test(url)) {
+  // Query parameters (?, =, &, +, !, (), comma) are permitted after the path.
+  if (!/^\/[a-zA-Z0-9\/_.:@%~-]+(\?[a-zA-Z0-9\/_.:@%~=&+!(),-]*)?$/.test(url)) {
     throw new Error(
-      `Invalid API path: contains disallowed characters. Path must match /[a-zA-Z0-9/_.:@%~-]+`
+      `Invalid API path: contains disallowed characters. Path must match /[a-zA-Z0-9/_.:@%~-]+(\\?[a-zA-Z0-9/_.:@%~=&+!(),-]*)?`
     );
   }
 


### PR DESCRIPTION
## Summary

This PR fixes the URL validation in `ai-assistant`'s `kubernetes_api_request` tool (`ai-assistant/packages/ai-cli/src/kubectl.ts`). Previously, the character-allowlist regex rejected `?`, `=`, `&`, and `+`, causing all Kubernetes API queries with query parameters (e.g. `?labelSelector=...`, `?fieldSelector=...`, `?limit=...`, `?continue=...`, `?watch=true`) to fail with a validation error.

This change updates the regex to permit standard Kubernetes API query strings while continuing to enforce path-prefix restrictions (`/`) and preventing flag/command injection.

---

## Related Issue

Fixes #1253

---

## Changes

- **`ai-assistant/packages/ai-cli/src/kubectl.ts`**:
  - Updated `buildKubectlArgs` URL validation regex to allow standard query parameter characters (`?`, `=`, `&`, `+`, `!`, `()`, `,`) after the path component.
  - Updated tool descriptions and schema descriptions to indicate query parameter support.
- **`ai-assistant/packages/ai-cli/src/kubectl.test.ts`**:
  - Added unit test for label selector and field selector query parameters (`?labelSelector=app=nginx&fieldSelector=status.phase=Running`).
  - Added unit test for pagination and continuation tokens (`?limit=100&continue=...`).
  - Added unit test for set-based selectors and encoded characters (`?labelSelector=tier+in+(frontend,backend),!deprecated`).
  - Added security regression tests verifying dangerous shell characters (`;`, `` ` ``, `$`) in query strings are rejected.

---

## Steps to Test

1. Run unit test suite:
   ```bash
   cd ai-assistant/packages/ai-cli
   npm test
   ```
 2. Verify all kubectl.test.ts test cases pass, including new query parameter test cases.
3.Test tool call manually via createKubectlTool():

```typescript
const tool = createKubectlTool();
const result = await tool.invoke({
  url: '/api/v1/namespaces/default/pods?labelSelector=app=nginx',
  method: 'GET'
});
```