### PR TITLE
app-catalog: Add revision values viewer and history diff (#1269)

### DIFF
--- a/app-catalog/locales/en/translation.json
+++ b/app-catalog/locales/en/translation.json
@@ -89,5 +89,22 @@
   "Installed": "Installed",
   "Current Version": "Current Version",
   "Latest Version": "Latest Version",
-  "Version": "Version"
+  "Version": "Version",
+  "Compare Revisions": "Compare Revisions",
+  "View Values": "View Values",
+  "Compare with current": "Compare with current",
+  "Revision {{ version }} Values - {{ releaseName }}": "Revision {{ version }} Values - {{ releaseName }}",
+  "User defined values only": "User defined values only",
+  "Show user defined values only": "Show user defined values only",
+  "Values copied to clipboard": "Values copied to clipboard",
+  "Failed to copy values to clipboard": "Failed to copy values to clipboard",
+  "Copy to clipboard": "Copy to clipboard",
+  "Compare Revisions - {{ releaseName }}": "Compare Revisions - {{ releaseName }}",
+  "Base Revision": "Base Revision",
+  "Compare With": "Compare With",
+  "Swap revisions": "Swap revisions",
+  "Revision {{ version }}": "Revision {{ version }}",
+  "Both panes display the same revision": "Both panes display the same revision",
+  "Left: Revision {{ base }} | Right: Revision {{ target }}": "Left: Revision {{ base }} | Right: Revision {{ target }}",
+  "Actions": "Actions"
 }

--- a/app-catalog/src/components/releases/Detail.tsx
+++ b/app-catalog/src/components/releases/Detail.tsx
@@ -10,6 +10,7 @@ import {
   StatusLabel,
 } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 import {
+  Box,
   Button,
   DialogActions,
   DialogContent,
@@ -29,6 +30,8 @@ import {
   rollbackRelease,
 } from '../../api/releases';
 import { EditorDialog } from './EditorDialog';
+import { RevisionDiffDialog } from './RevisionDiffDialog';
+import { RevisionValuesDialog } from './RevisionValuesDialog';
 
 const { createRouteURL } = Router;
 export default function ReleaseDetail() {
@@ -43,6 +46,11 @@ export default function ReleaseDetail() {
   const [isEditorOpen, setIsEditorOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [isUpdateRelease, setIsUpdateRelease] = useState(false);
+  const [isValuesDialogOpen, setIsValuesDialogOpen] = useState<boolean>(false);
+  const [selectedRevisionForValues, setSelectedRevisionForValues] = useState<any | null>(null);
+  const [isDiffDialogOpen, setIsDiffDialogOpen] = useState<boolean>(false);
+  const [diffBaseVersion, setDiffBaseVersion] = useState<number | undefined>(undefined);
+  const [diffTargetVersion, setDiffTargetVersion] = useState<number | undefined>(undefined);
   const { enqueueSnackbar } = useSnackbar();
   const history = useHistory();
 
@@ -55,6 +63,9 @@ export default function ReleaseDetail() {
   useEffect(() => {
     getReleaseHistory(namespace, releaseName).then(response => {
       setReleaseHistory(response);
+      if (response?.releases?.length && !revertVersion) {
+        setRevertVersion(response.releases[0].version.toString());
+      }
     });
   }, [update]);
 
@@ -155,11 +166,11 @@ export default function ReleaseDetail() {
             fullWidth
           >
             {releaseHistory &&
-              releaseHistory.releases.map((release: any) => {
+              releaseHistory.releases.map((rel: any) => {
                 return (
-                  <MenuItem value={release?.version}>
-                    {release?.version} - {release?.info?.description || 'N/A'} (
-                    {new Date(release?.info.last_deployed).toLocaleString()})
+                  <MenuItem key={rel?.version} value={rel?.version?.toString()}>
+                    {rel?.version} - {rel?.info?.description || 'N/A'} (
+                    {new Date(rel?.info.last_deployed).toLocaleString()})
                   </MenuItem>
                 );
               })}
@@ -167,6 +178,7 @@ export default function ReleaseDetail() {
         </DialogContent>
         <DialogActions>
           <Button
+            disabled={!revertVersion}
             onClick={() => {
               rollbackRelease(
                 release.namespace,
@@ -220,7 +232,12 @@ export default function ReleaseDetail() {
                 />,
                 <ActionButton
                   description={t('Rollback')}
-                  onClick={() => setRollbackPopup(true)}
+                  onClick={() => {
+                    if (releaseHistory?.releases?.length) {
+                      setRevertVersion(releaseHistory.releases[0].version.toString());
+                    }
+                    setRollbackPopup(true);
+                  }}
                   icon="mdi:undo"
                   iconButtonProps={{ disabled: release.version === 1 }}
                 />,
@@ -269,7 +286,28 @@ export default function ReleaseDetail() {
       )}
 
       {releaseHistory && (
-        <SectionBox title={t('History')}>
+        <SectionBox
+          title={
+            <SectionHeader
+              title={t('History')}
+              actions={[
+                <ActionButton
+                  description={t('Compare Revisions')}
+                  onClick={() => {
+                    const sorted = [...releaseHistory.releases].sort(
+                      (a: any, b: any) => b.version - a.version
+                    );
+                    setDiffTargetVersion(sorted[0]?.version);
+                    setDiffBaseVersion(sorted.length > 1 ? sorted[1]?.version : sorted[0]?.version);
+                    setIsDiffDialogOpen(true);
+                  }}
+                  icon="mdi:compare"
+                  iconButtonProps={{ disabled: releaseHistory.releases?.length < 2 }}
+                />,
+              ]}
+            />
+          }
+        >
           <SimpleTable
             data={
               releaseHistory === null
@@ -285,37 +323,83 @@ export default function ReleaseDetail() {
               },
               {
                 label: t('Description'),
-                getter: data => data.info.description,
+                getter: data => data.info?.description || 'N/A',
               },
               {
                 label: t('Status'),
                 getter: data => (
-                  <StatusLabel status={release?.info.status === 'deployed' ? 'success' : 'error'}>
-                    {data.info.status}
+                  <StatusLabel status={data?.info?.status === 'deployed' ? 'success' : 'error'}>
+                    {data.info?.status}
                   </StatusLabel>
                 ),
               },
               {
                 label: t('Chart'),
-                getter: data => data.chart.metadata.name,
+                getter: data => data.chart?.metadata?.name,
               },
               {
                 label: t('App Version'),
-                getter: data => data.chart.metadata.appVersion,
+                getter: data => data.chart?.metadata?.appVersion,
               },
               {
                 label: t('Updated'),
                 // Key by the deploy timestamp (epoch) so TimeAgo remounts when the value
                 // changes, instead of showing a reused row's stale age after a re-sort.
                 getter: data => {
-                  const deployedAt = new Date(data.info.last_deployed).getTime();
+                  const deployedAt = new Date(data.info?.last_deployed).getTime();
                   return <DateLabel key={deployedAt} date={deployedAt} format="mini" />;
                 },
+              },
+              {
+                label: t('Actions'),
+                getter: data => (
+                  <Box display="flex" gap={1}>
+                    <ActionButton
+                      description={t('View Values')}
+                      onClick={() => {
+                        setSelectedRevisionForValues(data);
+                        setIsValuesDialogOpen(true);
+                      }}
+                      icon="mdi:file-document-box-outline"
+                    />
+                    <ActionButton
+                      description={t('Compare with current')}
+                      onClick={() => {
+                        setDiffBaseVersion(data.version);
+                        setDiffTargetVersion(release?.version);
+                        setIsDiffDialogOpen(true);
+                      }}
+                      icon="mdi:compare"
+                      iconButtonProps={{ disabled: data.version === release?.version }}
+                    />
+                  </Box>
+                ),
               },
             ]}
           />
         </SectionBox>
       )}
+
+      <RevisionValuesDialog
+        open={isValuesDialogOpen}
+        onClose={() => {
+          setIsValuesDialogOpen(false);
+          setSelectedRevisionForValues(null);
+        }}
+        releaseName={releaseName}
+        releaseNamespace={namespace}
+        revision={selectedRevisionForValues}
+      />
+
+      <RevisionDiffDialog
+        open={isDiffDialogOpen}
+        onClose={() => setIsDiffDialogOpen(false)}
+        releaseName={releaseName}
+        releaseNamespace={namespace}
+        releases={releaseHistory?.releases || []}
+        initialBaseVersion={diffBaseVersion}
+        initialTargetVersion={diffTargetVersion}
+      />
     </>
   );
 }

--- a/app-catalog/src/components/releases/RevisionDiffDialog.test.tsx
+++ b/app-catalog/src/components/releases/RevisionDiffDialog.test.tsx
@@ -1,0 +1,167 @@
+/** @vitest-environment jsdom */
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { RevisionDiffDialog } from './RevisionDiffDialog';
+
+vi.mock('@kinvolk/headlamp-plugin/lib', () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, any>) => {
+      if (!params) return key;
+      return Object.entries(params).reduce(
+        (acc, [k, v]) => acc.replace(`{{ ${k} }}`, String(v)).replace(`{{${k}}}`, String(v)),
+        key
+      );
+    },
+  }),
+}));
+
+vi.mock('@kinvolk/headlamp-plugin/lib/CommonComponents', () => ({
+  Dialog: ({ open, title, children }: any) =>
+    open ? (
+      <div role="dialog" aria-label={title}>
+        <h2>{title}</h2>
+        {children}
+      </div>
+    ) : null,
+}));
+
+vi.mock('@monaco-editor/react', () => ({
+  DiffEditor: ({ original, modified }: any) => (
+    <div data-testid="mock-diff-editor">
+      <textarea data-testid="diff-original" value={original} readOnly />
+      <textarea data-testid="diff-modified" value={modified} readOnly />
+    </div>
+  ),
+}));
+
+describe('RevisionDiffDialog', () => {
+  const mockReleases = [
+    {
+      version: 1,
+      chart: {
+        metadata: { name: 'my-chart', version: '1.0.0' },
+        values: { replicaCount: 1, image: { tag: 'v1' } },
+      },
+      config: { replicaCount: 1 },
+      info: { last_deployed: '2026-09-01T10:00:00Z', description: 'Initial deploy' },
+    },
+    {
+      version: 2,
+      chart: {
+        metadata: { name: 'my-chart', version: '1.1.0' },
+        values: { replicaCount: 1, image: { tag: 'v2' } },
+      },
+      config: { replicaCount: 3 },
+      info: { last_deployed: '2026-09-02T10:00:00Z', description: 'Scale to 3' },
+    },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders nothing when closed', () => {
+    render(
+      <RevisionDiffDialog
+        open={false}
+        onClose={vi.fn()}
+        releaseName="test-release"
+        releaseNamespace="default"
+        releases={mockReleases}
+      />
+    );
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('renders diff editor comparing base and target revisions', () => {
+    render(
+      <RevisionDiffDialog
+        open
+        onClose={vi.fn()}
+        releaseName="test-release"
+        releaseNamespace="default"
+        releases={mockReleases}
+      />
+    );
+
+    expect(screen.getByRole('dialog')).toBeDefined();
+    const originalPane = screen.getByTestId('diff-original') as HTMLTextAreaElement;
+    const modifiedPane = screen.getByTestId('diff-modified') as HTMLTextAreaElement;
+
+    expect(originalPane.value).toContain('replicaCount: 1');
+    expect(originalPane.value).toContain('tag: v1');
+
+    expect(modifiedPane.value).toContain('replicaCount: 3');
+    expect(modifiedPane.value).toContain('tag: v2');
+  });
+
+  it('swaps revisions when swap button is clicked', () => {
+    render(
+      <RevisionDiffDialog
+        open
+        onClose={vi.fn()}
+        releaseName="test-release"
+        releaseNamespace="default"
+        releases={mockReleases}
+      />
+    );
+
+    const swapBtn = screen.getByRole('button', { name: /Swap revisions/i });
+    fireEvent.click(swapBtn);
+
+    const originalPane = screen.getByTestId('diff-original') as HTMLTextAreaElement;
+    const modifiedPane = screen.getByTestId('diff-modified') as HTMLTextAreaElement;
+
+    expect(originalPane.value).toContain('replicaCount: 3');
+    expect(originalPane.value).toContain('tag: v2');
+
+    expect(modifiedPane.value).toContain('replicaCount: 1');
+    expect(modifiedPane.value).toContain('tag: v1');
+  });
+
+  it('toggles user defined values only', () => {
+    render(
+      <RevisionDiffDialog
+        open
+        onClose={vi.fn()}
+        releaseName="test-release"
+        releaseNamespace="default"
+        releases={mockReleases}
+      />
+    );
+
+    const checkbox = screen.getByRole('checkbox', { name: /Show user defined values only/i });
+    fireEvent.click(checkbox);
+
+    const originalPane = screen.getByTestId('diff-original') as HTMLTextAreaElement;
+    const modifiedPane = screen.getByTestId('diff-modified') as HTMLTextAreaElement;
+
+    expect(originalPane.value).toContain('replicaCount: 1');
+    expect(originalPane.value).not.toContain('tag: v1');
+
+    expect(modifiedPane.value).toContain('replicaCount: 3');
+    expect(modifiedPane.value).not.toContain('tag: v2');
+  });
+
+  it('calls onClose when close button is clicked', () => {
+    const handleClose = vi.fn();
+    render(
+      <RevisionDiffDialog
+        open
+        onClose={handleClose}
+        releaseName="test-release"
+        releaseNamespace="default"
+        releases={mockReleases}
+      />
+    );
+
+    const closeBtn = screen.getByRole('button', { name: /Close/i });
+    fireEvent.click(closeBtn);
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app-catalog/src/components/releases/RevisionDiffDialog.tsx
+++ b/app-catalog/src/components/releases/RevisionDiffDialog.tsx
@@ -1,0 +1,225 @@
+import { Icon } from '@iconify/react';
+import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
+import { Dialog } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { DiffEditor } from '@monaco-editor/react';
+import {
+  Box,
+  Button,
+  Checkbox,
+  DialogActions,
+  DialogContent,
+  FormControl,
+  FormControlLabel,
+  Grid,
+  IconButton,
+  InputLabel,
+  MenuItem,
+  Select,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import React, { useEffect, useMemo, useState } from 'react';
+import { jsonToYAML } from '../../helpers';
+
+export interface RevisionDiffDialogProps {
+  open: boolean;
+  onClose: () => void;
+  releaseName: string;
+  releaseNamespace: string;
+  releases: any[];
+  initialBaseVersion?: number;
+  initialTargetVersion?: number;
+}
+
+/**
+ * Dialog displaying a side-by-side Monaco DiffEditor comparing values between two revisions.
+ */
+export function RevisionDiffDialog({
+  open,
+  onClose,
+  releaseName,
+  releaseNamespace,
+  releases,
+  initialBaseVersion,
+  initialTargetVersion,
+}: RevisionDiffDialogProps) {
+  const { t } = useTranslation();
+  const sortedReleases = useMemo(
+    () => (releases ? [...releases].sort((a, b) => b.version - a.version) : []),
+    [releases]
+  );
+
+  const defaultTarget = useMemo(() => {
+    if (initialTargetVersion !== undefined) return initialTargetVersion;
+    return sortedReleases.length > 0 ? sortedReleases[0].version : 1;
+  }, [initialTargetVersion, sortedReleases]);
+
+  const defaultBase = useMemo(() => {
+    if (initialBaseVersion !== undefined) return initialBaseVersion;
+    if (sortedReleases.length > 1) {
+      return sortedReleases[1].version;
+    }
+    return sortedReleases.length > 0 ? sortedReleases[0].version : 1;
+  }, [initialBaseVersion, sortedReleases]);
+
+  const [baseVersion, setBaseVersion] = useState<number>(defaultBase);
+  const [targetVersion, setTargetVersion] = useState<number>(defaultTarget);
+  const [isUserValuesOnly, setIsUserValuesOnly] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setBaseVersion(defaultBase);
+      setTargetVersion(defaultTarget);
+    }
+  }, [open, defaultBase, defaultTarget]);
+
+  const themeName =
+    typeof window !== 'undefined' ? localStorage.getItem('headlampThemePreference') : null;
+
+  const baseRelease = useMemo(
+    () => sortedReleases.find(r => r.version === baseVersion),
+    [sortedReleases, baseVersion]
+  );
+
+  const targetRelease = useMemo(
+    () => sortedReleases.find(r => r.version === targetVersion),
+    [sortedReleases, targetVersion]
+  );
+
+  const baseYaml = useMemo(() => {
+    if (!baseRelease) return '';
+    const userConfig = baseRelease.config || {};
+    const chartValues = baseRelease.chart?.values || {};
+    const valuesObj = isUserValuesOnly ? userConfig : Object.assign({}, chartValues, userConfig);
+    return jsonToYAML(valuesObj);
+  }, [baseRelease, isUserValuesOnly]);
+
+  const targetYaml = useMemo(() => {
+    if (!targetRelease) return '';
+    const userConfig = targetRelease.config || {};
+    const chartValues = targetRelease.chart?.values || {};
+    const valuesObj = isUserValuesOnly ? userConfig : Object.assign({}, chartValues, userConfig);
+    return jsonToYAML(valuesObj);
+  }, [targetRelease, isUserValuesOnly]);
+
+  const handleSwap = () => {
+    setBaseVersion(targetVersion);
+    setTargetVersion(baseVersion);
+  };
+
+  return (
+    <Dialog
+      open={open}
+      maxWidth="lg"
+      fullWidth
+      withFullScreen
+      onClose={onClose}
+      title={
+        releaseNamespace
+          ? t('Compare Revisions - {{ releaseName }} ({{ releaseNamespace }})', {
+              releaseName,
+              releaseNamespace,
+            })
+          : t('Compare Revisions - {{ releaseName }}', { releaseName })
+      }
+    >
+      <Box px={3} pt={1} pb={1} display="flex" flexDirection="column" gap={1.5}>
+        <Grid container spacing={2} alignItems="center">
+          <Grid item xs={12} sm={5}>
+            <FormControl fullWidth size="small">
+              <InputLabel id="base-revision-label">{t('Base Revision')}</InputLabel>
+              <Select
+                labelId="base-revision-label"
+                id="base-revision-select"
+                value={baseVersion}
+                label={t('Base Revision')}
+                onChange={e => setBaseVersion(Number(e.target.value))}
+              >
+                {sortedReleases.map(r => (
+                  <MenuItem key={r.version} value={r.version}>
+                    {t('Revision {{ version }}', { version: r.version })}
+                    {r.chart?.metadata?.version ? ` (${r.chart.metadata.version})` : ''}
+                    {r.info?.last_deployed
+                      ? ` - ${new Date(r.info.last_deployed).toLocaleDateString()}`
+                      : ''}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Grid>
+          <Grid item xs={12} sm={2} textAlign="center">
+            <Tooltip title={t('Swap revisions')}>
+              <IconButton onClick={handleSwap} size="small" aria-label={t('Swap revisions')}>
+                <Icon icon="mdi:swap-horizontal" width={24} height={24} />
+              </IconButton>
+            </Tooltip>
+          </Grid>
+          <Grid item xs={12} sm={5}>
+            <FormControl fullWidth size="small">
+              <InputLabel id="target-revision-label">{t('Compare With')}</InputLabel>
+              <Select
+                labelId="target-revision-label"
+                id="target-revision-select"
+                value={targetVersion}
+                label={t('Compare With')}
+                onChange={e => setTargetVersion(Number(e.target.value))}
+              >
+                {sortedReleases.map(r => (
+                  <MenuItem key={r.version} value={r.version}>
+                    {t('Revision {{ version }}', { version: r.version })}
+                    {r.chart?.metadata?.version ? ` (${r.chart.metadata.version})` : ''}
+                    {r.info?.last_deployed
+                      ? ` - ${new Date(r.info.last_deployed).toLocaleDateString()}`
+                      : ''}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Grid>
+        </Grid>
+        <Box display="flex" justifyContent="space-between" alignItems="center">
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={isUserValuesOnly}
+                onChange={e => setIsUserValuesOnly(e.target.checked)}
+                inputProps={{ 'aria-label': t('Show user defined values only') }}
+                size="small"
+              />
+            }
+            label={<Typography variant="body2">{t('User defined values only')}</Typography>}
+          />
+          <Typography variant="caption" color="textSecondary">
+            {baseVersion === targetVersion
+              ? t('Both panes display the same revision')
+              : t('Left: Revision {{ base }} | Right: Revision {{ target }}', {
+                  base: baseVersion,
+                  target: targetVersion,
+                })}
+          </Typography>
+        </Box>
+      </Box>
+      <DialogContent sx={{ p: 2, height: '520px' }}>
+        <DiffEditor
+          original={baseYaml}
+          modified={targetYaml}
+          language="yaml"
+          height="100%"
+          theme={themeName === 'dark' ? 'vs-dark' : 'light'}
+          options={{
+            readOnly: true,
+            renderSideBySide: true,
+            minimap: { enabled: false },
+            scrollBeyondLastLine: false,
+            automaticLayout: true,
+          }}
+        />
+      </DialogContent>
+      <DialogActions sx={{ px: 3, py: 1.5 }}>
+        <Button onClick={onClose} variant="outlined">
+          {t('Close')}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/app-catalog/src/components/releases/RevisionValuesDialog.test.tsx
+++ b/app-catalog/src/components/releases/RevisionValuesDialog.test.tsx
@@ -1,0 +1,167 @@
+/** @vitest-environment jsdom */
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { RevisionValuesDialog } from './RevisionValuesDialog';
+
+const mockEnqueueSnackbar = vi.fn();
+
+vi.mock('notistack', () => ({
+  useSnackbar: () => ({
+    enqueueSnackbar: mockEnqueueSnackbar,
+  }),
+}));
+
+vi.mock('@kinvolk/headlamp-plugin/lib', () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, any>) => {
+      if (!params) return key;
+      return Object.entries(params).reduce(
+        (acc, [k, v]) => acc.replace(`{{ ${k} }}`, String(v)).replace(`{{${k}}}`, String(v)),
+        key
+      );
+    },
+  }),
+}));
+
+vi.mock('@kinvolk/headlamp-plugin/lib/CommonComponents', () => ({
+  Dialog: ({ open, title, children }: any) =>
+    open ? (
+      <div role="dialog" aria-label={title}>
+        <h2>{title}</h2>
+        {children}
+      </div>
+    ) : null,
+}));
+
+vi.mock('@monaco-editor/react', () => ({
+  default: ({ value }: any) => <textarea data-testid="mock-monaco-editor" value={value} readOnly />,
+}));
+
+describe('RevisionValuesDialog', () => {
+  const mockRevision = {
+    version: 2,
+    chart: {
+      metadata: {
+        name: 'my-chart',
+        version: '1.2.0',
+        appVersion: '2.0.0',
+      },
+      values: {
+        replicaCount: 1,
+        image: { repository: 'nginx', tag: 'latest' },
+      },
+    },
+    config: {
+      replicaCount: 3,
+    },
+    info: {
+      description: 'Upgrade release to 1.2.0',
+      status: 'deployed',
+      last_deployed: '2026-09-01T10:00:00Z',
+    },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders nothing when closed', () => {
+    render(
+      <RevisionValuesDialog
+        open={false}
+        onClose={vi.fn()}
+        releaseName="test-release"
+        releaseNamespace="default"
+        revision={mockRevision}
+      />
+    );
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('renders dialog with revision details and computed values', () => {
+    render(
+      <RevisionValuesDialog
+        open
+        onClose={vi.fn()}
+        releaseName="test-release"
+        releaseNamespace="default"
+        revision={mockRevision}
+      />
+    );
+
+    expect(screen.getByRole('dialog')).toBeDefined();
+    expect(screen.getByText('my-chart')).toBeDefined();
+    expect(screen.getAllByText(/1\.2\.0/).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('2.0.0')).toBeDefined();
+
+    const editor = screen.getByTestId('mock-monaco-editor') as HTMLTextAreaElement;
+    expect(editor.value).toContain('replicaCount: 3');
+    expect(editor.value).toContain('repository: nginx');
+  });
+
+  it('toggles user defined values only', () => {
+    render(
+      <RevisionValuesDialog
+        open
+        onClose={vi.fn()}
+        releaseName="test-release"
+        releaseNamespace="default"
+        revision={mockRevision}
+      />
+    );
+
+    const checkbox = screen.getByRole('checkbox', { name: /Show user defined values only/i });
+    expect((checkbox as HTMLInputElement).checked).toBe(false);
+
+    fireEvent.click(checkbox);
+    expect((checkbox as HTMLInputElement).checked).toBe(true);
+
+    const editor = screen.getByTestId('mock-monaco-editor') as HTMLTextAreaElement;
+    expect(editor.value).toContain('replicaCount: 3');
+    expect(editor.value).not.toContain('repository: nginx');
+  });
+
+  it('copies YAML content to clipboard on copy button click', async () => {
+    render(
+      <RevisionValuesDialog
+        open
+        onClose={vi.fn()}
+        releaseName="test-release"
+        releaseNamespace="default"
+        revision={mockRevision}
+      />
+    );
+
+    const copyBtn = screen.getByRole('button', { name: /Copy to clipboard/i });
+    fireEvent.click(copyBtn);
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalled();
+  });
+
+  it('calls onClose when Close button is clicked', () => {
+    const handleClose = vi.fn();
+    render(
+      <RevisionValuesDialog
+        open
+        onClose={handleClose}
+        releaseName="test-release"
+        releaseNamespace="default"
+        revision={mockRevision}
+      />
+    );
+
+    const closeBtn = screen.getByRole('button', { name: /Close/i });
+    fireEvent.click(closeBtn);
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app-catalog/src/components/releases/RevisionValuesDialog.tsx
+++ b/app-catalog/src/components/releases/RevisionValuesDialog.tsx
@@ -1,0 +1,149 @@
+import { Icon } from '@iconify/react';
+import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
+import { Dialog } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import Editor from '@monaco-editor/react';
+import {
+  Box,
+  Button,
+  Checkbox,
+  DialogActions,
+  DialogContent,
+  FormControlLabel,
+  IconButton,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import { useSnackbar } from 'notistack';
+import React, { useMemo, useState } from 'react';
+import { jsonToYAML } from '../../helpers';
+
+export interface RevisionValuesDialogProps {
+  open: boolean;
+  onClose: () => void;
+  releaseName: string;
+  releaseNamespace: string;
+  revision: any | null;
+}
+
+/**
+ * Dialog displaying read-only Helm values for a specific release revision.
+ */
+export function RevisionValuesDialog({
+  open,
+  onClose,
+  releaseName,
+  releaseNamespace,
+  revision,
+}: RevisionValuesDialogProps) {
+  const { t } = useTranslation();
+  const { enqueueSnackbar } = useSnackbar();
+  const [isUserValuesOnly, setIsUserValuesOnly] = useState(false);
+
+  const themeName =
+    typeof window !== 'undefined' ? localStorage.getItem('headlampThemePreference') : null;
+
+  const yamlContent = useMemo(() => {
+    if (!revision) return '';
+    const userConfig = revision.config || {};
+    const chartValues = revision.chart?.values || {};
+    const valuesObj = isUserValuesOnly ? userConfig : Object.assign({}, chartValues, userConfig);
+    return jsonToYAML(valuesObj);
+  }, [revision, isUserValuesOnly]);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(yamlContent);
+      enqueueSnackbar(t('Values copied to clipboard'), { variant: 'success' });
+    } catch {
+      enqueueSnackbar(t('Failed to copy values to clipboard'), { variant: 'error' });
+    }
+  };
+
+  if (!revision) return null;
+
+  const chartName = revision.chart?.metadata?.name || '';
+  const chartVersion = revision.chart?.metadata?.version || '';
+  const appVersion = revision.chart?.metadata?.appVersion || '';
+
+  return (
+    <Dialog
+      open={open}
+      maxWidth="md"
+      fullWidth
+      withFullScreen
+      onClose={onClose}
+      title={
+        releaseNamespace
+          ? t('Revision {{ version }} Values - {{ releaseName }} ({{ releaseNamespace }})', {
+              version: revision.version,
+              releaseName,
+              releaseNamespace,
+            })
+          : t('Revision {{ version }} Values - {{ releaseName }}', {
+              version: revision.version,
+              releaseName,
+            })
+      }
+    >
+      <Box px={3} pt={1} pb={0} display="flex" flexDirection="column" gap={1}>
+        <Box display="flex" justifyContent="space-between" alignItems="center" flexWrap="wrap">
+          <Box display="flex" gap={2} alignItems="center">
+            {chartName && (
+              <Typography variant="body2" color="textSecondary">
+                {t('Chart')}: <strong>{chartName}</strong> ({chartVersion})
+              </Typography>
+            )}
+            {appVersion && (
+              <Typography variant="body2" color="textSecondary">
+                {t('App Version')}: <strong>{appVersion}</strong>
+              </Typography>
+            )}
+            {revision.info?.description && (
+              <Typography variant="body2" color="textSecondary">
+                {revision.info.description}
+              </Typography>
+            )}
+          </Box>
+          <Box display="flex" alignItems="center" gap={1}>
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={isUserValuesOnly}
+                  onChange={e => setIsUserValuesOnly(e.target.checked)}
+                  inputProps={{ 'aria-label': t('Show user defined values only') }}
+                  size="small"
+                />
+              }
+              label={<Typography variant="body2">{t('User defined values only')}</Typography>}
+            />
+            <Tooltip title={t('Copy to clipboard')}>
+              <IconButton onClick={handleCopy} size="small" aria-label={t('Copy to clipboard')}>
+                <Icon icon="mdi:content-copy" width={20} height={20} />
+              </IconButton>
+            </Tooltip>
+          </Box>
+        </Box>
+      </Box>
+      <DialogContent sx={{ p: 2, height: '500px' }}>
+        <Editor
+          value={yamlContent}
+          language="yaml"
+          height="100%"
+          theme={themeName === 'dark' ? 'vs-dark' : 'light'}
+          options={{
+            readOnly: true,
+            lineNumbers: 'on',
+            minimap: { enabled: false },
+            scrollBeyondLastLine: false,
+            automaticLayout: true,
+          }}
+        />
+      </DialogContent>
+      <DialogActions sx={{ px: 3, py: 1.5 }}>
+        <Button onClick={onClose} variant="outlined">
+          {t('Close')}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary
Adds an in-app Helm revision values inspector and a side-by-side Monaco diff editor to the App Catalog plugin (`Apps -> Installed -> <Release>`), addressing #1269. Also fixes the status evaluation bug in historical revisions.

## Changes

### 1. Revision Values Viewer (`RevisionValuesDialog.tsx`)
- Adds a "View Values" action in the History table for each revision.
- Opens a read-only Monaco Editor displaying the YAML values of that specific revision.
- Allows toggling between:
  - "User defined values only" (`release.config`)
  - Full merged values including chart defaults (`chart.values + config`)
- Includes a copy-to-clipboard action.

### 2. Revision Diff Viewer (`RevisionDiffDialog.tsx`)
- Adds a "Compare Revisions" action button to the History section header.
- Adds an inline "Compare with current" action on each historical row.
- Renders a side-by-side Monaco `DiffEditor` comparing any two revisions.
- Provides base and target dropdown selectors with a one-click swap action.
- Supports diffing either user overrides or full computed values.
- Automatically synchronizes with Headlamp light and dark themes.

### 3. Release Detail Improvements (`Detail.tsx`)
- Corrects line 293 where `release?.info.status` (current release status) was checked instead of `data.info.status` (individual revision status).
- Ensures the rollback dialog initializes `revertVersion` when opened, preventing invalid rollback requests.
- Integrates both new dialogs into the History section.

### 4. Internationalization & Tests
- Adds all new user-facing strings to `locales/en/translation.json` with `useTranslation()`.
- Adds unit tests in `RevisionValuesDialog.test.tsx` and `RevisionDiffDialog.test.tsx` covering dialog rendering, values switching, clipboard copying, and diff comparisons.

## Validation
- All 10 unit tests pass (`vitest run`).
- ESLint passed with 0 errors and 0 warnings (`eslint -c package.json`).
- Prettier formatting check passed (`prettier --check`).

Fixes #1269
