### PR TITLE
metal3: BareMetalHost: Share fleet naming across the overview

### DIFF
--- a/metal3/src/BareMetalHost/Overview.tsx
+++ b/metal3/src/BareMetalHost/Overview.tsx
@@ -31,7 +31,13 @@ import { CRDGuard } from '../common/CRDGuard';
 import { HostStatusLabel } from './HostStatusLabel';
 import { bareMetalHostClass } from './List';
 import type { InProgressHost } from './overviewStats';
-import { computeOverview, groupByLabel, inProgressHosts, labelKeys } from './overviewStats';
+import {
+  computeOverview,
+  fleetNameFor,
+  groupByLabel,
+  inProgressHosts,
+  labelKeys,
+} from './overviewStats';
 
 /**
  * The globally selected namespaces (empty means all), read from Headlamp's shared
@@ -118,10 +124,9 @@ function OverviewContent() {
   const allInProgress = inProgressHosts(hosts, now);
 
   // Which fleet a host belongs to under the current grouping, for the list columns.
+  // Shares its naming with groupByLabel so the Fleets table and these columns agree.
   const fleetOf = (host: KubeObject): string =>
-    effectiveGroupKey
-      ? host.jsonData.metadata?.labels?.[effectiveGroupKey] ?? `(no ${effectiveGroupKey})`
-      : 'All hosts';
+    fleetNameFor(host.jsonData.metadata?.labels, effectiveGroupKey);
 
   const fleetRows: FleetRow[] = fleets.map(fleet => {
     const s = computeOverview(fleet.hosts);

--- a/metal3/src/BareMetalHost/overviewStats.test.ts
+++ b/metal3/src/BareMetalHost/overviewStats.test.ts
@@ -18,6 +18,7 @@ import type { KubeObject } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
 import { describe, expect, it } from 'vitest';
 import {
   computeOverview,
+  fleetNameFor,
   groupByLabel,
   inProgressHosts,
   labelKeys,
@@ -202,5 +203,40 @@ describe('computeOverview', () => {
     ];
     const s = computeOverview(hosts);
     expect(s.attention.map(h => h.metadata.name)).toEqual(['broken']);
+  });
+});
+
+describe('fleetNameFor', () => {
+  it('returns the label value when it is set', () => {
+    expect(fleetNameFor({ rack: 'r1' }, 'rack')).toBe('r1');
+  });
+
+  it('names a missing label distinctly', () => {
+    expect(fleetNameFor({ other: 'x' }, 'rack')).toBe('(no rack)');
+    expect(fleetNameFor(undefined, 'rack')).toBe('(no rack)');
+  });
+
+  it('names a present-but-empty label distinctly, never blank', () => {
+    expect(fleetNameFor({ rack: '' }, 'rack')).toBe('(empty)');
+  });
+
+  it('returns the all-hosts fleet when no grouping label is given', () => {
+    expect(fleetNameFor({ rack: 'r1' }, '')).toBe('All hosts');
+  });
+
+  it('agrees with the fleet names groupByLabel produces', () => {
+    const hosts = [
+      host({ name: 'a', labels: { rack: 'r1' } }),
+      host({ name: 'b', labels: { rack: '' } }),
+      host({ name: 'c' }),
+    ];
+    const fleets = groupByLabel(hosts, 'rack');
+    // Every host's computed fleet name must match the fleet it was grouped into.
+    hosts.forEach(h => {
+      const name = fleetNameFor(h.jsonData.metadata?.labels, 'rack');
+      const owning = fleets.find(f => f.hosts.includes(h));
+      expect(owning?.name).toBe(name);
+    });
+    expect(fleets.map(f => f.name).sort()).toEqual(['(empty)', '(no rack)', 'r1']);
   });
 });

--- a/metal3/src/BareMetalHost/overviewStats.ts
+++ b/metal3/src/BareMetalHost/overviewStats.ts
@@ -209,6 +209,27 @@ export function labelKeys(hosts: KubeObject[]): string[] {
   return [...keys].sort();
 }
 
+/** The fleet name used when no grouping label is selected. */
+export const ALL_HOSTS_FLEET = 'All hosts';
+
+/**
+ * The fleet name a host belongs to under a given grouping label. Missing label vs
+ * a present-but-empty value are distinct, and both need a usable name, so they map
+ * to "(no <key>)" and "(empty)" respectively rather than to a blank cell. Shared by
+ * the fleet grouping and the per-host Fleet columns so the two always agree.
+ *
+ * @param labels - The host's `metadata.labels`, if any.
+ * @param labelKey - The grouping label, or '' for no grouping.
+ * @returns The fleet name to display.
+ */
+export function fleetNameFor(labels: Record<string, string> | undefined, labelKey: string): string {
+  if (!labelKey) {
+    return ALL_HOSTS_FLEET;
+  }
+  const value = labels?.[labelKey];
+  return value === undefined ? `(no ${labelKey})` : value === '' ? '(empty)' : value;
+}
+
 /**
  * Groups hosts into fleets by the value of a label key. Hosts missing the label
  * fall into a "(no <key>)" fleet. An empty key returns a single "All hosts" fleet,
@@ -219,13 +240,11 @@ export function labelKeys(hosts: KubeObject[]): string[] {
  */
 export function groupByLabel(hosts: KubeObject[], labelKey: string): Fleet[] {
   if (!labelKey) {
-    return [{ name: 'All hosts', hosts }];
+    return [{ name: ALL_HOSTS_FLEET, hosts }];
   }
   const groups = new Map<string, KubeObject[]>();
   hosts.forEach(h => {
-    const value = h.jsonData.metadata?.labels?.[labelKey];
-    // Missing label vs a present-but-empty value are distinct; both need a usable name.
-    const name = value === undefined ? `(no ${labelKey})` : value === '' ? '(empty)' : value;
+    const name = fleetNameFor(h.jsonData.metadata?.labels, labelKey);
     if (!groups.has(name)) {
       groups.set(name, []);
     }


### PR DESCRIPTION
Fixes #1285

## Problem

The overview named fleets in two places, and the two disagreed.

`groupByLabel` deliberately distinguishes a missing label from a present-but-empty one, and gives both a readable name:

```ts
const value = h.jsonData.metadata?.labels?.[labelKey];
// Missing label vs a present-but-empty value are distinct; both need a usable name.
const name = value === undefined ? `(no ${labelKey})` : value === '' ? '(empty)' : value;
```

The Fleet column in the "In progress" and "Needs attention" tables re-derived the same name independently, with `??`:

```ts
const fleetOf = (host: KubeObject): string =>
  effectiveGroupKey
    ? host.jsonData.metadata?.labels?.[effectiveGroupKey] ?? `(no ${effectiveGroupKey})`
    : 'All hosts';
```

`??` only falls back on `null`/`undefined`, so a label present with an empty value returned `''` and rendered as a blank cell — while the same host appeared under `(empty)` in the Fleets table directly above it. One page described one host's fleet two different ways.

## Change

Extract the naming into an exported `fleetNameFor(labels, labelKey)` in `overviewStats.ts` and call it from both sites, so the two cannot drift apart again. `'All hosts'` becomes a shared `ALL_HOSTS_FLEET` constant for the same reason.

| Label state | Fleets table | Fleet column (before) | Fleet column (after) |
| --- | --- | --- | --- |
| `rack=r1` | `r1` | `r1` | `r1` |
| `rack=` (empty) | `(empty)` | *blank* | `(empty)` |
| no `rack` label | `(no rack)` | `(no rack)` | `(no rack)` |

## Testing

Run from `metal3/`:

- `tsc --noEmit` — passes
- `eslint src/` — passes
- `prettier --check src/` — passes
- `vitest run` — 64 passed, 1 skipped (5 new)
- `vite build` — builds

The new tests cover set, empty and missing label values, and one asserts directly that `fleetNameFor` agrees with the fleet each host was grouped into by `groupByLabel`, so the two staying consistent is now enforced rather than assumed.