### PR TITLE
ai-assistant: Add resource details header action for direct AI troubleshooting

### DIFF
--- a/ai-assistant/src/components/details/ResourceAIAction.test.tsx
+++ b/ai-assistant/src/components/details/ResourceAIAction.test.tsx
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ResourceAIAction } from './ResourceAIAction';
+
+const mockSetEvent = vi.fn();
+const mockSetIsUIPanelOpen = vi.fn();
+const mockSetInitialPrompt = vi.fn();
+let mockPluginConfig: { previewEnabled?: boolean } = { previewEnabled: true };
+
+vi.mock('@kinvolk/headlamp-plugin/lib', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('../../pluginState', () => ({
+  useGlobalState: () => ({
+    event: null,
+    setEvent: mockSetEvent,
+    isUIPanelOpen: false,
+    setIsUIPanelOpen: mockSetIsUIPanelOpen,
+    initialPrompt: '',
+    setInitialPrompt: mockSetInitialPrompt,
+  }),
+  usePluginConfig: () => mockPluginConfig,
+}));
+
+describe('ResourceAIAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPluginConfig = { previewEnabled: true };
+  });
+
+  it('renders the Ask AI button when item is provided and preview is enabled', () => {
+    const item = { kind: 'Pod', metadata: { name: 'test-pod' } };
+    render(<ResourceAIAction item={item} />);
+
+    const button = screen.getByRole('button', { name: 'Ask AI' });
+    expect(button).toBeDefined();
+  });
+
+  it('populates event, initialPrompt, and opens panel on click', () => {
+    const item = {
+      kind: 'Deployment',
+      metadata: { name: 'nginx-deployment', namespace: 'default' },
+    };
+    render(<ResourceAIAction item={item} />);
+
+    const button = screen.getByRole('button', { name: 'Ask AI' });
+    fireEvent.click(button);
+
+    expect(mockSetEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'headlamp.details-view',
+        title: 'Deployment: nginx-deployment',
+        resource: item,
+        resourceKind: 'Deployment',
+      })
+    );
+    expect(mockSetInitialPrompt).toHaveBeenCalledWith(
+      'Diagnose status of Deployment nginx-deployment'
+    );
+    expect(mockSetIsUIPanelOpen).toHaveBeenCalledWith(true);
+  });
+
+  it('falls back gracefully when item has no kind or name', () => {
+    const item = {};
+    render(<ResourceAIAction item={item} />);
+
+    const button = screen.getByRole('button', { name: 'Ask AI' });
+    fireEvent.click(button);
+
+    expect(mockSetEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'headlamp.details-view',
+        title: 'Resource',
+        resource: item,
+        resourceKind: '',
+      })
+    );
+    expect(mockSetInitialPrompt).toHaveBeenCalledWith('Diagnose status of this resource');
+    expect(mockSetIsUIPanelOpen).toHaveBeenCalledWith(true);
+  });
+
+  it('returns null when item is undefined', () => {
+    const { container } = render(<ResourceAIAction />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('returns null when previewEnabled is false', () => {
+    mockPluginConfig = { previewEnabled: false };
+    const item = { kind: 'Pod', metadata: { name: 'test-pod' } };
+    const { container } = render(<ResourceAIAction item={item} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/ai-assistant/src/components/details/ResourceAIAction.tsx
+++ b/ai-assistant/src/components/details/ResourceAIAction.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
+import { ActionButton } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import React from 'react';
+import { type HeadlampEventPayload, useGlobalState, usePluginConfig } from '../../pluginState';
+
+export interface ResourceAIActionProps {
+  /** The Kubernetes resource whose details view is currently open. */
+  item?: any;
+}
+
+/**
+ * Details view header action button that directly opens the AI Assistant
+ * drawer with the active resource bound into context and an initial prompt pre-populated.
+ *
+ * @param props - Component props containing the active resource item.
+ * @returns An ActionButton or null if disabled/unavailable.
+ */
+export function ResourceAIAction({ item }: ResourceAIActionProps): React.ReactElement | null {
+  const pluginState = useGlobalState();
+  const pluginConfig = usePluginConfig();
+  const { t } = useTranslation();
+
+  const previewEnabled = pluginConfig?.previewEnabled ?? true;
+  if (!previewEnabled || !item) {
+    return null;
+  }
+
+  const handleAskAI = () => {
+    const resourceKind = item.kind || item.jsonData?.kind || '';
+    const resourceName = item.metadata?.name || item.jsonData?.metadata?.name || item.name || '';
+
+    const title =
+      resourceKind && resourceName
+        ? `${resourceKind}: ${resourceName}`
+        : resourceKind || resourceName || 'Resource';
+
+    pluginState.setEvent({
+      ...pluginState.event,
+      type: 'headlamp.details-view',
+      title,
+      resource: item,
+      resourceKind,
+    } as HeadlampEventPayload);
+
+    const prompt =
+      resourceKind && resourceName
+        ? `Diagnose status of ${resourceKind} ${resourceName}`
+        : resourceKind
+        ? `Diagnose status of this ${resourceKind}`
+        : 'Diagnose status of this resource';
+
+    pluginState.setInitialPrompt?.(prompt);
+    pluginState.setIsUIPanelOpen(true);
+  };
+
+  const askAiLabel = t('Ask AI');
+
+  return <ActionButton description={askAiLabel} icon="mdi:robot-outline" onClick={handleAskAI} />;
+}
+
+export default ResourceAIAction;

--- a/ai-assistant/src/index.tsx
+++ b/ai-assistant/src/index.tsx
@@ -19,6 +19,7 @@ import '@headlamp-k8s/ai-ui/icons/iconBundles';
 import { proactiveDiagnosisManager } from '@headlamp-k8s/ai-ui/diagnosis/ProactiveDiagnosisManager';
 import {
   registerAppBarAction,
+  registerDetailsViewHeaderAction,
   registerPluginSettings,
   registerResourceTableColumnsProcessor,
   registerUIPanel,
@@ -29,6 +30,7 @@ import Event from '@kinvolk/headlamp-plugin/lib/K8s/event';
 import React from 'react';
 import HeadlampAIPrompt from './components/appbar/HeadlampAIPrompt';
 import HeadlampEventHandler from './components/appbar/HeadlampEventHandler';
+import { ResourceAIAction } from './components/details/ResourceAIAction';
 import AIPanelComponent from './components/panel/AIPanelComponent';
 import Settings from './components/settings/Settings';
 import type { RawK8sEvent } from './kubernetes/EventFetcher';
@@ -49,6 +51,8 @@ registerUIPanel({
 registerAppBarAction(HeadlampAIPrompt);
 
 registerAppBarAction(HeadlampEventHandler);
+
+registerDetailsViewHeaderAction(ResourceAIAction);
 
 registerPluginSettings(PLUGIN_NAME, Settings);
 
@@ -123,3 +127,4 @@ registerResourceTableColumnsProcessor(function addAIDiagnosisToEvents({ id, colu
 
 // Export the cluster change notifier for external use
 export { useClusterChangeNotifier, ClusterChangeNotifier } from './hooks/useClusterChangeNotifier';
+export { ResourceAIAction } from './components/details/ResourceAIAction';

--- a/ai-assistant/src/modal.tsx
+++ b/ai-assistant/src/modal.tsx
@@ -1744,6 +1744,14 @@ export default function AIPrompt(props: {
     }
   }, [apiError, dynamicPrompts]);
 
+  // Set initial prompt when triggered by an external action (e.g. details view header action)
+  useEffect(() => {
+    if (_pluginSetting?.initialPrompt) {
+      setPromptVal(_pluginSetting.initialPrompt);
+      _pluginSetting.setInitialPrompt('');
+    }
+  }, [_pluginSetting?.initialPrompt]);
+
   const disableSettingsButton = useMemo(() => {
     // Compensate the @ symbol not getting encoded in the history's URL
     const currentURL = location.pathname.replace(/@/g, '%40');

--- a/ai-assistant/src/pluginState.tsx
+++ b/ai-assistant/src/pluginState.tsx
@@ -280,6 +280,7 @@ function usePluginSettings() {
 
   // Add state to control UI panel visibility - always start closed (don't restore from storage)
   const [isUIPanelOpen, setIsUIPanelOpenState] = React.useState(false);
+  const [initialPrompt, setInitialPrompt] = React.useState('');
 
   // Add state for enabled tools - will be initialized properly using initializeToolsState
   const [enabledTools, setEnabledToolsState] = React.useState<string[]>([]);
@@ -353,6 +354,8 @@ function usePluginSettings() {
     setActiveProvider,
     isUIPanelOpen,
     setIsUIPanelOpen,
+    initialPrompt,
+    setInitialPrompt,
     enabledTools,
     setEnabledTools,
     toolsInitialized,


### PR DESCRIPTION
### Description

This pull request implements a resource details view header action ("Ask AI") in the `ai-assistant` plugin, resolving issue #1273.

### Changes

1. **Details View Header Action (`ResourceAIAction.tsx`):**
   - Implemented `ResourceAIAction` component registered via Headlamp's `registerDetailsViewHeaderAction`.
   - Renders an "Ask AI" action button with the `mdi:robot-outline` icon on any active resource details page.
   - Respects plugin preview settings, hiding when `previewEnabled` is false.

2. **Context Binding and Drawer Integration:**
   - On button click, extracts the active resource kind and name from `item`.
   - Updates `pluginState.setEvent` with `type: 'headlamp.details-view'`, setting `resource`, `resourceKind`, and formatted `title`.
   - Opens the AI Assistant panel via `pluginState.setIsUIPanelOpen(true)`.

3. **Prompt Pre-population:**
   - Added `initialPrompt` state and setter to `pluginState.tsx`.
   - Pre-fills the assistant input in `modal.tsx` with a tailored prompt (`Diagnose status of <kind> <name>`) when opened via "Ask AI", allowing users to immediately execute diagnosis or refine their question.

4. **Localization & Testing:**
   - All user-facing strings are wrapped with `t()`.
   - Added comprehensive unit tests in `ResourceAIAction.test.tsx` verifying action rendering, state dispatching, prompt pre-population, and graceful handling of missing or disabled items (5/5 passing).

### Testing Done

- Unit tests:
  - `npx vitest run src/components/details/ResourceAIAction.test.tsx` (5/5 passed).
  - `npx vitest run src/pluginState.test.ts src/prompts/promptGenerator.test.ts` (21/21 passed).
- Linting: ESLint passed with 0 errors and 0 warnings.
- TypeScript: `tsc --noEmit` passed with 0 errors.
- Prettier: `prettier --check` passed cleanly across all modified files.

Fixes #1273

Signed-off-by: Aamod007 <aamodkumar2006@gmail.com>
