### PR TITLE
app-catalog: releases: Use the shared namespace filter

### DIFF
--- a/app-catalog/src/components/releases/List.tsx
+++ b/app-catalog/src/components/releases/List.tsx
@@ -4,13 +4,14 @@ import {
   DateLabel,
   Link,
   SectionBox,
-  SectionHeader,
+  SectionFilterHeader,
   SimpleTable,
   StatusLabel,
 } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 import { Box, Checkbox } from '@mui/material';
 import { useSnackbar } from 'notistack';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useSelector } from 'react-redux';
 import { fetchLatestAppVersion } from '../../api/charts';
 import {
   deleteRelease,
@@ -101,6 +102,20 @@ function parseReleaseKey(key: string): { namespace: string; name: string } | nul
 }
 
 /**
+ * The globally selected namespaces (empty means all), read from Headlamp's shared
+ * filter store the way its list views do. Uses react-redux directly because the
+ * internal filter module is not exposed to plugins at runtime.
+ *
+ * @returns The selected namespace names, empty when no namespace filter is set.
+ */
+function useSelectedNamespaces(): string[] {
+  const namespaces = useSelector(
+    (state: { filter?: { namespaces?: Set<string> } }) => state.filter?.namespaces
+  );
+  return useMemo(() => (namespaces ? [...namespaces] : []), [namespaces]);
+}
+
+/**
  * @returns formatted version string
  * @param v - version string
  */
@@ -126,7 +141,7 @@ export default function ReleaseList({ fetchReleases = listReleases }: ReleaseLis
   const [releases, setReleases] = useState<Release[] | null>(null);
   const [latestMap, setLatestMap] = useState<Record<string, string>>({});
   const [nameFilter, setNameFilter] = useState('');
-  const [namespaceFilter, setNamespaceFilter] = useState('');
+  const selectedNamespaces = useSelectedNamespaces();
   const [openDeleteAlert, setOpenDeleteAlert] = useState<boolean>(false);
   const [rollbackPopup, setRollbackPopup] = useState<boolean>(false);
   const [selectedRelease, setSelectedRelease] = useState<Release | null>(null);
@@ -191,18 +206,12 @@ export default function ReleaseList({ fetchReleases = listReleases }: ReleaseLis
     return releases.filter(release => {
       const matchesName =
         !nameFilter || release.name.toLowerCase().includes(nameFilter.toLowerCase());
-      const matchesNamespace = !namespaceFilter || release.namespace === namespaceFilter;
+      const matchesNamespace =
+        selectedNamespaces.length === 0 || selectedNamespaces.includes(release.namespace);
 
       return matchesName && matchesNamespace;
     });
-  }, [releases, nameFilter, namespaceFilter]);
-
-  const availableNamespaces = useMemo(() => {
-    if (!releases) return [];
-
-    const namespaces = new Set(releases.map(r => r.namespace));
-    return Array.from(namespaces).sort();
-  }, [releases]);
+  }, [releases, nameFilter, selectedNamespaces]);
 
   // Count how many of the currently visible (filtered) releases are selected
   const selectedVisibleCount = useMemo(() => {
@@ -583,16 +592,13 @@ export default function ReleaseList({ fetchReleases = listReleases }: ReleaseLis
         onConfirm={handleConfirmRollback}
         onCancel={() => setRollbackPopup(false)}
       />
-      <SectionHeader
+      <SectionFilterHeader
         title={t('Installed')}
         actions={[
           <ReleaseFilters
             key="filters"
             nameFilter={nameFilter}
-            namespaceFilter={namespaceFilter}
-            availableNamespaces={availableNamespaces}
             onNameFilterChange={setNameFilter}
-            onNamespaceFilterChange={setNamespaceFilter}
           />,
         ]}
       />

--- a/app-catalog/src/components/releases/ReleaseFilters.tsx
+++ b/app-catalog/src/components/releases/ReleaseFilters.tsx
@@ -1,23 +1,15 @@
-import { Autocomplete, Box, TextField } from '@mui/material';
+import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
+import { TextField } from '@mui/material';
 import { useEffect, useRef, useState } from 'react';
 
 /** Props for the filter bar rendered in the releases list header. */
 interface ReleaseFiltersProps {
   nameFilter: string;
-  namespaceFilter: string;
-  /** Namespace strings derived from the currently loaded releases, used to populate the dropdown. */
-  availableNamespaces: string[];
   onNameFilterChange: (value: string) => void;
-  onNamespaceFilterChange: (value: string) => void;
 }
 
-export function ReleaseFilters({
-  nameFilter,
-  namespaceFilter,
-  availableNamespaces,
-  onNameFilterChange,
-  onNamespaceFilterChange,
-}: ReleaseFiltersProps) {
+export function ReleaseFilters({ nameFilter, onNameFilterChange }: ReleaseFiltersProps) {
+  const { t } = useTranslation();
   const [inputValue, setInputValue] = useState(nameFilter);
   const timeoutRef = useRef<NodeJS.Timeout>();
 
@@ -42,29 +34,15 @@ export function ReleaseFilters({
   }, [inputValue, onNameFilterChange]);
 
   return (
-    <Box display="flex" gap={2} alignItems="center">
-      <TextField
-        sx={{
-          width: { xs: '100%', sm: '200px', md: '250px' },
-          margin: { xs: '0.5rem 0', sm: '0 1rem' },
-        }}
-        id="outlined-basic"
-        label="Search"
-        value={inputValue}
-        onChange={event => {
-          setInputValue(event.target.value);
-        }}
-      />
-      <Autocomplete
-        sx={{ width: { xs: '100%', sm: '200px', md: '250px' } }}
-        options={availableNamespaces}
-        getOptionLabel={option => option || 'All'}
-        value={namespaceFilter || null}
-        onChange={(event, newValue) => {
-          onNamespaceFilterChange(newValue || '');
-        }}
-        renderInput={params => <TextField {...params} label="Namespace" size="small" />}
-      />
-    </Box>
+    <TextField
+      sx={{ width: { xs: '100%', sm: '200px', md: '250px' } }}
+      id="outlined-basic"
+      label={t('Search')}
+      size="small"
+      value={inputValue}
+      onChange={event => {
+        setInputValue(event.target.value);
+      }}
+    />
   );
 }

--- a/app-catalog/src/components/releases/ReleaseList.stories.tsx
+++ b/app-catalog/src/components/releases/ReleaseList.stories.tsx
@@ -48,6 +48,9 @@ const mockReleases = [
 ];
 
 const initialState = {
+  filter: {
+    namespaces: new Set<string>(),
+  },
   config: {
     settings: {
       tableRowsPerPageOptions: [15, 25, 50],


### PR DESCRIPTION
## Summary

The **Installed** view of the `app-catalog` plugin (Apps → Installed) used its own namespace filter: a bespoke single-select MUI `Autocomplete` backed by local component state. This made it inconsistent with the rest of Headlamp, where every list view shares one multi-select namespace filter.

Concretely, the old control:

- looked and behaved differently from the standard namespace filter;
- only allowed **one** namespace at a time, while Headlamp's is multi-select;
- kept its state locally, so the selection was lost as soon as you navigated away, and was never shared with native views (Pods, Deployments, …) or with other plugins.

This PR replaces it with Headlamp's shared filter. `SectionHeader` becomes `SectionFilterHeader`, which appends the standard `NamespacesAutocomplete`. The selection now lives in the global `filter.namespaces` store, so it is multi-select, persisted per cluster in `localStorage`, mirrored into the `?namespace=` query parameter, and preserved when moving between the Helm views and the rest of Headlamp.

### Behaviour change

Namespace options now come from the cluster (`Namespace.useList()`, or `allowedNamespaces` from the cluster settings) instead of being derived from the loaded releases. That is the point of the change, but it means namespaces without releases appear in the dropdown, and listing namespaces requires the matching RBAC.

## Steps to Test

1. Build and install the plugin, then start Headlamp against a cluster that has Helm releases in **at least two** namespaces.
2. Go to **Apps → Installed**. The namespace control is the standard multi-select chip autocomplete, identical to the one on **Workloads → Pods**.
3. Select two namespaces. Only releases from those namespaces remain in the table, and the URL gains `?namespace=<ns1> <ns2>`.
4. Navigate to **Workloads → Pods**. The same two namespaces are still selected.
5. Change the selection there, then go back to **Apps → Installed**. The new selection is applied.
6. Reload the page while on **Installed**. The selection is restored from `localStorage`.
7. Open `…/apps/installed?namespace=<some-ns>` directly in a fresh tab. That namespace is selected on first load.
8. Clear the selection. All releases are shown again.
9. Type in the **Search** field. It still debounces and combines with the namespace filter.
10. Use the header checkbox. Select-all still only covers the currently visible (filtered) rows.