### PR TITLE
kueue: Scope the access check to the namespace on detail pages

### DIFF
--- a/kueue/src/components/common/KueueAdminResourceAccess.tsx
+++ b/kueue/src/components/common/KueueAdminResourceAccess.tsx
@@ -6,6 +6,7 @@ import {
 } from '@kinvolk/headlamp-plugin/lib/components/common';
 import { KubeObjectClass } from '@kinvolk/headlamp-plugin/lib/lib/k8s/KubeObject';
 import { ReactNode, useState } from 'react';
+import { resolveAuthNamespace } from '../../utils/authNamespace';
 
 interface KueueAdminResourceAccessProps {
   /** Kueue resource class to check access for. */
@@ -14,6 +15,8 @@ interface KueueAdminResourceAccessProps {
   resourceLabel: string;
   /** Kubernetes verb to verify before rendering the page. */
   verb: 'get' | 'list';
+  /** Namespace to scope the check to. Ignored for cluster-scoped resources. */
+  namespace?: string;
   /** Optional sentence describing the resource scope in denied messages. */
   accessDescription?: string;
   /** Page content to render after the user is authorized. */
@@ -24,6 +27,7 @@ export default function KueueAdminResourceAccess({
   resourceClass,
   resourceLabel,
   verb,
+  namespace,
   accessDescription = `Kueue ${resourceLabel} are cluster-scoped admin resources.`,
   children,
 }: KueueAdminResourceAccessProps) {
@@ -44,6 +48,7 @@ export default function KueueAdminResourceAccess({
       <AuthVisible
         item={resourceClass}
         authVerb={verb}
+        namespace={resolveAuthNamespace(resourceClass, namespace)}
         onAuthResult={result => setAllowed(result.allowed)}
         onError={() => setAllowed(false)}
       >

--- a/kueue/src/components/localqueues/Detail.tsx
+++ b/kueue/src/components/localqueues/Detail.tsx
@@ -25,6 +25,7 @@ export default function LocalQueueDetail() {
       resourceClass={LocalQueue}
       resourceLabel="LocalQueues"
       verb="get"
+      namespace={namespace}
       accessDescription="Kueue LocalQueues are namespaced user queue resources."
     >
       <DetailsGrid

--- a/kueue/src/components/workloads/Detail.tsx
+++ b/kueue/src/components/workloads/Detail.tsx
@@ -429,6 +429,7 @@ export default function WorkloadDetail() {
       resourceClass={Workload}
       resourceLabel="Workloads"
       verb="get"
+      namespace={namespace}
       accessDescription="Kueue Workloads are namespaced user workload resources."
     >
       <DetailsGrid

--- a/kueue/src/utils/authNamespace.test.ts
+++ b/kueue/src/utils/authNamespace.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { resolveAuthNamespace } from './authNamespace';
+
+const namespaced = { isNamespaced: true };
+const clusterScoped = { isNamespaced: false };
+
+describe('resolveAuthNamespace', () => {
+  it('scopes the check to the namespace for a namespaced resource', () => {
+    expect(resolveAuthNamespace(namespaced, 'data-sci')).toBe('data-sci');
+  });
+
+  it('leaves the check cluster-wide when a namespaced resource has no namespace yet', () => {
+    expect(resolveAuthNamespace(namespaced)).toBeUndefined();
+    expect(resolveAuthNamespace(namespaced, '')).toBeUndefined();
+  });
+
+  it('ignores a namespace passed for a cluster-scoped resource', () => {
+    // Narrowing a cluster-wide check would ask whether the user holds the verb in one
+    // namespace, which is not what the caller means for a cluster-scoped resource.
+    expect(resolveAuthNamespace(clusterScoped, 'data-sci')).toBeUndefined();
+  });
+
+  it('returns undefined for a cluster-scoped resource with no namespace', () => {
+    expect(resolveAuthNamespace(clusterScoped)).toBeUndefined();
+  });
+});

--- a/kueue/src/utils/authNamespace.ts
+++ b/kueue/src/utils/authNamespace.ts
@@ -1,0 +1,23 @@
+import { KubeObjectClass } from '@kinvolk/headlamp-plugin/lib/lib/k8s/KubeObject';
+
+/**
+ * Returns the namespace an access check should be scoped to.
+ *
+ * A SelfSubjectAccessReview with no namespace asks whether the user holds the verb
+ * cluster-wide. That is the right question for cluster-scoped resources and the wrong one
+ * for namespaced resources, where a user granted access through a namespace-scoped
+ * RoleBinding would be refused despite being able to read the resource.
+ *
+ * Cluster-scoped classes therefore always resolve to `undefined`, so a namespace passed by
+ * mistake cannot narrow a check that is meant to be cluster-wide.
+ */
+export function resolveAuthNamespace(
+  resourceClass: Pick<KubeObjectClass, 'isNamespaced'>,
+  namespace?: string
+): string | undefined {
+  if (!resourceClass.isNamespaced) {
+    return undefined;
+  }
+
+  return namespace || undefined;
+}


### PR DESCRIPTION
## Summary

Fixes #1199 for the detail pages.

`KueueAdminResourceAccess` gates every Kueue page on a SelfSubjectAccessReview with no
namespace, which asks whether the user holds the verb across the whole cluster. That is the
right question for `ClusterQueue` and `ResourceFlavor`. `Workload` and `LocalQueue` are
namespaced, so a user whose access comes from a namespace-scoped RoleBinding fails the check and
sees the denial message in place of a resource they can read.

`AuthVisible` already accepts a `namespace` prop and forwards it to `getAuthorization`, and the
detail routes are `/kueue/<type>/:namespace/:name`, so the namespace is in `useParams` and can be
handed to the check.

## Changes

- `KueueAdminResourceAccess` takes an optional `namespace` and passes it through
- `workloads/Detail` and `localqueues/Detail` pass the namespace from the route
- `resolveAuthNamespace` holds the rule, with unit tests

The helper returns `undefined` for cluster-scoped classes, so a namespace supplied by mistake
cannot narrow a check meant to be cluster-wide. The two cluster-scoped views keep asking exactly
what they asked before.

## Not included

The list pages. They have no single namespace to check against, so what replaces the cluster-wide
gate there is a behaviour decision, and this fix does not settle it. Letting the list render and
return what the user can read would match how Headlamp treats namespaced lists elsewhere, though
that seems worth a maintainer's call first.

## Testing

`npx vitest run` passes 44 tests across 7 files, including the 4 new ones.

Reverting `resolveAuthNamespace` to always return `undefined`, which is the behaviour before
this change, fails exactly one test, `scopes the check to the namespace for a namespaced
resource`. The other three keep passing, since they pin the behaviour that must not change for
`ClusterQueue` and `ResourceFlavor`.

`tsc --noEmit`, `eslint` and `prettier --check` are all clean.

I have not exercised this against a live cluster with a namespace-scoped ServiceAccount. The
reproduction steps in #1199 cover that path.
