### PR TITLE
fix(kro): default omitted replicas to 1 instead of 0

### DIFF
--- a/kro/src/resources/subResources.test.ts
+++ b/kro/src/resources/subResources.test.ts
@@ -14,6 +14,13 @@ describe('getSubResourceHealth', () => {
       status: 'error',
       label: '0/0 ready',
     });
+    // Kubernetes defaults spec.replicas to 1 when omitted, so this is healthy.
+    expect(
+      getSubResourceHealth('Deployment', { spec: {}, status: { readyReplicas: 1 } })
+    ).toEqual({ status: 'success', label: '1/1 ready' });
+    expect(
+      getSubResourceHealth('StatefulSet', { spec: {}, status: { readyReplicas: 1 } })
+    ).toEqual({ status: 'success', label: '1/1 ready' });
   });
 
   it('maps PVC phases', () => {
@@ -66,6 +73,9 @@ describe('getResolvedValues', () => {
     expect(
       getResolvedValues('Deployment', { spec: { replicas: 2 }, status: { readyReplicas: 2 } })
     ).toBe('replicas: 2/2');
+    expect(getResolvedValues('Deployment', { spec: {}, status: { readyReplicas: 1 } })).toBe(
+      'replicas: 1/1'
+    );
     expect(
       getResolvedValues('Service', { spec: { type: 'ClusterIP', clusterIP: '10.0.0.1' } })
     ).toBe('type: ClusterIP, clusterIP: 10.0.0.1');

--- a/kro/src/resources/subResources.ts
+++ b/kro/src/resources/subResources.ts
@@ -46,7 +46,8 @@ function findCondition(resource: any, type: string): KubeCondition | undefined {
 export function getSubResourceHealth(kind: string, resource: any): SubResourceHealth {
   switch (kind) {
     case 'Deployment': {
-      const desired = resource?.spec?.replicas ?? 0;
+      // Kubernetes defaults spec.replicas to 1 when the field is omitted.
+      const desired = resource?.spec?.replicas ?? 1;
       const ready = resource?.status?.readyReplicas ?? 0;
       return {
         status: desired > 0 && ready >= desired ? 'success' : 'error',
@@ -54,7 +55,7 @@ export function getSubResourceHealth(kind: string, resource: any): SubResourceHe
       };
     }
     case 'StatefulSet': {
-      const desired = resource?.spec?.replicas ?? 0;
+      const desired = resource?.spec?.replicas ?? 1;
       const ready = resource?.status?.readyReplicas ?? 0;
       return {
         status: desired > 0 && ready >= desired ? 'success' : 'error',
@@ -133,7 +134,7 @@ export function getResolvedValues(kind: string, resource: any): string {
     }
     case 'Deployment':
     case 'StatefulSet': {
-      const desired = resource?.spec?.replicas ?? 0;
+      const desired = resource?.spec?.replicas ?? 1;
       const ready = resource?.status?.readyReplicas ?? 0;
       return `replicas: ${ready}/${desired}`;
     }


### PR DESCRIPTION
## Summary

Fixes the kro plugin's sub-resource health check treating a healthy Deployment or StatefulSet as unhealthy when `spec.replicas` is omitted from the manifest.

## Related Issue

Fixes #1259

## Changes

- `kro/src/resources/subResources.ts`: default `desired` replicas to `1` instead of `0` for the `Deployment` and `StatefulSet` cases in both `getSubResourceHealth` and `getResolvedValues`, matching Kubernetes' own default for an omitted `spec.replicas`.
- `kro/src/resources/subResources.test.ts`: added coverage for a Deployment/StatefulSet with `spec.replicas` omitted and one ready replica, asserting a success status and "1/1 ready" instead of the previous "1/0 ready" error.

## Steps to Test

1. `cd kro && npm install`
2. `npx vitest run src/resources/subResources.test.ts` - all tests pass, including the new cases.
3. Optionally, create a kro `ResourceGraphDefinition` with a Deployment that omits `spec.replicas`, create an instance, and check the Instance Detail page's Sub-resources section shows a green success badge with "1/1 ready" once the pod is up, instead of a red error badge showing "1/0 ready".

## Screenshots (if applicable)

N/A, no visual change beyond the badge color/label for this specific case, and I did not have a live cluster to capture a screenshot against.

## Notes for the Reviewer

- The existing test asserting `spec.replicas: 0` still returns an error status is unchanged and still passes, since `?? 1` only applies when the field is missing/undefined, not when it is explicitly `0`.
