### PR TITLE
fix(kro): default omitted spec.replicas to 1 matching Kubernetes API

### DIFF
--- a/kro/src/resources/subResources.test.ts
+++ b/kro/src/resources/subResources.test.ts
@@ -16,6 +16,25 @@ describe('getSubResourceHealth', () => {
     });
   });
 
+  it('defaults omitted replicas to 1 (Kubernetes API default)', () => {
+    // When spec.replicas is omitted, Kubernetes defaults to 1.
+    // A single ready pod should be success, not error.
+    expect(
+      getSubResourceHealth('Deployment', { spec: {}, status: { readyReplicas: 1 } })
+    ).toEqual({ status: 'success', label: '1/1 ready' });
+    expect(
+      getSubResourceHealth('StatefulSet', { spec: {}, status: { readyReplicas: 1 } })
+    ).toEqual({ status: 'success', label: '1/1 ready' });
+    // Pod not yet ready with omitted replicas should be error.
+    expect(
+      getSubResourceHealth('Deployment', { spec: {}, status: { readyReplicas: 0 } })
+    ).toEqual({ status: 'error', label: '0/1 ready' });
+    // No status at all with omitted replicas.
+    expect(
+      getSubResourceHealth('Deployment', { spec: {}, status: {} })
+    ).toEqual({ status: 'error', label: '0/1 ready' });
+  });
+
   it('maps PVC phases', () => {
     expect(getSubResourceHealth('PersistentVolumeClaim', { status: { phase: 'Bound' } })).toEqual({
       status: 'success',
@@ -70,6 +89,19 @@ describe('getResolvedValues', () => {
       getResolvedValues('Service', { spec: { type: 'ClusterIP', clusterIP: '10.0.0.1' } })
     ).toBe('type: ClusterIP, clusterIP: 10.0.0.1');
     expect(getResolvedValues('Service', { spec: { clusterIP: 'None' } })).toBe('type: ClusterIP');
+  });
+
+  it('defaults omitted replicas to 1 in resolved values', () => {
+    // When spec.replicas is omitted, should show /1 not /0.
+    expect(
+      getResolvedValues('Deployment', { spec: {}, status: { readyReplicas: 1 } })
+    ).toBe('replicas: 1/1');
+    expect(
+      getResolvedValues('StatefulSet', { spec: {}, status: { readyReplicas: 1 } })
+    ).toBe('replicas: 1/1');
+    expect(
+      getResolvedValues('Deployment', { spec: {}, status: {} })
+    ).toBe('replicas: 0/1');
   });
 
   it('returns empty for kinds without resolved values', () => {

--- a/kro/src/resources/subResources.ts
+++ b/kro/src/resources/subResources.ts
@@ -46,7 +46,8 @@ function findCondition(resource: any, type: string): KubeCondition | undefined {
 export function getSubResourceHealth(kind: string, resource: any): SubResourceHealth {
   switch (kind) {
     case 'Deployment': {
-      const desired = resource?.spec?.replicas ?? 0;
+      // Kubernetes defaults spec.replicas to 1 when omitted.
+      const desired = resource?.spec?.replicas ?? 1;
       const ready = resource?.status?.readyReplicas ?? 0;
       return {
         status: desired > 0 && ready >= desired ? 'success' : 'error',
@@ -54,7 +55,8 @@ export function getSubResourceHealth(kind: string, resource: any): SubResourceHe
       };
     }
     case 'StatefulSet': {
-      const desired = resource?.spec?.replicas ?? 0;
+      // Kubernetes defaults spec.replicas to 1 when omitted.
+      const desired = resource?.spec?.replicas ?? 1;
       const ready = resource?.status?.readyReplicas ?? 0;
       return {
         status: desired > 0 && ready >= desired ? 'success' : 'error',
@@ -133,7 +135,8 @@ export function getResolvedValues(kind: string, resource: any): string {
     }
     case 'Deployment':
     case 'StatefulSet': {
-      const desired = resource?.spec?.replicas ?? 0;
+      // Kubernetes defaults spec.replicas to 1 when omitted.
+      const desired = resource?.spec?.replicas ?? 1;
       const ready = resource?.status?.readyReplicas ?? 0;
       return `replicas: ${ready}/${desired}`;
     }


### PR DESCRIPTION

## What's going on here?
#1249
So I ran into this while looking at how the kro plugin renders sub-resource health on the Instance Detail page. If you create a Deployment through a ResourceGraphDefinition and don't explicitly write `replicas: 1` in the spec (which, let's be honest, most people don't — Kubernetes already defaults it to 1 for you), the dashboard ends up showing a red error badge with the label "1/0 ready" even though the pod is running just fine.

The root cause is pretty simple. In `subResources.ts`, the code does:

```typescript
const desired = resource?.spec?.replicas ?? 0;
```

When `spec.replicas` isn't in the manifest, this falls back to `0`. So you end up with `desired = 0` and `ready = 1`, and the health check goes "well, `0 > 0` is false, so this must be broken" and slaps an error badge on it. The resolved values column also shows `replicas: 1/0` which just looks wrong.

The thing is, Kubernetes treats omitted `replicas` as 1 — it's right there in the API spec. So the fallback here should be 1, not 0.

## What I changed

Honestly not a huge diff. Just swapped `?? 0` to `?? 1` in three spots:

- The Deployment branch in `getSubResourceHealth()`
- The StatefulSet branch in `getSubResourceHealth()` (same logic, duplicated for both kinds)
- The Deployment/StatefulSet branch in `getResolvedValues()`

That's it for the source. I also added a couple of test blocks in `subResources.test.ts` to make sure this actually works — things like "if replicas is omitted and one pod is ready, that should be success with 1/1 ready" and "if replicas is omitted and nothing is ready yet, that should be error with 0/1 ready". Same thing for `getResolvedValues`.

Nothing else is touched. All the existing behavior for explicit replicas (like `replicas: 3` or scale-to-zero with `replicas: 0`) stays exactly the same.

## Quick before/after

| Situation | Before | After |
|---|---|---|
| No `spec.replicas`, 1 pod ready | `error`, `1/0 ready` | `success`, `1/1 ready` |
| No `spec.replicas`, pod not ready yet | `error`, `0/0 ready` | `error`, `0/1 ready` |
| Explicit `replicas: 2`, both ready | `success`, `2/2 ready` | Same, no change |
| Explicit `replicas: 0` (scale-to-zero) | `error`, `0/0 ready` | Same, no change |

## Tests

All passing:

```
 src/resources/subResources.test.ts (10 tests) 2ms

 Test Files  1 passed (1)
      Tests  10 passed (10)
```
