### PR TITLE
flux: Check condition status, not just presence, for Ready column

### DIFF
--- a/flux/src/helm-releases/Inventory.tsx
+++ b/flux/src/helm-releases/Inventory.tsx
@@ -109,14 +109,13 @@ export function HelmInventory(props: Readonly<{ name: string; namespace: string 
         {
           header: 'Ready',
           accessorFn: item => {
-            if (item.status) {
-              return item.status.conditions?.findIndex(
-                c => c.type === 'Ready' || c.type === 'Available' || c.type === 'NamesAccepted'
-              ) !== -1
-                ? 'True'
-                : 'False';
+            const condition = item.status?.conditions?.find(
+              c => c.type === 'Ready' || c.type === 'Available' || c.type === 'NamesAccepted'
+            );
+            if (!condition) {
+              return item.status ? 'False' : '';
             }
-            return '';
+            return condition.status === 'True' ? 'True' : 'False';
           },
         },
         {

--- a/flux/src/kustomizations/Inventory.tsx
+++ b/flux/src/kustomizations/Inventory.tsx
@@ -108,12 +108,11 @@ export function GetResourcesFromInventory(
         {
           header: t('Ready'),
           accessorFn: (item: KubeObject) => {
-            if (item.jsonData?.status) {
-              return item.jsonData.status.conditions?.findIndex(c => c.type === 'Ready') !== -1
-                ? t('True')
-                : t('False');
+            const ready = item.jsonData?.status?.conditions?.find(c => c.type === 'Ready');
+            if (!ready) {
+              return t('Unknown');
             }
-            return t('Unknown');
+            return ready.status === 'True' ? t('True') : t('False');
           },
         },
         {


### PR DESCRIPTION
The Kustomization and HelmRelease inventory tables computed Ready by checking whether a Ready/Available/NamesAccepted condition type was present in the list, not what its status was. A resource whose Ready condition was False still showed as Ready = True.

Use the condition's actual status instead, matching how StatusLabel.tsx already does it elsewhere in this plugin.