### PR TITLE
ai-assistant: navigate resource links within Headlamp

### DIFF
--- a/ai-assistant/e2e/ai-assistant.spec.ts
+++ b/ai-assistant/e2e/ai-assistant.spec.ts
@@ -234,4 +234,41 @@ Inspect pod status, recent events, and container logs before recommending a fix.
       fullPage: true,
     });
   });
+
+  test('navigates resource links within Headlamp', async ({ context, page }) => {
+    await page.goto('/c/main/nodes');
+
+    const tokenLogin = page.getByRole('button', { name: 'Use A Token' });
+    if (await tokenLogin.isVisible()) {
+      const token = process.env.HEADLAMP_TOKEN;
+      expect(
+        token,
+        'HEADLAMP_TOKEN must be set when Headlamp requires authentication'
+      ).toBeTruthy();
+      await tokenLogin.click();
+      await page.getByRole('textbox', { name: 'ID token' }).fill(token!);
+      await page.getByRole('button', { name: 'Authenticate' }).click();
+    }
+
+    await page.goto('/settings/plugins/%40headlamp-k8s%2Fai-assistant');
+    await page.getByText('Developer Options', { exact: true }).click();
+    await page.getByRole('checkbox', { name: 'Mock Testing Model' }).check();
+    await page.getByRole('checkbox', { name: /Test Mode/ }).check();
+    await page.getByRole('button', { name: 'AI Assistant' }).click();
+
+    await page.getByRole('button', { name: 'Add Test Response' }).click();
+    await page
+      .getByRole('textbox', { name: 'Response Content' })
+      .fill(
+        '[web](https://headlamp/resource-details?cluster=main&kind=Deployment&resource=web&ns=demo)'
+      );
+    await page.getByRole('button', { name: 'Add Response' }).click();
+
+    const resourceLink = page.getByRole('link', { name: 'web', exact: true });
+    await expect(resourceLink).not.toHaveAttribute('target', '_blank');
+    const pageCount = context.pages().length;
+    await resourceLink.click();
+    await expect(page).toHaveURL(/\/c\/main\/deployments\/demo\/web$/);
+    await expect.poll(() => context.pages().length).toBe(pageCount);
+  });
 });

--- a/ai-assistant/src/ContentRenderer.test.tsx
+++ b/ai-assistant/src/ContentRenderer.test.tsx
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  createRouteURL: vi.fn(() => '/c/test-cluster/pods/default/test-pod'),
+  push: vi.fn(),
+}));
+
+vi.mock('@kinvolk/headlamp-plugin/lib', () => ({
+  K8s: {
+    ResourceClasses: {
+      Pod: class Pod {
+        static apiName = 'pods';
+        static detailsRoute = 'Pod';
+        static isNamespaced = true;
+
+        constructor() {
+          throw new Error('KubeObject routing dependencies are unavailable');
+        }
+      },
+    },
+  },
+  Router: { createRouteURL: mocks.createRouteURL },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('react-router-dom', () => ({
+  Link: React.forwardRef<
+    HTMLAnchorElement,
+    React.AnchorHTMLAttributes<HTMLAnchorElement> & { to: string }
+  >(({ children, onClick, to, ...props }, ref) => (
+    <a
+      ref={ref}
+      href={to}
+      onClick={event => {
+        event.preventDefault();
+        onClick?.(event);
+      }}
+      {...props}
+    >
+      {children}
+    </a>
+  )),
+  useHistory: () => ({ push: mocks.push }),
+}));
+
+import ContentRenderer from './ContentRenderer';
+
+describe('ContentRenderer resource links', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('navigates to a resource within Headlamp without constructing a KubeObject', () => {
+    render(
+      <ContentRenderer content="[test-pod](https://headlamp/resource-details?cluster=test-cluster&kind=Pod&resource=test-pod&ns=default)" />
+    );
+
+    const link = screen.getByRole('link', { name: 'test-pod' });
+    expect(link.getAttribute('target')).toBeNull();
+
+    fireEvent.click(link);
+
+    expect(mocks.createRouteURL).toHaveBeenCalledWith('Pod', {
+      cluster: 'test-cluster',
+      name: 'test-pod',
+      namespace: 'default',
+    });
+    expect(mocks.push).toHaveBeenCalledWith('/c/test-cluster/pods/default/test-pod');
+  });
+});

--- a/ai-assistant/src/api/clusterActions.test.ts
+++ b/ai-assistant/src/api/clusterActions.test.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  clusterRequest: vi.fn(),
+}));
+
+vi.mock('@kinvolk/headlamp-plugin/lib', () => ({
+  clusterAction: vi.fn(),
+}));
+
+vi.mock('@kinvolk/headlamp-plugin/lib/ApiProxy', () => ({
+  apply: vi.fn(),
+  clusterRequest: mocks.clusterRequest,
+}));
+
+vi.mock('@kinvolk/headlamp-plugin/lib/Utils', () => ({
+  getCluster: () => 'Headlamp',
+}));
+
+import { handleActualApiRequest } from './clusterActions';
+
+describe('handleActualApiRequest resource links', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uses the collection kind for metadata-wrapped table rows', async () => {
+    mocks.clusterRequest.mockResolvedValue({
+      kind: 'Table',
+      columnDefinitions: [{ name: 'Node' }, { name: 'Status' }, { name: 'Pool' }],
+      rows: [
+        {
+          cells: ['aks-agentpool-000001', 'Ready', 'agentpool'],
+          object: {
+            kind: 'PartialObjectMetadata',
+            metadata: { name: 'aks-agentpool-000001' },
+          },
+        },
+      ],
+    });
+    const aiManager = { history: [] };
+
+    const result = await handleActualApiRequest(
+      '/api/v1/nodes',
+      'GET',
+      '',
+      vi.fn(),
+      aiManager,
+      '',
+      'Headlamp'
+    );
+
+    expect(result).toContain(
+      'https://headlamp/resource-details?cluster=Headlamp&kind=nodes&resource=aks-agentpool-000001'
+    );
+    expect(result).not.toContain('kind=PartialObjectMetadata');
+  });
+
+  it('extracts the collection kind from namespaced list URLs', async () => {
+    mocks.clusterRequest.mockResolvedValue({
+      kind: 'Table',
+      columnDefinitions: [{ name: 'Name' }, { name: 'Status' }],
+      rows: [
+        {
+          cells: ['test-pod', 'Running'],
+          object: {
+            kind: 'PartialObjectMetadata',
+            metadata: { name: 'test-pod', namespace: 'default' },
+          },
+        },
+      ],
+    });
+
+    const result = await handleActualApiRequest(
+      '/api/v1/namespaces/default/pods',
+      'GET',
+      '',
+      vi.fn(),
+      { history: [] },
+      '',
+      'Headlamp'
+    );
+
+    expect(result).toContain(
+      'https://headlamp/resource-details?cluster=Headlamp&kind=pods&resource=test-pod&ns=default'
+    );
+  });
+});

--- a/ai-assistant/src/api/clusterActions.tsx
+++ b/ai-assistant/src/api/clusterActions.tsx
@@ -639,16 +639,11 @@ export const handleActualApiRequest = async (
     } else if (response?.kind === 'Table') {
       // ...existing code...
       const extractKindFromUrl = (url: string) => {
-        // Extract from URLs like /api/v1/pods, /apis/apps/v1/deployments, etc.
-        const match = url.match(/\/(api\/v1\/[^\/]+|apis\/[^\/]+\/[^\/]+\/[^\/]+)/);
-        const kind = match ? match[1] : null;
-        if (kind?.length > 1) {
-          const kindParts = kind.split('/');
-          if (kindParts.length > 1) {
-            return kindParts[kindParts.length - 1]; // Return the last part as the kind
-          }
-        }
-        return kind;
+        const path = new URL(url, 'http://dummy.com').pathname;
+        const match = path.match(
+          /^\/(?:api\/[^/]+|apis\/[^/]+\/[^/]+)\/(?:namespaces\/[^/]+\/)?([^/]+)/
+        );
+        return match?.[1] ?? null;
       };
 
       const resourceKind = extractKindFromUrl(url);
@@ -668,14 +663,17 @@ export const handleActualApiRequest = async (
       const tableRows = itemsToShow.map((row: any) => {
         const cells = row.cells || [];
         const namespace = row.object?.metadata?.namespace;
+        const objectKind = row.object?.kind;
+        const kind =
+          objectKind && objectKind !== 'PartialObjectMetadata' ? objectKind : resourceKind;
 
         const paddedCells = columnHeaders.map((_, index) => {
           let cellValue = cells[index] || '-';
 
           // For the name column (first column), create a special link marker
-          if (index === 0 && resourceKind && cellValue !== '-') {
+          if (index === 0 && kind && cellValue !== '-') {
             const linkData = {
-              kind: resourceKind,
+              kind,
               name: cellValue,
               namespace: namespace,
             };

--- a/ai-assistant/src/headlampLink.ts
+++ b/ai-assistant/src/headlampLink.ts
@@ -22,8 +22,8 @@
  * It is exported from `@headlamp-k8s/ai-common/ai` which is already browser-only.
  */
 
-import { ResourceClasses } from '@kinvolk/headlamp-plugin/lib/lib/k8s';
-import { KubeObject } from '@kinvolk/headlamp-plugin/lib/lib/k8s/KubeObject';
+import { K8s, Router } from '@kinvolk/headlamp-plugin/lib';
+import type { KubeObject } from '@kinvolk/headlamp-plugin/lib/lib/k8s/KubeObject';
 
 const HEADLAMP_LINK_HOST = 'headlamp';
 const HEADLAMP_RESOURCE_DETAILS_LINK = 'resource-details';
@@ -67,11 +67,11 @@ export function getHeadlampLink(link: string | null | undefined) {
 
       // @todo: Add support for CRDs
       // Guard against ResourceClasses being undefined at runtime
-      let resourceClass = ResourceClasses?.[kind];
+      let resourceClass = K8s.ResourceClasses?.[kind];
       // If we couldn't match it like this, iterate and try to match it from the API name
-      if (!resourceClass && ResourceClasses) {
-        for (const className in ResourceClasses) {
-          const rc = ResourceClasses[className];
+      if (!resourceClass && K8s.ResourceClasses) {
+        for (const className in K8s.ResourceClasses) {
+          const rc = K8s.ResourceClasses[className];
           if (rc.apiName === kind) {
             resourceClass = rc;
             break;
@@ -85,20 +85,11 @@ export function getHeadlampLink(link: string | null | undefined) {
         cluster &&
         (resourceClass.isNamespaced ? !!namespace : true)
       ) {
-        // Create an instance
-        const instance = new resourceClass(
-          {
-            kind,
-            metadata: {
-              name: resource,
-              ...(resourceClass.isNamespaced ? { namespace } : {}),
-            },
-          },
-          cluster
-        );
-
-        linkResult.kubeObject = instance;
-        linkResult.url = instance.getDetailsLink();
+        linkResult.url = Router.createRouteURL(resourceClass.detailsRoute, {
+          cluster,
+          name: resource,
+          ...(resourceClass.isNamespaced ? { namespace } : {}),
+        });
       }
     } else if (urlPath === HEADLAMP_CLUSTER_LINK) {
       // It's a cluster link


### PR DESCRIPTION
## Summary

- resolve AI Assistant resource links directly through the Headlamp router
- avoid constructing a KubeObject when generating resource detail routes
- unit tests, and an e2e test

## Reproduction

Ask about pods needing attention, click on a link. It should open inside headlamp, not in a browser.

<img width="1728" height="1012" alt="Screenshot 2026-09-02 at 11 18 00" src="https://github.com/user-attachments/assets/39175588-aea1-4c93-bd92-c626e032fb06" />
