### PR TITLE
Fix deprecated Gemini model IDs in provider catalog

### DIFF
--- a/ai-assistant/packages/ai-common/src/providers/catalog.ts
+++ b/ai-assistant/packages/ai-common/src/providers/catalog.ts
@@ -277,10 +277,9 @@ export const modelProviders: ModelProvider[] = [
         type: 'select',
         required: true,
         options: [
-          'gemini-3-pro-preview',
-          'gemini-2.5-pro',
+          'gemini-3.1-pro-preview',
           'gemini-2.5-flash',
-          'gemini-2.5-flash-lite',
+          'gemini-3.5-flash-lite',
         ],
         default: 'gemini-2.5-flash',
       },


### PR DESCRIPTION
Google has deprecated several Gemini model IDs used in the provider catalog, causing API errors like:

```
This model models/gemini-2.5-pro is no longer available to new users.
Please update your code to use models/gemini-3.1-pro-preview...
```

This PR updates the Gemini model list in `catalog.ts` to currently-available replacements:

| Deprecated model | Status | Replacement |
|---|---|---|
| `gemini-3-pro-preview` | Shut down Nov 18, 2025 | `gemini-3.1-pro-preview` |
| `gemini-2.5-pro` | Deprecated | `gemini-3.1-pro-preview` (removed as a duplicate — already covered above) |
| `gemini-2.5-flash-lite` | Deprecated | `gemini-3.5-flash-lite` |

`gemini-2.5-flash` is kept as-is (still GA, no shutdown announced) and remains the default.


You can take look at the deprecated models in [Gemini deprecations page](https://ai.google.dev/gemini-api/docs/deprecations).