### PR TITLE
metal3: BareMetalHost: Use the disk type field instead of rotational

### DIFF
--- a/metal3/src/BareMetalHost/Details.tsx
+++ b/metal3/src/BareMetalHost/Details.tsx
@@ -23,6 +23,7 @@ import {
 } from '@kinvolk/headlamp-plugin/lib/components/common';
 import { useParams } from 'react-router-dom';
 import { CRDGuard } from '../common/CRDGuard';
+import { formatDiskType } from './diskType';
 import { bareMetalHostClass } from './List';
 
 /** Bytes as a short size string, terabytes when large, gigabytes otherwise. */
@@ -151,7 +152,7 @@ export function BareMetalHostDetail(props: { name?: string; namespace?: string }
                     { label: 'Disk', getter: (d: any) => d.name || '-' },
                     { label: 'Model', getter: (d: any) => d.model || '-' },
                     { label: 'Size', getter: (d: any) => formatBytes(d.sizeBytes) },
-                    { label: 'Type', getter: (d: any) => (d.rotational ? 'HDD' : 'SSD') },
+                    { label: 'Type', getter: (d: any) => formatDiskType(d) },
                   ]}
                   data={hw.storage}
                 />

--- a/metal3/src/BareMetalHost/diskType.test.ts
+++ b/metal3/src/BareMetalHost/diskType.test.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { formatDiskType } from './diskType';
+
+describe('formatDiskType', () => {
+  it('uses the reported type, including NVME', () => {
+    expect(formatDiskType({ type: 'HDD' })).toBe('HDD');
+    expect(formatDiskType({ type: 'SSD' })).toBe('SSD');
+    expect(formatDiskType({ type: 'NVME' })).toBe('NVME');
+  });
+
+  it('prefers type over the deprecated rotational flag', () => {
+    // An NVMe drive is not rotational, but it is not an SSD either.
+    expect(formatDiskType({ type: 'NVME', rotational: false })).toBe('NVME');
+    expect(formatDiskType({ type: 'HDD', rotational: true })).toBe('HDD');
+  });
+
+  it('reports an unknown type as unknown rather than guessing SSD', () => {
+    expect(formatDiskType({})).toBe('-');
+    expect(formatDiskType(undefined)).toBe('-');
+    expect(formatDiskType({ type: '' })).toBe('-');
+    expect(formatDiskType({ type: '   ' })).toBe('-');
+    // rotational is omitempty, so a false is indistinguishable from absent.
+    expect(formatDiskType({ rotational: false })).toBe('-');
+  });
+
+  it('falls back to rotational only when it is true', () => {
+    expect(formatDiskType({ rotational: true })).toBe('HDD');
+  });
+
+  it('normalises the enum case and passes unknown values through', () => {
+    expect(formatDiskType({ type: 'nvme' })).toBe('NVME');
+    expect(formatDiskType({ type: 'ssd' })).toBe('SSD');
+    expect(formatDiskType({ type: 'Optane' })).toBe('Optane');
+  });
+});

--- a/metal3/src/BareMetalHost/diskType.ts
+++ b/metal3/src/BareMetalHost/diskType.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** The disk types the operator reports in `status.hardware.storage[].type`. */
+export const DISK_TYPES = ['HDD', 'SSD', 'NVME'] as const;
+export type DiskType = (typeof DISK_TYPES)[number];
+
+/** One entry of a host's `status.hardware.storage`, in the fields we read. */
+export interface StorageDevice {
+  /** Device type, one of HDD, SSD or NVME. Absent on older operator versions. */
+  type?: string;
+  /**
+   * Whether the disk is spinning media. Deprecated upstream in favour of `type`,
+   * and serialised with `omitempty`, so `false` and "not reported" are the same
+   * absence on the wire and it can only ever confirm a disk *is* rotational.
+   */
+  rotational?: boolean;
+}
+
+/**
+ * Formats a storage device's type for display.
+ *
+ * `type` is the field the operator recommends: it is an enum of HDD, SSD and
+ * NVME, so it distinguishes the three, and it is only set when the value is
+ * actually known. The older `rotational` boolean cannot do either — it collapses
+ * SSD and NVME into one value, and because it is `omitempty` a `false` is
+ * indistinguishable from a disk introspection never reported on. So `rotational`
+ * is consulted only as a fallback and only when true, and an unknown type is
+ * reported as unknown rather than guessed at.
+ *
+ * @param disk - The storage entry, if present.
+ * @returns The disk type, or `'-'` when it cannot be determined.
+ */
+export function formatDiskType(disk?: StorageDevice): string {
+  const reported = disk?.type?.trim();
+  if (reported) {
+    // Match the documented enum case-insensitively, but pass an unrecognised
+    // value straight through so a type added upstream still shows.
+    return DISK_TYPES.find(t => t === reported.toUpperCase()) ?? reported;
+  }
+  // Only a true rotational tells us anything; false or absent are the same here.
+  return disk?.rotational === true ? 'HDD' : '-';
+}


### PR DESCRIPTION
Fixes #1284

## Problem

The Hardware → Storage table derived a disk's type from the `rotational` boolean:

```tsx
{ label: 'Type', getter: (d: any) => (d.rotational ? 'HDD' : 'SSD') },
```

Upstream documents that field as deprecated in favour of `type` ([`hardwaredata_types.go`](https://github.com/metal3-io/baremetal-operator/blob/main/apis/metal3.io/v1alpha1/hardwaredata_types.go)):

```go
// Whether this disk represents rotational storage.
// This field is not recommended for usage, please
// prefer using 'Type' field instead, this field
// will be deprecated eventually.
Rotational bool `json:"rotational,omitempty"`

// Device type, one of: HDD, SSD, NVME.
// +kubebuilder:validation:Enum=HDD;SSD;NVME;
Type DiskType `json:"type,omitempty"`
```

Two consequences:

- **NVMe drives displayed as SSD.** One boolean cannot express the three values `type` does.
- **Unknown disks displayed as SSD.** `rotational` is serialised with `omitempty`, so a `false` and a value introspection never reported are the same absence on the wire. Any disk without the field fell to the `else` branch and was presented, with no hedging, as `SSD` — the column stated something definite about hardware the plugin had no data for.

## Change

`formatDiskType()` reads `type` in preference, and falls back to `rotational` only when it is `true`, since a true is the one thing that field can still tell us reliably. A disk whose type cannot be determined now reads `-`. An unrecognised `type` value is passed through unchanged so a type added upstream still displays.

The logic is a pure module with unit tests, matching how the plugin already separates `parseHostAnnotation`, `formatHostSelector` and the action helpers.

| Input | Before | After |
| --- | --- | --- |
| `{ type: 'NVME' }` | `SSD` | `NVME` |
| `{ type: 'HDD' }` | `SSD` | `HDD` |
| `{ rotational: true }` | `HDD` | `HDD` |
| `{}` (not reported) | `SSD` | `-` |

## Testing

Run from `metal3/`:

- `tsc --noEmit` — passes
- `eslint src/` — passes
- `prettier --check src/` — passes
- `vitest run` — 64 passed, 1 skipped (5 new)
- `vite build` — builds

No behaviour change for hosts that report `type`, which is the field current operator versions set.