### PR TITLE
kueue: Fix namespaceSelector nil vs empty semantics

### DIFF
--- a/kueue/src/resources/clusterQueue.test.ts
+++ b/kueue/src/resources/clusterQueue.test.ts
@@ -82,7 +82,7 @@ describe('ClusterQueue formatters', () => {
   });
 
   it('formats namespace selectors', () => {
-    expect(renderLabelSelector()).toBe('All namespaces');
+    expect(renderLabelSelector()).toBe('No namespaces');
     expect(renderLabelSelector({})).toBe('All namespaces');
     expect(renderLabelSelector({ matchLabels: { team: 'platform' } })).toBe('team=platform');
     expect(

--- a/kueue/src/resources/clusterQueueFormatters.ts
+++ b/kueue/src/resources/clusterQueueFormatters.ts
@@ -242,8 +242,10 @@ export function renderStringList(values: string[]) {
 
 /** Render a Kubernetes label selector as compact detail text. */
 export function renderLabelSelector(selector?: LabelSelectorLike) {
+  // Kueue defaults namespaceSelector to nil, meaning no namespaces are eligible.
+  // An explicit empty selector ({}) is what matches every namespace.
   if (!selector) {
-    return 'All namespaces';
+    return 'No namespaces';
   }
 
   const labels = Object.entries(selector.matchLabels || {}).map(


### PR DESCRIPTION
Per the Kueue API, a nil namespaceSelector means no namespaces are eligible, while an explicit empty selector matches every namespace. renderLabelSelector had this backwards, showing All namespaces for a ClusterQueue that actually admits none.