### PR TITLE
kyverno: resources: Add policy impact aggregation module with unit tests

### DIFF
--- a/kyverno/src/resources/policyImpact.test.ts
+++ b/kyverno/src/resources/policyImpact.test.ts
@@ -149,6 +149,41 @@ describe('collectPolicyImpact', () => {
     expect(impact.namespaces).toEqual(new Set(['team-checkout']));
   });
 
+  test('a namespaced Policy is invisible without policyNamespace, found via Copilot review on real cluster data', () => {
+    // Real report from a namespaced Policy (kyverno.io/v1 Policy, not
+    // ClusterPolicy) installed on the live cluster. Kyverno encodes its
+    // identity in result.policy as "team-checkout/require-cost-center-label",
+    // the same <namespace>/<name> convention bucketReportResults already
+    // documents. Passing just policy.metadata.name, the obvious thing a
+    // caller holding a Policy object would do, silently returns zero impact
+    // even though this exact report has real failures.
+    const reports = [
+      report('team-checkout', badPod, [
+        {
+          policy: 'team-checkout/require-cost-center-label',
+          rule: 'check-for-cost-center-label',
+          result: 'fail',
+          message:
+            "validation error: the 'cost-center' label is required on all Pods in this namespace.",
+        },
+      ]),
+    ];
+
+    const withoutNamespace = collectPolicyImpact('require-cost-center-label', reports, []);
+    expect(withoutNamespace.resources).toEqual([]);
+
+    const withNamespace = collectPolicyImpact(
+      'require-cost-center-label',
+      reports,
+      [],
+      'team-checkout'
+    );
+    expect(withNamespace.counts.fail).toBe(1);
+    expect(withNamespace.resources[0]).toEqual(
+      expect.objectContaining({ kind: 'Pod', name: 'bad-pod', status: 'fail' })
+    );
+  });
+
   test('groups by kind across both namespaced and cluster-scoped reports', () => {
     const policyReports = [report('team-checkout', badPod, [{ policy: 'p', result: 'fail' }])];
     const clusterReports = [

--- a/kyverno/src/resources/policyImpact.test.ts
+++ b/kyverno/src/resources/policyImpact.test.ts
@@ -270,6 +270,68 @@ describe('collectPolicyImpact', () => {
 
     expect(impact.resources[0].name).toBe('from-resources-array');
   });
+
+  test('keeps every resource when a single result references more than one, found via Copilot review', () => {
+    // resources[] is typed as an array. The original code only ever read
+    // resources[0], silently dropping every later resource a result
+    // referenced.
+    const multiResourceReport = new PolicyReport({
+      apiVersion: 'wgpolicyk8s.io/v1alpha2',
+      kind: 'PolicyReport',
+      metadata: {
+        name: 'multi-resource',
+        namespace: 'team-checkout',
+        uid: 'r-3',
+        creationTimestamp: '2026-08-04T07:33:45Z',
+        resourceVersion: '1',
+      },
+      results: [
+        {
+          policy: 'p',
+          result: 'fail',
+          resources: [
+            { kind: 'Pod', name: 'first', namespace: 'team-checkout', uid: 'uid-first' },
+            { kind: 'Pod', name: 'second', namespace: 'team-checkout', uid: 'uid-second' },
+          ],
+        },
+      ],
+    } as any);
+
+    const impact = collectPolicyImpact('p', [multiResourceReport], []);
+
+    expect(impact.resources.map(r => r.name).sort()).toEqual(['first', 'second']);
+  });
+
+  test('prefers the UID over the name-based key so same-named resources from different API groups do not collapse, found via Copilot review', () => {
+    const crossGroupReport = new PolicyReport({
+      apiVersion: 'wgpolicyk8s.io/v1alpha2',
+      kind: 'PolicyReport',
+      metadata: {
+        name: 'cross-group',
+        namespace: 'team-checkout',
+        uid: 'r-4',
+        creationTimestamp: '2026-08-04T07:33:45Z',
+        resourceVersion: '1',
+      },
+      results: [
+        {
+          policy: 'p',
+          result: 'fail',
+          resources: [{ kind: 'Widget', name: 'shared-name', namespace: 'team-checkout', uid: 'widget-a' }],
+        },
+        {
+          policy: 'p',
+          result: 'pass',
+          resources: [{ kind: 'Widget', name: 'shared-name', namespace: 'team-checkout', uid: 'widget-b' }],
+        },
+      ],
+    } as any);
+
+    const impact = collectPolicyImpact('p', [crossGroupReport], []);
+
+    expect(impact.resources).toHaveLength(2);
+    expect(impact.resources.map(r => r.uid).sort()).toEqual(['widget-a', 'widget-b']);
+  });
 });
 
 describe('describeMatchReasons', () => {
@@ -294,6 +356,31 @@ describe('describeMatchReasons', () => {
     const reasons = describeMatchReasons(rules, 'Deployment');
 
     expect(reasons[0]).toContain('No rule in this policy explicitly lists kind "Deployment"');
+  });
+
+  test('recognizes a wildcard kind as an explicit match, found via Copilot review', () => {
+    const wildcardRules: PolicyRule[] = [
+      { name: 'check-everything', match: { any: [{ resources: { kinds: ['*'] } }] } },
+    ];
+
+    const reasons = describeMatchReasons(wildcardRules, 'Deployment');
+
+    expect(reasons[0]).toContain('Rule "check-everything" matches kind "Deployment"');
+  });
+
+  test('mentions a namespace label selector, not just a resource label selector, found via Copilot review', () => {
+    const namespaceSelectorRules: PolicyRule[] = [
+      {
+        name: 'check-team-namespaces',
+        match: {
+          any: [{ resources: { kinds: ['Pod'], namespaceSelector: { team: 'checkout' } } }],
+        },
+      },
+    ];
+
+    const reasons = describeMatchReasons(namespaceSelectorRules, 'Pod');
+
+    expect(reasons[0]).toContain('a namespace label selector');
   });
 });
 

--- a/kyverno/src/resources/policyImpact.test.ts
+++ b/kyverno/src/resources/policyImpact.test.ts
@@ -1,0 +1,297 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, test, vi } from 'vitest';
+import { PolicyRule } from './kyvernoPolicy';
+import { collectPolicyImpact, describeMatchReasons, suggestFix } from './policyImpact';
+import { ClusterPolicyReport, PolicyReport } from './policyReport';
+
+// policyReport.ts extends KubeObject from @kinvolk/headlamp-plugin/lib/k8s/cluster,
+// which only resolves at real build time through a rollup-only external/globals
+// mapping in the shared vite config (build.rollupOptions.external / output.globals).
+// Vite's own import-analysis tries to resolve that path before vitest's mock
+// registry gets a chance to substitute it, since it is a deep, non-relative
+// package path, not a file that genuinely exists where Vite looks. No test in
+// this plugin has been able to construct a real resource class instance
+// because of this, it isn't specific to this file. Mocking the local
+// ./policyReport module instead sidesteps it: it is a real file on disk, so
+// Vite resolves it fine, and this reimplements PolicyReportBase's actual
+// getters exactly (see policyReport.ts), so collectPolicyImpact, which only
+// ever touches .results / .scope / .jsonData at runtime, behaves identically
+// to how it would against the real classes.
+vi.mock('./policyReport', () => {
+  class PolicyReportBase {
+    jsonData: any;
+    constructor(json: any) {
+      this.jsonData = json;
+    }
+    get results() {
+      return this.jsonData.results || [];
+    }
+    get scope() {
+      return this.jsonData.scope;
+    }
+  }
+  class PolicyReport extends PolicyReportBase { }
+  class ClusterPolicyReport extends PolicyReportBase { }
+  return { PolicyReport, ClusterPolicyReport };
+});
+
+// Real reports pulled from a live kind cluster running Kyverno v1.18.2, with a
+// legacy ClusterPolicy (require-app-label) and a CEL ValidatingPolicy
+// (require-team-label) both installed, trimmed of fields collectPolicyImpact
+// does not read. On this Kyverno version, `resources[]` never populates in the
+// aggregated PolicyReport, identity always lives on `scope`, confirmed for both
+// background-scanned resources and a pod created seconds before checking, and
+// confirmed identical for the legacy and CEL policy. See notes/02-policy-impact-map.md.
+
+function report(
+  namespace: string,
+  scope: Record<string, unknown>,
+  results: Record<string, unknown>[]
+): PolicyReport {
+  return new PolicyReport({
+    apiVersion: 'wgpolicyk8s.io/v1alpha2',
+    kind: 'PolicyReport',
+    metadata: {
+      name: String(scope.uid),
+      namespace,
+      uid: 'report-' + String(scope.uid),
+      creationTimestamp: '2026-08-04T07:33:45Z',
+      resourceVersion: '1',
+    },
+    scope,
+    results,
+  } as any);
+}
+
+const badPod = {
+  apiVersion: 'v1',
+  kind: 'Pod',
+  name: 'bad-pod',
+  namespace: 'team-checkout',
+  uid: '0bb9bfaa-31ca-436f-9034-f6ae5853ebd5',
+};
+
+const goodTeamPod = {
+  apiVersion: 'v1',
+  kind: 'Pod',
+  name: 'good-team-pod',
+  namespace: 'team-checkout',
+  uid: '929b2f17-493d-44d2-a2c6-b53c251baf93',
+};
+
+const corednsDeployment = {
+  apiVersion: 'apps/v1',
+  kind: 'Deployment',
+  name: 'coredns',
+  namespace: 'kube-system',
+  uid: '43aec13f-5c85-40b8-95ea-ac2cd3a8ecc9',
+};
+
+describe('collectPolicyImpact', () => {
+  test('aggregates real fail and pass results for the legacy require-app-label policy', () => {
+    const reports = [
+      report('team-checkout', badPod, [
+        {
+          policy: 'require-app-label',
+          rule: 'check-for-app-label',
+          result: 'fail',
+          message: "validation error: The label 'app' is required on all Pods.",
+        },
+      ]),
+    ];
+
+    const impact = collectPolicyImpact('require-app-label', reports, []);
+
+    expect(impact.counts.fail).toBe(1);
+    expect(impact.resources).toEqual([
+      expect.objectContaining({ kind: 'Pod', name: 'bad-pod', status: 'fail' }),
+    ]);
+  });
+
+  test('aggregates real fail and pass results for the CEL require-team-label policy', () => {
+    const reports = [
+      report('team-checkout', badPod, [
+        {
+          policy: 'require-team-label',
+          result: 'fail',
+          message: "the 'team' label is required on all pods",
+          source: 'KyvernoValidatingPolicy',
+        },
+      ]),
+      report('team-checkout', goodTeamPod, [
+        {
+          policy: 'require-team-label',
+          result: 'pass',
+          message: 'success',
+          source: 'KyvernoValidatingPolicy',
+        },
+      ]),
+    ];
+
+    const impact = collectPolicyImpact('require-team-label', reports, []);
+
+    expect(impact.counts).toEqual({ pass: 1, fail: 1, warn: 0, error: 0, skip: 0 });
+    expect(impact.namespaces).toEqual(new Set(['team-checkout']));
+  });
+
+  test('groups by kind across both namespaced and cluster-scoped reports', () => {
+    const policyReports = [report('team-checkout', badPod, [{ policy: 'p', result: 'fail' }])];
+    const clusterReports = [
+      new ClusterPolicyReport({
+        apiVersion: 'wgpolicyk8s.io/v1alpha2',
+        kind: 'ClusterPolicyReport',
+        metadata: {
+          name: 'cluster-report',
+          uid: 'cr-1',
+          creationTimestamp: '2026-08-04T07:33:45Z',
+          resourceVersion: '1',
+        },
+        scope: corednsDeployment,
+        results: [{ policy: 'p', result: 'fail' }],
+      } as any),
+    ];
+
+    const impact = collectPolicyImpact('p', policyReports, clusterReports);
+
+    expect(Array.from(impact.byKind.keys()).sort()).toEqual(['Deployment', 'Pod']);
+    expect(impact.byKind.get('Deployment')).toHaveLength(1);
+    expect(impact.byKind.get('Pod')).toHaveLength(1);
+  });
+
+  test('returns an empty summary for a policy with zero results, not an error', () => {
+    const reports = [report('team-checkout', badPod, [{ policy: 'require-app-label', result: 'fail' }])];
+
+    const impact = collectPolicyImpact('a-policy-nothing-matches', reports, []);
+
+    expect(impact.resources).toEqual([]);
+    expect(impact.byKind.size).toBe(0);
+    expect(impact.namespaces.size).toBe(0);
+    expect(impact.counts).toEqual({ pass: 0, fail: 0, warn: 0, error: 0, skip: 0 });
+  });
+
+  test('handles null report lists the same as empty ones, useList() returns null while loading', () => {
+    const impact = collectPolicyImpact('any-policy', null, null);
+
+    expect(impact.resources).toEqual([]);
+  });
+
+  test('keeps the worst status when a resource appears more than once for the same policy', () => {
+    // Not reproduced live: on the current Kyverno version a resource gets exactly
+    // one report entry per policy (see notes/02-policy-impact-map.md), so this
+    // exercises collectPolicyImpact's documented dedup contract defensively,
+    // in case a version or mode produces more than one result per resource.
+    const reports = [
+      report('team-checkout', badPod, [
+        { policy: 'p', rule: 'r1', result: 'pass' },
+        { policy: 'p', rule: 'r2', result: 'fail' },
+      ]),
+    ];
+
+    const impact = collectPolicyImpact('p', reports, []);
+
+    expect(impact.resources).toHaveLength(1);
+    expect(impact.resources[0].status).toBe('fail');
+  });
+
+  test('falls back to resources[] when a report populates it instead of scope', () => {
+    // Not reproduced live either, see the module comment above. resources[] is
+    // in the PolicyReportResult type and collectPolicyImpact explicitly checks
+    // it first, so it needs coverage even without a live example to point at.
+    const withResourcesArray = new PolicyReport({
+      apiVersion: 'wgpolicyk8s.io/v1alpha2',
+      kind: 'PolicyReport',
+      metadata: {
+        name: 'admission-style',
+        namespace: 'team-checkout',
+        uid: 'r-2',
+        creationTimestamp: '2026-08-04T07:33:45Z',
+        resourceVersion: '1',
+      },
+      results: [
+        {
+          policy: 'p',
+          result: 'fail',
+          resources: [{ kind: 'Pod', name: 'from-resources-array', namespace: 'team-checkout' }],
+        },
+      ],
+    } as any);
+
+    const impact = collectPolicyImpact('p', [withResourcesArray], []);
+
+    expect(impact.resources[0].name).toBe('from-resources-array');
+  });
+});
+
+describe('describeMatchReasons', () => {
+  const rules: PolicyRule[] = [
+    {
+      name: 'check-pods',
+      match: {
+        any: [{ resources: { kinds: ['Pod'], namespaces: ['team-checkout'] } }],
+      },
+    },
+  ];
+
+  test('explains a direct kind match with its namespace scope', () => {
+    const reasons = describeMatchReasons(rules, 'Pod');
+
+    expect(reasons).toEqual([
+      'Rule "check-pods" matches kind "Pod" and namespaces [team-checkout].',
+    ]);
+  });
+
+  test('admits when no rule explicitly matches the kind, autogen or background scan territory', () => {
+    const reasons = describeMatchReasons(rules, 'Deployment');
+
+    expect(reasons[0]).toContain('No rule in this policy explicitly lists kind "Deployment"');
+  });
+});
+
+describe('suggestFix', () => {
+  const target = { policy: 'require-app-label', status: 'fail' as const };
+
+  test('points at validate.pattern for a pattern-based rule', () => {
+    const rule: PolicyRule = { name: 'r', validate: { pattern: {} } };
+    expect(suggestFix(rule, target)).toContain('pattern');
+  });
+
+  test('points at validate.cel for a CEL-based rule', () => {
+    const rule: PolicyRule = { name: 'r', validate: { cel: {} } };
+    expect(suggestFix(rule, { ...target, policy: 'require-team-label' })).toContain(
+      'CEL expression'
+    );
+  });
+
+  test('falls back to a generic message when the rule uses no recognized mechanism', () => {
+    const rule: PolicyRule = { name: 'r' };
+    expect(suggestFix(rule, target)).toContain('rule "r" on policy "require-app-label"');
+  });
+
+  test('never leaks the literal string "undefined" when rule.name is missing', () => {
+    // suggestFix is written for the legacy PolicyRule shape. A CEL
+    // ValidatingPolicy's validations have no "rules" or "name" at all, see
+    // notes/02-policy-impact-map.md, full CEL-aware explanations are
+    // deferred to PR-4, but this guards the one part that could otherwise
+    // produce broken-looking output today: rule.name being undefined.
+    const ruleWithNoName = {} as PolicyRule;
+    const result = suggestFix(ruleWithNoName, target);
+
+    expect(result).not.toContain('undefined');
+    expect(result).toContain('this rule');
+  });
+});

--- a/kyverno/src/resources/policyImpact.ts
+++ b/kyverno/src/resources/policyImpact.ts
@@ -191,7 +191,7 @@ export function describeMatchReasons(rules: PolicyRule[], kind: string): string[
 
   if (reasons.length > 0) return reasons;
   return [
-    `No rule in this policy explicitly lists kind "${kind}" in its match block; it was likely reached through a generated rule, a wildcard selector, or a background scan.`,
+    `No rule in this policy explicitly lists kind "${kind}" in its match block; it was likely reached through a generated rule or a background scan.`,
   ];
 }
 

--- a/kyverno/src/resources/policyImpact.ts
+++ b/kyverno/src/resources/policyImpact.ts
@@ -68,27 +68,36 @@ function ingest(
     // Background-scan reports put the resource identity on the report's
     // `scope` rather than per-result `resources[]` (Kyverno emits one
     // PolicyReport per scanned resource in that mode), so `resources[]` is
-    // the primary source and `scope` is the fallback.
-    const res = result.resources?.[0];
-    const kind = res?.kind || reportScope?.kind || 'Unknown';
-    const name = res?.name || reportScope?.name || '(unscoped)';
-    const namespace = res?.namespace || reportScope?.namespace || reportNamespace;
-    const uid = res?.uid || reportScope?.uid;
-    const key = `${kind}/${namespace || ''}/${name}`;
-    const existing = byResource.get(key);
+    // the primary source and `scope` is the fallback. A result can reference
+    // more than one resource, so every entry gets its own map slot, not just
+    // the first, otherwise later resources are silently dropped.
+    const resourceRefs =
+      result.resources && result.resources.length > 0 ? result.resources : [reportScope];
 
-    if (!existing || STATUS_RANK[result.result] > STATUS_RANK[existing.status]) {
-      byResource.set(key, {
-        policy: policyName,
-        kind,
-        name,
-        namespace,
-        uid,
-        status: result.result,
-        rule: result.rule,
-        message: result.message,
-        severity: result.severity,
-      });
+    for (const res of resourceRefs) {
+      const kind = res?.kind || reportScope?.kind || 'Unknown';
+      const name = res?.name || reportScope?.name || '(unscoped)';
+      const namespace = res?.namespace || reportScope?.namespace || reportNamespace;
+      const uid = res?.uid || reportScope?.uid;
+      // Prefer the UID when it's available. The name-based key alone can
+      // collide for distinct objects that share kind, namespace, and name,
+      // for example the same name used by two different API groups.
+      const key = uid || `${kind}/${namespace || ''}/${name}`;
+      const existing = byResource.get(key);
+
+      if (!existing || STATUS_RANK[result.result] > STATUS_RANK[existing.status]) {
+        byResource.set(key, {
+          policy: policyName,
+          kind,
+          name,
+          namespace,
+          uid,
+          status: result.result,
+          rule: result.rule,
+          message: result.message,
+          severity: result.severity,
+        });
+      }
     }
   }
 }
@@ -162,7 +171,9 @@ export function describeMatchReasons(rules: PolicyRule[], kind: string): string[
     const selectors = [...(rule.match?.any || []), ...(rule.match?.all || [])];
     for (const selector of selectors) {
       const kinds = selector.resources?.kinds || [];
-      if (!kinds.includes(kind)) continue;
+      // Kyverno match kinds support "*" as a wildcard for every kind, an
+      // exact-membership check alone would reject a kind matched this way.
+      if (!kinds.includes(kind) && !kinds.includes('*')) continue;
 
       const parts = [`kind "${kind}"`];
       if (selector.resources?.namespaces?.length) {
@@ -170,6 +181,9 @@ export function describeMatchReasons(rules: PolicyRule[], kind: string): string[
       }
       if (selector.resources?.selector) {
         parts.push('a label selector');
+      }
+      if (selector.resources?.namespaceSelector) {
+        parts.push('a namespace label selector');
       }
       reasons.push(`Rule "${rule.name}" matches ${parts.join(' and ')}.`);
     }

--- a/kyverno/src/resources/policyImpact.ts
+++ b/kyverno/src/resources/policyImpact.ts
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { PolicyRule } from './kyvernoPolicy';
+import {
+  ClusterPolicyReport,
+  PolicyReport,
+  PolicyReportInterface,
+  PolicyReportResult,
+  PolicyResultStatus,
+} from './policyReport';
+
+// Minimal shape needed to open a ViolationDrillDown dialog from anywhere in the
+// plugin (the Violations view, the Policy Impact panel, or a Map node).
+export interface DrillDownTarget {
+  policy: string;
+  rule?: string;
+  kind?: string;
+  name?: string;
+  namespace?: string;
+  message?: string;
+  severity?: string;
+  status: PolicyResultStatus;
+}
+
+export type ImpactedResource = DrillDownTarget & { uid?: string };
+
+export interface PolicyImpactSummary {
+  resources: ImpactedResource[];
+  byKind: Map<string, ImpactedResource[]>;
+  namespaces: Set<string>;
+  counts: Record<PolicyResultStatus, number>;
+}
+
+// When a resource shows up in more than one report result for the same policy
+// (evaluated by more than one rule), the worst status wins for the summary view.
+const STATUS_RANK: Record<PolicyResultStatus, number> = {
+  error: 4,
+  fail: 3,
+  warn: 2,
+  skip: 1,
+  pass: 0,
+};
+
+function ingest(
+  policyName: string,
+  results: PolicyReportResult[],
+  reportScope: PolicyReportInterface['scope'],
+  reportNamespace: string | undefined,
+  byResource: Map<string, ImpactedResource>
+) {
+  for (const result of results) {
+    if (result.policy !== policyName) continue;
+
+    // Background-scan reports put the resource identity on the report's
+    // `scope` rather than per-result `resources[]` (Kyverno emits one
+    // PolicyReport per scanned resource in that mode), so `resources[]` is
+    // the primary source and `scope` is the fallback.
+    const res = result.resources?.[0];
+    const kind = res?.kind || reportScope?.kind || 'Unknown';
+    const name = res?.name || reportScope?.name || '(unscoped)';
+    const namespace = res?.namespace || reportScope?.namespace || reportNamespace;
+    const uid = res?.uid || reportScope?.uid;
+    const key = `${kind}/${namespace || ''}/${name}`;
+    const existing = byResource.get(key);
+
+    if (!existing || STATUS_RANK[result.result] > STATUS_RANK[existing.status]) {
+      byResource.set(key, {
+        policy: policyName,
+        kind,
+        name,
+        namespace,
+        uid,
+        status: result.result,
+        rule: result.rule,
+        message: result.message,
+        severity: result.severity,
+      });
+    }
+  }
+}
+
+/**
+ * Builds the set of resources a policy actually touched, grouped by kind, from
+ * the live PolicyReport / ClusterPolicyReport results already on the cluster.
+ * This reflects what Kyverno evaluated rather than a static re-implementation
+ * of its match logic, so it stays correct across selector, CEL, and autogen rules.
+ */
+export function collectPolicyImpact(
+  policyName: string,
+  policyReports: PolicyReport[] | null,
+  clusterPolicyReports: ClusterPolicyReport[] | null
+): PolicyImpactSummary {
+  const byResource = new Map<string, ImpactedResource>();
+
+  for (const report of policyReports || []) {
+    ingest(policyName, report.results, report.scope, report.jsonData.metadata.namespace, byResource);
+  }
+  for (const report of clusterPolicyReports || []) {
+    ingest(policyName, report.results, report.scope, undefined, byResource);
+  }
+
+  const resources = Array.from(byResource.values());
+  const byKind = new Map<string, ImpactedResource[]>();
+  const namespaces = new Set<string>();
+  const counts: Record<PolicyResultStatus, number> = {
+    pass: 0,
+    fail: 0,
+    warn: 0,
+    error: 0,
+    skip: 0,
+  };
+
+  for (const r of resources) {
+    const list = byKind.get(r.kind || 'Unknown') || [];
+    list.push(r);
+    byKind.set(r.kind || 'Unknown', list);
+    if (r.namespace) namespaces.add(r.namespace);
+    counts[r.status]++;
+  }
+
+  return { resources, byKind, namespaces, counts };
+}
+
+/**
+ * Explains, in plain language, which rule and selector caused a policy to
+ * consider a given resource kind. Read directly from the policy spec so the
+ * explanation stays accurate even for policies with several rules.
+ */
+export function describeMatchReasons(rules: PolicyRule[], kind: string): string[] {
+  const reasons: string[] = [];
+
+  for (const rule of rules) {
+    const selectors = [...(rule.match?.any || []), ...(rule.match?.all || [])];
+    for (const selector of selectors) {
+      const kinds = selector.resources?.kinds || [];
+      if (!kinds.includes(kind)) continue;
+
+      const parts = [`kind "${kind}"`];
+      if (selector.resources?.namespaces?.length) {
+        parts.push(`namespaces [${selector.resources.namespaces.join(', ')}]`);
+      }
+      if (selector.resources?.selector) {
+        parts.push('a label selector');
+      }
+      reasons.push(`Rule "${rule.name}" matches ${parts.join(' and ')}.`);
+    }
+  }
+
+  if (reasons.length > 0) return reasons;
+  return [
+    `No rule in this policy explicitly lists kind "${kind}" in its match block; it was likely reached through a generated rule, a wildcard selector, or a background scan.`,
+  ];
+}
+
+/**
+ * Heuristic remediation guidance built from the actual failing rule
+ * definition. Deliberately conservative: it points at the exact clause that
+ * failed rather than guessing at the user's intent.
+ */
+export function suggestFix(rule: PolicyRule, target: DrillDownTarget): string {
+  // rule.name is only guaranteed on the legacy kyverno.io/v1 rule shape this
+  // function was written for. A CEL ValidatingPolicy's validations have no
+  // "rules" at all, so a caller that hasn't adapted one into a PolicyRule yet
+  // would otherwise leak the literal string "undefined" into this text.
+  const ruleLabel = rule.name ? `rule "${rule.name}"` : 'this rule';
+
+  if (rule.validate?.pattern) {
+    return `This rule enforces the pattern below on ${target.kind || 'the resource'}. Update the manifest so every field matches the pattern, then re-apply it.`;
+  }
+  if (rule.validate?.anyPattern) {
+    return `This rule requires the resource to satisfy at least one of several patterns. Compare the resource against each entry in validate.anyPattern and adjust it to match one of them.`;
+  }
+  if (rule.validate?.deny) {
+    return `This rule denies matching resources outright rather than asking for a change. Check the match and exclude blocks on ${ruleLabel} to see whether this resource should be excluded instead of edited.`;
+  }
+  if (rule.validate?.cel) {
+    return `This rule is enforced with a CEL expression. Review validate.cel.expressions on ${ruleLabel} and adjust the resource so the expression evaluates to true.`;
+  }
+  if (rule.mutate) {
+    return `This is a mutation rule; Kyverno should patch the resource automatically. If the patch did not apply, confirm the rule's match block covers this resource and that mutation was not skipped.`;
+  }
+  return `Review the message above together with ${ruleLabel} on policy "${target.policy}" to see what condition failed.`;
+}

--- a/kyverno/src/resources/policyImpact.ts
+++ b/kyverno/src/resources/policyImpact.ts
@@ -98,19 +98,34 @@ function ingest(
  * the live PolicyReport / ClusterPolicyReport results already on the cluster.
  * This reflects what Kyverno evaluated rather than a static re-implementation
  * of its match logic, so it stays correct across selector, CEL, and autogen rules.
+ *
+ * Kyverno encodes a namespaced policy's identity in report results as
+ * `<namespace>/<name>` (see bucketReportResults), cluster policies stay
+ * unprefixed. Pass `policyNamespace` for a namespaced Policy so this matches
+ * the qualified form, otherwise every result is silently filtered out even
+ * when real data exists, `policyName` alone is never enough for a namespaced
+ * policy.
  */
 export function collectPolicyImpact(
   policyName: string,
   policyReports: PolicyReport[] | null,
-  clusterPolicyReports: ClusterPolicyReport[] | null
+  clusterPolicyReports: ClusterPolicyReport[] | null,
+  policyNamespace?: string
 ): PolicyImpactSummary {
+  const qualifiedName = policyNamespace ? `${policyNamespace}/${policyName}` : policyName;
   const byResource = new Map<string, ImpactedResource>();
 
   for (const report of policyReports || []) {
-    ingest(policyName, report.results, report.scope, report.jsonData.metadata.namespace, byResource);
+    ingest(
+      qualifiedName,
+      report.results,
+      report.scope,
+      report.jsonData.metadata.namespace,
+      byResource
+    );
   }
   for (const report of clusterPolicyReports || []) {
-    ingest(policyName, report.results, report.scope, undefined, byResource);
+    ingest(qualifiedName, report.results, report.scope, undefined, byResource);
   }
 
   const resources = Array.from(byResource.values());


### PR DESCRIPTION
## What this adds

A new module, `resources/policyImpact.ts`, that answers a question the plugin currently cannot: given one specific policy, which resources on the cluster does it actually affect, and are they passing or failing. Today the plugin can show a list of policies, or a flat list of every violation across the whole cluster, but nothing connects the two from a single policy's point of view. This is the first half of the Policy Impact Map feature from the proposal, pure logic, no UI yet, that comes in the next PR.

Three functions:

`collectPolicyImpact(policyName, policyReports, clusterPolicyReports)` walks every `PolicyReport` and `ClusterPolicyReport` already on the cluster, keeps only the results belonging to the target policy, resolves each result's resource identity, and groups the outcome by kind with pass and fail counts. It reads Kyverno's own reports rather than re-implementing Kyverno's match and selector logic client side, so it stays correct for label selectors, CEL expressions, and autogen rules without a second, drift-prone implementation of that logic living in the plugin.

`describeMatchReasons(rules, kind)` explains, in plain language, which rule and selector caused a policy to consider a given resource kind, or says plainly that it cannot tell when a resource was reached through autogen or a background scan rather than an explicit match block.

`suggestFix(rule, target)` gives remediation guidance based on which validation mechanism actually failed, pattern, anyPattern, deny, or CEL, pointing at the specific clause rather than guessing at intent.

## Verified against a live cluster, not assumed

Installed a real CEL based `ValidatingPolicy` on a kind cluster already running the legacy Kyverno policies, specifically to check whether `collectPolicyImpact` needed different handling for CEL policies. It does not. Both policy types report through the same `PolicyReport` and `ClusterPolicyReport` shape, confirmed directly against live data, including a pod created seconds before checking to force a genuinely fresh evaluation, not just background scan data.

`describeMatchReasons` and `suggestFix` are legacy policy only for now. A CEL `ValidatingPolicy` has a completely different spec shape (`matchConstraints.resourceRules`, `validations[].expression`, no `rules[]` at all), and giving CEL policies a real explanation and fix suggestion deserves the same live verification the aggregation function just got, not a same day guess. That work is already planned for a follow-up PR that extends `suggestFix` coverage anyway. What matters for this PR is that these two functions degrade safely rather than produce broken output when given something they do not recognize, confirmed by feeding real CEL policy data into both and fixing what came back.

## What that verification actually caught

Feeding a real CEL validation object into `suggestFix` produced the literal text `rule "undefined"` in the output, since CEL validations have no `rule.name` field at all. Fixed by falling back to `this rule` whenever a name is not present, applied everywhere the function references a rule by name, not just the one spot that happened to be tested first.

## Verification

- `npx tsc --noEmit`: clean
- `npx eslint` on both new files: clean
- `npm run test`: full suite passing
- Queried the live cluster directly through the Kubernetes API (the same objects `collectPolicyImpact` reads) and separately through the function itself, and confirmed both agree on every policy currently installed

## Screenshots and evidence to attach

1. Terminal output of `npx tsc --noEmit`, `npx eslint src/resources/policyImpact.ts src/resources/policyImpact.test.ts`, and `npm run test` from `kyverno/`, showing all three clean and the full suite passing.
<img width="1343" height="428" alt="Screenshot from 2026-09-12 08-37-50" src="https://github.com/user-attachments/assets/3ff6c56f-18c2-4afe-a489-4fbb40472472" />

2. The module run directly against live cluster data, showing its output grouped by kind for at least one legacy and one CEL based policy, to show both are handled correctly.
<img width="1612" height="913" alt="Screenshot from 2026-09-12 08-25-13" src="https://github.com/user-attachments/assets/f41e3cec-0f17-4145-9c18-218ac1544de4" />

